### PR TITLE
Build against LLVM 9 on macOS/Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,14 +113,12 @@ jobs:
       brew remove curl
       # prepare environment for the following steps
       source $HOME/.cargo/env
-      export LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config
-      # Temporary fix to make sure we have LLVM 10.0.1_1 or later
-      brew upgrade llvm
+      brew info llvm@9
     displayName: 'Provision macOS'
 
   - script: |
-      echo $LLVM_CONFIG_PATH
-      export LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config
+      # Temporary fix to use LLVM 9 due to problems with LLVM 10.0.1
+      export LLVM_CONFIG_PATH=$(brew --prefix llvm@9)/bin/llvm-config
       cargo build --release
     displayName: 'Fast build against host clang/LLVM'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,44 +111,31 @@ jobs:
       # whereas the brew version does not, this causes curl-sys to 
       # build its own curl which then fails to link on Azure Devops.
       brew remove curl
+      # prepare environment for the following steps
+      source $HOME/.cargo/env
+      export LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config
     displayName: 'Provision macOS'
 
-  - script: |
-      source $HOME/.cargo/env
-      cargo build --release
+  - script: cargo build --release
     displayName: 'Fast build against host clang/LLVM'
 
-  - script: |
-      source $HOME/.cargo/env
-      python3 ./scripts/test_translator.py  ./tests
+  - script: python3 ./scripts/test_translator.py  ./tests
     displayName: 'Test translator (fast build)'
 
-  - script: |
-      source $HOME/.cargo/env
-      cargo clean
+  - script: cargo clean
     displayName: 'Cargo clean'
 
-  - script: |
-      source $HOME/.cargo/env
-      python3 ./scripts/build_translator.py --with-llvm-version=7.0.1
+  - script: python3 ./scripts/build_translator.py --with-llvm-version=7.0.1
     displayName: 'Developer build against local LLVM 7'
 
-  - script: |
-      source $HOME/.cargo/env
-      python3 ./scripts/test_translator.py ./tests
+  - script: python3 ./scripts/test_translator.py ./tests
     displayName: 'Test translator against developer build (LLVM 7)'
 
-  - script: |
-      source $HOME/.cargo/env
-      cargo clean && rm -rf build
+  - script: cargo clean && rm -rf build
     displayName: 'Cargo clean && rm -rf build'
 
-  - script: |
-      source $HOME/.cargo/env
-      python3 ./scripts/build_translator.py --with-llvm-version=8.0.0
+  - script: python3 ./scripts/build_translator.py --with-llvm-version=8.0.0
     displayName: 'Developer build against local LLVM 8'
 
-  - script: |
-      source $HOME/.cargo/env
-      python3 ./scripts/test_translator.py ./tests
+  - script: python3 ./scripts/test_translator.py ./tests
     displayName: 'Test translator against developer build (LLVM 8)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,11 +114,14 @@ jobs:
       # prepare environment for the following steps
       source $HOME/.cargo/env
       export LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config
-      ls /usr/local/opt/llvm/bin/
-      brew info llvm
+      # Temporary fix to make sure we have LLVM 10.0.1_1 or later
+      brew upgrade llvm
     displayName: 'Provision macOS'
 
-  - script: cargo build --release
+  - script: |
+      echo $LLVM_CONFIG_PATH
+      export LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config
+      cargo build --release
     displayName: 'Fast build against host clang/LLVM'
 
   - script: python3 ./scripts/test_translator.py  ./tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,6 +114,8 @@ jobs:
       # prepare environment for the following steps
       source $HOME/.cargo/env
       export LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config
+      ls /usr/local/opt/llvm/bin/
+      brew info llvm
     displayName: 'Provision macOS'
 
   - script: cargo build --release

--- a/scripts/provision_mac.sh
+++ b/scripts/provision_mac.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # complain if we're not on macOS
 UNAME=$(uname -s)

--- a/scripts/provision_mac.sh
+++ b/scripts/provision_mac.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 # complain if we're not on macOS
 UNAME=$(uname -s)
@@ -21,7 +21,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 
 hb_packages=(python cmake ninja gpg ccache llvm)
 for item in "${hb_packages[@]}"; do
-  brew info "${item}" | grep --quiet 'Not installed' && brew install "${item}"
+  brew info "${item}" | grep 'Not installed' > /dev/null && brew install "${item}"
 done
 
 type -P "pip3" >/dev/null || {

--- a/scripts/provision_mac.sh
+++ b/scripts/provision_mac.sh
@@ -19,7 +19,9 @@ done
 SCRIPT_DIR="$(dirname "$0")"
 export HOMEBREW_NO_AUTO_UPDATE=1
 
-hb_packages=(python cmake ninja gpg ccache llvm)
+# NOTE(perl): Due to problems with LLVM 10.0.1 we request LLVM 9 for now
+# https://discourse.brew.sh/t/llvm-config-10-0-1-advertise-libxml2-tbd-as-system-libs/8593
+hb_packages=(python cmake ninja gpg ccache llvm@9)
 for item in "${hb_packages[@]}"; do
   brew info "${item}" | grep 'Not installed' > /dev/null && brew install "${item}"
 done

--- a/scripts/provision_mac.sh
+++ b/scripts/provision_mac.sh
@@ -30,7 +30,7 @@ type -P "pip3" >/dev/null || {
 
 # Python 3 packages
 pip3 install --user --upgrade pip
-pip3 install -r "$SCRIPT_DIR/requirements.txt" --user --disable-pip-version-check --quiet
+pip3 install -r "$SCRIPT_DIR/requirements.txt" --user --disable-pip-version-check
 
 RUST_TOOLCHAIN_FILE="$SCRIPT_DIR/../rust-toolchain"
 export RUST_VER=$(cat $RUST_TOOLCHAIN_FILE | tr -d '\n')

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -6,6 +6,6 @@ pip
 plumbum >= 1.6.3
 psutil
 pygments
-typing
+typing;python_version<"3.5"
 scan-build
 pyyaml


### PR DESCRIPTION
- llvm-config in LLVM 10.0.1 causes linker error (see #289) so we build against LLVM 9 instead
- Fix broken pipe errors.
- Allow more output when provisioning macOS 