### PR TITLE
Transfer the packed attribute on unions to repr(packed)

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -933,6 +933,7 @@ pub enum CDeclKind {
     Union {
         name: Option<String>,
         fields: Option<Vec<CFieldId>>,
+        is_packed: bool,
     },
 
     // Field

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -1614,6 +1614,7 @@ impl<'c> Translation<'c> {
 
             CDeclKind::Union {
                 fields: Some(ref fields),
+                is_packed,
                 ..
             } => {
                 let name = self
@@ -1642,13 +1643,18 @@ impl<'c> Translation<'c> {
                     }
                 }
 
+                let mut repr = vec!["C"];
+                if is_packed {
+                    repr.push("packed");
+                }
+
                 Ok(if field_syns.is_empty() {
                     // Empty unions are a GNU extension, but Rust doesn't allow empty unions.
                     ConvertedDecl::Item(
                         mk().span(s)
                             .pub_()
                             .call_attr("derive", vec!["Copy", "Clone"])
-                            .call_attr("repr", vec!["C"])
+                            .call_attr("repr", repr)
                             .struct_item(name, vec![], false),
                     )
                 } else {
@@ -1656,7 +1662,7 @@ impl<'c> Translation<'c> {
                         mk().span(s)
                             .pub_()
                             .call_attr("derive", vec!["Copy", "Clone"])
-                            .call_attr("repr", vec!["C"])
+                            .call_attr("repr", repr)
                             .union_item(name, field_syns),
                     )
                 })

--- a/tests/unions/src/test_unions.rs
+++ b/tests/unions/src/test_unions.rs
@@ -9,12 +9,12 @@ extern "C" {
     fn entry(_: c_uint, _: *mut c_int);
 }
 
-const BUFFER_SIZE: usize = 18;
+const BUFFER_SIZE: usize = 19;
 
 pub fn test_buffer() {
     let mut buffer = [0; BUFFER_SIZE];
     let mut rust_buffer = [0; BUFFER_SIZE];
-    let expected_buffer = [12, 12, 0, 1, 2, 3, 4, 0, 5, 6, 7, 8, 0, 8, 9, 10, 12, 17];
+    let expected_buffer = [12, 12, 0, 5, 1, 2, 3, 4, 0, 5, 6, 7, 8, 0, 8, 9, 10, 12, 18];
 
     unsafe {
         entry(BUFFER_SIZE as u32, buffer.as_mut_ptr());

--- a/tests/unions/src/unions.c
+++ b/tests/unions/src/unions.c
@@ -17,6 +17,11 @@ union union_with_anon_struct {
     };
 };
 
+union __attribute__((packed)) packed_union {
+    int as_int;
+    char as_chars[5];
+};
+
 void entry(const unsigned int buffer_size, int buffer[const])
 {
     int i = 0;
@@ -35,6 +40,7 @@ void entry(const unsigned int buffer_size, int buffer[const])
     buffer[i++] = sizeof(union my_union);
     buffer[i++] = sizeof(union my_union_flipped);
     buffer[i++] = sizeof(union empty_union);
+    buffer[i++] = sizeof(union packed_union);
     buffer[i++] = u1.as_int;
     buffer[i++] = u2.as_int;
     buffer[i++] = u3.as_chars[0];


### PR DESCRIPTION
Closes: https://github.com/immunant/c2rust/issues/346

---

This should be a straightforward solution to #346, and works for me on RIOT (which also means I can't easily test it on the main branch, as I still need my for-riot vendor branch that has #311 and the branch mentioned in #309 merged).

There are no tests yet; is

```
$ cargo +nightly-20109-12-05 build --locked --release
$  python3 scripts/test_translator.py ./tests
```

the right procedure?