### PR TITLE
Fix several CI papercuts

### DIFF
--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -33,6 +33,15 @@ jobs:
         path: testsuite
         submodules: true
 
+    - name: Cache Rust toolchain
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.rustup/toolchains
+          ~/.rustup/update-hashes
+          ~/.rustup/settings.toml
+        key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('rust-toolchain') }}
+
     - name: Cache Rust artifacts
       uses: actions/cache@v2
       with:

--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -60,12 +60,18 @@ jobs:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
 
+    - name: Get Image Version
+      id: get-image-ver
+      run: |
+        echo "::set-output name=version::$(echo $ImageVersion)"
+      shell: bash
+
     - name: Cache testsuite compile_commands
       uses: actions/cache@v2
       with:
         path: |
           ${{ github.workspace }}/testsuite/tests/**/compile_commands.json
-        key: ${{ runner.os }}-ccdb-${{ env.ImageVersion }}
+        key: ${{ runner.os }}-ccdb-${{ steps.get-image-ver.outputs.version }}
 
     - name: Provision Rust
       run:  rustup component add rustfmt-preview rustc-dev

--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -50,9 +50,7 @@ jobs:
       with:
         path: |
           ${{ github.workspace }}/testsuite/tests/**/compile_commands.json
-        key: ${{ runner.os }}-ccdb-${{ hashFiles('**/compile_commands.json') }}
-        restore-keys: |
-          ${{ runner.os }}-ccdb-
+        key: ${{ runner.os }}-ccdb-${{ env.ImageVersion }}
 
     - name: Provision Rust
       run:  rustup component add rustfmt-preview rustc-dev

--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -54,6 +54,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-
 
+    - name: Cache Python - pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+
     - name: Cache testsuite compile_commands
       uses: actions/cache@v2
       with:

--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -60,7 +60,7 @@ jobs:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
 
-    # TODO(pl): Figure out why json-c fails when caching compile comands
+    # TODO(pl): Figure out why json-c fails when caching compile commands
     # - name: Get Image Version
     #   id: get-image-ver
     #   run: |
@@ -108,9 +108,10 @@ jobs:
         export LLVM_CONFIG_PATH=/usr/bin/llvm-config-9
         cargo build --release
 
-    # Runs a set of commands using the runners shell
+    # TODO(pl): figure out why compile_commands.json may cause json-c to fail
     - name: Run c2rust testsuite
       run: |
+        find testsuite -type f -name compile_commands.json -delete
         export PATH=$PWD/target/release:$HOME/.local/bin:$PATH
         echo "PATH=$PATH"
         python3 testsuite/test.py curl json-c lua nginx zstd

--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -60,18 +60,19 @@ jobs:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
 
-    - name: Get Image Version
-      id: get-image-ver
-      run: |
-        echo "::set-output name=version::$(echo $ImageVersion)"
-      shell: bash
+    # TODO(pl): Figure out why json-c fails when caching compile comands
+    # - name: Get Image Version
+    #   id: get-image-ver
+    #   run: |
+    #     echo "::set-output name=version::$(echo $ImageVersion)"
+    #   shell: bash
 
-    - name: Cache testsuite compile_commands
-      uses: actions/cache@v2
-      with:
-        path: |
-          ${{ github.workspace }}/testsuite/tests/**/compile_commands.json
-        key: ${{ runner.os }}-ccdb-${{ steps.get-image-ver.outputs.version }}
+    # - name: Cache testsuite compile_commands
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: |
+    #       ${{ github.workspace }}/testsuite/tests/**/compile_commands.json
+    #     key: ${{ runner.os }}-ccdb-${{ steps.get-image-ver.outputs.version }}
 
     - name: Provision Rust
       run:  rustup component add rustfmt-preview rustc-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       env: >-
           CACHE_NAME=OSX_FAST_BUILD
           # https://github.com/immunant/c2rust/blob/master/README.md#building-c2rust
-          LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
+          LLVM_CONFIG_PATH=$(brew --prefix llvm@11)/bin/llvm-config
 
     # - os: linux
     #   dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,33 +13,10 @@ branches:
 matrix:
   fast_finish: true
   include:
-    # - os: osx
-    #   # osx_image: xcode9.3 # request macOS 10.13
-    #   env: >-
-    #       # https://docs.travis-ci.com/user/caching/#caches-and-build-matrices
-    #       CACHE_NAME=OSX_DEV_BUILD
-    #       PATH="/usr/local/opt/ccache/libexec:$PATH"
-    #       USE_CCACHE=1
-    #       CCACHE_COMPRESS=1
-    #       CCACHE_CPP2=1
-
     - os: osx
       env: >-
           CACHE_NAME=OSX_FAST_BUILD
           # https://github.com/immunant/c2rust/blob/master/README.md#building-c2rust
