### PR TITLE
c2rust-ast-builder: add dependency cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ name = "c2rust-ast-printer"
 version = "0.15.0"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo 0.44.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,9 @@ version = "0.2.0"
 [[package]]
 name = "c2rust-ast-builder"
 version = "0.15.0"
+dependencies = [
+ "cargo 0.44.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "c2rust-ast-exporter"

--- a/c2rust-ast-builder/Cargo.toml
+++ b/c2rust-ast-builder/Cargo.toml
@@ -11,3 +11,4 @@ repository = "https://github.com/immunant/c2rust"
 description = "Rust AST builder support crate for the C2Rust project"
 
 [dependencies]
+cargo = "0.44" # rustc

--- a/c2rust-ast-printer/Cargo.toml
+++ b/c2rust-ast-printer/Cargo.toml
@@ -9,3 +9,4 @@ description = "Customized version of libsyntax rust pretty-printer"
 
 [dependencies]
 log = "0.4"
+cargo = "0.44" # rustc_target


### PR DESCRIPTION
fix #332 error: ```can't find crate for `rustc` ```