### PR TITLE
ast-exporter: fix: No such file llvm-config

### DIFF
--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -214,9 +214,10 @@ impl LLVMInfo {
         fn find_llvm_config() -> Option<String> {
             // Explicitly provided path in LLVM_CONFIG_PATH
             env::var("LLVM_CONFIG_PATH")
-                .ok()
+            .ok()
+            .or_else(|| {
                 // Relative to LLVM_LIB_DIR
-                .or(env::var("LLVM_LIB_DIR").ok().map(|d| {
+                env::var("LLVM_LIB_DIR").ok().map(|d| {
                     String::from(
                         Path::new(&d)
                             .join("../bin/llvm-config")
@@ -224,9 +225,11 @@ impl LLVMInfo {
                             .unwrap()
                             .to_string_lossy(),
                     )
-                }))
+                })
+            })
+            .or_else(|| {
                 // In PATH
-                .or([
+                [
                     "llvm-config-13",
                     "llvm-config-12",
                     "llvm-config-11",
@@ -257,7 +260,8 @@ impl LLVMInfo {
                     } else {
                         None
                     }
-                }))
+                })
+            })
         }
 
         /// Invoke given `command`, if any, with the specified arguments.


### PR DESCRIPTION
use `or_else` instead of `or`

`or` evaluates all branches
`or_else` stops after first success

in my case, this branch fails

```rs
                // Relative to LLVM_LIB_DIR
                env::var("LLVM_LIB_DIR").ok().map(|d| {
                    String::from(
                        Path::new(&d)
                            .join("../bin/llvm-config")
                            .canonicalize()
                            .unwrap()
                            .to_string_lossy(),
                    )
                })
```

so `cargo build` throws

```
error: failed to run custom build command for `c2rust-ast-exporter v0.15.0 (/tmp/c2rust/c2rust-ast-exporter)`

Caused by:
  process didn't exit successfully: `/tmp/c2rust/target/debug/build/c2rust-ast-exporter-15a5bcc950a5a7b0/build-script-build` (exit status: 101)

  --- stderr
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', c2rust-ast-exporter/build.rs:253:30
```
