### PR TITLE
draft: package c2rust as a "nix flake"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,107 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1654639212,
+        "narHash": "sha256-EYa65aWjRd/aafvbWImj8HjCLgXmi6hMKFZeDHltLUI=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6c8c826f9727feeb5ec22412eca41e18ab3b92b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1654694478,
+        "narHash": "sha256-nFAMETXEhIrqnBe28u6vqy4ixSRr0BRrlZLlS0e7eoM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18de53ca965bd0678aaf09e5ce0daae05c58355a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1654742703,
+        "narHash": "sha256-KoS4Fqyj20G0JzTH3zreFxPE8f+H0fKHxbBiS5FI8a0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b37b28553b1009f34fc6ca06ba87329e2a584a98",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "github.com/mstone/c2rust";
+
+  inputs.crane.url = "github:ipetkov/crane";
+  inputs.crane.inputs.flake-utils.follows = "flake-utils";
+  inputs.crane.inputs.nixpkgs.follows = "nixpkgs";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  inputs.nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+  inputs.rust-overlay.inputs.flake-utils.follows = "flake-utils";
+  inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+
+  outputs = {self, nixpkgs, crane, rust-overlay, flake-utils}:
+    flake-utils.lib.simpleFlake {
+      inherit self nixpkgs;
+      name = "c2rust";
+      systems = flake-utils.lib.allSystems;
+      preOverlays = [ rust-overlay.overlay ];
+      overlay = final: prev: {
+        c2rust = rec {
+          c2rust = lib.c2rust { isShell = false; };
+          devShell = lib.c2rust { isShell = true; };
+          defaultPackage = c2rust;
+
+          rust = with final; with pkgs; (rust-bin.nightly."2022-02-14".minimal.override {
+            extensions = [ "rustfmt-preview" "rust-src" "rustc-dev" "llvm-tools-preview" ];
+	  });
+
+          lib.c2rust = { isShell, subpkg ? "c2rust", subdir ? "." }:
+            let
+              buildInputs = with final; with pkgs; [
+                rust
+                llvmPackages_latest.clang
+                llvmPackages_latest.libclang
+                cmake
+                llvmPackages_latest.llvm
+                openssl
+                pkgconfig
+                python3
+                rustup
+                zlib
+                curl
+              ] ++ final.lib.optionals isShell [
+                entr
+              ] ++ final.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+                Security
+              ]) ++ final.lib.optionals stdenv.isLinux ([
+              ]);
+            in with final; with pkgs; crane.lib.${final.system}.buildPackage {
+            pname = "${subpkg}";
+            version = "0.1";
+
+            src = self;
+
+            inherit buildInputs;
+            dontUseCmakeConfigure = true;
+            RUST_SYSROOT = "${rust}";
+
+            doCheck = false;
+          };
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "github.com/mstone/c2rust";
+  description = "help migrate C99-compliant code to Rust";
 
   inputs.crane.url = "github:ipetkov/crane";
   inputs.crane.inputs.flake-utils.follows = "flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,13 @@
             inherit buildInputs;
             dontUseCmakeConfigure = true;
             RUST_SYSROOT = "${rust}";
+            cargoExtraArgs = "--features dynamic-instrumentation";
+
+            preFixup = final.lib.optionalString stdenv.isDarwin ''
+              if [ -f "$out/bin/c2rust-instrument" ]; then
+                install_name_tool -add_rpath "${rust}/lib" "$out/bin/c2rust-instrument"
+              fi
+            '';
 
             doCheck = false;
           };


### PR DESCRIPTION
[Nix flakes](https://www.tweag.io/blog/2020-05-25-flakes/) are an emerging technology for composing software which solves a related but complementary problem to the one addressed today via `c2rust`'s `shell.nix`/`nix-shell` support.

This PR provides a rough-draft-quality flake for c2rust. Notable future work includes:

* testing. So far, I have only tested it on `aarch64-darwin`, where it works as expected so far, and is able to transpile and run the demo for my current subject of interest, [osqp](https://github.com/osqp/osqp).
* wider platform support. While untested so far, I expect builds to fail on `x86_64-linux` at least due to #356.

The benefit is that flakes enable easy building, development, and usage of c2rust with pinned, shareable, but still easily editable LLVM, clang, and rust toolchain versions via convenient commands like

* `nix build`
* `nix shell`
* etc.

or with URI-like "flake-refs" (which also support naming specific branches/commits/...) like:

* `nix build github:mstone/c2rust`, 
* `nix shell github:mstone/c2rust`, 
* `nix run github:mstone/c2rust`, or 
* `nix profile install github:mstone/c2rust` 

or their upstream equivalents, if merged.