### PR TITLE
Update the Travis script to run on Linux and OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ git:
 
 env:
   global:
-    - CXX=clang++
-    - CC=clang
     - USE_CCACHE=1
     - CCACHE_COMPRESS=1
     - CCACHE_CPP2=1
@@ -64,17 +62,17 @@ install:
 script:
   - |
     case "$CACHE_NAME" in
-      LINUX_JOB|OSX_JOB)
+      LINUX_DEV_BUILD|OSX_DEV_BUILD)
         ccache -s
         python3 ./scripts/build_translator.py --debug || travis_terminate 1
         ccache -s
         python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
         ;;
-      LINUX_JOB2)
+      LINUX_FAST_BUILD)
         cargo build
         python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
         ;;
-      OSX_JOB2)
+      OSX_FAST_BUILD)
         cargo build
         python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
         ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,15 +61,18 @@ install:
 # NOTE: travis doesn't automatically terminate if command fails.
 script:
   - |
-    if [["$CACHE_NAME" == "LINUX_JOB"] || ["$CACHE_NAME" == "OSX_JOB"]]; then
-      ccache -s
-      python3 ./scripts/build_translator.py --debug || travis_terminate 1
-      ccache -s
-      python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
-    else
-      cargo build
-      python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
-    fi
+    case "$CACHE_NAME" in
+      LINUX_JOB|OSX_JOB)
+        ccache -s
+        python3 ./scripts/build_translator.py --debug || travis_terminate 1
+        ccache -s
+        python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
+        ;;
+      LINUX_JOB2|OSX_JOB2)
+        cargo build
+        python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
+        ;;
+    esac
  # NOTE: disabled because it takes to long to compile on free plan :/
  # To enable, add `--with-clang` to build_translator.py line above.
  # - python3 ./scripts/build_cross_checks.py || travis_terminate 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: generic
-# note: xcode9.4/macOS 10.13 is the default for macOS
-# osx_image: xcode9.3 # request macOS 10.13
 dist: xenial
 sudo: required
 
@@ -18,6 +16,8 @@ env:
 matrix:
   fast_finish: true
   include:
+    # note: xcode9.4/macOS 10.13 is the default for macOS
+    # osx_image: xcode9.3 # request macOS 10.13
     - os: osx
       env: >-
           PATH="/usr/local/opt/ccache/libexec:$PATH"
@@ -47,10 +47,10 @@ cache:
 
 
 install:
-#   - HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade python
   - /usr/bin/env python3 --version
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      # - HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade python
       ./scripts/provision_mac.sh
     else
       sudo ./scripts/provision_deb.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: generic
 # note: xcode9.4/macOS 10.13 is the default for macOS
 # osx_image: xcode9.3 # request macOS 10.13
-os: linux
 dist: xenial
 sudo: required
 
@@ -26,7 +25,8 @@ matrix:
           PATH="/usr/local/opt/ccache/libexec:$PATH"
           # https://docs.travis-ci.com/user/caching/#caches-and-build-matrices
           CACHE_NAME=OSX_JOB
-    - env: CACHE_NAME=LINUX_JOB
+    - os: linux
+      env: CACHE_NAME=LINUX_JOB
 
 cache:
   # https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-os: osx
+language: generic
 # note: xcode9.4/macOS 10.13 is the default for macOS
 # osx_image: xcode9.3 # request macOS 10.13
-sudo: enabled
-language: generic
+os: linux
+dist: xenial
+sudo: required
 
 # TODO: figure out why submodule checkout fails
 git:
@@ -10,20 +11,29 @@ git:
 
 env:
   global:
-    - PATH="/usr/local/opt/ccache/libexec:$PATH"
     - CXX=clang++
     - CC=clang
     - USE_CCACHE=1
     - CCACHE_COMPRESS=1
     - CCACHE_CPP2=1
 
-# https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache
-cache: 
-  directories: # handle non-obvious Rust target dirs
+
+matrix:
+  fast_finish: true
+  include:
+    - os: osx
+      env: >-
+          PATH="/usr/local/opt/ccache/libexec:$PATH"
+          # https://docs.travis-ci.com/user/caching/#caches-and-build-matrices
+          CACHE_NAME=OSX_JOB
+    - env: CACHE_NAME=LINUX_JOB
+
+cache:
+  # https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache
+  directories:
     - $HOME/.rustup
     - $HOME/.cargo
     - $HOME/.ccache
