### PR TITLE
Ensure executability for all Python with a __main__

### DIFF
--- a/c2rust-refactor/doc/gen_command_docs.py
+++ b/c2rust-refactor/doc/gen_command_docs.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 '''
 Generate Markdown-formatted documentation for c2rust-refactor commands.  This
 works by extracting from the c2rust-refactor source code any doc comment

--- a/c2rust-refactor/doc/run_literate.py
+++ b/c2rust-refactor/doc/run_literate.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/c2rust-refactor/gen/process_ast.py
+++ b/c2rust-refactor/gen/process_ast.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from collections import namedtuple
 import re
 import sys

--- a/examples/json-c/translate.py
+++ b/examples/json-c/translate.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import json
 import os
 import sys

--- a/examples/libxml2/patch_translated_code.py
+++ b/examples/libxml2/patch_translated_code.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from common import Config

--- a/examples/libxml2/translate.py
+++ b/examples/libxml2/translate.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from common import (

--- a/examples/robotfindskitten/translate.py
+++ b/examples/robotfindskitten/translate.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import json
 import hashlib

--- a/examples/tinycc/translate.py
+++ b/examples/tinycc/translate.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from plumbum.cmd import mv, mkdir, rename

--- a/examples/tmux/translate.py
+++ b/examples/tmux/translate.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from plumbum.cmd import mv, mkdir

--- a/manual/preprocessors/generator_dispatch.py
+++ b/manual/preprocessors/generator_dispatch.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import json
 import os
 from plumbum.cmd import python3, cargo


### PR DESCRIPTION
Neither of the scripts I needed to run to reproduce the robotfindskitten results was executable, which strikes me as an easily-eliminated point of friction, so here's a patch to do so.

The way I did it had the side effect of making the interpreter lines identical across all of the scripts. (Some of the existing scripts included an extra, but harmless, space.)

For each Python script with a `__main__` block, I ran each of these three steps:

- delete existing interpreter if any: `sed -i '2,$b; /^#!/d'`
- insert interpreter: `sed -i '1i#!/usr/bin/env python3'`
- set executable permission bit: `chmod a+x`

To apply those steps to the right files, I prefixed each command with:

```sh
git grep -lFw __main__ '*.py' ':^:**/__main__.py' | xargs
```