### PR TITLE
Sketching some more pdg construction

### DIFF
--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -1,8 +1,9 @@
-use crate::graph::{Graph, Graphs, Node, NodeKind};
+use crate::graph::{Graph, GraphId, Graphs, Node, NodeId, NodeKind};
 use bincode;
 use c2rust_analysis_rt::events::{Event, EventKind};
 use c2rust_analysis_rt::mir_loc::Metadata;
 use rustc_middle::mir::Field;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
 
@@ -24,6 +25,32 @@ pub fn read_metadata(path: String) -> Metadata {
     bincode::deserialize_from(file).unwrap()
 }
 
+/** return the ptr referenced by an EventKind */
+fn get_ptr(kind: &EventKind) -> Option<&usize> {
+    Some(match kind {
+        EventKind::Copy(ptr) => ptr,
+        EventKind::Field(ptr, id) => ptr,
+        EventKind::Alloc { size, ptr } => ptr,
+        EventKind::Free { ptr } => ptr,
+        EventKind::Realloc { old_ptr, size, new_ptr } => old_ptr,
+        EventKind::Arg(ptr) => ptr,
+        EventKind::Ret(ptr) => ptr,
+        EventKind::Done => return None,
+        EventKind::LoadAddr(ptr) => ptr,
+        EventKind::StoreAddr(ptr) => ptr,
+    })
+}
+
+/** return the new ptr created by an EventKind */
+fn get_new_ptr(kind: &EventKind) -> Option<&usize> {
+    Some(match kind {
+        EventKind::Field(ptr, id) => todo!("ptr + id to offset"),
+        EventKind::Alloc { size, ptr } => ptr,
+        EventKind::Realloc { new_ptr, .. } => new_ptr,
+        _ => return None,
+    })
+}
+
 pub fn event_to_node_kind(event: &Event) -> Option<NodeKind> {
     match event.kind {
         EventKind::Alloc { .. } => Some(NodeKind::Malloc(1)),
@@ -37,30 +64,48 @@ pub fn event_to_node_kind(event: &Event) -> Option<NodeKind> {
     }
 }
 
-pub fn add_node(graphs: &mut Graphs, event: &Event) {
-    let node_kind = event_to_node_kind(event);
-    /* search for existing object */
+pub fn add_node(graphs: &mut Graphs, origins: &mut HashMap<NodeId, GraphId>, provenances: &mut HashMap<usize, NodeId>, event: &Event) -> Option<NodeId> {
+    let node_kind = match event_to_node_kind(event) {
+        Some(kind) => kind,
+        None => return None,
+    };
+    let (function, block, index) = todo!("event.mir_loc");
+    let source = get_ptr(&event.kind).and_then(|p| provenances.get(p)).cloned();
 
-    /* if no existing object, construct new object with event */
+    let node = Node {
+        function,
+        block,
+        index,
+        kind: node_kind,
+        source,
+        dest: todo!("event.dest"),
+    };
 
-    /*
-        if existing object, add to tree, point back to node that created the input
-            - for copy, point to the thing being copied
-            - for field, point to the base
-            - for offset, point to the base
-            - for free, point to
-    */
-    match event.kind {
-        e @ (EventKind::Alloc { .. } | EventKind::Realloc { .. }) => (),
-        _ => (),
+    let node_id = {
+        let graph_id = source.and_then(|source_node_id| {
+            /* search for existing graph */
+            origins.get(&source_node_id).cloned()
+        });
+        let graph_id = graph_id.unwrap_or_else(|| {
+            /* if no existing object, construct new graph */
+            graphs.graphs.push(Graph::new())
+        });
+        graphs.graphs[graph_id].nodes.push(node)
+    };
+
+    if let Some(&ptr) = get_new_ptr(&event.kind) {
+        provenances.insert(ptr, node_id);
     }
+    Some(node_id)
 }
 
 pub fn construct_pdg(events: &Vec<Event>) -> Graphs {
     let mut graphs = Graphs::new();
 
+    let mut origins = HashMap::<NodeId, GraphId>::new();
+    let mut provenances = HashMap::<usize, NodeId>::new();
     for event in events {
-        add_node(&mut graphs, event)
+        add_node(&mut graphs, &mut origins, &mut provenances, event);
     }
 
     graphs

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -26,7 +26,15 @@ pub struct Graph {
     /// The nodes in the graph.  Nodes are stored in increasing order by timestamp.  The first
     /// node, called the "root node", creates the object described by this graph, and all other
     /// nodes are derived from it.
-    nodes: IndexVec<NodeId, Node>,
+    pub nodes: IndexVec<NodeId, Node>,
+}
+
+impl Graph {
+    pub fn new() -> Graph {
+        Graph {
+            nodes: IndexVec::new(),
+        }
+    }
 }
 
 /// A node in the graph represents an operation on pointers.  It may produce a pointer from
@@ -44,22 +52,22 @@ pub struct Node {
     /// place to the caller's destination local is attributed to the `Call` terminator in the
     /// caller.  This way, the combination of `function` and `dest` accurately identifies the local
     /// modified by the operation.
-    function: DefPathHash,
+    pub function: DefPathHash,
     /// The basic block that contains this operation.
-    block: BasicBlock,
+    pub block: BasicBlock,
     /// The index within the basic block of the MIR statement or terminator that performed this
     /// operation.  As in `rustc_middle::mir::Location`, an index less than the number of
     /// statements in the block refers to that statement, and an index equal to the number of
     /// statements refers to the terminator.
-    index: usize,
+    pub index: usize,
     /// The MIR local where this operation stores its result.  This is `None` for operations that
     /// don't store anything and for operations whose result is a temporary not visible as a MIR
     /// local.
-    dest: Option<Local>,
+    pub dest: Option<Local>,
     /// The kind of operation that was performed.
-    kind: NodeKind,
+    pub kind: NodeKind,
     /// The `Node` that produced the input to this operation.
-    source: Option<NodeId>,
+    pub source: Option<NodeId>,
 }
 
 pub enum NodeKind {
@@ -110,7 +118,7 @@ pub enum NodeKind {
 pub struct Graphs {
     /// The graphs.  Each graph describes one object, or one group of objects that were all handled
     /// identically.
-    graphs: IndexVec<GraphId, Graph>,
+    pub graphs: IndexVec<GraphId, Graph>,
 
     /// Lookup table for finding all nodes in all graphs that store to a particular MIR local.
     by_local: HashMap<(DefPathHash, Local), Vec<(GraphId, NodeId)>>,


### PR DESCRIPTION
This isn't quite what we want, e.g. we should have the values of `provenances` and the keys of `origins` be `GraphId`-qualified `NodeId`s, not standalone ones, but it's a gesture at what I think we need to do as we see events.