### PR TITLE
Make build.rs template less Linux specific

### DIFF
--- a/c2rust-transpile/src/build_files/build.rs.hbs
+++ b/c2rust-transpile/src/build_files/build.rs.hbs
@@ -1,6 +1,6 @@
-#[cfg(target_os = "linux")]
+#[cfg(all(unix, not(target_os = "macos")))]
 fn main() {
-    // add linux dependencies here below
+    // add unix dependencies below
     // println!("cargo:rustc-flags=-l readline");
 }
 


### PR DESCRIPTION
There are many platforms that are unix-like, or UNIX derived that aren't Linux, such as the [BSDs](https://runbsd.info/) and [Illumos](https://www.illumos.org/). Frequently when encountering crate build issues on these platforms it's because of overly specific conditional compilation. In the interests of avoiding this in generated crates I propose this change.