### PR TITLE
Add "llvm-config-12" as a name for llvm-config

### DIFF
--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -227,6 +227,7 @@ impl LLVMInfo {
                 }))
                 // In PATH
                 .or([
+                    "llvm-config-12",
                     "llvm-config-11",
                     "llvm-config-10",
                     "llvm-config-9",


### PR DESCRIPTION
It took me a lot longer than it should have to figure out what had gone wrong; somehow, I didn't notice that I was getting errors from /usr/lib/llvm-11/lib/cmake/clang/ClangTargets.cmake rather than /usr/lib/llvm-12/lib/cmake/clang/ClangTargets.cmake.

[Why the heck is that file in clang-11 rather than libclang-11-dev, where all the files it refers to are?]