### PR TITLE
c2rust-ast-exporter: Adjust tinycbor redirect workaround to work when called from make

### DIFF
--- a/c2rust-ast-exporter/src/CMakeLists.txt
+++ b/c2rust-ast-exporter/src/CMakeLists.txt
@@ -16,7 +16,7 @@ ExternalProject_Add(tinycbor_build
             URL ${TINYCBOR_URL}
             URL_HASH MD5=${TINYCBOR_MD5}
             # the fd redirection here fails when the build run inside Cargo
-            CONFIGURE_COMMAND sed -i -r -e "s:'>&9':>$@:" -e "s:9>::" Makefile
+            CONFIGURE_COMMAND sed -i -r -e "s:^\\t.*9.*:\\trm -f $@ \&\& &:" -e "s:'>&9':'>>$@':" -e "s:9>.*::" Makefile
             BUILD_COMMAND make --quiet prefix=<INSTALL_DIR> CFLAGS=-fPIC
             INSTALL_COMMAND make --quiet prefix=<INSTALL_DIR> install            
             BUILD_IN_SOURCE 1


### PR DESCRIPTION
Building c2rust misbehaves when the caller of `cargo` is a `make`, as happens when one is building a Debian package for it.

The cause of the misbehavior is the workaround for tinycbor's `OUT='>9' 9>&$@` trick, during which the whole output of the `make` invocation that populates `tinycbor_build/.config` gets redirected into it, which (in the case of nested make) would then look like this:

```
make[6]: Entering directory '/home/chrysn/git/crates/c2rust/target/debug/build/c2rust-ast-exporter-5a9dd5744cfadeb6/out/build/tinycbor/src/tinycbor_build'
open_memstream-tested := 1
[...]
freestanding-tested := 1
make[6]: Leaving directory '/home/chrysn/git/crates/c2rust/target/debug/build/c2rust-ast-exporter-5a9dd5744cfadeb6/out/build/tinycbor/src/tinycbor_build'
```

and can not be properly processed later.

This patch changes the workaround so that tinycbor's OUT variable is still used; the file is unlinked and then appended to in tinycbor Makefile.configure.

### Testing

To reproduce, place this in c2rust/Makefile

```
all:
	cargo build
```

and compare

* `cd c2rust && cargo build`: works both before and after
* `cd c2rust && make`: works after; before, gives an error containing:

```
  make[5]: *** No rule to make target 'Entering', needed by 'make[6]'.  Stop.
```