-    - $HOME/Library/Caches/Homebrew
     - $TRAVIS_BUILD_DIR/ast-importer/target.travis
     - $TRAVIS_BUILD_DIR/cross-checks/rust-checks/config/target
     - $TRAVIS_BUILD_DIR/cross-checks/rust-checks/rustc-plugin/target
@@ -31,14 +41,21 @@ cache:
     - $TRAVIS_BUILD_DIR/cross-checks/rust-checks/derive-macros/target
     - $TRAVIS_BUILD_DIR/rust-refactor/target
 
+
 install:
 #   - HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade python
   - /usr/bin/env python3 --version
-  - ./scripts/provision_mac.sh
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      ./scripts/provision_mac.sh
+    else
+      sudo ./scripts/provision_deb.sh
+      ./scripts/provision_rust.sh
+    fi
   - . ~/.cargo/env
 
 # NOTE: travis doesn't automatically terminate if command fails.
-script: 
+script:
   - ccache -s
   - python3 ./scripts/build_translator.py --debug || travis_terminate 1
   - ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,11 +68,7 @@ script:
         ccache -s
         python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
         ;;
-      LINUX_FAST_BUILD)
-        cargo build
-        python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
-        ;;
-      OSX_FAST_BUILD)
+      LINUX_FAST_BUILD|OSX_FAST_BUILD)
         cargo build
         python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
         ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ matrix:
     - os: linux
       env: CACHE_NAME=LINUX_JOB
     - os: osx
-      env: CACHE_NAME=OSX_JOB2
+      env: >-
+           CACHE_NAME=OSX_JOB2
+           LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config
     - os: linux
       env: CACHE_NAME=LINUX_JOB2
 
@@ -73,7 +75,7 @@ script:
         python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
         ;;
       OSX_JOB2)
-        LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config cargo build
+        cargo build
         python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
         ;;
     esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,12 @@ script:
         ccache -s
         python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
         ;;
-      LINUX_JOB2|OSX_JOB2)
+      LINUX_JOB2)
         cargo build
+        python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
+        ;;
+      OSX_JOB2)
+        LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config cargo build
         python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
         ;;
     esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
   - /usr/bin/env python3 --version
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      # - HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade python
+      # HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade python
       ./scripts/provision_mac.sh
     else
       sudo ./scripts/provision_deb.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
           CACHE_NAME=OSX_JOB
     - os: linux
       env: CACHE_NAME=LINUX_JOB
+    - os: osx
+      env: CACHE_NAME=OSX_JOB2
+    - os: linux
+      env: CACHE_NAME=LINUX_JOB2
 
 cache:
   # https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache
@@ -57,14 +61,15 @@ install:
 # NOTE: travis doesn't automatically terminate if command fails.
 script:
   - |
-    ccache -s
-    python3 ./scripts/build_translator.py --debug || travis_terminate 1
-    ccache -s
-    python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
-  - |
-    cargo clean
-    cargo build
-    python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
+    if [["$CACHE_NAME" == "LINUX_JOB"] || ["$CACHE_NAME" == "OSX_JOB"]]
+      ccache -s
+      python3 ./scripts/build_translator.py --debug || travis_terminate 1
+      ccache -s
+      python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
+    else
+      cargo build
+      python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
+    fi
  # NOTE: disabled because it takes to long to compile on free plan :/
  # To enable, add `--with-clang` to build_translator.py line above.
  # - python3 ./scripts/build_cross_checks.py || travis_terminate 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ env:
 matrix:
   fast_finish: true
   include:
-    # note: xcode9.4/macOS 10.13 is the default for macOS
-    # osx_image: xcode9.3 # request macOS 10.13
     - os: osx
+      # osx_image: xcode9.3 # request macOS 10.13
       env: >-
           PATH="/usr/local/opt/ccache/libexec:$PATH"
           # https://docs.travis-ci.com/user/caching/#caches-and-build-matrices

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,15 @@ matrix:
       env: >-
           PATH="/usr/local/opt/ccache/libexec:$PATH"
           # https://docs.travis-ci.com/user/caching/#caches-and-build-matrices
-          CACHE_NAME=OSX_JOB
+          CACHE_NAME=OSX_DEV_BUILD
     - os: linux
