### PR TITLE
Disarm C's doc comments even inside lines

### DIFF
--- a/c2rust-transpile/src/rust_ast/comment_store.rs
+++ b/c2rust-transpile/src/rust_ast/comment_store.rs
@@ -150,8 +150,6 @@ impl CommentStore {
                     let begin = line.trim_start();
                     if begin.starts_with("//!")
                         || begin.starts_with("///")
-                        || begin.starts_with("/**")
-                        || begin.starts_with("/*!")
                     {
                         let begin_loc = line.len() - begin.len();
                         line.insert(2+begin_loc, ' ');
@@ -159,6 +157,8 @@ impl CommentStore {
                     line
                 })
                 .join("\n")
+                .replace("/**", "/* *")
+                .replace("/*!", "/* !")
         }
 
         let lines: Vec<String> = lines.into_iter().map(translate_comment).collect();

--- a/tests/comments/src/comments.c
+++ b/tests/comments/src/comments.c
@@ -63,6 +63,7 @@ int test_fn() {
   return x + CONSTANT1;
 
   /* after all statements */
+  /** even a double comment is not turned into a doc comment *//** */
 }
 
 /* after all functions */


### PR DESCRIPTION
This is a straightforward fix for #310, accompanied by an extension to the test cases to cover the new behavior. The new test failed with the old code, and now passes.