### PR TITLE
Use raw identifier for reserved keywords

### DIFF
--- a/c2rust-bitfields/tests/test_structs.rs
+++ b/c2rust-bitfields/tests/test_structs.rs
@@ -623,3 +623,41 @@ fn test_bool_bits() {
     assert!(bool_bits.y());
     assert!(bool_bits.z());
 }
+
+#[repr(C)]
+#[derive(BitfieldStruct)]
+struct ReservedNames {
+    #[bitfield(name = "r#use", ty = "bool", bits = "0..=0")]
+    #[bitfield(name = "r#as", ty = "bool", bits = "1..=1")]
+    use_as: [u8; 1],
+}
+
+#[test]
+fn test_reserved_names() {
+    let mut reserved_names = ReservedNames {
+        use_as: [u8::max_value(); 1],
+    };
+
+    assert!(reserved_names.r#use());
+    assert!(reserved_names.r#as());
+
+    reserved_names.set_as(false);
+
+    assert!(reserved_names.r#use());
+    assert!(!reserved_names.r#as());
+
+    reserved_names.set_use(false);
+
+    assert!(!reserved_names.r#use());
+    assert!(!reserved_names.r#as());
+
+    reserved_names.set_use(true);
+
+    assert!(reserved_names.r#use());
+    assert!(!reserved_names.r#as());
+
+    reserved_names.set_as(true);
+
+    assert!(reserved_names.r#use());
+    assert!(reserved_names.r#as());
+}

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -132,6 +132,14 @@ pub const RESERVED_NAMES: [&str; 103] = [
     "str",
 ];
 
+/// Keywords that cannot be expressed as a raw identifier [0] because they can be used as path
+/// segments. The list of path segment keywords can be found here [1]. For discussion of this
+/// topic see [2].
+/// [0] https://doc.rust-lang.org/edition-guide/rust-2018/module-system/raw-identifiers.html
+/// [1] https://github.com/rust-lang/rust/blob/04488afe34512aa4c33566eb16d8c912a3ae04f9/src/librustc_span/symbol.rs#L1331
+/// [2] https://internals.rust-lang.org/t/raw-identifiers-dont-work-for-all-identifiers/9094
+pub const RESERVED_PATH_SEGMENT_NAMES: [&str; 4] = ["super", "self", "Self", "crate"];
+
 impl TypeConverter {
     pub fn new(emit_no_std: bool) -> TypeConverter {
         TypeConverter {

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -544,6 +544,7 @@ impl<'a> Translation<'a> {
 
                 // Now we must use the bitfield methods to initialize bitfields
                 for (field_name, val) in bitfield_inits {
+                    let field_name = strip_raw_ident(&field_name);
                     let field_name_setter = format!("set_{}", field_name);
                     let struct_ident = mk().ident_expr("init");
                     is_unsafe |= val.is_unsafe();
@@ -679,6 +680,7 @@ impl<'a> Translation<'a> {
                 .borrow()
                 .resolve_field_name(None, field_id)
                 .ok_or("Could not find bitfield name")?;
+            let field_name = strip_raw_ident(&field_name);
             let setter_name = format!("set_{}", field_name);
             let lhs_expr_read =
                 mk().method_call_expr(lhs_expr.clone(), field_name, Vec::<P<Expr>>::new());
@@ -747,5 +749,15 @@ impl<'a> Translation<'a> {
 
             return Ok(WithStmts::new(stmts, val));
         })
+    }
+}
+
+fn strip_raw_ident(ident: &str) -> &str {
+    const RAW_IDENT_PREFIX: &str = "r#";
+
+    if ident.starts_with(RAW_IDENT_PREFIX) {
+        &ident[RAW_IDENT_PREFIX.len()..]
+    } else {
+        ident
     }
 }


### PR DESCRIPTION
Resolves #279

Unfortunately, we cannot use a raw identifier for all keywords see the comment [here](https://github.com/immunant/c2rust/blob/99e56b7e659d43f7b0a1dcae2c3d7144aa5a20e3/c2rust-transpile/src/convert_type.rs#L135). 

Signed-off-by: David McNeil <mcneil.david2@gmail.com>