### PR TITLE
Improve python3 dependency awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ C2Rust requires LLVM 6, 7, or 8 with its corresponding clang compiler and librar
 
 - **Ubuntu 16.04, 18.04 & 18.10:**
 
-        apt install build-essential llvm-6.0 clang-6.0 libclang-6.0-dev cmake libssl-dev pkg-config
+        apt install build-essential llvm-6.0 clang-6.0 libclang-6.0-dev cmake libssl-dev pkg-config python3
 
 - **Arch Linux:**
 
-        pacman -S base-devel llvm clang cmake openssl
+        pacman -S base-devel llvm clang cmake openssl python
         
 - **NixOS / nix:**
 

--- a/c2rust-refactor/build.rs
+++ b/c2rust-refactor/build.rs
@@ -11,7 +11,7 @@ fn process_ast(mode: &str, dest: &Path) {
         .arg(mode)
         .arg(dest)
         .spawn()
-        .expect("failed to run process_ast.py. Make sure python3 is in your path.");
+        .expect("failed to run process_ast.py. Make sure python3 is in your PATH.");
 
     let ret = p.wait().expect("failed to wait on process_ast.py");
 

--- a/c2rust-refactor/build.rs
+++ b/c2rust-refactor/build.rs
@@ -11,7 +11,7 @@ fn process_ast(mode: &str, dest: &Path) {
         .arg(mode)
         .arg(dest)
         .spawn()
-        .expect("failed to run process_ast.py. Are you missing python3?");
+        .expect("failed to run process_ast.py. Make sure python3 is in your path.");
 
     let ret = p.wait().expect("failed to wait on process_ast.py");
 

--- a/c2rust-refactor/build.rs
+++ b/c2rust-refactor/build.rs
@@ -11,7 +11,7 @@ fn process_ast(mode: &str, dest: &Path) {
         .arg(mode)
         .arg(dest)
         .spawn()
-        .expect("failed to run process_ast.py");
+        .expect("failed to run process_ast.py. Are you missing python3?");
 
     let ret = p.wait().expect("failed to wait on process_ast.py");
 


### PR DESCRIPTION
Fixes https://github.com/immunant/c2rust/issues/187. Adds a bit more detail to the panic message and adds python3 to the dependencies listed in the README.