### PR TITLE
Add pkg-config to the list of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ C2Rust requires LLVM 6 or 7 and its corresponding libraries and clang compiler. 
 
 - **Ubuntu 16.04, 18.04 & 18.10:**
 
-        apt install build-essential llvm-6.0 clang-6.0 libclang-6.0-dev cmake libssl-dev
+        apt install build-essential llvm-6.0 clang-6.0 libclang-6.0-dev cmake libssl-dev pkg-config
 
 - **Arch Linux:**
 


### PR DESCRIPTION
`pkg-config` is required for building openssl, so it was added to the list of dependencies.

I'm unsure if modifying Arch Linux or brew dependencies is needed and if yes, then how the package is called there.

Also, what's the purpose of OpenSSL in a tool for translating C to Rust? Such dependency seems rather weird to me.