### PR TITLE
Add Support for Testing Non-Native Targets

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -15,6 +15,8 @@ from typing import List, Callable
 
 import plumbum as pb
 
+from plumbum.machines import LocalCommand as Command
+
 
 class Colors:
     # Terminal escape codes
@@ -316,9 +318,6 @@ def _invoke(console_output, cmd, *arguments):
         msg = "cmd exited with code {}: {}".format(pee.retcode, cmd[arguments])
         logging.critical(pee.stderr)
         die(msg, pee.retcode)
-
-
-Command = pb.machines.LocalCommand
 
 
 def get_cmd_or_die(cmd: str) -> Command:

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -330,6 +330,17 @@ def get_cmd_or_die(cmd: str) -> Command:
         die("{} not in path".format(cmd), errno.ENOENT)
 
 
+def get_cmd_or_install(cmd: str, install_cmd: Command) -> Command:
+    """
+    lookup named command or install it first
+    """
+    try:
+        return pb.local[cmd]
+    except pb.CommandNotFound:
+        install_cmd()
+        return pb.local[cmd]
+
+
 def ensure_dir(path):
     if not os.path.exists(path):
         logging.debug("creating dir %s", path)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -9,3 +9,4 @@ pygments
 typing;python_version<"3.5"
 scan-build
 pyyaml
+ziglang

--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -2,6 +2,7 @@
 
 import errno
 import os
+from pathlib import Path
 import sys
 import logging
 import argparse
@@ -9,6 +10,7 @@ import re
 
 from common import (
     config as c,
+    get_cmd_or_install,
     pb,
     Colors,
     get_cmd_or_die,
@@ -33,11 +35,16 @@ from rust_file import (
 from typing import Generator, List, Optional, Set, Iterable
 
 # Tools we will need
+sudo = get_cmd_or_die("sudo")
 clang = get_cmd_or_die("clang")
 rustc = get_cmd_or_die("rustc")
 diff = get_cmd_or_die("diff")
 ar = get_cmd_or_die("ar")
+rustup = get_cmd_or_die("rustup")
 cargo = get_cmd_or_die("cargo")
+cargo_zigbuild = get_cmd_or_install("cargo-zigbuild", cargo["install", "cargo-zigbuild"])
+apt = get_cmd_or_die("apt")
+update_binfmts = get_cmd_or_install("update_binfmts", sudo[apt["install", "-y", "binfmt-support"]])
 
 
 # Intermediate files
@@ -489,21 +496,16 @@ class TestDirectory:
 
         # Try and build test binary
         with pb.local.cwd(self.full_path):
-            args = ["build"]
+            args = ["zigbuild"]
 
             if c.BUILD_TYPE == 'release':
                 args.append('--release')
 
             if self.target:
-                if not rustc_has_target(self.target):
-                    self.print_status(Colors.OKBLUE, "SKIPPED",
-                      "building test {} because the {} target is not installed"
-                      .format(self.name, self.target))
-                    sys.stdout.write('\n')
-                    return []
+                _retcode, _stdout, _stderr = rustup[["target", "add", self.target]].run(retcode=None)
                 args.append(["--target", self.target])
 
-            retcode, stdout, stderr = cargo[args].run(retcode=None)
+            retcode, stdout, stderr = cargo_zigbuild[args].run(retcode=None)
 
         if retcode != 0:
             _, main_file_path_short = os.path.split(main_file.path)
@@ -516,6 +518,27 @@ class TestDirectory:
 
             return outcomes
 
+        if self.target:
+            c_target = self.target.replace("-unknown", "")
+            
+            arch = self.target.split("-")[0]
+            qemu_arch = f"qemu-{arch}"
+            stdout = update_binfmts["--display", qemu_arch](retcode=None)
+            enable = sudo[update_binfmts["--enable", qemu_arch]]
+            if "enabled" in stdout:
+                pass
+            elif "disabled" in stdout:
+                enable()
+            else:
+                sudo[apt["install", "-y", "qemu-user", "qemu-user-static"]]()
+                enable()
+
+            qemu_ld_prefix = Path("/usr") / c_target
+            if not qemu_ld_prefix.exists():
+                sudo[apt["install", "-y", f"gcc-{c_target}"]]()
+        else:
+            qemu_ld_prefix = None
+
         for test_file in self.rs_test_files:
             if not test_file.pass_expected:
                 continue
@@ -524,13 +547,19 @@ class TestDirectory:
             extensionless_file_name, _ = os.path.splitext(file_name)
 
             for test_function in test_file.test_functions:
-                args = ["run", "{}::{}".format(extensionless_file_name, test_function.name)]
+                args = ["run"]
+
+                if self.target:
+                    args.append(["--target", self.target])
+                
+                args.append("{}::{}".format(extensionless_file_name, test_function.name))
 
                 if c.BUILD_TYPE == 'release':
                     args.append('--release')
 
                 with pb.local.cwd(self.full_path):
-                    retcode, stdout, stderr = cargo[args].run(retcode=None)
+                    with pb.local.env(QEMU_LD_PREFIX=qemu_ld_prefix):
+                        retcode, stdout, stderr = cargo_zigbuild[args].run(retcode=None)
 
                 logging.debug("stdout:%s\n", stdout)
 


### PR DESCRIPTION
Fixes https://github.com/immunant/c2rust/issues/410.

Added support to `scripts/test_translator.py` for cross-compiling using `cargo zigbuild` and `zig cc` and for emulation using `qemu`.

More specifically, `cargo zigbuild` is used in place of `cargo` for building and running the test crates.  It uses `zig cc` as the linker, which has seamless cross-compilation that just works.

`qemu` is used to emulate other targets and architectures.  These are small test programs, so this should be fine, and doing it this way allows all tests to be run locally, which is very convenient.

I wasn't sure how dependencies should be managed, but for this, I just had them installed in `test_translator.py` itself, assuming it's running Ubuntu Linux.  I assume there's a better way to do this that's more cross-platform, but I wasn't sure how to do that yet, so I just did it inline first to make things quick.  We can fix that next.

Specifically for dependencies,
* `cargo-zigbuild` is installed using `cargo install`
* `zig cc` is installed through `pip install ziglang` (added it to `requirements.txt`)
* `rustc` targets are installed through `rustup target add`
* `qemu` is installed through `apt` (`qemu-user`, `qemu-user-static`)
* `qemu` dynamic libraries are installed through `apt` (`gcc-${triple}`)
* `update-binfmts` (for enabling `qemu` `binfmt_misc` support) is installed through `apt` (`binfmt-support`)
* `qemu` `binfmt_misc` entries are added through `update-binfmts --enable`

Note, however, that the `asm.arm` and `asm.aarch64` tests, the ones I was trying to test, don't appear to work out of the box.  I'm not sure if the errors in them are due to something wrong in the cross compilation and emulation, are they are simply errors in the tests themselves since I assume they weren't being tested as regularly.  Specifically, `asm.arm` fails at runtime on an assertion, and `asm.aarch64` fails to compile, saying an asm argument is unused.