### PR TITLE
Conservatively handle potential flexible array members

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -1720,10 +1720,12 @@ class TranslateASTVisitor final
 
         if (auto CA = dyn_cast_or_null<ConstantArrayType>(
                 D->getType().getTypePtr())) {
-            // If the array has a size of 1, and struct field count is
-            // greater than 1, and if the (struct field count - 1) is equal to
-            // the index, it is most likely a flexible array.
-            return (CA->getSize() == 1 && FieldCount > 1 &&
+            // If the array has a size of 1, struct field count is greater
+            // than 1, and the (struct field count - 1) is equal to the index,
+            // the field may be a flexible array member.
+            auto arrayLen = CA->getSize();
+            return (arrayLen == 1 &&
+                    FieldCount > 1 &&
                     FieldCount - 1 == D->getFieldIndex());
         }
         return false;

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -430,7 +430,6 @@ class TranslateASTVisitor final
     CborEncoder *encoder;
     std::unordered_map<string, uint64_t> filenames;
     std::set<std::pair<void *, ASTEntryTag>> exportedTags;
-    std::unordered_set<Decl *> warnedFlexibleArrayDecls;
 
     // Returns true when a new entry is added to exportedTags
     bool markForExport(void *ptr, ASTEntryTag tag) {
@@ -1555,24 +1554,6 @@ class TranslateASTVisitor final
         if (!D->isCanonicalDecl())
             return true;
 
-        // Check to see if the FieldDecl might be a flexible array member,
-        // if it is print a warning message.
-        if (maybeFlexibleArrayDecl(D) && !warnedFlexibleArrayDecls.count(D)) {
-            // Insert the Decl into the set, if it has not been warned about
-            // yet.
-            warnedFlexibleArrayDecls.insert(D);
-
-            printWarning(
-                "this may be an unsupported flexible array member with size of "
-                "1, "
-                "omit the size if this field is intended to be a flexible "
-                "array member. "
-                "Note that you must fix any struct size calculations after "
-                "doing so or else it will likely be off (by one). "
-                "See section 6.7.2.1 of the C99 standard.",
-                D);
-        }
-
         std::vector<void *> childIds;
         auto t = D->getType();
         auto record = D->getParent();
@@ -1713,24 +1694,6 @@ class TranslateASTVisitor final
     }
 
   private:
-    bool maybeFlexibleArrayDecl(FieldDecl *D) {
-        const ASTRecordLayout &Layout =
-            Context->getASTRecordLayout(D->getParent());
-        unsigned FieldCount = Layout.getFieldCount();
-
-        if (auto CA = dyn_cast_or_null<ConstantArrayType>(
-                D->getType().getTypePtr())) {
-            // If the array has a size of 1, struct field count is greater
-            // than 1, and the (struct field count - 1) is equal to the index,
-            // the field may be a flexible array member.
-            auto arrayLen = CA->getSize();
-            return (arrayLen == 1 &&
-                    FieldCount > 1 &&
-                    FieldCount - 1 == D->getFieldIndex());
-        }
-        return false;
-    }
-
     // Inspired by a lambda function within `clang/lib/Sema/SemaType.cpp`
     bool isVaList(Decl *D, QualType T) {
         if (auto *RD = dyn_cast<RecordDecl>(D))

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -130,6 +130,17 @@ impl TypedAstContext {
         }
     }
 
+    /// Can the given field decl be a flexible array member?
+    pub fn maybe_flexible_array(&self, typ: CTypeId) -> bool {
+        let field_ty = self.resolve_type(typ);
+        match field_ty.kind {
+            CTypeKind::IncompleteArray(_) |
+            CTypeKind::ConstantArray(_, 1) => true,
+
+            _ => false,
+        }
+    }
+
     pub fn resolve_type_id(&self, typ: CTypeId) -> CTypeId {
         match self.index(typ).kind {
             CTypeKind::Attributed(ty, _) => self.resolve_type_id(ty.ctype),

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -135,6 +135,7 @@ impl TypedAstContext {
         let field_ty = self.resolve_type(typ);
         match field_ty.kind {
             CTypeKind::IncompleteArray(_) |
+            CTypeKind::ConstantArray(_, 0) |
             CTypeKind::ConstantArray(_, 1) => true,
 
             _ => false,

--- a/tests/structs/src/flex_array_members.c
+++ b/tests/structs/src/flex_array_members.c
@@ -1,19 +1,28 @@
 #include <stdlib.h>
 
+// Clang does not allow a flexible array member as the sole field in a struct
+
+struct gnu_flex {
+  int x;
+  int flex[0];
+};
+
 struct c99_flex {
   int x;
   int flex[];
 };
 
-struct old_style_flex {
+struct c89_flex {
   int x;
   int flex[1];
 };
 
+// TODO(C++): Need to handle flex arrays in unions per g++ behavior
+
 void exercise_flex_arrays(const unsigned sz, int buf[const]) {
   int i = 0;
 
-  struct c99_flex *s = (struct c99_flex*) calloc(sizeof(int), 10);
+  struct gnu_flex *s = (struct gnu_flex*) calloc(sizeof(int), 11);
   buf[i++] = s->flex[0];
   buf[i++] = s->flex[1];
   buf[i++] = s->flex[2];
@@ -21,12 +30,20 @@ void exercise_flex_arrays(const unsigned sz, int buf[const]) {
   s->flex[5] = 10;
   buf[i++] = s->flex[5];
 
-  struct old_style_flex *t = (struct old_style_flex*) calloc(sizeof(int), 10);
+  struct c99_flex *t = (struct c99_flex*) calloc(sizeof(int), 11);
   buf[i++] = t->flex[0];
   buf[i++] = t->flex[1];
   buf[i++] = t->flex[2];
 
-  t->flex[0] = 10;
-  t->flex[5] = 15;
+  t->flex[5] = 10;
   buf[i++] = t->flex[5];
+
+  struct c89_flex *u = (struct c89_flex*) calloc(sizeof(int), 11);
+  buf[i++] = u->flex[0];
+  buf[i++] = u->flex[1];
+  buf[i++] = u->flex[2];
+
+  u->flex[0] = 10;
+  u->flex[5] = 15;
+  buf[i++] = u->flex[5];
 }

--- a/tests/structs/src/flex_array_members.c
+++ b/tests/structs/src/flex_array_members.c
@@ -1,0 +1,32 @@
+#include <stdlib.h>
+
+struct c99_flex {
+  int x;
+  int flex[];
+};
+
+struct old_style_flex {
+  int x;
+  int flex[1];
+};
+
+void exercise_flex_arrays(const unsigned sz, int buf[const]) {
+  int i = 0;
+
+  struct c99_flex *s = (struct c99_flex*) calloc(sizeof(int), 10);
+  buf[i++] = s->flex[0];
+  buf[i++] = s->flex[1];
+  buf[i++] = s->flex[2];
+
+  s->flex[5] = 10;
+  buf[i++] = s->flex[5];
+
+  struct old_style_flex *t = (struct old_style_flex*) calloc(sizeof(int), 10);
+  buf[i++] = t->flex[0];
+  buf[i++] = t->flex[1];
+  buf[i++] = t->flex[2];
+
+  t->flex[0] = 10;
+  t->flex[5] = 15;
+  buf[i++] = t->flex[5];
+}

--- a/tests/structs/src/test_flex_array_members.rs
+++ b/tests/structs/src/test_flex_array_members.rs
@@ -9,12 +9,12 @@ extern "C" {
     fn exercise_flex_arrays(_: c_uint, _: *mut c_int);
 }
 
-const BUFFER_SIZE: usize = 8;
+const BUFFER_SIZE: usize = 12;
 
 pub fn test_flex_array_members() {
     let mut buffer = [0; BUFFER_SIZE];
     let mut rust_buffer = [0; BUFFER_SIZE];
-    let expected_buffer = [0, 0, 0, 10, 0, 0, 0, 15];
+    let expected_buffer = [0, 0, 0, 10, 0, 0, 0, 10, 0, 0, 0, 15];
 
     unsafe {
         exercise_flex_arrays(BUFFER_SIZE as u32, buffer.as_mut_ptr());

--- a/tests/structs/src/test_flex_array_members.rs
+++ b/tests/structs/src/test_flex_array_members.rs
@@ -1,0 +1,26 @@
+extern crate libc;
+
+use flex_array_members::{rust_exercise_flex_arrays};
+use self::libc::{c_int, c_uint, size_t};
+
+#[link(name = "test")]
+extern "C" {
+    #[no_mangle]
+    fn exercise_flex_arrays(_: c_uint, _: *mut c_int);
+}
+
+const BUFFER_SIZE: usize = 8;
+
+pub fn test_flex_array_members() {
+    let mut buffer = [0; BUFFER_SIZE];
+    let mut rust_buffer = [0; BUFFER_SIZE];
+    let expected_buffer = [0, 0, 0, 10, 0, 0, 0, 15];
+
+    unsafe {
+        exercise_flex_arrays(BUFFER_SIZE as u32, buffer.as_mut_ptr());
+        rust_exercise_flex_arrays(BUFFER_SIZE as u32, rust_buffer.as_mut_ptr());
+    }
+
+    assert_eq!(buffer, rust_buffer);
+    assert_eq!(buffer, expected_buffer);
+}


### PR DESCRIPTION
We don't need to break on flexible array member fields if we handle these fields with `.offset()` rather than array indexing.