### PR TITLE
asm: Ignore the `i` constraint

### DIFF
--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -142,6 +142,11 @@ fn parse_constraints(
         "r" => {
             constraints = "reg".into();
         }
+        "i" => {
+            // Rust inline assembly has no constraint for that, but uses the argument as an
+            // immediate value anyway
+            constraints = "reg".into();
+        }
         _ => {
             let is_explicit_reg = constraints.starts_with('"');
             let is_tied = !constraints.contains(|c: char| !c.is_ascii_digit());
@@ -271,9 +276,6 @@ fn translate_machine_constraint(constraint: &str, arch: Arch) -> Option<(&str, b
         },
         Arch::Riscv => match constraint {
             "f" => "freg",
-            /* Rust inline assembly has no constraint for that, but uses the argument as an
-            * immediate value anyway */
-            "i" => "reg",
             _ => return None,
         },
     };

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -271,6 +271,9 @@ fn translate_machine_constraint(constraint: &str, arch: Arch) -> Option<(&str, b
         },
         Arch::Riscv => match constraint {
             "f" => "freg",
+            /* Rust inline assembly has no constraint for that, but uses the argument as an
+            * immediate value anyway */
+            "i" => "reg",
             _ => return None,
         },
     };


### PR DESCRIPTION
RISC-V code that contains things like

```c
    __asm__ volatile (
        "csrrc %[dest], mstatus, %[mask]"
        :[dest]    "=r" (state)
        :[mask]    "i" (MSTATUS_MIE)
        : "memory"
        );
```

currently doesn't recognize the `i` constraint, and turns the code into

```rust
    asm!(
        "csrrc {0}, mstatus, {1}", lateout(reg) state, inlateout(i) MSTATUS_MIE => _,
        options(preserves_flags)
    );
```

which fails to compile with errors like

```
error: invalid register class `i`: unknown register class
    --> .../out/riot_c2rust_replaced.rs:1576:56
     |
1576 |         "csrrc {0}, mstatus, {1}", lateout(reg) state, inlateout(i) MSTATUS_MIE => _,
     |       
```

The attached patch ignores the `i` constraint -- [according to GCC docs](https://gcc.gnu.org/onlinedocs/gcc/Simple-Constraints.html#Simple-Constraints) it means "An immediate integer operand (one with constant value) is allowed". The Rust assembly not only has no constraint for that, it appears to allow that by default -- after applying that patch, it generated code like `csrrci	s3,mstatus,8` which is the immediate version of `csrrc`.