### PR TITLE
update xzoom dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/immunant/snudown.git
 [submodule "examples/xzoom/xzoom"]
 	path = examples/xzoom/repo
-	url = git://git.r-36.net/xzoom
+	url = git://r-36.net/xzoom
 [submodule "examples/grabc/repo"]
 	path = examples/grabc/repo
 	url = https://github.com/immunant/grabc.git


### PR DESCRIPTION
When installing via git and cargo the following error occurs:
```sh
$ cargo +nightly-2019-12-05 install --git https://github.com/immunant/c2rust.git c2rust
    Updating git repository `https://github.com/immunant/c2rust.git`
warning: spurious network error (2 tries remaining): remote error: access denied or repository not exported: /xzoom; class=Net (12)
warning: spurious network error (1 tries remaining): remote error: access denied or repository not exported: /xzoom; class=Net (12)
error: failed to update submodule `examples/xzoom/xzoom`

Caused by:
  failed to fetch submodule `examples/xzoom/xzoom` from git://git.r-36.net/xzoom

Caused by:
  remote error: access denied or repository not exported: /xzoom; class=Net (12)
```
This seems to be induced by a change of the the git url of the xzoomp project  `http://r-36.net/scm/xzoom/log.html`