### PR TITLE
Handle _Static_assert gracefully. Closes #276

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -857,6 +857,13 @@ class TranslateASTVisitor final
         abort();
     }
 
+    bool VisitStaticAssertDecl(StaticAssertDecl *SAD) {
+        std::vector<void *> childIds = {SAD->getAssertExpr(), SAD->getMessage()};
+        auto T = QualType(); // don't care about the type
+        encode_entry(SAD, TagStaticAssertDecl, childIds, T);
+        return true;
+    }
+
     bool VisitLabelStmt(LabelStmt *LS) {
 
         std::vector<void *> childIds = {LS->getSubStmt()};

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -858,7 +858,10 @@ class TranslateASTVisitor final
     }
 
     bool VisitStaticAssertDecl(StaticAssertDecl *SAD) {
-        std::vector<void *> childIds = {SAD->getAssertExpr(), SAD->getMessage()};
+        std::vector<void *> childIds = {SAD->getAssertExpr()};
+        auto msg = SAD->getMessage();
+        if (msg != nullptr)
+            childIds.push_back(msg);
         auto T = QualType(); // don't care about the type
         encode_entry(SAD, TagStaticAssertDecl, childIds, T);
         return true;

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -862,8 +862,7 @@ class TranslateASTVisitor final
         auto msg = SAD->getMessage();
         if (msg != nullptr)
             childIds.push_back(msg);
-        auto T = QualType(); // don't care about the type
-        encode_entry(SAD, TagStaticAssertDecl, childIds, T);
+        encode_entry(SAD, TagStaticAssertDecl, childIds, QualType()); // 4th argument unused
         return true;
     }
 

--- a/c2rust-ast-exporter/src/ast_tags.hpp
+++ b/c2rust-ast-exporter/src/ast_tags.hpp
@@ -23,6 +23,8 @@ enum ASTEntryTag {
 
     TagNonCanonicalDecl,
 
+    TagStaticAssertDecl,
+
     TagMacroObjectDef,
     TagMacroFunctionDef,
 

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -2036,6 +2036,19 @@ impl ConversionContext {
                     self.processed_nodes.insert(new_id, OTHER_DECL);
                 }
 
+                ASTEntryTag::TagStaticAssertDecl if expected_ty & DECL != 0 => {
+                    let assert_expr = CExprId(node.children[0]
+                        .expect("StaticAssert must point to an expression"));
+                    let message = if node.children.len() > 1 {
+                        Some(CExprId(node.children[1]
+                            .expect("Expected static assert message")))
+                    } else {
+                        None
+                    };
+                    let static_assert = CDeclKind::StaticAssert{ assert_expr, message };
+                    self.add_decl(new_id, located(node, static_assert));
+                }
+
                 t => panic!("Could not translate node {:?} as type {}", t, expected_ty),
             }
         }

--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -174,7 +174,13 @@ fn immediate_decl_children(kind: &CDeclKind) -> Vec<SomeId> {
         Field { typ, .. } => intos![typ.ctype],
         MacroObject { .. } | MacroFunction { .. } => vec![],
         NonCanonicalDecl { canonical_decl } => intos![canonical_decl],
-        StaticAssert {assert_expr, ..} => intos![assert_expr],
+        StaticAssert {assert_expr, message} => {
+            if message.is_some() {
+                intos![assert_expr, message.unwrap()]
+            } else {
+                intos![assert_expr]
+            }
+        },
     }
 }
 

--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -174,6 +174,7 @@ fn immediate_decl_children(kind: &CDeclKind) -> Vec<SomeId> {
         Field { typ, .. } => intos![typ.ctype],
         MacroObject { .. } | MacroFunction { .. } => vec![],
         NonCanonicalDecl { canonical_decl } => intos![canonical_decl],
+        StaticAssert {assert_expr, ..} => intos![assert_expr],
     }
 }
 

--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -176,7 +176,7 @@ fn immediate_decl_children(kind: &CDeclKind) -> Vec<SomeId> {
         NonCanonicalDecl { canonical_decl } => intos![canonical_decl],
         StaticAssert { assert_expr, message } => {
             if let Some(message) = message {
-                intos![assert_expr, message.unwrap()]
+                intos![assert_expr, message]
             } else {
                 intos![assert_expr]
             }

--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -175,7 +175,7 @@ fn immediate_decl_children(kind: &CDeclKind) -> Vec<SomeId> {
         MacroObject { .. } | MacroFunction { .. } => vec![],
         NonCanonicalDecl { canonical_decl } => intos![canonical_decl],
         StaticAssert { assert_expr, message } => {
-            if message.is_some() {
+            if let Some(message) = message {
                 intos![assert_expr, message.unwrap()]
             } else {
                 intos![assert_expr]

--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -174,7 +174,7 @@ fn immediate_decl_children(kind: &CDeclKind) -> Vec<SomeId> {
         Field { typ, .. } => intos![typ.ctype],
         MacroObject { .. } | MacroFunction { .. } => vec![],
         NonCanonicalDecl { canonical_decl } => intos![canonical_decl],
-        StaticAssert {assert_expr, message} => {
+        StaticAssert { assert_expr, message } => {
             if message.is_some() {
                 intos![assert_expr, message.unwrap()]
             } else {

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -947,6 +947,11 @@ pub enum CDeclKind {
 
     NonCanonicalDecl {
         canonical_decl: CDeclId,
+    },
+
+    StaticAssert {
+        assert_expr: CExprId,
+        message: Option<CExprId>
     }
 }
 

--- a/c2rust-transpile/src/c_ast/print.rs
+++ b/c2rust-transpile/src/c_ast/print.rs
@@ -743,6 +743,10 @@ impl<W: Write> Printer<W> {
                 }
             }
 
+            Some(&CDeclKind::StaticAssert { .. }) => {
+                self.writer.write_fmt(format_args!("static_assert(...)"))
+            }
+
             None => panic!("Could not find declaration with ID {:?}", decl_id),
             // _ => unimplemented!("Printer::print_decl"),
         }

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2009,6 +2009,11 @@ impl<'c> Translation<'c> {
             // Do not translate non-canonical decls. They will be translated at
             // their canonical declaration.
             CDeclKind::NonCanonicalDecl { .. } => Ok(ConvertedDecl::NoItem),
+
+            CDeclKind::StaticAssert { .. } => {
+                warn!("ignoring static assert during translation");
+                Ok(ConvertedDecl::NoItem)
+            }
         }
     }
 


### PR DESCRIPTION
Without this PR, the c2rust transpiler barfs on translation units that use this feature. With it, we emit a warning instead.