### PR TITLE
Moved bitfields derive code into separate crate for re-export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,16 @@ dependencies = [
 
 [[package]]
 name = "c2rust-bitfields"
+version = "0.1.1"
+dependencies = [
+ "c2rust-bitfields-derive 0.1.0",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "c2rust-bitfields-derive"
 version = "0.1.0"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/c2rust-bitfields-derive/Cargo.toml
+++ b/c2rust-bitfields-derive/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "c2rust-bitfields-derive"
+version = "0.1.0"
+authors = [
+    "The C2Rust Project Developers <c2rust@immunant.com>",
+    "Daniel Kolsoi <djk@immunant.com>",
+]
+license = "BSD-3-Clause"
+homepage = "https://c2rust.com/"
+repository = "https://github.com/immunant/c2rust/tree/master/c2rust-bitfields-derive"
+edition = "2018"
+description = "C-compatible struct bitfield derive implementation used in the C2Rust project"
+readme = "README.md"
+
+[dependencies]
+syn = { version = "0.15", features = ["full"] }
+quote = "0.6"
+
+[lib]
+proc-macro = true

--- a/c2rust-bitfields-derive/src/lib.rs
+++ b/c2rust-bitfields-derive/src/lib.rs
@@ -290,7 +290,7 @@ fn bitfield_struct_impl(struct_item: ItemStruct) -> Result<TokenStream, Error> {
                         val >>= unused_bits;
                     }
 
-                    val.wrap().into()
+                    val.wrapped_into()
                 }
             )*
         }

