### PR TITLE
Fix shell.nix for unstable

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     pkgs.llvm
     pkgs.openssl
     pkgs.pkgconfig
-    pkgs.python35
+    pkgs.python3
     pkgs.rustup
     pkgs.zlib
   ];


### PR DESCRIPTION
At least nixpkgs-unstable has removed the python35 package.

Sticking to `python3` should be fine.