### PR TITLE
Add support for AAPCSABIBuiltinVaList

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -351,6 +351,14 @@ impl TypedAstContext {
                 self.is_va_list_struct(typ)
             }
 
+            BuiltinVaListKind::AAPCSABIBuiltinVaList => {
+                // The mechanism applies: va_list is a `struct __va_list { ... }` as per
+                // https://documentation-service.arm.com/static/5f201281bb903e39c84d7eae
+                // ("Procedure Call Standard for the Arm Architecture Release 2020Q2, Document
+                // number IHI 0042J") Section 8.1.4 "Additional Types"
+                self.is_va_list_struct(typ)
+            }
+
             kind => unimplemented!("va_list type {:?} not yet implemented", kind),
         }
     }


### PR DESCRIPTION
As the base type is defined to be `struct __va_list { ... }`, the
existing is_va_list mechanism can be applied.

---

I can't test this in full because I don't have any practical functions to call (they all but come in via standard headers), but the result of the the transpilation looks good as in this test case:

```
$ cat compile_commands.json
[
  {
    "arguments": [
      "clang-12",
      "-target", "arm-none-eabi",
      "-o", "a.out",
      "test.c"
    ],
    "directory": "/tmp/varargs/",
    "file": "test.c"
  }
]
$ cat test.c
int printf(const char *format, ...);

void demo2(void) {
        printf("hello %d\n", 62);
}
$ c2rust transpile compile_commands.json
Transpiling test.c
$ cat test.rs
#![allow(dead_code, mutable_transmutes, non_camel_case_types, non_snake_case,
         non_upper_case_globals, unused_assignments, unused_mut)]
#![register_tool(c2rust)]
#![feature(register_tool)]
extern "C" {
    #[no_mangle]
    fn printf(_: *const libc::c_char, _: ...) -> libc::c_int;
}
#[no_mangle]
pub unsafe extern "C" fn demo2() {
    printf(b"hello %d\n\x00" as *const u8 as *const libc::c_char,
           62 as libc::c_int);
}
```

Before the patch, c2rust would have panicked with:

```
thread 'main' panicked at 'not yet implemented: va_list type AAPCSABIBuiltinVaList not yet implemented', c2rust-transpile/src/c_ast/mod.rs:354:21
```