### PR TITLE
Fix warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,13 +134,11 @@ name = "c2rust"
 version = "0.16.0"
 dependencies = [
  "c2rust-transpile",
- "chrono",
  "clap",
  "env_logger",
  "git-testament",
  "log",
  "regex",
- "rustc_version",
  "shlex",
 ]
 
@@ -257,19 +255,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time 0.1.44",
- "winapi",
-]
 
 [[package]]
 name = "clang-sys"
@@ -436,7 +421,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "time 0.3.9",
+ "time",
 ]
 
 [[package]]
@@ -599,25 +584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,15 +726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,12 +736,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "semver"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 
 [[package]]
 name = "serde"
@@ -935,17 +886,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
@@ -991,12 +931,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "which"

--- a/c2rust-ast-printer/src/pprust.rs
+++ b/c2rust-ast-printer/src/pprust.rs
@@ -55,8 +55,8 @@ impl Comments {
 
     pub fn trailing_comment(
         &mut self,
-        span: proc_macro2::Span,
-        next_pos: Option<usize>,
+        _span: proc_macro2::Span,
+        _next_pos: Option<usize>,
     ) -> Option<String> {
         /*if let Some(cmnt) = self.next() {
             if cmnt.style != comments::Trailing { return None; }

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -1894,7 +1894,8 @@ impl ConversionContext {
                         .expect("Expected attribute array on var decl");
 
                     assert!(has_static_duration || has_thread_duration || !is_externally_visible,
-                            format!("Variable cannot be extern without also being static or thread-local: {}", ident));
+                            "Variable cannot be extern without also being static or thread-local: {}",
+                            ident);
 
                     let initializer = node
                         .children
@@ -1957,7 +1958,7 @@ impl ConversionContext {
                         None
                     };
 
-                    let mut is_packed = has_packed_attribute(attrs);
+                    let is_packed = has_packed_attribute(attrs);
 
                     let record = CDeclKind::Struct {
                         name,
@@ -1995,7 +1996,7 @@ impl ConversionContext {
                         None
                     };
 
-                    let mut is_packed = has_packed_attribute(attrs);
+                    let is_packed = has_packed_attribute(attrs);
 
                     let record = CDeclKind::Union {
                         name,

--- a/c2rust-transpile/src/compile_cmds/mod.rs
+++ b/c2rust-transpile/src/compile_cmds/mod.rs
@@ -20,10 +20,11 @@ pub struct CompileCmd {
     /// to rerun the exact compilation step for the translation unit in the environment
     /// the build system uses. Parameters use shell quoting and shell escaping of quotes,
     /// with ‘"’ and ‘\’ being the only special characters. Shell expansion is not supported.
-    command: Option<String>,
+    #[serde(skip_deserializing)]
+    _command: Option<String>,
     /// The compile command executed as list of strings. Either arguments or command is required.
-    #[serde(default)]
-    arguments: Vec<String>,
+    #[serde(default, skip_deserializing)]
+    _arguments: Vec<String>,
     /// The name of the output created by this compilation step. This field is optional. It can
     /// be used to distinguish different processing modes of the same input file.
     output: Option<String>,

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -388,7 +388,7 @@ fn get_extra_args_macos() -> Vec<String> {
     args
 }
 
-fn invoke_refactor(build_dir: &PathBuf) -> Result<(), Error> {
+fn invoke_refactor(_build_dir: &PathBuf) -> Result<(), Error> {
     return Ok(());
 }
 

--- a/c2rust-transpile/src/rust_ast/mod.rs
+++ b/c2rust-transpile/src/rust_ast/mod.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 static SPAN_LIMIT: AtomicU32 = AtomicU32::new(0);
 
-fn raise_span_limit(new_limit: u32) {
+fn raise_span_limit(_new_limit: u32) {
     let limit = SPAN_LIMIT.load(Ordering::Relaxed);
     let new_limit = 0x2000000;
     if new_limit >= limit {

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -376,7 +376,7 @@ fn rewrite_reserved_reg_operands(
     for (idx, reg, mods) in rewrite_idxs {
         let operand = &mut operands[idx];
         let name = format!("restmp{}", n_moved);
-        if let Some((_idx, in_expr)) = operand.in_expr {
+        if let Some((_idx, _in_expr)) = operand.in_expr {
             let move_input = if att_syntax {
                 format!("mov %{}, {{{}:{}}}\n", reg, name, mods)
             } else {
@@ -384,7 +384,7 @@ fn rewrite_reserved_reg_operands(
             };
             prolog.push_str(&move_input);
         }
-        if let Some((_idx, out_expr)) = operand.out_expr {
+        if let Some((_idx, _out_expr)) = operand.out_expr {
             let move_output = if att_syntax {
                 format!("\nmov {{{}:{}}}, %{}", name, mods, reg)
             } else {
@@ -555,7 +555,7 @@ fn rewrite_asm<F: Fn(&str) -> bool, M: Fn(usize) -> usize>(
             if let Some(end_idx) = chunk.find('}') {
                 let ref_str = &chunk[..end_idx];
                 if let Some(colon_idx) = ref_str.find(':') {
-                    let (before_mods, modifiers) = ref_str.split_at(colon_idx + 1);
+                    let (before_mods, _modifiers) = ref_str.split_at(colon_idx + 1);
                     out.push_str("{");
                     let idx: usize = before_mods
                         .trim_matches(|c: char| !c.is_ascii_digit())
@@ -720,7 +720,7 @@ impl<'c> Translation<'c> {
         let mut inputs_by_register = HashMap::new();
         let mut other_inputs = Vec::new();
         for (i, input) in inputs.iter().enumerate() {
-            let (_dir_spec, mem_only, parsed) = parse_constraints(&input.constraints, arch)?;
+            let (_dir_spec, _mem_only, parsed) = parse_constraints(&input.constraints, arch)?;
             // Only pair operands with an explicit register or index
             if is_regname_or_int(&*parsed) {
                 inputs_by_register.insert(parsed, (i, input.clone()));
@@ -820,7 +820,7 @@ impl<'c> Translation<'c> {
                     out_expr = mk().mutbl().addr_of_expr(out_expr);
                 }
 
-                if let Some(tied_operand) = tied_operands.get(&(output_idx, true)) {
+                if let Some(_tied_operand) = tied_operands.get(&(output_idx, true)) {
                     // If we have an input operand tied to an output operand,
                     // we need to replicate clang's behavior: the inline assembly
                     // uses the larger type internally, and the smaller value gets

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -28,7 +28,7 @@ impl<'c> Translation<'c> {
     pub fn enum_for_i64(&self, enum_type_id: CTypeId, value: i64) -> Box<Expr> {
         let def_id = match self.ast_context.resolve_type(enum_type_id).kind {
             CTypeKind::Enum(def_id) => def_id,
-            _ => panic!("{:?} does not point to an `enum` type"),
+            _ => panic!("{:?} does not point to an `enum` type", enum_type_id),
         };
 
         let (variants, underlying_type_id) = match self.ast_context[def_id].kind {
@@ -37,7 +37,7 @@ impl<'c> Translation<'c> {
                 integral_type,
                 ..
             } => (variants, integral_type),
-            _ => panic!("{:?} does not point to an `enum` declaration"),
+            _ => panic!("{:?} does not point to an `enum` declaration", def_id),
         };
 
         for &variant_id in variants {
@@ -104,7 +104,6 @@ impl<'c> Translation<'c> {
             }
 
             CLiteral::Floating(val, ref c_str) => {
-                let mut bytes: Vec<u8> = vec![];
                 let str = if c_str.is_empty() {
                     let mut buffer = dtoa::Buffer::new();
                     buffer.format(val).to_string()

--- a/c2rust/Cargo.toml
+++ b/c2rust/Cargo.toml
@@ -24,10 +24,6 @@ regex = "1.3"
 shlex = "1.1"
 c2rust-transpile = { version = "0.16.0", path = "../c2rust-transpile" }
 
-[build-dependencies]
-rustc_version = "0.4"
-chrono = "0.4"
-
 [features]
 # Force static linking of LLVM
 llvm-static = ["c2rust-transpile/llvm-static"]

--- a/c2rust/build.rs
+++ b/c2rust/build.rs
@@ -2,9 +2,6 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
-use chrono::{Duration, NaiveDate};
-use rustc_version::Channel;
-
 fn main() {
     let sysroot = Command::new(env::var("RUSTC").unwrap())
         .arg("--print=sysroot")

--- a/c2rust/src/main.rs
+++ b/c2rust/src/main.rs
@@ -51,7 +51,7 @@ where
     let mut cmd_path = cmd_path.as_path().canonicalize().unwrap();
     cmd_path.pop(); // remove current executable
     cmd_path.push(format!("c2rust-{}", subcommand));
-    assert!(cmd_path.exists(), format!("{:?} is missing", cmd_path));
+    assert!(cmd_path.exists(), "{:?} is missing", cmd_path);
     exit(
         Command::new(cmd_path.into_os_string())
             .args(args)


### PR DESCRIPTION
Builds should complete cleanly so it is easier to spot new warnings and potential issues.