### PR TITLE
Fix LGTM.com configuration file (lgtm.yml)

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -5,19 +5,27 @@ path_classifiers:
     - cross-checks/c-checks/clang-plugin/test
     - cross-checks/rust-checks/rustc-plugin/tests
     - cross-checks/rust-checks/derive-macros/tests
+  library:
+    - dependencies
+    
 extraction:
   python:
     python_setup:
-      requirements_files:
-        - scripts/requirements.txt
       version: 3
       setup_py: false
   cpp:
-    # prepare:
+    prepare:
+      packages:
+        - python3-psutil
+        
     after_prepare:
-      - sudo scripts/provision_deb.sh
+      - "curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path -y"
+
+    configure:
+      command:
+        - "echo Deliberately not running cmake..."
+      
     index:
       build_command:
-        - scripts/build_translator.py
-  exclude:
-    - dependencies/**
+        - "cat /usr/lib/python3/dist-packages/plumbum/__init__.py > /dev/null" # trick to install python3-plumbum
+        - "PATH=\"$HOME/.cargo/bin:$PATH\" scripts/build_translator.py"


### PR DESCRIPTION
Hi team,

I noticed you started using LGTM.com's automated code review for pull requests, but that there were some problems with your `lgtm.yml` file. I've tweaked it a bit: it should now fully work for Python 3 analysis, and it's almost there for C/C++ analysis as well.

The latter is not quite working due to a build error I can't work around:
```
[2018-08-31 16:11:08] [build] [933/935] Creating library symlink lib/libclangTooling.so.6 lib/libclangTooling.so
[2018-08-31 16:11:08] [build] [934/935] Building CXX object tools/clang/tools/extra/ast-exporter/CMakeFiles/ast-exporter.dir/AstExporter.cpp.o
[2018-08-31 16:11:08] [build] FAILED: tools/clang/tools/extra/ast-exporter/CMakeFiles/ast-exporter.dir/AstExporter.cpp.o 
[2018-08-31 16:11:08] [build] /usr/bin/clang++  -DGTEST_HAS_RTTI=0 -D_DEBUG -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Itools/clang/tools/extra/ast-exporter -I/opt/src/dependencies/llvm-6.0.1/src/tools/clang/tools/extra/ast-exporter -I/opt/src/dependencies/llvm-6.0.1/src/tools/clang/include -Itools/clang/include -I/usr/include/libxml2 -Iinclude -I/opt/src/dependencies/llvm-6.0.1/src/include -I/opt/src/dependencies/tinycbor.a8e0b17c0e54/include -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -std=c++11 -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wcovered-switch-default -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wstring-conversion -fcolor-diagnostics -ffunction-sections -fdata-sections -fno-common -Woverloaded-virtual -Wno-nested-anon-types -O2 -g    -UNDEBUG  -fno-exceptions -fno-rtti -MD -MT tools/clang/tools/extra/ast-exporter/CMakeFiles/ast-exporter.dir/AstExporter.cpp.o -MF tools/clang/tools/extra/ast-exporter/CMakeFiles/ast-exporter.dir/AstExporter.cpp.o.d -o tools/clang/tools/extra/ast-exporter/CMakeFiles/ast-exporter.dir/AstExporter.cpp.o -c /opt/src/dependencies/llvm-6.0.1/src/tools/clang/tools/extra/ast-exporter/AstExporter.cpp
[2018-08-31 16:11:08] [build] In file included from /opt/src/dependencies/llvm-6.0.1/src/tools/clang/tools/extra/ast-exporter/AstExporter.cpp:24:
[2018-08-31 16:11:08] [build] /opt/src/dependencies/tinycbor.a8e0b17c0e54/include/tinycbor/cbor.h:37:10: fatal error: 'tinycbor-version.h' file not found
[2018-08-31 16:11:08] [build] #include "tinycbor-version.h"
[2018-08-31 16:11:08] [build]          ^~~~~~~~~~~~~~~~~~~~
[2018-08-31 16:11:08] [build] 1 error generated.
[2018-08-31 16:11:08] [build] ninja: build stopped: subcommand failed.
```

I'm getting this both on the LGTM cloud infrastructure and on my local Ubuntu 18.04 machine. The problem appears to be that `tinycbor-version.h` is not copied into the `dependencies/tinycbor.xxxx/include` directory during the early stages of the build. When `AstExporter.cpp` is then looking for it later, the build fails.

Any suggestions on how to work around this?

(full disclosure: I'm on the LGTM.com team)