### PR TITLE
Fix Continuous Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ name = "aho-corasick"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -89,13 +89,13 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.52.0"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.29.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -107,7 +107,7 @@ dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ name = "bstr"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -209,8 +209,8 @@ version = "0.15.0"
 name = "c2rust-ast-exporter"
 version = "0.15.0"
 dependencies = [
- "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.53.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.29.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -359,7 +359,7 @@ dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys 0.12.7+1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "opener 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -403,10 +403,10 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.28.1"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -664,7 +664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "either"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -879,7 +879,7 @@ name = "fwdansi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1110,7 +1110,7 @@ dependencies = [
  "globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1191,7 +1191,7 @@ name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1370,7 +1370,7 @@ dependencies = [
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "open 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.2.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1498,11 +1498,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nom"
-version = "4.2.3"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1749,7 +1749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1953,7 +1953,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2593,7 +2593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "which"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2703,7 +2703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-"checksum bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1c85344eb535a31b62f0af37be84441ba9e7f0f4111eb0530f43d15e513fe57"
+"checksum bindgen 0.53.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bitmaps 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
@@ -2717,10 +2717,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cargo 0.44.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a527349b7aae57518eec4bce77914669ba3c4a0ec7d6330575cea80edd251a4"
 "checksum cargo-platform 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
 "checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
-"checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
+"checksum cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
-"checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+"checksum clang-sys 0.29.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
@@ -2745,7 +2745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum diff 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
-"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+"checksum either 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 "checksum elasticlunr-rs 2.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f66a620976c38dbbbcd6355910432cef8b0911b3af86332029752379f0ff7924"
 "checksum ena 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8944dc8fa28ce4a38f778bd46bf7d923fe73eed5a439398507246c8e017e6f36"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
@@ -2826,7 +2826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum mdbook 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "031bdd9d4893c983e2f69ebc4b59070feee8276a584c4aabdcb351235ea28016"
-"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum memchr 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime_guess 1.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0d977de9ee851a0b16e932979515c0f3da82403183879811bc97d50bd9cc50f7"
 "checksum miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"
@@ -2838,7 +2838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum mount 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e25c06012941aaf8c75f2eaf7ec5c48cf69f9fc489ab3eb3589edc107e386f0b"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum new_debug_unreachable 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f40f005c60db6e03bae699e414c58bf9aa7ea02a2d0b9bfbcf19286cc4c82b30"
-"checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+"checksum nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 "checksum notify 4.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "199628fc33b21bc767baa057490b00b382ecbae030803a7b36292422d15b778b"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"
@@ -2974,7 +2974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum vte 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f42f536e22f7fcbb407639765c8fd78707a33109301f834a594758bedd6e8cf"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
+"checksum which 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-[![Travis Build Status]][travis] [![GitHub Actions Status]][github] [![Azure Build Status]][azure] [![Latest Version]][crates.io] [![Rustc Version]](#)
+[![GitHub Actions Status]][github] [![Azure Build Status]][azure] [![Latest Version]][crates.io] [![Rustc Version]](#)
 
 [GitHub Actions Status]: https://github.com/immunant/c2rust/workflows/c2rust-testsuite/badge.svg
 [github]: https://github.com/immunant/c2rust/actions
-[Travis Build Status]: https://api.travis-ci.org/immunant/c2rust.svg?branch=master
-[travis]: https://travis-ci.org/immunant/c2rust
 [Azure Build Status]: https://dev.azure.com/immunant/c2rust/_apis/build/status/immunant.c2rust?branchName=master
 [azure]: https://dev.azure.com/immunant/c2rust/_build/latest?definitionId=1&branchName=master
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ To learn more about using and developing C2Rust, check out the [manual](https://
 
 ### Prerequisites
 
-C2Rust requires LLVM 6 or later with its corresponding clang compiler and libraries. Python 3.4 or later, CMake 3.4.3 or later, and openssl (1.0) are also required. These prerequisites may be installed with the following commands, depending on your platform:
+C2Rust requires LLVM 7 or later with its corresponding clang compiler and libraries. Python 3.4 or later, CMake 3.4.3 or later, and openssl (1.0) are also required. These prerequisites may be installed with the following commands, depending on your platform:
 
-- **Ubuntu 16.04, 18.04 & 18.10:**
+- **Ubuntu 18.04, Debian 10, and later:**
 
-        apt install build-essential llvm-6.0 clang-6.0 libclang-6.0-dev cmake libssl-dev pkg-config python3
+        apt install build-essential llvm clang libclang-dev cmake libssl-dev pkg-config python3
 
 - **Arch Linux:**
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,7 @@ jobs:
       export PATH="/home/docker/.cargo/bin:$PATH"
       export RUSTUP_HOME=/home/docker/.rustup
       export CARGO_HOME=$AGENT_TEMPDIRECTORY/.cargo
+      export GNUPGHOME=$AGENT_TEMPDIRECTORY
       python3 ./scripts/build_translator.py --with-llvm-version=10.0.1
     displayName: 'Developer build against local LLVM 10'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,14 +23,14 @@ jobs:
     matrix:
       arch:
         containerImage: immunant/c2rust:archlinux-base-latest
-      debian9:
-        containerImage: immunant/c2rust:debian-stretch-latest
       debian10:
         containerImage: immunant/c2rust:debian-buster-latest
-      fedora29:
-        containerImage: immunant/c2rust:fedora-29-latest
-      ubuntu16:
-        containerImage: immunant/c2rust:ubuntu-xenial-latest
+      debian11:
+        containerImage: immunant/c2rust:debian-bullseye-latest
+      fedora34:
+        containerImage: immunant/c2rust:fedora-34-latest
+      ubuntu20:
+        containerImage: immunant/c2rust:ubuntu-focal-latest
       ubuntu18:
         containerImage: immunant/c2rust:ubuntu-bionic-latest
   container: $[ variables['containerImage'] ]

--- a/c2rust-ast-exporter/Cargo.toml
+++ b/c2rust-ast-exporter/Cargo.toml
@@ -19,9 +19,9 @@ serde_bytes = "0.11"
 serde_cbor = "0.10"
 
 [build-dependencies]
-bindgen = { version = "0.52", features = ["logging"] }
+bindgen = { version = "0.53", features = ["logging"] }
 cmake = "0.1"
-clang-sys = "0.28"
+clang-sys = "0.29"
 env_logger = "0.7"
 
 [features]

--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -227,6 +227,7 @@ impl LLVMInfo {
                 }))
                 // In PATH
                 .or([
+                    "llvm-config-13",
                     "llvm-config-12",
                     "llvm-config-11",
                     "llvm-config-10",
@@ -237,7 +238,13 @@ impl LLVMInfo {
                     "llvm-config-6.1",
                     "llvm-config-6.0",
                     "llvm-config",
-                    // Homebrew install location on MacOS
+                    // Homebrew install locations on MacOS
+                    "/usr/local/opt/llvm@13/bin/llvm-config",
+                    "/usr/local/opt/llvm@12/bin/llvm-config",
+                    "/usr/local/opt/llvm@11/bin/llvm-config",
+                    "/usr/local/opt/llvm@10/bin/llvm-config",
+                    "/usr/local/opt/llvm@9/bin/llvm-config",
+                    "/usr/local/opt/llvm@8/bin/llvm-config",
                     "/usr/local/opt/llvm/bin/llvm-config",
                 ]
                 .iter()

--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -235,8 +235,6 @@ impl LLVMInfo {
                     "llvm-config-8",
                     "llvm-config-7",
                     "llvm-config-7.0",
-                    "llvm-config-6.1",
-                    "llvm-config-6.0",
                     "llvm-config",
                     // Homebrew install locations on MacOS
                     "/usr/local/opt/llvm@13/bin/llvm-config",

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -586,7 +586,13 @@ class TranslateASTVisitor final
         auto ty = ast->getType();
         auto isVaList = false;
         auto encodeMacroExpansions = true;
-        encode_entry_raw(ast, tag, ast->getSourceRange(), ty, ast->isRValue(), isVaList,
+#if CLANG_VERSION_MAJOR < 13
+        bool isRValue = ast->isRValue();
+#else
+        assert(Context && "Expected Context to be non-NULL");
+        bool isRValue = ast->Classify(*Context).isRValue();
+#endif
+        encode_entry_raw(ast, tag, ast->getSourceRange(), ty, isRValue, isVaList,
                          encodeMacroExpansions, childIds, extra);
         typeEncoder.VisitQualType(ty);
     }
@@ -1128,7 +1134,7 @@ class TranslateASTVisitor final
 #else // CLANG_VERSION_MAJOR >= 7
             auto ExpansionRange = Mgr.getImmediateExpansionRange(Begin);
 #endif
-            curMacroExpansionSource = 
+            curMacroExpansionSource =
                 Lexer::getSourceText(ExpansionRange, Mgr, Context->getLangOpts());
         }
 
@@ -2488,11 +2494,11 @@ class TranslateConsumer : public clang::ASTConsumer {
                                             raw_text.size());
                     cbor_encoder_close_container(&array, &entry);
                 }
-            } else { 
+            } else {
                 // this happens when the C file contains no comments
                 cbor_encoder_create_array(&outer, &array, 0);
             }
-#endif // CLANG_VERSION_MAJOR >= 10              
+#endif // CLANG_VERSION_MAJOR >= 10
             cbor_encoder_close_container(&outer, &array);
 
             // 5. Target VaList type as BuiltiVaListKind
@@ -2527,12 +2533,12 @@ class TranslateAction : public clang::ASTFrontendAction {
     virtual std::unique_ptr<clang::ASTConsumer>
     CreateASTConsumer(clang::CompilerInstance &Compiler,
                       llvm::StringRef InFile) {
-        
+
 #if CLANG_VERSION_MAJOR < 10
         const InputKind::Language lang_c = InputKind::Language::C;
 #else
         const Language lang_c = Language::C;
-#endif // CLANG_VERSION_MAJOR    
+#endif // CLANG_VERSION_MAJOR
         if(this->getCurrentFileKind().getLanguage() != lang_c) {
             return nullptr;
         }
@@ -2639,7 +2645,18 @@ Outputs process(int argc, const char *argv[], int *result) {
     static uint64_t source_path_count = 0;
     auto argv_ = augment_argv(argc, argv);
     int argc_ = argv_.size() - 1; // ignore the extra nullptr
+
+#if CLANG_VERSION_MAJOR < 13
     CommonOptionsParser OptionsParser(argc_, argv_.data(), MyToolCategory);
+#else
+    Expected<CommonOptionsParser> parseResult =
+        CommonOptionsParser::create(argc_, argv_.data(), MyToolCategory);
+    if(auto err = parseResult.takeError()) {
+        logAllUnhandledErrors(std::move(err), errs(), "[Parse Error] ");
+        assert(0 && "Failed to parse command line options");
+    }
+    CommonOptionsParser& OptionsParser = *parseResult;
+#endif
 
     // the logic below assumes we're only translating one source file
     assert(OptionsParser.getSourcePathList().size() - 1 ==

--- a/c2rust-ast-exporter/src/lib.rs
+++ b/c2rust-ast-exporter/src/lib.rs
@@ -115,7 +115,7 @@ unsafe fn marshal_result(result: *const ExportResult) -> HashMap<String, Vec<u8>
         // Convert CBOR bytes
         let csize = *res.sizes.offset(i);
         let cbytes = *res.bytes.offset(i);
-        let bytes = slice::from_raw_parts(cbytes, csize);
+        let bytes = slice::from_raw_parts(cbytes, csize as usize);
         let mut v = Vec::new();
         v.extend_from_slice(bytes);
 

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -3,12 +3,12 @@
 set -e
 
 # do we have docker?
-type -P docker >/dev/null || { 
-    echo >&2 "docker not in path."; exit 1; 
+type -P docker >/dev/null || {
+    echo >&2 "docker not in path."; exit 1;
 }
 
 # ... and the right version?
-docker --version | grep -q "Docker version 17" && { 
+docker --version | grep -q "Docker version 17" && {
     echo "Docker version too old. Please upgrade."; exit 1; }
 
 REPO_NAME=immunant/c2rust
@@ -16,12 +16,12 @@ DATE_TAG=$(date +'%Y%m%d')
 SCRIPT_DIR="$(dirname "$0")"
 
 declare -A IMAGES  # associative arrays are only supported in bash 4 and higher
+IMAGES["ubuntu:focal"]="1"
 IMAGES["ubuntu:bionic"]="1" # any non-empty string will do
-IMAGES["ubuntu:xenial"]="1"
+IMAGES["debian:bullseye"]="1"
 IMAGES["debian:buster"]="1"
-IMAGES["debian:stretch"]="1"
-IMAGES["archlinux/base"]="1"
-IMAGES["fedora:29"]="1"
+IMAGES["archlinux:base"]="1"
+IMAGES["fedora:34"]="1"
 
 build_image() {
     BASE_IMAGE=${1}
@@ -47,7 +47,7 @@ if [ "$1" == "" ]; then
 
         echo $"Usage: $0 {${options}|build-all|push-all}"
         exit 1
-fi        
+fi
 
 if [ "${IMAGES[$1]}" != "" ]; then
         build_image "$1"

--- a/scripts/provision_deb.sh
+++ b/scripts/provision_deb.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-# Are we on a supported distro? Note: We can't use dpkg-vendor 
+# Are we on a supported distro? Note: We can't use dpkg-vendor
 # because it is installed via `build-essential`.
 grep -Ei 'debian|buntu|mint' /etc/*release > /dev/null || {
-    echo >&2 "Run this script on a Debian-based host."; exit 1; 
+    echo >&2 "Run this script on a Debian-based host."; exit 1;
 }
 
 # Make debconf use a frontend that expects no interactive input
@@ -31,7 +31,9 @@ apt-get install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates
 # gnupg2: required for gnupg2 key retrieval
+# llvm: required for llvm-config
 apt-get install -qq \
+    clang \
     cmake \
     curl \
     dirmngr \
@@ -39,7 +41,9 @@ apt-get install -qq \
     gnupg2 \
     gperf \
     htop \
+    libclang-dev \
     libssl-dev \
+    llvm \
     ninja-build \
     pkg-config \
     python-dev \
@@ -50,28 +54,14 @@ apt-get install -qq \
     libncurses5-dev \
     luarocks
 
-# Older releases do not include clang 6 and later so we grab 
-# the latest versions of those packages from the LLVM project. 
-export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
-curl -s https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-apt-add-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-7 main"
-
-apt-get update -qq
-# libclang-7.0-dev: for fast builds against host libclang
-apt-get install -qq clang-7 libclang-7-dev 
-
 apt-get clean # clear apt-caches to reduce image size
 
-update-alternatives --install /usr/bin/clang clang /usr/bin/clang-7 100
-update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-7 100
-# update-alternatives --install /usr/bin/lldb lldb /usr/bin/lldb-7 100
-
-pip3 install --upgrade pip
+python3 -m pip install --upgrade pip
 # Current version of scan-build requires setuptools 20.5 or newer to parse
 # environment markers in install_requires
-pip3 install "setuptools >= 20.5" --disable-pip-version-check --quiet
+python3 -m pip install "setuptools >= 20.5" --disable-pip-version-check --quiet
 # Install python3 packages
-pip3 install -r $SCRIPT_DIR/requirements.txt --disable-pip-version-check --quiet
+python3 -m pip install -r $SCRIPT_DIR/requirements.txt --disable-pip-version-check --quiet
 
 # Set the system-wide Lua path to include luarocks directories
 luarocks path > /etc/profile.d/luarocks-path.sh

--- a/scripts/provision_dnf.sh
+++ b/scripts/provision_dnf.sh
@@ -7,13 +7,22 @@ SCRIPT_DIR="$(dirname "$0")"
 . /etc/os-release
 
 # TODO: might have to do something similar to support RHEL
-if [ "$NAME" != "Fedora Linux" ]; then
+if [ "$NAME" != "Fedora" ]; then
     echo >&2 "Run this script on a Fedora host."; exit 1;
 fi
 
 # redhat-rpm-config avoids problem when pip3-installing psutils
 dnf install --quiet --assumeyes \
-    ninja-build make cmake llvm-devel clang-devel openssl-devel redhat-rpm-config python3-devel xz
+    clang-devel \
+    cmake \
+    diffutils \
+    llvm-devel \
+    make \
+    ninja-build \
+    openssl-devel \
+    python3-devel \
+    redhat-rpm-config \
+    xz
 
 pip3 install --upgrade pip
 # Current version of scan-build requires setuptools 20.5 or newer to parse

--- a/scripts/provision_dnf.sh
+++ b/scripts/provision_dnf.sh
@@ -7,8 +7,8 @@ SCRIPT_DIR="$(dirname "$0")"
 . /etc/os-release
 
 # TODO: might have to do something similar to support RHEL
-if [ "$NAME" != "Fedora" ]; then
-    echo >&2 "Run this script on a Fedora host."; exit 1; 
+if [ "$NAME" != "Fedora Linux" ]; then
+    echo >&2 "Run this script on a Fedora host."; exit 1;
 fi
 
 # redhat-rpm-config avoids problem when pip3-installing psutils

--- a/scripts/provision_mac.sh
+++ b/scripts/provision_mac.sh
@@ -5,14 +5,14 @@ set -e
 # complain if we're not on macOS
 UNAME=$(uname -s)
 if [ "$UNAME" != "Darwin" ]; then
-  echo >&2 "Run this script on a macOS host."; exit 1; 
+  echo >&2 "Run this script on a macOS host."; exit 1;
 fi
 
 # make sure we have all prerequisites
 prereqs=(brew clang)
 for prereq in "${prereqs[@]}"; do
-    type -P "$prereq" >/dev/null || { 
-        echo >&2 "$prereq not in path."; exit 1; 
+    type -P "$prereq" >/dev/null || {
+        echo >&2 "$prereq not in path."; exit 1;
     }
 done
 
@@ -21,7 +21,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 
 # NOTE: Pin LLVM to a known good version since new releases
 # tend not to be backwards compatible
-hb_packages=(python cmake ninja gpg ccache llvm@11)
+hb_packages=(python cmake ninja gpg llvm)
 for item in "${hb_packages[@]}"; do
   brew info "${item}" | grep 'Not installed' > /dev/null && brew install "${item}"
 done

--- a/scripts/provision_yum.sh
+++ b/scripts/provision_yum.sh
@@ -6,13 +6,13 @@ SCRIPT_DIR="$(dirname "$0")"
 
 . /etc/os-release
 
-if [ "$NAME" != "CentOS Linux" ]; then
-    echo >&2 "Run this script on a CentOS host."; exit 1; 
+if [ "$NAME" != "Fedora Linux" ]; then
+    echo >&2 "Run this script on a Fedora host."; exit 1;
 fi
 
 # required to install ninja-build
 yum install --quiet --assumeyes epel-release
-# NOTE: CentOS version of cmake is too old 
+# NOTE: CentOS version of cmake is too old
 yum install --quiet --assumeyes which ninja-build make cmake
 
 yum install --quiet --assumeyes luarocks
@@ -24,4 +24,4 @@ luarocks path > /etc/profile.d/luarocks-path.sh
 luarocks install penlight
 
 # TODO: provision remaining packages and test
-echo >&2 "Provisioning incomplete."; exit 1; 
+echo >&2 "Provisioning incomplete."; exit 1;


### PR DESCRIPTION
Note: overlaps with and incorporates some changes from #357 authored by @fw-immunant. 

  - Deprecate Ubuntu 16.04, Debian Stretch (9), Fedora 29, and LLVM 6.
  - Use distro clang/LLVM packages instead of those packaged by LLVM developers
  - Support LLVM 13 (required for Darwin and Arch, co-authored with @fw-immunant )
  - Fix GNUPG problem (authored by @fw-immunant)
  - Roll bindgen and clang-sys to silence warnings on Darwin
  - Remove Travis status badges.
  - Reconfigure Azure Pipelines to use new docker images
  