--- a/c2rust-bitfields-derive/src/lib.rs
+++ b/c2rust-bitfields-derive/src/lib.rs
@@ -1,0 +1,300 @@
+#![recursion_limit = "512"]
+
+extern crate proc_macro;
+extern crate quote;
+extern crate syn;
+
+use proc_macro::{Span, TokenStream};
+use quote::__rt;
+use quote::quote;
+use syn::parse::Error;
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::{
+    parse_macro_input, Attribute, Field, Fields, Ident, ItemStruct, Lit, Meta, NestedMeta, Path,
+    PathArguments, PathSegment, Token,
+};
+
+#[cfg(target_endian = "big")]
+compile_error!("Big endian architectures are not currently supported");
+
+/// This struct keeps track of a single bitfield attr's params
+/// as well as the bitfield's field name.
+#[derive(Debug)]
+struct BFFieldAttr {
+    field_name: Ident,
+    name: String,
+    ty: String,
+    bits: (String, __rt::Span),
+}
+
+fn parse_bitfield_attr(attr: &Attribute, field_ident: &Ident) -> Result<BFFieldAttr, Error> {
+    let mut name = None;
+    let mut ty = None;
+    let mut bits = None;
+    let mut bits_span = None;
+
+    if let Meta::List(meta_list) = attr.parse_meta()? {
+        for nested_meta in meta_list.nested {
+            if let NestedMeta::Meta(Meta::NameValue(meta_name_value)) = nested_meta {
+                let rhs_string = match meta_name_value.lit {
+                    Lit::Str(lit_str) => lit_str.value(),
+                    _ => {
+                        let err_str = "Found bitfield attribute with non str literal assignment";
+                        let span = meta_name_value.ident.span();
+
+                        return Err(Error::new(span, err_str));
+                    }
+                };
+
+                let lhs_string = meta_name_value.ident.to_string();
+
+                match lhs_string.as_str() {
+                    "name" => name = Some(rhs_string),
+                    "ty" => ty = Some(rhs_string),
+                    "bits" => {
+                        bits = Some(rhs_string);
+                        bits_span = Some(meta_name_value.ident.span());
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    if name.is_none() || ty.is_none() || bits.is_none() {
+        let mut missing_fields = Vec::new();
+
+        if name.is_none() {
+            missing_fields.push("name");
+        }
+
+        if ty.is_none() {
+            missing_fields.push("ty");
+        }
+
+        if bits.is_none() {
+            missing_fields.push("bits");
+        }
+
+        let err_str = format!("Missing bitfield params: {:?}", missing_fields);
+        let span = attr.path.segments.span();
+
+        return Err(Error::new(span, err_str));
+    }
+
+    Ok(BFFieldAttr {
+        field_name: field_ident.clone(),
+        name: name.unwrap(),
+        ty: ty.unwrap(),
+        bits: (bits.unwrap(), bits_span.unwrap()),
+    })
+}
+
+fn filter_and_parse_fields(field: &Field) -> Vec<Result<BFFieldAttr, Error>> {
+    let attrs: Vec<_> = field
+        .attrs
+        .iter()
+        .filter(|attr| attr.path.segments.last().unwrap().value().ident == "bitfield")
+        .collect();
+
+    if attrs.len() == 0 {
+        return Vec::new();
+    }
+
+    attrs
+        .into_iter()
+        .map(|attr| parse_bitfield_attr(attr, &field.ident.as_ref().unwrap()))
+        .collect()
+}
+
+fn parse_bitfield_ty_path(field: &BFFieldAttr) -> Path {
+    let leading_colon = if field.ty.starts_with("::") {
+        Some(Token![::]([
+            Span::call_site().into(),
+            Span::call_site().into(),
+        ]))
+    } else {
+        None
+    };
+
+    let mut segments = Punctuated::new();
+    let mut segment_strings = field.ty.split("::").peekable();
+
+    while let Some(segment_string) = segment_strings.next() {
+        segments.push_value(PathSegment {
+            ident: Ident::new(segment_string, Span::call_site().into()),
+            arguments: PathArguments::None,
+        });
+
+        if segment_strings.peek().is_some() {
+            segments.push_punct(Token![::]([
+                Span::call_site().into(),
+                Span::call_site().into(),
+            ]));
+        }
+    }
+
+    Path {
+        leading_colon,
+        segments,
+    }
+}
+
+#[proc_macro_derive(BitfieldStruct, attributes(bitfield))]
+pub fn bitfield_struct(input: TokenStream) -> TokenStream {
+    let struct_item = parse_macro_input!(input as ItemStruct);
+
+    match bitfield_struct_impl(struct_item) {
+        Ok(ts) => ts,
+        Err(error) => error.to_compile_error().into(),
+    }
+}
+
+fn bitfield_struct_impl(struct_item: ItemStruct) -> Result<TokenStream, Error> {
+    // REVIEW: Should we throw a compile error if bit ranges on a single field overlap?
+    let struct_ident = struct_item.ident;
+    let fields = match struct_item.fields {
+        Fields::Named(named_fields) => named_fields.named,
+        Fields::Unnamed(_) => {
+            let err_str =
+                "Unnamed struct fields are not currently supported but may be in the future.";
+            let span = struct_ident.span();
+
+            return Err(Error::new(span, err_str));
+        }
+        Fields::Unit => {
+            let err_str = "Cannot create bitfield struct out of struct with no fields";
+            let span = struct_ident.span();
+
+            return Err(Error::new(span, err_str));
+        }
+    };
+    let bitfields: Result<Vec<BFFieldAttr>, Error> =
+        fields.iter().flat_map(filter_and_parse_fields).collect();
+    let bitfields = bitfields?;
+    let field_types: Vec<_> = bitfields.iter().map(parse_bitfield_ty_path).collect();
+    let field_types_return = &field_types;
+    let field_types_typedef = &field_types;
+    let field_types_setter_arg = &field_types;
+    let method_names: Vec<_> = bitfields
+        .iter()
+        .map(|field| Ident::new(&field.name, Span::call_site().into()))
+        .collect();
+    let field_names: Vec<_> = bitfields.iter().map(|field| &field.field_name).collect();
+    let field_names_setters = &field_names;
+    let field_names_getters = &field_names;
+    let method_name_setters: Vec<_> = method_names
+        .iter()
+        .map(|field_ident| {
+            let span = Span::call_site().into();
+            let setter_name = &format!("set_{}", field_ident);
+
+            Ident::new(setter_name, span)
+        })
+        .collect();
+    let field_bit_info: Result<Vec<_>, Error> = bitfields
+        .iter()
+        .map(|field| {
+            let bit_string = &field.bits.0;
+            let nums: Vec<_> = bit_string.split("..=").collect();
+            let err_str = "bits param must be in the format \"1..=4\"";
+
+            if nums.len() != 2 {
+                return Err(Error::new(field.bits.1, err_str));
+            }
+
+            let lhs = nums[0].parse::<usize>();
+            let rhs = nums[1].parse::<usize>();
+
+            let (lhs, rhs) = match (lhs, rhs) {
+                (Err(_), _) | (_, Err(_)) => return Err(Error::new(field.bits.1, err_str)),
+                (Ok(lhs), Ok(rhs)) => (lhs, rhs),
+            };
+
+            Ok(quote! { (#lhs, #rhs) })
+        })
+        .collect();
+    let field_bit_info = field_bit_info?;
+    let field_bit_info_setters = &field_bit_info;
+    let field_bit_info_getters = &field_bit_info;
+
+    // TODO: Method visibility determined by struct field visibility?
+    let q = quote! {
+        #[automatically_derived]
+        impl #struct_ident {
+            #(
+                /// This method allows you to write to a bitfield with a value
+                pub fn #method_name_setters(&mut self, int: #field_types_setter_arg) {
+                    fn zero_bit(byte: &mut u8, n_bit: u64) {
+                        let bit = 1 << n_bit;
+
+                        *byte &= !bit as u8;
+                    }
+
+                    fn one_bit(byte: &mut u8, n_bit: u64) {
+                        let bit = 1 << n_bit;
+
+                        *byte |= bit as u8;
+                    }
+
+                    let mut field = &mut self.#field_names_setters;
+                    let (lhs_bit, rhs_bit) = #field_bit_info_setters;
+
+                    for (i, bit_index) in (lhs_bit..=rhs_bit).enumerate() {
+                        let byte_index = bit_index / 8;
+                        let mut byte = &mut field[byte_index];
+                        let bit = 1 << i;
+                        let read_bit = (int as usize) & bit;
+
+                        if read_bit == 0 {
+                            zero_bit(byte, (bit_index % 8) as u64);
+                        } else {
+                            one_bit(byte, (bit_index % 8) as u64);
+                        }
+                    }
+                }
+
+                /// This method allows you to read from a bitfield to a value
+                pub fn #method_names(&self) -> #field_types_return {
+                    use c2rust_bitfields::BoolOrInt;
+
+                    type IntType = #field_types_typedef;
+
+                    let is_signed = <IntType as BoolOrInt>::is_signed();
+
+                    let field = self.#field_names_getters;
+                    let (lhs_bit, rhs_bit) = #field_bit_info_getters;
+                    let mut val = 0;
+
+                    for (i, bit_index) in (lhs_bit..=rhs_bit).enumerate() {
+                        let byte_index = bit_index / 8;
+                        let byte = field[byte_index];
+                        let bit = 1 << (bit_index % 8);
+                        let read_bit = byte & bit;
+
+                        if read_bit != 0 {
+                            let write_bit = 1 << i;
+
+                            val |= write_bit;
+                        }
+                    }
+
+                    // If the int type is signed, attempt to sign extend unconditionally
+                    if is_signed {
+                        let total_bit_size = <IntType as BoolOrInt>::calculate_total_bit_size();
+                        let bit_width = rhs_bit - lhs_bit + 1;
+                        let unused_bits = total_bit_size - bit_width;
+
+                        val <<= unused_bits;
+                        val >>= unused_bits;
+                    }
+
+                    val.wrap().into()
+                }
+            )*
+        }
+    };
+
+    Ok(q.into())
+}

--- a/c2rust-bitfields/Cargo.toml
+++ b/c2rust-bitfields/Cargo.toml
@@ -13,14 +13,10 @@ description = "C-compatible struct bitfield implementation used in the C2Rust pr
 readme = "README.md"
 
 [dependencies]
-syn = { version = "0.15", features = ["full"] }
-quote = "0.6"
+c2rust-bitfields-derive = { version = "0.1", path = "../c2rust-bitfields-derive" }
 
 [dev-dependencies]
 libc = "0.2"
 
 [features]
 no_std = []
-
-[lib]
-proc-macro = true

--- a/c2rust-bitfields/src/lib.rs
+++ b/c2rust-bitfields/src/lib.rs
@@ -8,14 +8,14 @@ mod private {
 
 use private::Wrapper;
 
-pub trait BoolOrInt {
+pub trait BoolOrInt: Sized {
     fn is_signed() -> bool;
 
-    fn wrap(self) -> Wrapper<Self> where Self: Sized {
-        Wrapper(self)
+    fn wrapped_into<T>(self) -> T where Wrapper<Self>: Into<T> {
+        Wrapper(self).into()
     }
 
-    fn calculate_total_bit_size() -> usize where Self: Sized {
+    fn calculate_total_bit_size() -> usize {
         #[cfg(not(feature = "no_std"))]
         let ret = ::std::mem::size_of::<Self>() * 8;
         #[cfg(feature = "no_std")]

--- a/c2rust-bitfields/src/lib.rs
+++ b/c2rust-bitfields/src/lib.rs
@@ -2,18 +2,8 @@ extern crate c2rust_bitfields_derive;
 
 pub use c2rust_bitfields_derive::BitfieldStruct;
 
-mod private {
-    pub struct Wrapper<T>(pub T);
-}
-
-use private::Wrapper;
-
-pub trait BoolOrInt: Sized {
+pub trait FieldType: Sized {
     fn is_signed() -> bool;
-
-    fn wrapped_into<T>(self) -> T where Wrapper<Self>: Into<T> {
-        Wrapper(self).into()
-    }
 
     fn calculate_total_bit_size() -> usize {
         #[cfg(not(feature = "no_std"))]
@@ -23,36 +13,114 @@ pub trait BoolOrInt: Sized {
 
         ret
     }
+
+    fn get_bit(&self, bit: usize) -> bool;
+
+    fn set_field(&self, field: &mut [u8], bit_range: (usize, usize)) {
+        fn zero_bit(byte: &mut u8, n_bit: u64) {
+            let bit = 1 << n_bit;
+
+            *byte &= !bit as u8;
+        }
+
+        fn one_bit(byte: &mut u8, n_bit: u64) {
+            let bit = 1 << n_bit;
+
+            *byte |= bit as u8;
+        }
+
+        let (lhs_bit, rhs_bit) = bit_range;
+
+        for (i, bit_index) in (lhs_bit..=rhs_bit).enumerate() {
+            let byte_index = bit_index / 8;
+            let byte = &mut field[byte_index];
+
+            if self.get_bit(i) {
+                one_bit(byte, (bit_index % 8) as u64);
+            } else {
+                zero_bit(byte, (bit_index % 8) as u64);
+            }
+        }
+    }
+
+    fn get_field(field: &[u8], bit_range: (usize, usize)) -> Self;
 }
 
 macro_rules! impl_int {
     ($($typ: ident),+) => {
         $(
-            impl BoolOrInt for $typ {
+            impl FieldType for $typ {
                 fn is_signed() -> bool {
                     $typ::min_value() != 0
                 }
-            }
-
-            impl Into<$typ> for Wrapper<$typ> {
-                fn into(self) -> $typ {
-                    self.0
+                fn get_bit(&self, bit: usize) -> bool {
+                    ((*self >> bit) & 1) == 1
                 }
-            }
 
-            impl Into<bool> for Wrapper<$typ> {
-                fn into(self) -> bool {
-                    self.0 != 0
+                fn get_field(field: &[u8], bit_range: (usize, usize)) -> Self {
+                    let (lhs_bit, rhs_bit) = bit_range;
+                    let mut val = 0;
+
+                    for (i, bit_index) in (lhs_bit..=rhs_bit).enumerate() {
+                        let byte_index = bit_index / 8;
+                        let byte = field[byte_index];
+                        let bit = 1 << (bit_index % 8);
+                        let read_bit = byte & bit;
+
+                        if read_bit != 0 {
+                            let write_bit = 1 << i;
+
+                            val |= write_bit;
+                        }
+                    }
+
+                    let bit_width = rhs_bit - lhs_bit + 1;
+
+                    // If the int type is signed, attempt to sign extend unconditionally
+                    if Self::is_signed() {
+                        let total_bit_size = Self::calculate_total_bit_size();
+                        let unused_bits = total_bit_size - bit_width;
+
+                        val <<= unused_bits;
+                        val >>= unused_bits;
+                    }
+
+                    val
                 }
             }
         )+
     };
 }
 
+
+
+
 impl_int!{u8, u16, u32, u64, u128, i8, i16, i32, i64, i128}
 
-impl BoolOrInt for bool {
+impl FieldType for bool {
     fn is_signed() -> bool {
         false
+    }
+
+    fn get_bit(&self, _bit: usize) -> bool {
+        *self
+    }
+
+    fn get_field(field: &[u8], bit_range: (usize, usize)) -> Self {
+        let (lhs_bit, rhs_bit) = bit_range;
+        let mut val = false;
+
+        for bit_index in lhs_bit..=rhs_bit {
+            let byte_index = bit_index / 8;
+            let byte = field[byte_index];
+            let bit = 1 << (bit_index % 8);
+            let read_bit = byte & bit;
+
+            if read_bit != 0 {
+                val = true;
+            }
+        }
+
+        val
     }
 }

--- a/c2rust-bitfields/src/lib.rs
+++ b/c2rust-bitfields/src/lib.rs
@@ -1,361 +1,58 @@
-#![recursion_limit = "512"]
+extern crate c2rust_bitfields_derive;
 
-extern crate proc_macro;
-extern crate quote;
-extern crate syn;
+pub use c2rust_bitfields_derive::BitfieldStruct;
 
-use proc_macro::{Span, TokenStream};
-use quote::__rt;
-use quote::quote;
-use syn::parse::Error;
-use syn::punctuated::Punctuated;
-use syn::spanned::Spanned;
-use syn::{
-    parse_macro_input, Attribute, Field, Fields, Ident, ItemStruct, Lit, Meta, NestedMeta, Path,
-    PathArguments, PathSegment, Token,
-};
-
-#[cfg(target_endian = "big")]
-compile_error!("Big endian architectures are not currently supported");
-
-/// This struct keeps track of a single bitfield attr's params
-/// as well as the bitfield's field name.
-#[derive(Debug)]
-struct BFFieldAttr {
-    field_name: Ident,
-    name: String,
-    ty: String,
-    bits: (String, __rt::Span),
+mod private {
+    pub struct Wrapper<T>(pub T);
 }
 
-fn parse_bitfield_attr(attr: &Attribute, field_ident: &Ident) -> Result<BFFieldAttr, Error> {
-    let mut name = None;
-    let mut ty = None;
-    let mut bits = None;
-    let mut bits_span = None;
+use private::Wrapper;
 
-    if let Meta::List(meta_list) = attr.parse_meta()? {
-        for nested_meta in meta_list.nested {
-            if let NestedMeta::Meta(Meta::NameValue(meta_name_value)) = nested_meta {
-                let rhs_string = match meta_name_value.lit {
-                    Lit::Str(lit_str) => lit_str.value(),
-                    _ => {
-                        let err_str = "Found bitfield attribute with non str literal assignment";
-                        let span = meta_name_value.ident.span();
+pub trait BoolOrInt {
+    fn is_signed() -> bool;
 
-                        return Err(Error::new(span, err_str));
-                    }
-                };
+    fn wrap(self) -> Wrapper<Self> where Self: Sized {
+        Wrapper(self)
+    }
 
-                let lhs_string = meta_name_value.ident.to_string();
+    fn calculate_total_bit_size() -> usize where Self: Sized {
+        #[cfg(not(feature = "no_std"))]
+        let ret = ::std::mem::size_of::<Self>() * 8;
+        #[cfg(feature = "no_std")]
+        let ret = ::core::mem::size_of::<Self>() * 8;
 
-                match lhs_string.as_str() {
-                    "name" => name = Some(rhs_string),
-                    "ty" => ty = Some(rhs_string),
-                    "bits" => {
-                        bits = Some(rhs_string);
-                        bits_span = Some(meta_name_value.ident.span());
-                    }
-                    _ => {}
+        ret
+    }
+}
+
+macro_rules! impl_int {
+    ($($typ: ident),+) => {
+        $(
+            impl BoolOrInt for $typ {
+                fn is_signed() -> bool {
+                    $typ::min_value() != 0
                 }
             }
-        }
-    }
 
-    if name.is_none() || ty.is_none() || bits.is_none() {
-        let mut missing_fields = Vec::new();
-
-        if name.is_none() {
-            missing_fields.push("name");
-        }
-
-        if ty.is_none() {
-            missing_fields.push("ty");
-        }
-
-        if bits.is_none() {
-            missing_fields.push("bits");
-        }
-
-        let err_str = format!("Missing bitfield params: {:?}", missing_fields);
-        let span = attr.path.segments.span();
-
-        return Err(Error::new(span, err_str));
-    }
-
-    Ok(BFFieldAttr {
-        field_name: field_ident.clone(),
-        name: name.unwrap(),
-        ty: ty.unwrap(),
-        bits: (bits.unwrap(), bits_span.unwrap()),
-    })
-}
-
-fn filter_and_parse_fields(field: &Field) -> Vec<Result<BFFieldAttr, Error>> {
-    let attrs: Vec<_> = field
-        .attrs
-        .iter()
-        .filter(|attr| attr.path.segments.last().unwrap().value().ident == "bitfield")
-        .collect();
-
-    if attrs.len() == 0 {
-        return Vec::new();
-    }
-
-    attrs
-        .into_iter()
-        .map(|attr| parse_bitfield_attr(attr, &field.ident.as_ref().unwrap()))
-        .collect()
-}
-
-fn parse_bitfield_ty_path(field: &BFFieldAttr) -> Path {
-    let leading_colon = if field.ty.starts_with("::") {
-        Some(Token![::]([
-            Span::call_site().into(),
-            Span::call_site().into(),
-        ]))
-    } else {
-        None
-    };
-
-    let mut segments = Punctuated::new();
-    let mut segment_strings = field.ty.split("::").peekable();
-
-    while let Some(segment_string) = segment_strings.next() {
-        segments.push_value(PathSegment {
-            ident: Ident::new(segment_string, Span::call_site().into()),
-            arguments: PathArguments::None,
-        });
-
-        if segment_strings.peek().is_some() {
-            segments.push_punct(Token![::]([
-                Span::call_site().into(),
-                Span::call_site().into(),
-            ]));
-        }
-    }
-
-    Path {
-        leading_colon,
-        segments,
-    }
-}
-
-#[proc_macro_derive(BitfieldStruct, attributes(bitfield))]
-pub fn bitfield_struct(input: TokenStream) -> TokenStream {
-    let struct_item = parse_macro_input!(input as ItemStruct);
-
-    match bitfield_struct_impl(struct_item) {
-        Ok(ts) => ts,
-        Err(error) => error.to_compile_error().into(),
-    }
-}
-
-fn bitfield_struct_impl(struct_item: ItemStruct) -> Result<TokenStream, Error> {
-    // REVIEW: Should we throw a compile error if bit ranges on a single field overlap?
-    let struct_ident = struct_item.ident;
-    let fields = match struct_item.fields {
-        Fields::Named(named_fields) => named_fields.named,
-        Fields::Unnamed(_) => {
-            let err_str =
-                "Unnamed struct fields are not currently supported but may be in the future.";
-            let span = struct_ident.span();
-
-            return Err(Error::new(span, err_str));
-        }
-        Fields::Unit => {
-            let err_str = "Cannot create bitfield struct out of struct with no fields";
-            let span = struct_ident.span();
-
-            return Err(Error::new(span, err_str));
-        }
-    };
-    let bitfields: Result<Vec<BFFieldAttr>, Error> =
-        fields.iter().flat_map(filter_and_parse_fields).collect();
-    let bitfields = bitfields?;
-    let field_types: Vec<_> = bitfields.iter().map(parse_bitfield_ty_path).collect();
-    let field_types_return = &field_types;
-    let field_types_typedef = &field_types;
-    let field_types_setter_arg = &field_types;
-    let method_names: Vec<_> = bitfields
-        .iter()
-        .map(|field| Ident::new(&field.name, Span::call_site().into()))
-        .collect();
-    let field_names: Vec<_> = bitfields.iter().map(|field| &field.field_name).collect();
-    let field_names_setters = &field_names;
-    let field_names_getters = &field_names;
-    let method_name_setters: Vec<_> = method_names
-        .iter()
-        .map(|field_ident| {
-            let span = Span::call_site().into();
-            let setter_name = &format!("set_{}", field_ident);
-
-            Ident::new(setter_name, span)
-        })
-        .collect();
-    let field_bit_info: Result<Vec<_>, Error> = bitfields
-        .iter()
-        .map(|field| {
-            let bit_string = &field.bits.0;
-            let nums: Vec<_> = bit_string.split("..=").collect();
-            let err_str = "bits param must be in the format \"1..=4\"";
-
-            if nums.len() != 2 {
-                return Err(Error::new(field.bits.1, err_str));
+            impl Into<$typ> for Wrapper<$typ> {
+                fn into(self) -> $typ {
+                    self.0
+                }
             }
 
-            let lhs = nums[0].parse::<usize>();
-            let rhs = nums[1].parse::<usize>();
-
-            let (lhs, rhs) = match (lhs, rhs) {
-                (Err(_), _) | (_, Err(_)) => return Err(Error::new(field.bits.1, err_str)),
-                (Ok(lhs), Ok(rhs)) => (lhs, rhs),
-            };
-
-            Ok(quote! { (#lhs, #rhs) })
-        })
-        .collect();
-    let field_bit_info = field_bit_info?;
-    let field_bit_info_setters = &field_bit_info;
-    let field_bit_info_getters = &field_bit_info;
-    let calc_total_bit_size_fn = generate_calc_total_bit_size_fn(field_bit_info.len());
-
-    // TODO: Method visibility determined by struct field visibility?
-    let q = quote! {
-        #[automatically_derived]
-        impl #struct_ident {
-            #(
-                /// This method allows you to write to a bitfield with a value
-                pub fn #method_name_setters(&mut self, int: #field_types_setter_arg) {
-                    fn zero_bit(byte: &mut u8, n_bit: u64) {
-                        let bit = 1 << n_bit;
-
-                        *byte &= !bit as u8;
-                    }
-
-                    fn one_bit(byte: &mut u8, n_bit: u64) {
-                        let bit = 1 << n_bit;
-
-                        *byte |= bit as u8;
-                    }
-
-                    let mut field = &mut self.#field_names_setters;
-                    let (lhs_bit, rhs_bit) = #field_bit_info_setters;
-
-                    for (i, bit_index) in (lhs_bit..=rhs_bit).enumerate() {
-                        let byte_index = bit_index / 8;
-                        let mut byte = &mut field[byte_index];
-                        let bit = 1 << i;
-                        let read_bit = (int as usize) & bit;
-
-                        if read_bit == 0 {
-                            zero_bit(byte, (bit_index % 8) as u64);
-                        } else {
-                            one_bit(byte, (bit_index % 8) as u64);
-                        }
-                    }
+            impl Into<bool> for Wrapper<$typ> {
+                fn into(self) -> bool {
+                    self.0 != 0
                 }
-
-                /// This method allows you to read from a bitfield to a value
-                pub fn #method_names(&self) -> #field_types_return {
-                    type IntType = #field_types_typedef;
-
-                    trait BoolOrInt {
-                        fn is_signed() -> bool;
-                    }
-
-                    /// This wrapper allows us to convert an int value
-                    /// to the return type which may be an int or a bool.
-                    /// We must use a wrapper because rust doesn't let
-                    /// you impl std traits on std types.
-                    struct Wrapper<T>(T);
-
-                    macro_rules! impl_int {
-                        ($($typ: ident),+) => {
-                            $(
-                                impl BoolOrInt for $typ {
-                                    fn is_signed() -> bool {
-                                        $typ::min_value() != 0
-                                    }
-                                }
-
-                                impl Into<$typ> for Wrapper<$typ> {
-                                    fn into(self) -> $typ {
-                                        self.0
-                                    }
-                                }
-
-                                impl Into<bool> for Wrapper<$typ> {
-                                    fn into(self) -> bool {
-                                        self.0 != 0
-                                    }
-                                }
-                            )+
-                        };
-                    }
-
-                    impl_int!{u8, u16, u32, u64, u128, i8, i16, i32, i64, i128}
-
-                    impl BoolOrInt for bool {
-                        fn is_signed() -> bool {
-                            false
-                        }
-                    }
-
-                    let is_signed = <IntType as BoolOrInt>::is_signed();
-
-                    let field = self.#field_names_getters;
-                    let (lhs_bit, rhs_bit) = #field_bit_info_getters;
-                    let mut val = 0;
-
-                    for (i, bit_index) in (lhs_bit..=rhs_bit).enumerate() {
-                        let byte_index = bit_index / 8;
-                        let byte = field[byte_index];
-                        let bit = 1 << (bit_index % 8);
-                        let read_bit = byte & bit;
-
-                        if read_bit != 0 {
-                            let write_bit = 1 << i;
-
-                            val |= write_bit;
-                        }
-                    }
-
-                    // If the int type is signed, attempt to sign extend unconditionally
-                    if is_signed {
-                        #calc_total_bit_size_fn
-
-                        let total_bit_size = calc_total_bit_size();
-                        let bit_width = rhs_bit - lhs_bit + 1;
-                        let unused_bits = total_bit_size - bit_width;
-
-                        val <<= unused_bits;
-                        val >>= unused_bits;
-                    }
-
-                    Wrapper(val).into()
-                }
-            )*
-        }
+            }
+        )+
     };
-
-    Ok(q.into())
 }
 
-fn generate_calc_total_bit_size_fn(count: usize) -> Vec<__rt::TokenStream> {
-    #[cfg(not(feature = "no_std"))]
-    let quoted = quote! {
-        fn calc_total_bit_size() -> usize {
-            ::std::mem::size_of::<IntType>() * 8
-        }
-    };
+impl_int!{u8, u16, u32, u64, u128, i8, i16, i32, i64, i128}
 
-    #[cfg(feature = "no_std")]
-    let quoted = quote! {
-        fn calc_total_bit_size() -> usize {
-            ::core::mem::size_of::<IntType>() * 8
-        }
-    };
-
-    vec![quoted; count]
+impl BoolOrInt for bool {
+    fn is_signed() -> bool {
+        false
+    }
 }


### PR DESCRIPTION
Now the `BoolOrInt` trait is only generated once, not number of fields times. And similarly I moved `generate_calc_total_bit_size_fn` which generates code to do a sizeof, to the trait rather than being codegened. This should hopefully give `quote` a lot less work to do.