### PR TITLE
Keep original label names from C code

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -7,6 +7,7 @@ use std::fmt::{self, Debug, Display};
 use std::mem;
 use std::ops::Index;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 pub use c2rust_ast_exporter::clang_ast::{BuiltinVaListKind, SrcFile, SrcLoc, SrcSpan};
 
@@ -65,6 +66,9 @@ pub struct TypedAstContext {
     // sequence of #include statement locations and the file being included at
     // that location.
     include_map: Vec<Vec<SrcLoc>>,
+
+    // Names of the labels defined in the C source code.
+    pub label_names: IndexMap<CLabelId, Rc<str>>,
 
     // map expressions to the stack of macros they were expanded from
     pub macro_invocations: HashMap<CExprId, Vec<CDeclId>>,
@@ -178,6 +182,7 @@ impl TypedAstContext {
             macro_invocations: HashMap::new(),
             macro_expansions: HashMap::new(),
             macro_expansion_text: HashMap::new(),
+            label_names: Default::default(),
 
             comments: vec![],
             prenamed_decls: IndexMap::new(),

--- a/c2rust-transpile/src/cfg/loops.rs
+++ b/c2rust-transpile/src/cfg/loops.rs
@@ -54,7 +54,7 @@ pub fn match_loop_body(
             desired_body.swap_remove(&following);
 
             follow_entries.swap_remove(&following);
-            follow_entries.extend(&bb.successors());
+            follow_entries.extend(bb.successors());
             follow_entries.retain(|e| !body_blocks.contains_key(e));
             body_blocks.insert(following, bb);
         }
@@ -88,7 +88,7 @@ pub fn heuristic_loop_body(
 ) -> () {
     if follow_entries.len() > 1 {
         for follow_entry in follow_entries.clone().iter() {
-            let mut following: Label = *follow_entry;
+            let mut following: Label = follow_entry.clone();
 
             loop {
                 // If this block might have come from 2 places, give up
@@ -104,16 +104,16 @@ pub fn heuristic_loop_body(
                 };
                 let succs = bb.successors();
 
-                body_blocks.insert(following, bb);
+                body_blocks.insert(following.clone(), bb);
                 follow_entries.swap_remove(&following);
-                follow_entries.extend(&succs);
+                follow_entries.extend(succs.clone());
 
                 // If it has more than one successor, don't try following the successor
                 if succs.len() != 1 {
                     break;
                 }
 
-                following = *succs.iter().next().unwrap();
+                following = succs.iter().next().unwrap().clone();
             }
         }
     }

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -54,7 +54,7 @@ use crate::cfg::loops::*;
 use crate::cfg::multiples::*;
 
 /// These labels identify basic blocks in a regular CFG.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum Label {
     /// Some labels come directly from the C side (namely those created from labels, cases, and
     /// defaults). For those, we just re-use the `CLabelId` of the C AST node.
@@ -289,7 +289,7 @@ impl<S1, S2> BasicBlock<StructureLabel<S1>, S2> {
             .get_labels()
             .iter()
             .filter_map(|&slbl| match slbl {
-                &StructureLabel::GoTo(tgt) => Some(tgt),
+                StructureLabel::GoTo(tgt) => Some(tgt.clone()),
                 _ => None,
             })
             .collect()
@@ -524,7 +524,7 @@ impl<L: Serialize + Ord + Hash, St: Serialize> Serialize for Cfg<L, St> {
 
 /// Reaching the end of a body without encountering a `return` means different things depending on
 /// the function we are in.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub enum ImplicitReturnType {
     /// The `main` function implicitly returns `0`
     Main,
@@ -572,16 +572,16 @@ impl Cfg<Label, StmtOrDecl> {
         }
 
         let mut cfg_builder = CfgBuilder::new(c_label_to_goto);
-        let entry = cfg_builder.entry;
+        let entry = cfg_builder.entry.clone();
         cfg_builder.per_stmt_stack.push(PerStmt::new(
             stmt_ids.get(0).cloned(),
-            entry,
+            entry.clone(),
             IndexSet::new(),
         ));
 
         translator.with_scope(|| -> Result<(), TranslationError> {
             let body_exit =
-                cfg_builder.convert_stmts_help(translator, ctx, stmt_ids, Some(ret), entry)?;
+                cfg_builder.convert_stmts_help(translator, ctx, stmt_ids, Some(ret.clone()), entry)?;
 
             if let Some(body_exit) = body_exit {
                 let mut wip = cfg_builder.new_wip_block(body_exit);
@@ -652,12 +652,12 @@ use std::fmt::Debug;
 
 /// The polymorphism here is only to make it clear exactly how little these functions need to know
 /// about the actual contents of the CFG - we only actual call these on one monomorphic CFG type.
-impl<Lbl: Copy + Ord + Hash + Debug, Stmt> Cfg<Lbl, Stmt> {
+impl<Lbl: Clone + Ord + Hash + Debug, Stmt> Cfg<Lbl, Stmt> {
     /// Removes blocks that cannot be reached from the CFG
     pub fn prune_unreachable_blocks_mut(&mut self) -> () {
         let visited: IndexSet<Lbl> = {
             let mut visited: IndexSet<Lbl> = IndexSet::new();
-            let mut to_visit: Vec<Lbl> = vec![self.entries];
+            let mut to_visit: Vec<Lbl> = vec![self.entries.clone()];
 
             while let Some(lbl) = to_visit.pop() {
                 if visited.contains(&lbl) {
@@ -673,7 +673,7 @@ impl<Lbl: Copy + Ord + Hash + Debug, Stmt> Cfg<Lbl, Stmt> {
 
                 for lbl in blk.terminator.get_labels() {
                     if !visited.contains(lbl) {
-                        to_visit.push(*lbl);
+                        to_visit.push(lbl.clone());
                     }
                 }
             }
@@ -694,14 +694,14 @@ impl<Lbl: Copy + Ord + Hash + Debug, Stmt> Cfg<Lbl, Stmt> {
         let mut proposed_rewrites: IndexMap<Lbl, Lbl> = self
             .nodes
             .iter()
-            .filter_map(|(lbl, bb)| Cfg::empty_bb(bb).map(|tgt| (*lbl, tgt)))
+            .filter_map(|(lbl, bb)| Cfg::empty_bb(bb).map(|tgt| (lbl.clone(), tgt)))
             .collect();
 
         // Rewrites to actually apply. Keys are labels to basic blocks that were remapped into the
         // basic block corresponding to the value.
         let mut actual_rewrites: IndexMap<Lbl, Lbl> = IndexMap::new();
 
-        while let Some((from, to)) = proposed_rewrites.iter().map(|(f, t)| (*f, *t)).next() {
+        while let Some((from, to)) = proposed_rewrites.iter().map(|(f, t)| (f.clone(), t.clone())).next() {
             proposed_rewrites.swap_remove(&from);
             let mut from_any: IndexSet<Lbl> = indexset![from];
 
@@ -715,9 +715,9 @@ impl<Lbl: Copy + Ord + Hash + Debug, Stmt> Cfg<Lbl, Stmt> {
             // Check if there were already some rewrites applied
             let to_final = match actual_rewrites.get(&to_intermediate) {
                 None => to_intermediate,
-                Some(&to_final) => {
+                Some(to_final) => {
                     from_any.insert(to_intermediate);
-                    to_final
+                    to_final.clone()
                 }
             };
 
@@ -733,13 +733,13 @@ impl<Lbl: Copy + Ord + Hash + Debug, Stmt> Cfg<Lbl, Stmt> {
                         // target, don't delete it
                         continue;
                     }
-                    actual_rewrites.insert(from, to_final);
+                    actual_rewrites.insert(from, to_final.clone());
                 }
             }
         }
 
         // Apply the remaps to the entries
-        self.entries = *actual_rewrites.get(&self.entries).unwrap_or(&self.entries);
+        self.entries = actual_rewrites.get(&self.entries).unwrap_or(&self.entries).clone();
 
         // We keep only the basic blocks that weren't remapped to anything.
         self.nodes
@@ -749,7 +749,7 @@ impl<Lbl: Copy + Ord + Hash + Debug, Stmt> Cfg<Lbl, Stmt> {
         for bb in self.nodes.values_mut() {
             for lbl in bb.terminator.get_labels_mut() {
                 if let Some(new_lbl) = actual_rewrites.get(lbl) {
-                    *lbl = *new_lbl;
+                    *lbl = new_lbl.clone();
                 }
             }
         }
@@ -761,8 +761,8 @@ impl<Lbl: Copy + Ord + Hash + Debug, Stmt> Cfg<Lbl, Stmt> {
     /// Given an empty `BasicBlock` that ends in a `Jump`, return the target label. In all other
     /// cases, return `None`.
     fn empty_bb(bb: &BasicBlock<Lbl, Stmt>) -> Option<Lbl> {
-        match bb.terminator {
-            Jump(lbl) if bb.body.is_empty() => Some(lbl),
+        match &bb.terminator {
+            Jump(lbl) if bb.body.is_empty() => Some(lbl.clone()),
             _ => None,
         }
     }
@@ -1116,7 +1116,7 @@ struct WipBlock {
 }
 
 impl Extend<Stmt> for WipBlock {
-    fn extend<T: IntoIterator<Item = Stmt>>(&mut self, iter: T) {
+    fn extend<T: IntoIterator<Item=Stmt>>(&mut self, iter: T) {
         for stmt in iter.into_iter() {
             self.body.push(StmtOrDecl::Stmt(stmt))
         }
@@ -1157,7 +1157,7 @@ impl CfgBuilder {
             .last_mut()
             .expect("'per_stmt_stack' is empty")
             .nodes
-            .insert(lbl, bb)
+            .insert(lbl.clone(), bb)
         {
             None => {}
             Some(_) => panic!("Label {:?} cannot identify two basic blocks", lbl),
@@ -1165,10 +1165,10 @@ impl CfgBuilder {
 
         self.loops
             .last_mut()
-            .map(|&mut (_, ref mut loop_vec)| loop_vec.push(lbl));
+            .map(|&mut (_, ref mut loop_vec)| loop_vec.push(lbl.clone()));
         self.multiples
             .last_mut()
-            .map(|&mut (_, ref mut arm_vec)| arm_vec.push(lbl));
+            .map(|&mut (_, ref mut arm_vec)| arm_vec.push(lbl.clone()));
     }
 
     /// Create a basic block from a WIP block by tacking on the right terminator. Once this is done,
@@ -1216,7 +1216,7 @@ impl CfgBuilder {
         // Add the loop contents to the outer loop (if there is one)
         self.loops
             .last_mut()
-            .map(|&mut (_, ref mut outer_loop)| outer_loop.extend(loop_contents.iter()));
+            .map(|&mut (_, ref mut outer_loop)| outer_loop.extend(loop_contents.iter().cloned()));
 
         self.last_per_stmt_mut().loop_info.add_loop(
             loop_id,
@@ -1237,7 +1237,7 @@ impl CfgBuilder {
         // Add the arm contents to the outer arm (if there is one)
         self.multiples
             .last_mut()
-            .map(|&mut (_, ref mut outer_arm)| outer_arm.extend(arm_contents.iter()));
+            .map(|&mut (_, ref mut outer_arm)| outer_arm.extend(arm_contents.iter().cloned()));
 
         (arm_start, arm_contents.into_iter().collect())
     }
@@ -1336,7 +1336,7 @@ impl CfgBuilder {
                 // We feed the optional output label into the entry label of the next block
                 for stmt in stmt_ids {
                     let new_label: Label = lbl.unwrap_or(slf.fresh_label());
-                    let sub_in_tail = in_tail.filter(|_| Some(stmt) == last);
+                    let sub_in_tail = in_tail.clone().filter(|_| Some(stmt) == last);
                     lbl = slf.convert_stmt_help(translator, ctx, *stmt, sub_in_tail, new_label)?;
                 }
 
@@ -1370,9 +1370,9 @@ impl CfgBuilder {
         // Add to the per_stmt_stack
         let live_in: IndexSet<CDeclId> = self.currently_live.last().unwrap().clone();
         self.per_stmt_stack
-            .push(PerStmt::new(Some(stmt_id), entry, live_in));
+            .push(PerStmt::new(Some(stmt_id), entry.clone(), live_in));
 
-        let mut wip = self.new_wip_block(entry);
+        let mut wip = self.new_wip_block(entry.clone());
 
         wip.span = translator
             .get_span(SomeId::Stmt(stmt_id))
@@ -1419,7 +1419,7 @@ impl CfgBuilder {
                     let next_entry = self.fresh_label();
                     let then_entry = self.fresh_label();
                     let else_entry = if false_variant.is_none() {
-                        next_entry
+                        next_entry.clone()
                     } else {
                         self.fresh_label()
                     };
@@ -1434,37 +1434,37 @@ impl CfgBuilder {
                     self.add_wip_block(
                         wip,
                         match cond_val {
-                            Some(true) => Jump(then_entry),
-                            Some(false) => Jump(else_entry),
-                            None => Branch(val, then_entry, else_entry),
+                            Some(true) => Jump(then_entry.clone()),
+                            Some(false) => Jump(else_entry.clone()),
+                            None => Branch(val, then_entry.clone(), else_entry.clone()),
                         },
                     );
 
                     // Then case
-                    self.open_arm(then_entry);
+                    self.open_arm(then_entry.clone());
                     let then_stuff =
-                        self.convert_stmt_help(translator, ctx, true_variant, in_tail, then_entry)?;
+                        self.convert_stmt_help(translator, ctx, true_variant, in_tail.clone(), then_entry)?;
                     if let Some(then_end) = then_stuff {
                         let wip_then = self.new_wip_block(then_end);
-                        self.add_wip_block(wip_then, Jump(next_entry));
+                        self.add_wip_block(wip_then, Jump(next_entry.clone()));
                     }
                     let then_arm = self.close_arm();
 
                     // Else case
-                    self.open_arm(else_entry);
+                    self.open_arm(else_entry.clone());
                     if let Some(false_var) = false_variant {
                         let else_stuff = self
-                            .convert_stmt_help(translator, ctx, false_var, in_tail, else_entry)?;
+                            .convert_stmt_help(translator, ctx, false_var, in_tail.clone(), else_entry)?;
                         if let Some(else_end) = else_stuff {
                             let wip_else = self.new_wip_block(else_end);
-                            self.add_wip_block(wip_else, Jump(next_entry));
+                            self.add_wip_block(wip_else, Jump(next_entry.clone()));
                         }
                     };
                     let else_arm = self.close_arm();
 
                     self.last_per_stmt_mut()
                         .multiple_info
-                        .add_multiple(next_entry, vec![then_arm, else_arm]);
+                        .add_multiple(next_entry.clone(), vec![then_arm, else_arm]);
 
                     // Return
                     Ok(Some(self.new_wip_block(next_entry)))
@@ -1478,7 +1478,7 @@ impl CfgBuilder {
                     let body_entry = self.fresh_label();
                     let next_entry = self.fresh_label();
 
-                    self.add_wip_block(wip, Jump(cond_entry));
+                    self.add_wip_block(wip, Jump(cond_entry.clone()));
                     self.open_loop();
 
                     // Condition
@@ -1486,29 +1486,29 @@ impl CfgBuilder {
                         .convert_condition(ctx, true, condition)?
                         .discard_unsafe();
                     let cond_val = translator.ast_context[condition].kind.get_bool();
-                    let mut cond_wip = self.new_wip_block(cond_entry);
+                    let mut cond_wip = self.new_wip_block(cond_entry.clone());
                     cond_wip.extend(stmts);
 
                     self.add_wip_block(
                         cond_wip,
                         match cond_val {
-                            Some(true) => Jump(body_entry),
-                            Some(false) => Jump(next_entry),
-                            None => Branch(val, body_entry, next_entry),
+                            Some(true) => Jump(body_entry.clone()),
+                            Some(false) => Jump(next_entry.clone()),
+                            None => Branch(val, body_entry.clone(), next_entry.clone()),
                         },
                     );
 
                     // Body
                     let saw_unmatched_break = self.last_per_stmt_mut().saw_unmatched_break;
                     let saw_unmatched_continue = self.last_per_stmt_mut().saw_unmatched_continue;
-                    self.break_labels.push(next_entry);
-                    self.continue_labels.push(cond_entry);
+                    self.break_labels.push(next_entry.clone());
+                    self.continue_labels.push(cond_entry.clone());
 
                     let body_stuff =
-                        self.convert_stmt_help(translator, ctx, body_stmt, None, body_entry)?;
+                        self.convert_stmt_help(translator, ctx, body_stmt, None, body_entry.clone())?;
                     if let Some(body_end) = body_stuff {
                         let wip_body = self.new_wip_block(body_end);
-                        self.add_wip_block(wip_body, Jump(cond_entry));
+                        self.add_wip_block(wip_body, Jump(cond_entry.clone()));
                     }
 
                     self.last_per_stmt_mut().saw_unmatched_break = saw_unmatched_break;
@@ -1518,7 +1518,7 @@ impl CfgBuilder {
                     self.close_loop();
 
                     //Return
-                    Ok(Some(self.new_wip_block(next_entry)))
+                    Ok(Some(self.new_wip_block(next_entry.clone())))
                 }
 
                 CStmtKind::DoWhile {
@@ -1529,20 +1529,20 @@ impl CfgBuilder {
                     let cond_entry = self.fresh_label();
                     let next_entry = self.fresh_label();
 
-                    self.add_wip_block(wip, Jump(body_entry));
+                    self.add_wip_block(wip, Jump(body_entry.clone()));
                     self.open_loop();
 
                     // Body
                     let saw_unmatched_break = self.last_per_stmt_mut().saw_unmatched_break;
                     let saw_unmatched_continue = self.last_per_stmt_mut().saw_unmatched_continue;
-                    self.break_labels.push(next_entry);
-                    self.continue_labels.push(cond_entry);
+                    self.break_labels.push(next_entry.clone());
+                    self.continue_labels.push(cond_entry.clone());
 
                     let body_stuff =
-                        self.convert_stmt_help(translator, ctx, body_stmt, None, body_entry)?;
+                        self.convert_stmt_help(translator, ctx, body_stmt, None, body_entry.clone())?;
                     if let Some(body_end) = body_stuff {
                         let wip_body = self.new_wip_block(body_end);
-                        self.add_wip_block(wip_body, Jump(cond_entry));
+                        self.add_wip_block(wip_body, Jump(cond_entry.clone()));
                     }
 
                     self.last_per_stmt_mut().saw_unmatched_break = saw_unmatched_break;
@@ -1560,9 +1560,9 @@ impl CfgBuilder {
                     self.add_wip_block(
                         cond_wip,
                         match cond_val {
-                            Some(true) => Jump(body_entry),
-                            Some(false) => Jump(next_entry),
-                            None => Branch(val, body_entry, next_entry),
+                            Some(true) => Jump(body_entry.clone()),
+                            Some(false) => Jump(next_entry.clone()),
+                            None => Branch(val, body_entry, next_entry.clone()),
                         },
                     );
 
@@ -1586,7 +1586,7 @@ impl CfgBuilder {
 
                     self.with_scope(translator, |slf| -> Result<(), TranslationError> {
                         // Init
-                        slf.add_wip_block(wip, Jump(init_entry));
+                        slf.add_wip_block(wip, Jump(init_entry.clone()));
                         let init_stuff: Option<Label> = match init {
                             None => Some(init_entry),
                             Some(init) => {
@@ -1595,7 +1595,7 @@ impl CfgBuilder {
                         };
                         if let Some(init_end) = init_stuff {
                             let wip_init = slf.new_wip_block(init_end);
-                            slf.add_wip_block(wip_init, Jump(cond_entry));
+                            slf.add_wip_block(wip_init, Jump(cond_entry.clone()));
                         }
 
                         slf.open_loop();
@@ -1606,32 +1606,32 @@ impl CfgBuilder {
                                 .convert_condition(ctx, true, cond)?
                                 .discard_unsafe();
                             let cond_val = translator.ast_context[cond].kind.get_bool();
-                            let mut cond_wip = slf.new_wip_block(cond_entry);
+                            let mut cond_wip = slf.new_wip_block(cond_entry.clone());
                             cond_wip.extend(stmts);
                             slf.add_wip_block(
                                 cond_wip,
                                 match cond_val {
-                                    Some(true) => Jump(body_entry),
-                                    Some(false) => Jump(next_label),
-                                    None => Branch(val, body_entry, next_label),
+                                    Some(true) => Jump(body_entry.clone()),
+                                    Some(false) => Jump(next_label.clone()),
+                                    None => Branch(val, body_entry.clone(), next_label.clone()),
                                 },
                             );
                         } else {
-                            slf.add_block(cond_entry, BasicBlock::new_jump(body_entry));
+                            slf.add_block(cond_entry.clone(), BasicBlock::new_jump(body_entry.clone()));
                         }
 
                         // Body
                         let saw_unmatched_break = slf.last_per_stmt_mut().saw_unmatched_break;
                         let saw_unmatched_continue = slf.last_per_stmt_mut().saw_unmatched_continue;
-                        slf.break_labels.push(next_label);
-                        slf.continue_labels.push(incr_entry);
+                        slf.break_labels.push(next_label.clone());
+                        slf.continue_labels.push(incr_entry.clone());
 
                         let body_stuff =
                             slf.convert_stmt_help(translator, ctx, body, None, body_entry)?;
 
                         if let Some(body_end) = body_stuff {
                             let wip_body = slf.new_wip_block(body_end);
-                            slf.add_wip_block(wip_body, Jump(incr_entry));
+                            slf.add_wip_block(wip_body, Jump(incr_entry.clone()));
                         }
 
                         slf.last_per_stmt_mut().saw_unmatched_break = saw_unmatched_break;
@@ -1662,12 +1662,12 @@ impl CfgBuilder {
 
                 CStmtKind::Label(sub_stmt) => {
                     let this_label = Label::FromC(stmt_id);
-                    self.add_wip_block(wip, Jump(this_label));
+                    self.add_wip_block(wip, Jump(this_label.clone()));
                     self.last_per_stmt_mut().c_labels_defined.insert(stmt_id);
 
                     // Sub stmt
                     let sub_stmt_next =
-                        self.convert_stmt_help(translator, ctx, sub_stmt, in_tail, this_label)?;
+                        self.convert_stmt_help(translator, ctx, sub_stmt, in_tail.clone(), this_label)?;
                     Ok(sub_stmt_next.map(|l| self.new_wip_block(l)))
                 }
 
@@ -1694,12 +1694,12 @@ impl CfgBuilder {
 
                 CStmtKind::Compound(ref comp_stmts) => {
                     let comp_entry = self.fresh_label();
-                    self.add_wip_block(wip, Jump(comp_entry));
+                    self.add_wip_block(wip, Jump(comp_entry.clone()));
                     let next_lbl = self.convert_stmts_help(
                         translator,
                         ctx,
                         comp_stmts.as_slice(),
-                        in_tail,
+                        in_tail.clone(),
                         comp_entry,
                     )?;
 
@@ -1711,14 +1711,14 @@ impl CfgBuilder {
                     // We simply inline the common statement at this point rather
                     // than to try and create new control-flow blocks.
                     let blk_or_wip = if let CExprKind::Unary(_, UnOp::Extension, sube, _) =
-                        translator.ast_context[expr].kind
+                    translator.ast_context[expr].kind
                     {
                         if let CExprKind::Statements(_, stmtid) = translator.ast_context[sube].kind
                         {
                             let comp_entry = self.fresh_label();
-                            self.add_wip_block(wip, Jump(comp_entry));
+                            self.add_wip_block(wip, Jump(comp_entry.clone()));
                             let next_lbl = self
-                                .convert_stmt_help(translator, ctx, stmtid, in_tail, comp_entry)?;
+                                .convert_stmt_help(translator, ctx, stmtid, in_tail.clone(), comp_entry)?;
 
                             Ok(next_lbl.map(|l| self.new_wip_block(l)))
                         } else {
@@ -1749,10 +1749,14 @@ impl CfgBuilder {
 
                 CStmtKind::Break => {
                     self.last_per_stmt_mut().saw_unmatched_break = true;
-                    let tgt_label = *self.break_labels.last().ok_or(format_err!(
-                        "Cannot find what to break from in this ({:?}) 'break' statement",
-                        stmt_id,
-                    ))?;
+                    let tgt_label =
+                        self.break_labels
+                            .last()
+                            .ok_or(format_err!(
+                                "Cannot find what to break from in this ({:?}) 'break' statement",
+                                stmt_id,
+                            ))?
+                            .clone();
                     self.add_wip_block(wip, Jump(tgt_label));
 
                     Ok(None)
@@ -1760,10 +1764,14 @@ impl CfgBuilder {
 
                 CStmtKind::Continue => {
                     self.last_per_stmt_mut().saw_unmatched_continue = true;
-                    let tgt_label = *self.continue_labels.last().ok_or(format_err!(
-                        "Cannot find what to continue from in this ({:?}) 'continue' statement",
-                        stmt_id,
-                    ))?;
+                    let tgt_label =
+                        self.continue_labels
+                            .last()
+                            .ok_or(format_err!(
+                                "Cannot find what to continue from in this ({:?}) 'continue' statement",
+                                stmt_id,
+                            ))?
+                            .clone();
                     self.add_wip_block(wip, Jump(tgt_label));
 
                     Ok(None)
@@ -1772,7 +1780,7 @@ impl CfgBuilder {
                 CStmtKind::Case(case_expr, sub_stmt, cie) => {
                     self.last_per_stmt_mut().saw_unmatched_case = true;
                     let this_label = Label::FromC(stmt_id);
-                    self.add_wip_block(wip, Jump(this_label));
+                    self.add_wip_block(wip, Jump(this_label.clone()));
 
                     // Case
                     let resolved = translator.ast_context.resolve_expr(case_expr);
@@ -1802,29 +1810,29 @@ impl CfgBuilder {
                             stmt_id,
                         ))?
                         .cases
-                        .push((mk().lit_pat(branch), this_label));
+                        .push((mk().lit_pat(branch), this_label.clone()));
 
                     // Sub stmt
                     let sub_stmt_next =
-                        self.convert_stmt_help(translator, ctx, sub_stmt, in_tail, this_label)?;
+                        self.convert_stmt_help(translator, ctx, sub_stmt, in_tail.clone(), this_label)?;
                     Ok(sub_stmt_next.map(|l| self.new_wip_block(l)))
                 }
 
                 CStmtKind::Default(sub_stmt) => {
                     self.last_per_stmt_mut().saw_unmatched_default = true;
                     let this_label = Label::FromC(stmt_id);
-                    self.add_wip_block(wip, Jump(this_label));
+                    self.add_wip_block(wip, Jump(this_label.clone()));
 
                     // Default case
                     self.switch_expr_cases
                         .last_mut()
                         .expect("'default' outside of 'switch'")
                         .default
-                        .get_or_insert(this_label);
+                        .get_or_insert(this_label.clone());
 
                     // Sub stmt
                     let sub_stmt_next =
-                        self.convert_stmt_help(translator, ctx, sub_stmt, in_tail, this_label)?;
+                        self.convert_stmt_help(translator, ctx, sub_stmt, in_tail.clone(), this_label)?;
                     Ok(sub_stmt_next.map(|l| self.new_wip_block(l)))
                 }
 
@@ -1841,21 +1849,21 @@ impl CfgBuilder {
                         .discard_unsafe();
                     wip.extend(stmts);
 
-                    let wip_label = wip.label;
+                    let wip_label = wip.label.clone();
                     self.add_wip_block(wip, End); // NOTE: the `End` here is temporary and gets updated
 
                     // Body
                     let saw_unmatched_break = self.last_per_stmt_mut().saw_unmatched_break;
                     let saw_unmatched_case = self.last_per_stmt_mut().saw_unmatched_case;
                     let saw_unmatched_default = self.last_per_stmt_mut().saw_unmatched_default;
-                    self.break_labels.push(next_label);
+                    self.break_labels.push(next_label.clone());
                     self.switch_expr_cases.push(SwitchCases::default());
 
                     let body_stuff =
-                        self.convert_stmt_help(translator, ctx, switch_body, in_tail, body_label)?;
+                        self.convert_stmt_help(translator, ctx, switch_body, in_tail.clone(), body_label)?;
                     if let Some(body_end) = body_stuff {
                         let body_wip = self.new_wip_block(body_end);
-                        self.add_wip_block(body_wip, Jump(next_label));
+                        self.add_wip_block(body_wip, Jump(next_label.clone()));
                     }
 
                     self.last_per_stmt_mut().saw_unmatched_break = saw_unmatched_break;
@@ -1868,7 +1876,10 @@ impl CfgBuilder {
                         .expect("No 'SwitchCases' to pop");
 
                     let mut cases: Vec<_> = switch_case.cases.clone();
-                    cases.push((mk().wild_pat(), switch_case.default.unwrap_or(next_label)));
+                    cases.push((
+                        mk().wild_pat(),
+                        switch_case.default.unwrap_or(next_label.clone()),
+                    ));
 
                     // Add the condition basic block terminator (we need the information built up during
                     // the conversion of the body to make the right terminator)
@@ -1901,17 +1912,17 @@ impl CfgBuilder {
 
         let out_end = self.fresh_label();
         let out_wip: Option<WipBlock> = out_wip.map(|w| {
-            self.add_wip_block(w, GenTerminator::Jump(out_end));
+            self.add_wip_block(w, GenTerminator::Jump(out_end.clone()));
             self.new_wip_block(out_end)
         });
 
         // Is the CFG for this statement self contained so can we reloop it immediately?
         if translator.tcfg.incremental_relooper
             && self
-                .per_stmt_stack
-                .last()
-                .unwrap()
-                .is_contained(&self.c_label_to_goto, self.currently_live.last().unwrap())
+            .per_stmt_stack
+            .last()
+            .unwrap()
+            .is_contained(&self.c_label_to_goto, self.currently_live.last().unwrap())
         {
             self.incrementally_reloop_subgraph(translator, in_tail, entry, out_wip)
         } else {
@@ -1923,7 +1934,7 @@ impl CfgBuilder {
 
             Ok(out_wip.map(|w| {
                 let next_lbl = self.fresh_label();
-                self.add_wip_block(w, GenTerminator::Jump(next_lbl));
+                self.add_wip_block(w, GenTerminator::Jump(next_lbl.clone()));
                 next_lbl
             }))
         }
@@ -1956,13 +1967,16 @@ impl CfgBuilder {
         // Close off the `wip` using a `break` terminator
         let brk_lbl: Label = self.fresh_label();
 
-        let (tail_expr, use_brk_lbl) = match in_tail {
+        let (tail_expr, use_brk_lbl) = match in_tail.clone() {
             Some(ImplicitReturnType::Main) => (
                 mk().return_expr(Some(mk().lit_expr(mk().int_lit(0, "")))),
                 false,
             ),
 
-            Some(ImplicitReturnType::Void) => (mk().return_expr(None as Option<Box<Expr>>), false),
+            Some(ImplicitReturnType::Void) => (
+                mk().return_expr(None as Option<Box<Expr>>),
+                false,
+            ),
 
             _ => (
                 mk().break_expr_value(Some(brk_lbl.pretty_print()), None as Option<Box<Expr>>),
@@ -1972,7 +1986,7 @@ impl CfgBuilder {
 
         let fallthrough_id: Option<Label> = out_wip.map(|mut w| {
             w.push_stmt(mk().semi_stmt(tail_expr.clone()));
-            let id = w.label;
+            let id = w.label.clone();
             self.add_wip_block(w, GenTerminator::End);
             id
         });
@@ -2007,7 +2021,7 @@ impl CfgBuilder {
         // Remove unnecessary break statements. We only need a break statement if we failed to
         // remove the tail expr.
         let need_block =
-            stmts.is_empty() || !IncCleanup::new(in_tail, brk_lbl).remove_tail_expr(&mut stmts);
+            stmts.is_empty() || !IncCleanup::new(in_tail, brk_lbl.clone()).remove_tail_expr(&mut stmts);
 
         if has_fallthrough && need_block && use_brk_lbl {
             translator.use_feature("label_break_value");
@@ -2029,7 +2043,7 @@ impl CfgBuilder {
             }
         }
         flattened_wip.extend(stmts);
-        let term = if let Some(l) = next_lbl {
+        let term = if let Some(l) = next_lbl.clone() {
             GenTerminator::Jump(l)
         } else {
             GenTerminator::End
@@ -2176,7 +2190,7 @@ impl Cfg<Label, StmtOrDecl> {
             }
 
             // All the edges starting from this node
-            let edges: Vec<(String, Label)> = match bb.terminator {
+            let edges: Vec<(String, Label)> = match bb.terminator.clone() {
                 End => vec![],
                 Jump(tgt) => vec![(String::from(""), tgt)],
                 Branch(_, tru, fal) => {
@@ -2185,10 +2199,10 @@ impl Cfg<Label, StmtOrDecl> {
                 Switch { ref cases, .. } => {
                     let cases: Vec<(String, Label)> = cases
                         .iter()
-                        .map(|&(ref pat, tgt)| -> (String, Label) {
+                        .map(|(pat, tgt)| -> (String, Label) {
                             let pat: String = pprust::pat_to_string(pat.deref());
 
-                            (pat, tgt)
+                            (pat, tgt.clone())
                         })
                         .collect();
                     cases

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -232,38 +232,39 @@ fn structured_cfg_help<S: StructuredStatement<E = Box<Expr>, P = Box<Pat>, L = L
                     }
                 };
 
-                let mut branch = |slbl: &StructureLabel<Stmt>| -> Result<S, TranslationError> {
-                    match slbl {
-                        &StructureLabel::Nested(ref nested) => {
-                            structured_cfg_help(exits.clone(), next, nested, used_loop_labels)
-                        }
-
-                        &StructureLabel::GoTo(to) | &StructureLabel::ExitTo(to)
-                            if next.contains(&to) =>
-                        {
-                            Ok(insert_goto(to, &next))
-                        }
-
-                        &StructureLabel::ExitTo(to) => {
-                            let mut immediate = true;
-                            for &(label, ref local) in &exits {
-                                if let Some(&(ref follow, exit_style)) = local.get(&to) {
-                                    let lbl = if immediate {
-                                        None
-                                    } else {
-                                        used_loop_labels.insert(label);
-                                        Some(label)
-                                    };
-
-                                    let mut new_cfg = S::mk_append(
-                                        insert_goto(to, follow),
-                                        S::mk_exit(exit_style, lbl),
-                                    );
-                                    new_cfg.extend_span(*span);
-                                    return Ok(new_cfg);
-                                }
-                                immediate = false;
+                let mut branch =
+                    |slbl: &StructureLabel<Stmt>| -> Result<S, TranslationError> {
+                        match slbl {
+                            StructureLabel::Nested(ref nested) => {
+                                structured_cfg_help(exits.clone(), next, nested, used_loop_labels)
                             }
+
+                            StructureLabel::GoTo(to) | StructureLabel::ExitTo(to)
+                                if next.contains(to) =>
+                            {
+                                Ok(insert_goto(to.clone(), &next))
+                            }
+
+                            StructureLabel::ExitTo(to) => {
+                                let mut immediate = true;
+                                for (label, local) in &exits {
+                                    if let Some(&(ref follow, exit_style)) = local.get(to) {
+                                        let lbl = if immediate {
+                                            None
+                                        } else {
+                                            used_loop_labels.insert(label.clone());
+                                            Some(label.clone())
+                                        };
+
+                                        let mut new_cfg = S::mk_append(
+                                            insert_goto(to.clone(), follow),
+                                            S::mk_exit(exit_style, lbl),
+                                        );
+                                        new_cfg.extend_span(*span);
+                                        return Ok(new_cfg);
+                                    }
+                                    immediate = false;
+                                }
 
                             Err(
                                 format_err!("Not a valid exit: {:?} has nothing to exit to", to)
@@ -271,14 +272,14 @@ fn structured_cfg_help<S: StructuredStatement<E = Box<Expr>, P = Box<Pat>, L = L
                             )
                         }
 
-                        &StructureLabel::GoTo(to) => Err(format_err!(
-                            "Not a valid exit: {:?} (GoTo isn't falling through to {:?})",
-                            to,
-                            next
-                        )
-                        .into()),
-                    }
-                };
+                            StructureLabel::GoTo(to) => Err(format_err!(
+                                "Not a valid exit: {:?} (GoTo isn't falling through to {:?})",
+                                to,
+                                next
+                            )
+                            .into()),
+                        }
+                    };
 
                 new_rest = S::mk_append(
                     new_rest,
@@ -311,7 +312,7 @@ fn structured_cfg_help<S: StructuredStatement<E = Box<Expr>, P = Box<Pat>, L = L
                     .map(|(lbl, body)| -> Result<(Label, S), TranslationError> {
                         let stmts =
                             structured_cfg_help(exits.clone(), next, body, used_loop_labels)?;
-                        Ok((*lbl, stmts))
+                        Ok((lbl.clone(), stmts))
                     })
                     .collect::<Result<Vec<(Label, S)>, TranslationError>>()?;
 
@@ -333,16 +334,16 @@ fn structured_cfg_help<S: StructuredStatement<E = Box<Expr>, P = Box<Pat>, L = L
                 these_exits.extend(
                     entries
                         .iter()
-                        .map(|e| (*e, (entries.clone(), ExitStyle::Continue))),
+                        .map(|e| (e.clone(), (entries.clone(), ExitStyle::Continue))),
                 );
-                these_exits.extend(next.iter().map(|e| (*e, (next.clone(), ExitStyle::Break))));
+                these_exits.extend(next.iter().map(|e| (e.clone(), (next.clone(), ExitStyle::Break))));
 
-                let mut exits_new = vec![(*label, these_exits)];
+                let mut exits_new = vec![(label.clone(), these_exits)];
                 exits_new.extend(exits.clone());
 
                 let body = structured_cfg_help(exits_new, entries, body, used_loop_labels)?;
                 let loop_lbl = if used_loop_labels.contains(label) {
-                    Some(*label)
+                    Some(label.clone())
                 } else {
                     None
                 };

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4076,7 +4076,7 @@ impl<'c> Translation<'c> {
                 let result_id = substmt_ids[n - 1];
 
                 let name = format!("<stmt-expr_{:?}>", compound_stmt_id);
-                let lbl = cfg::Label::FromC(compound_stmt_id);
+                let lbl = cfg::Label::FromC(compound_stmt_id, None);
 
                 let mut stmts = match self.ast_context[result_id].kind {
                     CStmtKind::Expr(expr_id) => {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4080,7 +4080,7 @@ impl<'c> Translation<'c> {
 
                 let mut stmts = match self.ast_context[result_id].kind {
                     CStmtKind::Expr(expr_id) => {
-                        let ret = cfg::ImplicitReturnType::StmtExpr(ctx, expr_id, lbl);
+                        let ret = cfg::ImplicitReturnType::StmtExpr(ctx, expr_id, lbl.clone());
                         self.convert_function_body(ctx, &name, &substmt_ids[0..(n - 1)], ret)?
                     }
 


### PR DESCRIPTION
I have added an `Option<Rc<str>>` field to the `cfg::Label::FromC`. This allows to preserve the names of blocks which are provided in the C source, potentially increasing the readability of transpiled code and making it easier to match original and transpiled code blocks. The label names are used as control flow variable values when `--ddebug-labels` is enabled. Unfortunately, Relooper really likes to dump those names in the `_` branch of matches, bringing the automatic label names to the front. Still, there are some situations where the old labels can be traced in the transpiled code. This will also significantly increase readability if Relooper is changed to use labeled blocks & breaks instead of a match on variable: the C label names can be directly used as block label names.

I had to make Label non-Copy. This is not a painful transition, and arguably there was no reason to make it Copy in the first place, since it was likely to carry some non-Copy data.