### PR TITLE
Std raw types

### DIFF
--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -20,6 +20,7 @@ pub struct TypeConverter {
     fields: HashMap<CDeclId, Renamer<FieldKey>>,
     suffix_names: HashMap<(CDeclId, &'static str), String>,
     features: HashSet<&'static str>,
+    use_libc_types: bool,
     emit_no_std: bool,
 }
 
@@ -133,13 +134,14 @@ pub const RESERVED_NAMES: [&str; 103] = [
 ];
 
 impl TypeConverter {
-    pub fn new(emit_no_std: bool) -> TypeConverter {
+    pub fn new(use_libc_types: bool, emit_no_std: bool) -> TypeConverter {
         TypeConverter {
             translate_valist: false,
             renamer: Renamer::new(&RESERVED_NAMES),
             fields: HashMap::new(),
             suffix_names: HashMap::new(),
             features: HashSet::new(),
+            use_libc_types,
             emit_no_std,
         }
     }
@@ -275,7 +277,7 @@ impl TypeConverter {
             CTypeKind::Void => {
                 Ok(mk()
                     .set_mutbl(mutbl)
-                    .ptr_ty(mk().path_ty(vec!["libc", "c_void"])))
+                    .ptr_ty(mk().path_ty(vec!["core", "ffi", "c_void"])))
             }
 
             CTypeKind::VariableArray(mut elt, _len) => {
@@ -301,6 +303,41 @@ impl TypeConverter {
         }
     }
 
+    /// Convert a primitive C type kind into the equivalent Rust type
+    pub fn convert_primitive_type_kind(&self, kind: &CTypeKind) -> Option<P<Ty>> {
+        let primitive_type = |ty: &str| {
+            let path = if self.use_libc_types {
+                vec!["libc", ty]
+            } else {
+                vec!["std", "os", "raw", ty]
+            };
+            mk().path_ty(mk().path(path))
+        };
+
+        match kind {
+            CTypeKind::Void => Some(mk().tuple_ty(vec![] as Vec<P<Ty>>)),
+            CTypeKind::Bool => Some(mk().path_ty(mk().path(vec!["bool"]))),
+            CTypeKind::Short => Some(primitive_type("c_short")),
+            CTypeKind::Int => Some(primitive_type("c_int")),
+            CTypeKind::Long => Some(primitive_type("c_long")),
+            CTypeKind::LongLong => Some(primitive_type("c_longlong")),
+            CTypeKind::UShort => Some(primitive_type("c_ushort")),
+            CTypeKind::UInt => Some(primitive_type("c_uint")),
+            CTypeKind::ULong => Some(primitive_type("c_ulong")),
+            CTypeKind::ULongLong => Some(primitive_type("c_ulonglong")),
+            CTypeKind::SChar => Some(primitive_type("c_schar")),
+            CTypeKind::UChar => Some(primitive_type("c_uchar")),
+            CTypeKind::Char => Some(primitive_type("c_char")),
+            CTypeKind::Float => Some(primitive_type("c_float")),
+            CTypeKind::Double => Some(primitive_type("c_double")),
+            CTypeKind::LongDouble => Some(mk().path_ty(mk().path(vec!["f128", "f128"]))),
+            CTypeKind::Int128 => Some(mk().path_ty(mk().path(vec!["i128"]))),
+            CTypeKind::UInt128 => Some(mk().path_ty(mk().path(vec!["u128"]))),
+
+            _ => None
+        }
+    }
+
     /// Convert a `C` type to a `Rust` one. For the moment, these are expected to have compatible
     /// memory layouts.
     pub fn convert(
@@ -315,26 +352,12 @@ impl TypeConverter {
             return Ok(ty);
         }
 
-        match ctxt.index(ctype).kind {
-            CTypeKind::Void => Ok(mk().tuple_ty(vec![] as Vec<P<Ty>>)),
-            CTypeKind::Bool => Ok(mk().path_ty(mk().path(vec!["bool"]))),
-            CTypeKind::Short => Ok(mk().path_ty(mk().path(vec!["libc", "c_short"]))),
-            CTypeKind::Int => Ok(mk().path_ty(mk().path(vec!["libc", "c_int"]))),
-            CTypeKind::Long => Ok(mk().path_ty(mk().path(vec!["libc", "c_long"]))),
-            CTypeKind::LongLong => Ok(mk().path_ty(mk().path(vec!["libc", "c_longlong"]))),
-            CTypeKind::UShort => Ok(mk().path_ty(mk().path(vec!["libc", "c_ushort"]))),
-            CTypeKind::UInt => Ok(mk().path_ty(mk().path(vec!["libc", "c_uint"]))),
-            CTypeKind::ULong => Ok(mk().path_ty(mk().path(vec!["libc", "c_ulong"]))),
-            CTypeKind::ULongLong => Ok(mk().path_ty(mk().path(vec!["libc", "c_ulonglong"]))),
-            CTypeKind::SChar => Ok(mk().path_ty(mk().path(vec!["libc", "c_schar"]))),
-            CTypeKind::UChar => Ok(mk().path_ty(mk().path(vec!["libc", "c_uchar"]))),
-            CTypeKind::Char => Ok(mk().path_ty(mk().path(vec!["libc", "c_char"]))),
-            CTypeKind::Double => Ok(mk().path_ty(mk().path(vec!["libc", "c_double"]))),
-            CTypeKind::LongDouble => Ok(mk().path_ty(mk().path(vec!["f128", "f128"]))),
-            CTypeKind::Float => Ok(mk().path_ty(mk().path(vec!["libc", "c_float"]))),
-            CTypeKind::Int128 => Ok(mk().path_ty(mk().path(vec!["i128"]))),
-            CTypeKind::UInt128 => Ok(mk().path_ty(mk().path(vec!["u128"]))),
+        let kind = &ctxt.index(ctype).kind;
+        if let Some(ty) = self.convert_primitive_type_kind(kind) {
+            return Ok(ty);
+        }
 
+        match *kind {
             CTypeKind::Pointer(qtype) => self.convert_pointer(ctxt, qtype),
 
             CTypeKind::Elaborated(ref ctype) => self.convert(ctxt, *ctype),

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -104,6 +104,7 @@ pub struct TranspilerConfig {
     pub reduce_type_annotations: bool,
     pub reorganize_definitions: bool,
     pub enabled_warnings: HashSet<Diagnostic>,
+    pub use_libc_types: bool,
     pub emit_no_std: bool,
     pub output_dir: Option<PathBuf>,
     pub translate_const_macros: bool,

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -53,7 +53,7 @@ impl<'c> Translation<'c> {
                     Some(mk().path_ty(vec![mk().path_segment_with_args(
                         "Vec",
                         mk().angle_bracketed_args(vec![
-                            mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_char"])),
+                            mk().mutbl().ptr_ty(self.convert_primitive_type_kind(&CTypeKind::Char)),
                         ]),
                     )])),
                     Some(
@@ -125,7 +125,7 @@ impl<'c> Translation<'c> {
                     Some(mk().path_ty(vec![mk().path_segment_with_args(
                         "Vec",
                         mk().angle_bracketed_args(vec![
-                            mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_char"])),
+                            mk().mutbl().ptr_ty(self.convert_primitive_type_kind(&CTypeKind::Char)),
                         ]),
                     )])),
                     Some(

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4033,10 +4033,10 @@ impl<'c> Translation<'c> {
                 }
                 let target_ty = self.convert_type(ty.ctype)?;
                 val.and_then(|x| {
-                    let intptr_t = mk().path_ty(vec!["libc", "intptr_t"]);
-                    let intptr = mk().cast_expr(x, intptr_t.clone());
+                    let r#usize = mk().ident_ty("usize");
+                    let intptr = mk().cast_expr(x, r#usize.clone());
                     Ok(WithStmts::new_unsafe_val(
-                        transmute_expr(intptr_t, target_ty, intptr, self.tcfg.emit_no_std)
+                        transmute_expr(r#usize, target_ty, intptr, self.tcfg.emit_no_std)
                     ))
                 })
             }

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -68,7 +68,7 @@ impl<'c> Translation<'c> {
                 let lhs = self.convert_condition(ctx, true, lhs)?;
                 let rhs = self.convert_condition(ctx, true, rhs)?;
                 lhs
-                    .map(|x| bool_to_int(mk().binary_expr(BinOpKind::from(op), x, rhs.to_expr())))
+                    .map(|x| self.convert_bool_to_int(mk().binary_expr(BinOpKind::from(op), x, rhs.to_expr())))
                     .and_then(|out| {
                         if ctx.is_unused() {
                             Ok(WithStmts::new(
@@ -655,7 +655,7 @@ impl<'c> Translation<'c> {
                     mk().binary_expr(BinOpKind::Eq, lhs, rhs)
                 };
 
-                Ok(bool_to_int(expr))
+                Ok(self.convert_bool_to_int(expr))
             }
             c_ast::BinOp::NotEqual => {
                 // Using is_some method for null comparison means we don't have to
@@ -677,12 +677,12 @@ impl<'c> Translation<'c> {
                     mk().binary_expr(BinOpKind::Ne, lhs, rhs)
                 };
 
-                Ok(bool_to_int(expr))
+                Ok(self.convert_bool_to_int(expr))
             }
-            c_ast::BinOp::Less => Ok(bool_to_int(mk().binary_expr(BinOpKind::Lt, lhs, rhs))),
-            c_ast::BinOp::Greater => Ok(bool_to_int(mk().binary_expr(BinOpKind::Gt, lhs, rhs))),
-            c_ast::BinOp::GreaterEqual => Ok(bool_to_int(mk().binary_expr(BinOpKind::Ge, lhs, rhs))),
-            c_ast::BinOp::LessEqual => Ok(bool_to_int(mk().binary_expr(BinOpKind::Le, lhs, rhs))),
+            c_ast::BinOp::Less => Ok(self.convert_bool_to_int(mk().binary_expr(BinOpKind::Lt, lhs, rhs))),
+            c_ast::BinOp::Greater => Ok(self.convert_bool_to_int(mk().binary_expr(BinOpKind::Gt, lhs, rhs))),
+            c_ast::BinOp::GreaterEqual => Ok(self.convert_bool_to_int(mk().binary_expr(BinOpKind::Ge, lhs, rhs))),
+            c_ast::BinOp::LessEqual => Ok(self.convert_bool_to_int(mk().binary_expr(BinOpKind::Le, lhs, rhs))),
 
             c_ast::BinOp::BitAnd => Ok(mk().binary_expr(BinOpKind::BitAnd, lhs, rhs)),
             c_ast::BinOp::BitOr => Ok(mk().binary_expr(BinOpKind::BitOr, lhs, rhs)),
@@ -1031,7 +1031,7 @@ impl<'c> Translation<'c> {
 
             c_ast::UnOp::Not => {
                 let val = self.convert_condition(ctx, false, arg)?;
-                Ok(val.map(|x| mk().cast_expr(x, mk().path_ty(vec!["libc", "c_int"]))))
+                Ok(val.map(|x| mk().cast_expr(x, self.convert_primitive_type_kind(&c_ast::CTypeKind::Int))))
             }
             c_ast::UnOp::Extension => {
                 let arg = self.convert_expr(ctx, arg)?;

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -147,7 +147,7 @@ impl<'c> Translation<'c> {
                 .map_or(false, |ty| self.ast_context.is_forward_declared_type(ty.ctype))
             {
                 real_arg_ty = Some(arg_ty.clone());
-                arg_ty = mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_void"]));
+                arg_ty = mk().mutbl().ptr_ty(mk().path_ty(vec!["core", "ffi", "c_void"]));
             }
 
             val.and_then(|val| {

--- a/c2rust/src/bin/c2rust-transpile.rs
+++ b/c2rust/src/bin/c2rust-transpile.rs
@@ -111,6 +111,7 @@ fn main() {
             }
         },
         replace_unsupported_decls: ReplaceMode::Extern,
+        use_libc_types: matches.is_present("use-libc-types"),
         emit_no_std: matches.is_present("emit-no-std"),
         enabled_warnings,
         log_level,

--- a/c2rust/src/transpile.yaml
+++ b/c2rust/src/transpile.yaml
@@ -164,10 +164,15 @@ args:
       short: W
       help: Enable the specified warning (all enables all warnings)
       takes_value: true
+  - use-libc-types:
+      long: use-libc-types
+      help: Use primitive types from libc crate instead of std::os::raw
+      takes_value: false
   - emit-no-std:
       long: emit-no-std
       help: Emit code using core rather than std
       takes_value: false
+      requires: use-libc-types
   - disable-refactoring:
       long: disable-refactoring
       help: Disable running refactoring tool after translation


### PR DESCRIPTION
Based on https://github.com/immunant/c2rust/issues/294, switches to `std::os::raw` types by default and adds optional `--use-libc-types` transpiler argument.