### PR TITLE
include git information in --version using git-testament

### DIFF
--- a/c2rust/Cargo.toml
+++ b/c2rust/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4"
 env_logger = "0.7"
 regex = "1.3"
 shlex = "0.1"
+git-testament = "0.2.1"
 c2rust-transpile = { version = "0.15.1", path = "../c2rust-transpile" }
 
 [build-dependencies]

--- a/c2rust/src/main.rs
+++ b/c2rust/src/main.rs
@@ -1,14 +1,17 @@
-#[macro_use(crate_version, crate_authors, load_yaml)]
+#[macro_use(crate_authors, load_yaml)]
 extern crate clap;
 use clap::{App, AppSettings, SubCommand};
 use std::env;
 use std::ffi::OsStr;
 use std::process::{exit, Command};
+use git_testament::{git_testament, render_testament};
+
+git_testament!(TESTAMENT);
 
 fn main() {
     let subcommand_yamls = [load_yaml!("transpile.yaml")];
     let matches = App::new("C2Rust")
-        .version(crate_version!())
+        .version(&*render_testament!(TESTAMENT))
         .author(crate_authors!(", "))
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommands(


### PR DESCRIPTION
addresses #388

example output:
```
$ cargo run --bin c2rust -- --version
C2Rust 0.15.1 :: cross-checks+133 (8dd651840 2022-05-09)
```