### PR TITLE
`c2rust_transpile::transpile` can only be called once; this is starting to fix it.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +227,7 @@ dependencies = [
  "itertools",
  "libc",
  "log",
+ "log-reroute",
  "pathdiff",
  "proc-macro2",
  "regex",
@@ -541,6 +548,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "log-reroute"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741a3ba679a9a1d331319dda1c7d8f204e9f6760fd867e28576a45d17048bc02"
+dependencies = [
+ "arc-swap",
+ "log",
+ "once_cell",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +618,12 @@ checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "opaque-debug"

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -2712,7 +2712,6 @@ ExportResult *make_export_result(const Outputs &outputs) {
 // Extract clang AST for the source file specified in the argument vector.
 // Note: The arguments should only reference one source file at a time.
 Outputs process(int argc, const char *argv[], int *result) {
-    static uint64_t source_path_count = 0;
     auto argv_ = augment_argv(argc, argv);
     int argc_ = argv_.size() - 1; // ignore the extra nullptr
 
@@ -2729,9 +2728,14 @@ Outputs process(int argc, const char *argv[], int *result) {
 #endif
 
     // the logic below assumes we're only translating one source file
-    assert(OptionsParser.getSourcePathList().size() - 1 ==
-               source_path_count++ &&
-           "Expected exactly one source path");
+    static size_t source_path_count = 0;
+    source_path_count++;
+    const size_t num_sources = OptionsParser.getSourcePathList().size();
+    assert(
+        (num_sources == 1 // newer clang versions
+        || num_sources == source_path_count // older clang versions
+        ) && "Expected exactly one source path"
+    );
 
     // CommonOptionsParser is stateful so the vector returned by
     // getSourcePathList() includes paths from past invocations.

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -26,6 +26,7 @@ indexmap = { version = "1.0.1", features = ["serde-1"] }
 itertools = "0.10"
 libc = "0.2"
 log = "0.4"
+log-reroute = "0.1"
 pathdiff = "0.2"
 proc-macro2 = "1.0"
 regex = "1"

--- a/c2rust-transpile/src/diagnostics.rs
+++ b/c2rust-transpile/src/diagnostics.rs
@@ -30,7 +30,7 @@ pub fn init(mut enabled_warnings: HashSet<Diagnostic>, log_level: log::LevelFilt
     enabled_warnings.extend(DEFAULT_WARNINGS.iter().cloned());
 
     let colors = ColoredLevelConfig::new();
-    fern::Dispatch::new()
+    let (_log_level, logger) = fern::Dispatch::new()
         .format(move |out, message, record| {
             let level_label = match record.level() {
                 Level::Error => "error",
@@ -63,8 +63,8 @@ pub fn init(mut enabled_warnings: HashSet<Diagnostic>, log_level: log::LevelFilt
                 .unwrap_or(true)
         })
         .chain(io::stderr())
-        .apply()
-        .expect("Could not set up diagnostics");
+        .into_log();
+    log_reroute::reroute_boxed(logger);
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
`c2rust_transpile::transpile` is a public library function, so it can be called by anyone, but calling it more than once panics.  This is because it initializes a global, init-once logger.

This adds a dependency on `log_reroute` so that the new logger can be swapped in every time.  Alternatively, the logging logic could be moved out of the library and into only the binary, but that seems like more work than this simple `log_reroute` change.