### PR TITLE
Fixed the `c2rust transpile` invalid idents panic on transpiling `long double`

### DIFF
--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -117,7 +117,7 @@ impl<'c> Translation<'c> {
                         self.use_crate(ExternCrate::F128);
 
                         let fn_path = mk().path_expr(vec!["f128", "f128", "new"]);
-                        let args = vec![mk().ident_expr(str)];
+                        let args = vec![mk().lit_expr(mk().float_unsuffixed_lit(&str))];
 
                         mk().call_expr(fn_path, args)
                     }

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -814,7 +814,7 @@ impl<'c> Translation<'c> {
                 self.use_crate(ExternCrate::F128);
 
                 let fn_path = mk().path_expr(vec!["f128", "f128", "new"]);
-                let args = vec![mk().ident_expr("1.")];
+                let args = vec![mk().lit_expr(mk().float_unsuffixed_lit("1."))];
 
                 mk().call_expr(fn_path, args)
             }
@@ -874,7 +874,7 @@ impl<'c> Translation<'c> {
                         self.use_crate(ExternCrate::F128);
 
                         let fn_path = mk().path_expr(vec!["f128", "f128", "new"]);
-                        let args = vec![mk().ident_expr("1.")];
+                        let args = vec![mk().lit_expr(mk().float_unsuffixed_lit("1."))];
 
                         mk().call_expr(fn_path, args)
                     }


### PR DESCRIPTION
Fixes https://github.com/immunant/c2rust/issues/449.

Changed `ident_expr()`s that were float literals to use `float_unsuffixed_lit()`, which fixes the `c2rust transpile` crash on invalid idents when transpiling `long double` to `f128`.  Now `tests/longdouble` works, so we should enable it by default and remove `--test-longdoubles`.  I think it makes more sense to put that in a separate PR, however.

The old `ident_expr` was a pre-`syn` way of inserting literals into the output.  That doesn't work with `syn` now, so we need to create them properly as literals.