-          LLVM_CONFIG_PATH=$(brew --prefix llvm@11)/bin/llvm-config
-
-    # - os: linux
-    #   dist: xenial
-    #   env: >-
-    #       CACHE_NAME=LINUX_DEV_BUILD
-    #       PATH="/usr/lib/ccache:/usr/bin:$PATH"
-    #       USE_CCACHE=1
-    #       CCACHE_CPP2=1
-    #       CCACHE_COMPRESS=1
-    #   before_script:
-    #     # Clang is not in `/usr/lib/ccache/`, so it needs to be added
-    #     - sudo /usr/sbin/update-ccache-symlinks
 
     - os: linux
       dist: xenial
@@ -51,22 +28,18 @@ cache:
   directories:
     - $HOME/.rustup
     - $HOME/.cargo
-    - $HOME/.ccache
-    - $TRAVIS_BUILD_DIR/ast-importer/target.travis
-    - $TRAVIS_BUILD_DIR/cross-checks/rust-checks/config/target
-    - $TRAVIS_BUILD_DIR/cross-checks/rust-checks/rustc-plugin/target
-    - $TRAVIS_BUILD_DIR/cross-checks/rust-checks/runtime/target
-    - $TRAVIS_BUILD_DIR/cross-checks/rust-checks/derive-macros/target
-    - $TRAVIS_BUILD_DIR/rust-refactor/target
+    - $TRAVIS_BUILD_DIR/c2rust-ast-importer/target.travis
+    - $TRAVIS_BUILD_DIR/c2rust-refactor/target
 
 install:
   - /usr/bin/env python3 --version
-  - echo $LLVM_CONFIG_PATH
-  - ls -la $LLVM_CONFIG_PATH
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       # HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade python
       ./scripts/provision_mac.sh
+      export LLVM_CONFIG_PATH=$(brew --prefix llvm@11)/bin/llvm-config
+      echo $LLVM_CONFIG_PATH
+      ls -la $LLVM_CONFIG_PATH
     else
       sudo -H ./scripts/provision_deb.sh
       ./scripts/provision_rust.sh
@@ -76,22 +49,8 @@ install:
 # NOTE: travis doesn't automatically terminate if command fails.
 script:
   - |
-    case "$CACHE_NAME" in
-      LINUX_DEV_BUILD|OSX_DEV_BUILD)
-        ccache -s
-        python3 ./scripts/build_translator.py --debug || travis_terminate 1
-        ccache -s
-        # `ccache` needs to be disabled when running tests, because in some instances
-        # the cached result would differ from the actual result thus causing a failure.
-        # This issue would usually occur in the `test_shuffle_vectors` test.
-        export CCACHE_DISABLE=1
-        python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
-        ;;
-      LINUX_FAST_BUILD|OSX_FAST_BUILD)
-        cargo build
-        python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
-        ;;
-    esac
+    cargo build || travis_terminate 1
+    python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       env: >-
           CACHE_NAME=OSX_FAST_BUILD
           # https://github.com/immunant/c2rust/blob/master/README.md#building-c2rust
-          LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config
+          LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
 
     # - os: linux
     #   dist: xenial
@@ -61,6 +61,8 @@ cache:
 
 install:
   - /usr/bin/env python3 --version
+  - echo $LLVM_CONFIG_PATH
+  - ls -la $LLVM_CONFIG_PATH
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       # HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade python
@@ -90,10 +92,6 @@ script:
         python3 ./scripts/test_translator.py --debug ./tests || travis_terminate 1
         ;;
     esac
- # NOTE: disabled because it takes to long to compile on free plan :/
- # To enable, add `--with-clang` to build_translator.py line above.
- # - python3 ./scripts/build_cross_checks.py || travis_terminate 1
- # - python3 ./scripts/test_cross_checks.py || travis_terminate 1
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,14 @@ branches:
     - master
     - feature/ci-dev
 
+
 matrix:
   fast_finish: true
   include:
     - os: osx
+      osx_image: xcode12.2 # macOS 10.15.7
       env: >-
           CACHE_NAME=OSX_FAST_BUILD
-          # https://github.com/immunant/c2rust/blob/master/README.md#building-c2rust
 
     - os: linux
       dist: xenial

--- a/tests/builtins/src/mem_x_fns.c
+++ b/tests/builtins/src/mem_x_fns.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 
 void mem_x(const char src[4], char dest[4]) {
     __builtin_memcpy(dest, src, strlen(src)+1);

--- a/tests/gotos/src/jump_into_loop.c
+++ b/tests/gotos/src/jump_into_loop.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 
 // This used to cause the translator to crash at translation time.
 // It doesn't do anything, but it does have interesting control-flow.

--- a/tests/pointers/src/ref_decay.c
+++ b/tests/pointers/src/ref_decay.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 
 typedef struct {


### PR DESCRIPTION
- [x] Travis CI had bit rotted on macOS. Fixed by rolling to macOS 10.15 and LLVM 11. This unmasked a few testsuite failures due to missing include directives; those are fixed by this PR.
- [x] GitHub Actions and caching of compile commands does not play well together. Worked around by disabling caching of compile commands. Can't reproduce outside of GitHub Actions.
- [x] Cache additional provisioning steps for GitHub Actions.