-      env: CACHE_NAME=LINUX_JOB
+      env: CACHE_NAME=LINUX_DEV_BUILD
     - os: osx
       env: >-
-           CACHE_NAME=OSX_JOB2
+           CACHE_NAME=OSX_FAST_BUILD
            LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config
     - os: linux
-      env: CACHE_NAME=LINUX_JOB2
+      env: CACHE_NAME=LINUX_FAST_BUILD
 
 cache:
   # https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
 # NOTE: travis doesn't automatically terminate if command fails.
 script:
   - |
-    if [["$CACHE_NAME" == "LINUX_JOB"] || ["$CACHE_NAME" == "OSX_JOB"]]
+    if [["$CACHE_NAME" == "LINUX_JOB"] || ["$CACHE_NAME" == "OSX_JOB"]]; then
       ccache -s
       python3 ./scripts/build_translator.py --debug || travis_terminate 1
       ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,15 @@ install:
 
 # NOTE: travis doesn't automatically terminate if command fails.
 script:
-  - ccache -s
-  - python3 ./scripts/build_translator.py --debug || travis_terminate 1
-  - ccache -s
-  - python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
+  - |
+    ccache -s
+    python3 ./scripts/build_translator.py --debug || travis_terminate 1
+    ccache -s
+    python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
+  - |
+    cargo clean
+    cargo build
+    python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
  # NOTE: disabled because it takes to long to compile on free plan :/
  # To enable, add `--with-clang` to build_translator.py line above.
  # - python3 ./scripts/build_cross_checks.py || travis_terminate 1

--- a/scripts/provision_deb.sh
+++ b/scripts/provision_deb.sh
@@ -29,6 +29,7 @@ apt-get install -qq \
     pkg-config \
     python-dev \
     python3-pip \
+    python3-setuptools \
     software-properties-common \
     unzip
 

--- a/scripts/provision_deb.sh
+++ b/scripts/provision_deb.sh
@@ -11,40 +11,31 @@ export DEBIAN_FRONTEND=noninteractive
 SCRIPT_DIR="$(dirname "$0")"
 
 apt-get update -qq
-# dirmngr is required for gnupg2 key retrieval
-apt-get install -qq --install-recommends dirmngr
-# libclang-6.0-dev allows builds against pre-built clang/llvm
-apt-get install -qq build-essential clang-6.0 cmake curl \
-    git gnupg2 gperf htop ninja-build python-dev \
-    software-properties-common unzip libssl-dev \
-    libclang-6.0-dev
+# gnupg2: required for gnupg2 key retrieval
+# libclang-6.0-dev: for fast builds against host libclang
+apt-get install -qq \
+    build-essential \
+    clang-6.0 \
+    cmake \
+    curl \
+    dirmngr \
+    git \
+    gnupg2 \
+    gperf \
+    htop \
+    libclang-6.0-dev \
+    libssl-dev \
+    ninja-build \
+    pkg-config \
+    python-dev \
+    python3-pip \
+    software-properties-common \
+    unzip
 
 update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
 update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 100
 # update-alternatives --install /usr/bin/lldb lldb /usr/bin/lldb-6.0 100
 
 # Install python3 and packages
-apt-get install -qq python3-pip
 pip3 install --no-cache-dir --disable-pip-version-check -r $SCRIPT_DIR/requirements.txt
 
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~# 
-# Dependencies for test programs #
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~# 
-
-apt-get install -qq automake autoconf libtool
-
-# lua dependencies
-apt-get install -qq libreadline-dev
-
-# lighttpd dependencies
-apt-get install -qq libbz2-dev
-
-# python dependencies
-apt-get install -qq python-setuptools tcl-dev liblzma-dev libgdbm-dev
-apt-get -qq --no-install-recommends install tk-dev
-
-# redis and sqlite dependencies
-apt-get install -qq tcl tcl-dev
-
-# varnish dependencies
-apt-get install -qq python-docutils graphviz


### PR DESCRIPTION
In this commit, the `.travis.yml` (Travis build script) has been
updated to build and test on both Linux and OS X. To achieve this
the `script` portion of the script, checks for the os type and runs
the correct provisioning script accordingly. Another change is, `matrix`
was added, and this sets the correct environment variables depending on
the os.