### PR TITLE
Update simd.rs to Rust 1.58

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4589,7 +4589,7 @@ impl<'c> Translation<'c> {
                 .implicit_default_expr(inner, is_static)?
                 .map(|val| vec_expr(val, count)))
         } else if let &CTypeKind::Vector(CQualTypeId { ctype, .. }, len) = resolved_ty {
-            self.implicit_vector_default(ctype, len, is_static)
+            self.implicit_vector_default(ctype, len, is_static).map_err(Into::into)
         } else {
             Err(format_err!("Unsupported default initializer: {:?}", resolved_ty).into())
         }

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -11,22 +11,20 @@ use crate::c_ast::CTypeKind::{Char, Double, Float, Int, LongLong, Short};
 
 use super::*;
 
-/// As of rustc 1.29, rust is known to be missing some SIMD functions.
+/// As of rustc 1.58, rust is known to be missing some SIMD functions.
 /// See https://github.com/rust-lang-nursery/stdsimd/issues/579
-static MISSING_SIMD_FUNCTIONS: [&str; 36] = [
+static MISSING_SIMD_FUNCTIONS: &[&str] = &[
     "_mm_and_si64",
     "_mm_andnot_si64",
     "_mm_cmpeq_pi16",
     "_mm_cmpeq_pi32",
     "_mm_cmpeq_pi8",
     "_mm_cvtm64_si64",
-    "_mm_cvtph_ps",
     "_mm_cvtsi32_si64",
     "_mm_cvtsi64_m64",
     "_mm_cvtsi64_si32",
     "_mm_empty",
     "_mm_free",
-    "_mm_loadu_si64",
     "_mm_madd_pi16",
     "_mm_malloc",
     "_mm_mulhi_pi16",

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -173,12 +173,8 @@ impl<'c> Translation<'c> {
                 ))?;
             }
 
-            // The majority of x86/64 SIMD is stable, however there are still some
-            // bits that are behind a feature gate.
-            self.use_feature("stdsimd");
-
             self.with_cur_file_item_store(|item_store| {
-                let std_or_core = if self.tcfg.emit_no_std { "core" } else { "std" }.to_string();
+                let std_or_core = if self.tcfg.emit_no_std { "core" } else { "std" };
 
                 // REVIEW: Also a linear lookup
                 if !SIMD_X86_64_ONLY.contains(&name) {
@@ -193,7 +189,7 @@ impl<'c> Translation<'c> {
                         .pub_();
 
                     item_store.add_use_with_attr(
-                        vec![std_or_core.clone(), "arch".into(), "x86".into()],
+                        vec![std_or_core.to_owned(), "arch".into(), "x86".into()],
                         name,
                         x86_attr,
                     );
@@ -212,7 +208,7 @@ impl<'c> Translation<'c> {
                     .pub_();
 
                 item_store.add_use_with_attr(
-                    vec![std_or_core, "arch".into(), "x86_64".into()],
+                    vec![std_or_core.to_owned(), "arch".into(), "x86_64".into()],
                     name,
                     x86_64_attr,
                 );


### PR DESCRIPTION
Removed stabilized intrinsics from the list of missing functions, added hard error on removed `__m64` intrinsics, removed unused feature flag.