### PR TITLE
CMake correctness; streamline `nix-shell` environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,19 +1,50 @@
 let
-  nixpkgs = import <nixpkgs> {};
-  inherit (nixpkgs) pkgs llvmPackages;
+  fetchFromGitHub = { owner, repo, rev, sha256 }: builtins.fetchTarball {
+    name = "source";
+    url = "https://api.github.com/repos/${owner}/${repo}/tarball/${rev}";
+    inherit sha256;
+  };
+  pkgs = import <nixpkgs> {
+    overlays = [
+      (import (fetchFromGitHub {
+        owner = "mozilla";
+        repo = "nixpkgs-mozilla";
+        rev = "4a07484cf0e49047f82d83fd119acffbad3b235f";
+        sha256 = "1qg9gj6xlz2zsbdsijn5z2km29lc90qzwkcm9p1rpn4bcmkknq1r";
+      } + "/rust-overlay.nix"))
+      (final: prev: {
+        rustChannelNightly = let rustChannel = final.rustChannelOf {
+          rustToolchain = ./rust-toolchain;
+          sha256 = "15219mpsg6bdgh137njrwzxvin9ipf20n62yykv34lk8j3z7h0xr";
+        }; in rustChannel // { rust = rustChannel.rust.override (args: {
+          extensions = args.extensions or [ ] ++ [ "rustc-dev" ];
+        }); };
+        rustChannel = final.rustChannelNightly;
+
+        cargo = final.rustChannel.rust;
+        rustc = final.rustChannel.rust;
+      })
+    ];
+  };
+  inherit (pkgs) lib llvmPackages;
   stdenv = pkgs.clangStdenv;
 in
 stdenv.mkDerivation {
   name = "c2rust";
-  buildInputs = [
-    pkgs.clang
+  nativeBuildInputs = [
     pkgs.cmake
-    pkgs.llvm
-    pkgs.openssl
     pkgs.pkgconfig
-    pkgs.python35
-    pkgs.rustup
+    pkgs.rustChannel.rust
+  ];
+  buildInputs = [
+    (lib.getDev llvmPackages.clang)
+    (lib.getDev llvmPackages.llvm)
+    pkgs.openssl
+    pkgs.python3
     pkgs.zlib
   ];
-  LIBCLANG_PATH="${llvmPackages.libclang}/lib";
+
+  CLANG_CMAKE_DIR = "${lib.getDev llvmPackages.libclang}/lib/cmake/clang";
+  LIBCLANG_PATH="${lib.getLib llvmPackages.libclang}/lib";
+  LLVM_CONFIG_PATH = "${lib.getDev llvmPackages.llvm}/bin/llvm-config";
 }


### PR DESCRIPTION
These allow `nix-shell --pure --show-trace --keep-going --run 'cargo build --release'` from a clean checkout to succeed.

## Don't assume LLVM & Clang share the same lib dir
Also, don't assume `llvm-config --libdir` shares the same `lib/` root as `llvm-config --cmakedir`.

## streamline `nix-shell` environment
Rustup is no longer required when using `nix-shell`. Instead, the required Rust nightly is already available.