### PR TITLE
force set gpg language to en

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -521,6 +521,8 @@ def check_sig(afile: str, asigfile: str) -> None:
     except pb.CommandNotFound:
         gpg = get_cmd_or_die("gpg")
 
+    # force set to english
+    gpg.env = {'LANG': 'en'}
     gpg_ver = gpg("--version")
     logging.debug("gpg version output:\n%s", gpg_ver)
     emsg = "{} in path is too old".format(gpg.executable.basename)


### PR DESCRIPTION
GnuPG takes the `LANG` environment variable as output language.

If we using the English to expect the output, I prefer set the `LANG` explicitly.