### PR TITLE
Limited support for va_list in structs

### DIFF
--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -553,6 +553,12 @@ impl Builder {
         Builder { span: span, ..self }
     }
 
+    pub fn generic_over<P: Make<GenericParam>>(mut self, param: P) -> Self {
+        let param = param.make(&self);
+        self.generics.params.push(param);
+        self
+    }
+
     pub fn prepare_meta_namevalue(&self, mnv: MetaNameValue) -> PreparedMetaItem {
         let mut tokens = TokenStream::new();
         mnv.eq_token.to_tokens(&mut tokens);
@@ -2277,6 +2283,23 @@ impl Builder {
 
     pub fn ty<T>(self, kind: Type) -> Type {
         kind
+    }
+
+    pub fn lt_param<L>(self, lifetime: L) -> GenericParam
+    where
+        L: Make<Lifetime>,
+    {
+        let lifetime = lifetime.make(&self);
+        GenericParam::Lifetime(LifetimeDef {
+            attrs: self.attrs.into(),
+            lifetime,
+            colon_token: None,
+            bounds: punct(vec![]),
+        })
+    }
+
+    pub fn lifetime<L: Make<Lifetime>>(self, lt: L) -> Lifetime {
+        lt.make(&self)
     }
 
     pub fn attribute<Pa, Ma>(self, style: AttrStyle, path: Pa, args: Ma) -> Attribute

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -20,7 +20,7 @@ pub struct TypeConverter {
     fields: HashMap<CDeclId, Renamer<FieldKey>>,
     suffix_names: HashMap<(CDeclId, &'static str), String>,
     features: HashSet<&'static str>,
-    emit_no_std: bool,
+    pub emit_no_std: bool,
 }
 
 pub const RESERVED_NAMES: [&str; 103] = [

--- a/tests/items/src/test_varargs.rs
+++ b/tests/items/src/test_varargs.rs
@@ -2,7 +2,7 @@
 extern crate libc;
 
 use varargs::{rust_call_printf, rust_call_vprintf, rust_my_printf, rust_simple_vacopy,
-              rust_restart_valist, rust_sample_stddev};
+              rust_valist_struct_member, rust_restart_valist, rust_sample_stddev};
 
 use std::ffi::CString;
 use self::libc::c_char;
@@ -16,6 +16,8 @@ extern "C" {
     fn my_printf(_: *const c_char, ...);
 
     fn simple_vacopy(_: *const c_char, ...);
+
+    fn valist_struct_member(_: *const c_char, ...);
 
     fn restart_valist(_: *const c_char, ...);
 
@@ -56,6 +58,14 @@ pub fn test_simple_vacopy() {
          simple_vacopy(fmt_str.as_ptr(), 10, 1.5);
          rust_simple_vacopy(fmt_str.as_ptr(), 10, 1.5);
      }
+ }
+
+ pub fn test_valist_struct_member() {
+    let fmt_str = CString::new("%d, %f\n").unwrap();
+    unsafe {
+        valist_struct_member(fmt_str.as_ptr(), 10, 1.5);
+        rust_valist_struct_member(fmt_str.as_ptr(), 10, 1.5);
+    }
  }
 
 pub fn test_restart_valist() {

--- a/tests/items/src/varargs.c
+++ b/tests/items/src/varargs.c
@@ -67,6 +67,19 @@ void simple_vacopy(const char *fmt, ...) {
   va_end(ap);
 }
 
+struct vastruct {
+    va_list args;
+};
+
+// pattern first seen in apache (util_script.c)
+void valist_struct_member(const char *fmt, ...) {
+  struct vastruct thestruct;
+
+  va_start(thestruct.args, fmt);
+  vprintf(fmt, thestruct.args);
+  va_end(thestruct.args);
+}
+
 // mirrors pattern from json-c's sprintbuf
 void restart_valist(const char *fmt, ...) {
     va_list ap;


### PR DESCRIPTION
Trying to transpile apache httpd 2.4.52 uncovered a pattern in `util_script.c` that the transpiler cannot handle. This patch (partially) addresses this limitation by supporting va_lists in structs. Fully supporting the pattern found in apache httpd will likely require substantial engineering effort. 