### PR TITLE
asm-casts: Run on no_std

### DIFF
--- a/c2rust-asm-casts/src/lib.rs
+++ b/c2rust-asm-casts/src/lib.rs
@@ -1,4 +1,5 @@
-use std::marker::PhantomData;
+#![no_std]
+use core::marker::PhantomData;
 
 /// Pseudo-structure that provides the inner type definition
 /// and cast functions for every pair of types used


### PR DESCRIPTION
There's nothing in the asm-casts crate that necessitates std (and the std::marker::PhantomData was changed to its alias core::marker::PhantomData). This PR just sets `#![no_std]` and switches over the PhantomData import.

This allows code produced with asm casts to be used in no_std environments. (Admittedly, that's a bit far-fetched as there's no official support for cross-platform transpilation yet, see https://github.com/immunant/c2rust/issues/305 -- but it's another stepping stone towards https://github.com/rust-lang/rust-bindgen/issues/1344).

I've tested this in a practical application (it builds and runs -- but I can't tell yet whether it actually executes any place with those casts), and run the local `cargo test` which runs the crate-internal coverage combo successfully.