### PR TITLE
Just ask rustc where its libraries are

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -206,19 +206,19 @@ def get_rust_toolchain_binpath() -> str:
 
 def _get_rust_toolchain_path(dirtype: str) -> str:
     """
-    Ask rustc for the correct path to its {lib,bin} directory. 
+    Ask rustc for the correct path to its {lib,bin} directory.
     """
 
-    if 'RUSTUP_HOME' in pb.local.env:
-        home = pb.local.env['RUSTUP_HOME']
-    else:
-        home = os.path.join(pb.local.env['HOME'], ".rustup")
+    # If rustup is being used, it will respect the RUSTUP_TOOLCHAIN environment
+    # variable, according to:
+    # https://github.com/rust-lang/rustup.rs/blob/master/README.md#override-precedence
+    #
+    # If rustup is not being used, we can't control the toolchain; but rustc
+    # will ignore this environment variable, so setting it is harmless.
 
-    if os.path.isdir(home):  # have rustup; request correct nightly
-        nightly = "+" + config.CUSTOM_RUST_NAME
-        sysroot = pb.local["rustc"](nightly, "--print", "sysroot")
-    else:  # no rustup, can't request correct nightly
-        sysroot = pb.local["rustc"]("--print", "sysroot")
+    sysroot = pb.local["rustc"].with_env(
+        RUSTUP_TOOLCHAIN=config.CUSTOM_RUST_NAME,
+    )("--print", "sysroot")
 
     return os.path.join(sysroot.rstrip(), dirtype)
 


### PR DESCRIPTION
Instead of trying to duplicate complicated and non-portable path-construction logic, let the `rustc` which rustup picks for us just tell us what we wanted to know.

Assuming this simplification works for everyone, then we can delete a bunch of other code from `scripts/common.py`, and remove the `distro` dependency. For ease of review, though, this is just the minimal change, sans all those deletions.