### PR TITLE
Enable compiling c2rust on stable

### DIFF
--- a/c2rust-ast-printer/src/lib.rs
+++ b/c2rust-ast-printer/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(crate_visibility_modifier)]
-
 extern crate syn;
 extern crate proc_macro2;
 

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -436,7 +436,8 @@ impl StructureState {
                 return (vec![s], span);
             }
 
-            Append(box Spanned {node: Empty, span: lhs_span}, rhs) => {
+            Append(spanned, rhs) if matches!(spanned.node, Empty) => {
+                let lhs_span = spanned.span;
                 let span = ast.span.substitute_dummy(lhs_span);
                 let span = span_subst_lo(span, lhs_span).unwrap_or_else(|| {
                     comment_store.move_comments(lhs_span.lo(), span.lo());

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(label_break_value)]
 #![feature(box_patterns)]
 
 extern crate colored;

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(box_patterns)]
-
 extern crate colored;
 extern crate dtoa;
 extern crate syn;

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(rustc_private)]
 #![feature(label_break_value)]
 #![feature(box_patterns)]
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -1106,6 +1106,14 @@ fn item_attrs(item: &mut Item) -> Option<&mut Vec<syn::Attribute>> {
     })
 }
 
+/// Unwrap a layer of parenthesization from an Expr, if present
+fn unparen(expr: &Box<Expr>) -> &Box<Expr> {
+    match **expr {
+        Expr::Paren(ExprParen { ref expr, .. }) => expr,
+        _ => expr,
+    }
+}
+
 /// This represents all of the ways a C expression can be used in a C program. Making this
 /// distinction is important for:
 ///
@@ -4303,8 +4311,7 @@ impl<'c> Translation<'c> {
             // we are casting to. Here, we can just remove the extraneous cast instead of generating
             // a new one.
             CExprKind::DeclRef(_, decl_id, _) if variants.contains(&decl_id) => {
-                return val.map(|x| match *x {
-                    Expr::Paren(ExprParen {expr: box Expr::Cast(ExprCast {ref expr, ..}), ..}) |
+                return val.map(|x| match **unparen(&x) {
                     Expr::Cast(ExprCast {ref expr, ..}) => expr.clone(),
                     _ => panic!(format!(
                         "DeclRef {:?} of enum {:?} is not cast",
@@ -4531,12 +4538,6 @@ impl<'c> Translation<'c> {
             // One simplification we can make at the cost of inspecting `val` more closely: if `val`
             // is already in the form `(x <op> y) as <ty>` where `<op>` is a Rust operator
             // that returns a boolean, we can simple output `x <op> y` or `!(x <op> y)`.
-            fn unparen(expr: &Box<Expr>) -> &Box<Expr> {
-                match **expr {
-                    Expr::Paren(ExprParen { ref expr, .. }) => expr,
-                    _ => expr,
-                }
-            }
             if let Expr::Cast(ExprCast { expr: ref arg, ..}) = **unparen(&val) {
                 if let Expr::Binary(ExprBinary {op, ..}) = **unparen(arg) {
                     match op {


### PR DESCRIPTION
I was reviewing our usage of nightly features and it turns out that the transpiler doesn't have a meaningful need for any nightly features. This PR compiles with rustc 1.58 stable.

Our tests don't pass with a stable compiler because the generated code contains `#![feature]`, but I think it's worthwhile to enable transpiling with stable as it's pretty easy to do so.