### PR TITLE
llvm 11 fixes

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -2562,7 +2562,7 @@ static std::vector<const char *> augment_argv(int argc, const char *argv[]) {
     SmallString<128> P("-extra-arg=-resource-dir=" CLANG_BIN_PATH);
     llvm::sys::path::append(P, "..", Twine("lib") + CLANG_LIBDIR_SUFFIX,
                             "clang", CLANG_VERSION_STRING);
-    std::string resource_dir = P.str();
+    std::string resource_dir = P.str().str();
     char *resource_dir_cstr = new char[resource_dir.length() + 1];
     strncpy(resource_dir_cstr, resource_dir.c_str(), resource_dir.length() + 1);
 

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -2463,7 +2463,7 @@ class TranslateConsumer : public clang::ASTConsumer {
             }
 #else  // CLANG_VERSION_MAJOR >= 10
             const FileID file = sourceMgr.getMainFileID();
-            auto comments = Context.getRawCommentList().getCommentsInFile(file);
+            auto comments = Context.Comments.getCommentsInFile(file);
             if (comments != nullptr) {
                 cbor_encoder_create_array(&outer, &array, comments->size());
                 for (auto comment : *comments) {


### PR DESCRIPTION
My Arch Linux bumped me to clang/llvm 11 today, which broke c2rust compilation.

This PR contains the fixes I needed to make it compile:

1. ASTContext::getRawCommentList() was removed. It was a getter for ASTContext::Comments, which is a public field. So there's a commit that directly accesses the field.

2. SmallString::str() changed semantics slightly, causing it to not map to std::string. A double `.str().str()` goes through StringRef to std::string. LLVM 11 offers a direct `std::string(X)` operator, but to keep this compatible, I kept the double call.

I did not test this on clang/llvm < 11...