### PR TITLE
Add shell.nix to pull in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ C2Rust requires LLVM 6, 7, or 8 with its corresponding clang compiler and librar
 - **Arch Linux:**
 
         pacman -S base-devel llvm clang cmake openssl
+        
+- **NixOS / nix:**
 
+        nix-shell
 
 - **OS X:** XCode command-line tools and recent LLVM (we recommend the Homebrew version) are required.
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+let
+  nixpkgs = import <nixpkgs> {};
+  inherit (nixpkgs) pkgs llvmPackages;
+  stdenv = pkgs.clangStdenv;
+in
+stdenv.mkDerivation {
+  name = "c2rust";
+  buildInputs = [
+    pkgs.clang
+    pkgs.cmake
+    pkgs.llvm
+    pkgs.openssl
+    pkgs.pkgconfig
+    pkgs.python35
+    pkgs.rustup
+    pkgs.zlib
+  ];
+  LIBCLANG_PATH="${llvmPackages.libclang}/lib";
+}


### PR DESCRIPTION
Allows a `nix` user to pull together an ad-hoc environment to build everything.