### PR TITLE
Fix collapsing of derive and cfg macros in refactoring

### DIFF
--- a/c2rust-refactor/gen/ast.txt
+++ b/c2rust-refactor/gen/ast.txt
@@ -255,10 +255,10 @@ struct Expr { id, kind, span, #[match=ignore] attrs }
 #[prec_contains_expr]
 enum ExprKind {
     Box(#[prec=PREFIX] expr),
-    Array(elems),
-    Call(#[prec=POSTFIX] #[prec_special=Callee] func, args),
-    MethodCall(path_seg, #[prec_first=POSTFIX] args),
-    Tup(elems),
+    Array(#[mac_table_seq] elems),
+    Call(#[prec=POSTFIX] #[prec_special=Callee] func, #[mac_table_seq] args),
+    MethodCall(path_seg, #[prec_first=POSTFIX] #[mac_table_seq] args),
+    Tup(#[mac_table_seq] elems),
     Binary(op, #[prec_left_of_binop=op] a, #[prec_right_of_binop=op] b),
     Unary(op, #[prec=PREFIX] a),
     Lit(lit),

--- a/c2rust-refactor/gen/mac_table.py
+++ b/c2rust-refactor/gen/mac_table.py
@@ -60,10 +60,12 @@ def do_collect_macros_body(se, target1, target2):
 
     if 'mac_table_record' in se.attrs:
         yield 'if let Some(invoc) = MaybeInvoc::as_invoc(%s) {' % target1
-        yield '  assert!(MaybeInvoc::as_invoc(%s).is_none(),' % target2
-        yield '    "impossible: found macro invocation in expanded AST");'
-        yield '  cx.record_one_macro(%s.id, invoc, MacNodeRef::%s(new));' % \
+        yield '  match MaybeInvoc::as_invoc(%s) {' % target2
+        yield '    Some(InvocKind::Attrs(..)) => {}'
+        yield '    Some(_) => panic!("impossible: found macro invocation in expanded AST"),'
+        yield '    None => cx.record_one_macro(%s.id, invoc, MacNodeRef::%s(new)),' % \
                 (target1, se.name)
+        yield '  }'
         yield '}'
 
 @linewise

--- a/c2rust-refactor/src/ast_manip/util.rs
+++ b/c2rust-refactor/src/ast_manip/util.rs
@@ -291,3 +291,9 @@ pub fn is_exported(item: &Item) -> bool {
 pub fn is_export_attr(attr: &Attribute) -> bool {
     attr.has_name(sym::no_mangle) || attr.has_name(sym::export_name)
 }
+
+/// Are the idents of the segments of `path` equivalent to the list of idents
+pub fn path_eq<T: AsRef<str>>(path: &Path, idents: &[T]) -> bool {
+    path.segments.len() == idents.len()
+        && path.segments.iter().zip(idents).all(|(p, i)| p.ident.as_str() == i.as_ref())
+}

--- a/c2rust-refactor/src/collapse/deleted.rs
+++ b/c2rust-refactor/src/collapse/deleted.rs
@@ -88,6 +88,11 @@ impl<'a, 'ast> Visitor<'ast> for CollectDeletedNodes<'a, 'ast> {
         visit::walk_item(self, x);
     }
 
+    fn visit_block(&mut self, block: &'ast Block) {
+        self.handle_seq(block.id, &block.stmts);
+        visit::walk_block(self, block);
+    }
+
     fn visit_mac(&mut self, mac: &'ast Mac) {
         visit::walk_mac(self, mac)
     }
@@ -229,6 +234,11 @@ impl<'a, 'ast> MutVisitor for RestoreDeletedNodes<'a, 'ast> {
             x
         });
         mut_visit::noop_flat_map_item(x, self)
+    }
+
+    fn visit_block(&mut self, block: &mut P<Block>) {
+        self.restore_seq(block.id, &mut block.stmts);
+        mut_visit::noop_visit_block(block, self)
     }
 
     fn visit_mac(&mut self, mac: &mut Mac) {

--- a/c2rust-refactor/src/collapse/mac_table.rs
+++ b/c2rust-refactor/src/collapse/mac_table.rs
@@ -289,7 +289,7 @@ fn is_macro_generated(sp: Span) -> bool {
 
 fn collect_macros_seq<'a, T>(old_seq: &'a [T], new_seq: &'a [T], cx: &mut Ctxt<'a>)
 where
-    T: CollectMacros + MaybeInvoc + GetNodeId + GetSpan + AsMacNodeRef,
+    T: CollectMacros + MaybeInvoc + GetNodeId + GetSpan + AsMacNodeRef + Debug,
 {
     let mut j = 0;
 
@@ -297,10 +297,11 @@ where
         if let Some(invoc) = old.as_invoc() {
             let invoc_id = cx.record_invoc(invoc);
             trace!(
-                "new {:?} from macro {:?} at {:?}",
+                "new {:?} from macro {:?} at {:?}: {:?}",
                 invoc_id,
                 old.get_node_id(),
-                old.get_span()
+                old.get_span(),
+                old,
             );
 
             let mut empty = true;

--- a/c2rust-refactor/src/collapse/mac_table.rs
+++ b/c2rust-refactor/src/collapse/mac_table.rs
@@ -337,6 +337,10 @@ where
                 cx.record_node_id_match(old.get_node_id(), new.get_node_id());
                 j += 1;
             }
+
+            if empty {
+                cx.record_empty_invoc(old.get_node_id(), invoc_id);
+            }
         } else {
             // For now, any time we see a node with a macro-generated span that wasn't eaten up by
             // the macro handling above, we assume it was created by a compiler plugin (such as
@@ -517,6 +521,9 @@ impl MaybeInvoc for Expr {
     fn as_invoc(&self) -> Option<InvocKind> {
         match self.kind {
             ExprKind::Mac(ref mac) => Some(InvocKind::Mac(mac)),
+            _ if has_macro_attr(&self.attrs) => {
+                Some(InvocKind::Attrs(&self.attrs))
+            }
             _ => None,
         }
     }

--- a/c2rust-refactor/src/collapse/mac_table.rs
+++ b/c2rust-refactor/src/collapse/mac_table.rs
@@ -387,7 +387,9 @@ fn is_derived<'a>(
                 // StructuralPartialEq is labeled with the right attribute.
                 match &i.kind {
                     ItemKind::Impl(_, _, _, _, Some(traitref), _, _) => {
-                        if path_eq(&traitref.path, &["$crate", "marker", "StructuralPartialEq"]) {
+                        if path_eq(&traitref.path, &["$crate", "marker", "StructuralPartialEq"])
+                            || path_eq(&traitref.path, &["$crate", "marker", "StructuralEq"])
+                        {
                             return true;
                         }
                     }

--- a/c2rust-refactor/src/collapse/macros.rs
+++ b/c2rust-refactor/src/collapse/macros.rs
@@ -219,6 +219,9 @@ impl<'a> MutVisitor for CollapseMacros<'a> {
                     trace!("ItemAttr: drop (generated): {:?} -> /**/", i);
                     return smallvec![];
                 }
+                _ => {
+                    error!("bad macro kind for item: {:?}", info.invoc);
+                }
             }
         }
         mut_visit::noop_flat_map_item(i, self)

--- a/c2rust-refactor/src/command.rs
+++ b/c2rust-refactor/src/command.rs
@@ -874,6 +874,13 @@ fn register_commit(reg: &mut Registry) {
             }).unwrap();
         }))
     });
+
+    reg.register("noop", |_args| {
+        Box::new(FuncCommand(|rs: &mut RefactorState| {
+            rs.transform_crate(Phase::Phase2, |_st, _cx| {
+            }).unwrap();
+        }))
+    });
 }
 
 pub fn register_commands(reg: &mut Registry) {

--- a/c2rust-refactor/src/command.rs
+++ b/c2rust-refactor/src/command.rs
@@ -869,8 +869,9 @@ fn register_commit(reg: &mut Registry) {
 
     reg.register("dump_crate", |_args| {
         Box::new(FuncCommand(|rs: &mut RefactorState| {
-            rs.load_crate();
-            eprintln!("{:#?}", rs.krate.as_ref().unwrap());
+            rs.transform_crate(Phase::Phase2, |st, _cx| {
+                eprintln!("{:#?}", st.krate());
+            }).unwrap();
         }))
     });
 }


### PR DESCRIPTION
We now support common derives (Debug, Clone, Copy, PartialEq, Eq, Hash) when refactoring. This also adds support for cfg attribute and function-like macros in most positions.