### PR TITLE
Got `cargo run` to work from the top-level directory.

### DIFF
--- a/c2rust/Cargo.toml
+++ b/c2rust/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 categories = ["development-tools", "development-tools::ffi", "command-line-utilities"]
 keywords = ["transpiler", "migration", "translation", "c"]
 readme = "README.md"
+default-run = "c2rust"
 
 [badges]
 travis-ci = { repository = "immunant/c2rust" }


### PR DESCRIPTION
Added `default-run = "c2rust"` to the `c2rust/Cargo.toml` so that `cargo run` works out of the box.