### PR TITLE
[feat.pdg] instrument mutable refs by taking raw ptrs first

### DIFF
--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -530,10 +530,6 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for CollectFunctionInstrumentationPoints<'a, 't
                         // For mutable borrows (let _n = &mut place), create a parallel binding that takes
                         // a raw pointer to the same place, without involving _n
 
-                        // We do not increment the statement index because we want to take a raw ptr
-                        // prior to the existing stmt that takes a mutable pointer
-                        //location.statement_index += 1;
-
                         // Remove outer deref if present, so we turn `&mut *x` into `addr_of!(x)` rather
                         // than `addr_of!(*x)`
                         let arg = match p.iter_projections().last() {
@@ -544,6 +540,11 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for CollectFunctionInstrumentationPoints<'a, 't
                             },
                             _ => Operand::Copy(p.clone()),
                         };
+
+                        // We do not increment the statement index because we want to take a raw ptr
+                        // prior to the existing stmt that takes a mutable pointer
+                        // location.statement_index += 1;
+
                         // Instrument mutable borrows by addr_of! on the place to be borrowed
                         InstrumentationOperand::Place(arg)
                     } else {


### PR DESCRIPTION
~This only instruments mutable references for now, but we can do the same thing or keep the old logic for immutable ones.~ Update: now instruments mutable references via `addr_of!` and immutable references by casting the reference.

Note that this changes `cast_ptr_to_usize` to actually take a raw ptr when the local to "cast" is not a reference or pointer. This may conflict with the previous behavior, in that previously a `usize` local-to-cast was simply passed through, and now it will be treated as a local whose address is should be taken. If both semantics still exist, this conflates them and we'll have to explicitly disambiguate somehow.

Example output:
```
main:5:4 -> copy_ref
main:5:5 -> copy_ref
main:8:11 -> copy_ref
main:8:12 -> copy_ref
main:8:22 -> copy_ref
main:8:23 -> copy_ref
main:13:4 -> copy_ref
main:13:5 -> copy_ref
main:15:11 -> copy_ref
main:16:5 -> copy_ref
main:18:0 -> copy(0x555f99f20ae0)
main:18:1 -> copy(0x555f99f20ae0)
main:5:4 -> copy_ref
main:5:5 -> copy_ref
main:27:4 -> copy_ref
main:28:0 -> copy(0x0)
main:28:0 -> copy(0x0)
main:29:9 -> copy_ref
main:31:6 -> copy_ref
main:32:0 -> copy(0x555f99f2aef0)
main:32:1 -> copy(0x555f99f2aef0)
test_load_self_store_self:1:2 -> malloc(0) -> 0x555f99f2af20
test_load_self_store_self:2:3 -> copy(0x555f99f2af20)
test_load_self_store_self:2:6 -> field(0x555f99f2af20, 3)
test_load_self_store_self:2:6 -> field(0x555f99f2af20, 3)
test_load_self_store_self:2:6 -> load(0x555f99f2af20)
test_load_self_store_self:2:7 -> field(0x555f99f2af20, 3)
test_load_self_store_self:2:7 -> field(0x555f99f2af20, 3)
test_load_self_store_self:2:7 -> store(0x555f99f2af20)
test_load_self_store_self:2:13 -> copy(0x555f99f2af20)
test_load_self_store_self:2:14 -> copy(0x555f99f2af20)
test_load_self_store_self:2:15 -> free(0x555f99f2af20)
graph 0 {
	node 0: (fn main) copy { src: _, dest: _10, bb: 5, stmt: 4 },
}
nodes_that_need_write = []


graph 1 {
	node 0: (fn main) copy { src: _, dest: _9, bb: 5, stmt: 5 },
}
nodes_that_need_write = []


graph 2 {
	node 0: (fn main) copy { src: _, dest: _19, bb: 8, stmt: 11 },
}
nodes_that_need_write = []


graph 3 {
	node 0: (fn main) copy { src: _, dest: _18, bb: 8, stmt: 12 },
}
nodes_that_need_write = []


graph 4 {
	node 0: (fn main) copy { src: _, dest: _27, bb: 8, stmt: 22 },
}
nodes_that_need_write = []


graph 5 {
	node 0: (fn main) copy { src: _, dest: _26, bb: 8, stmt: 23 },
}
nodes_that_need_write = []


graph 6 {
	node 0: (fn main) copy { src: _, dest: _23, bb: 13, stmt: 4 },
}
nodes_that_need_write = []


graph 7 {
	node 0: (fn main) copy { src: _, dest: _22, bb: 13, stmt: 5 },
}
nodes_that_need_write = []


graph 8 {
	node 0: (fn main) copy { src: _, dest: _29, bb: 15, stmt: 11 },
}
nodes_that_need_write = []


graph 9 {
	node 0: (fn main) copy { src: _, dest: _34, bb: 16, stmt: 5 },
}
nodes_that_need_write = []


graph 10 {
	node 0: (fn main) copy { src: _, dest: _30, bb: 18, stmt: 0 },
	node 1: (fn push) copy { src: node 0, dest: _2, bb: 0, stmt: 0 },
}
nodes_that_need_write = []


graph 11 {
	node 0: (fn main) copy { src: _, dest: _37, bb: 27, stmt: 4 },
}
nodes_that_need_write = []


graph 12 {
	node 0: (fn main) copy { src: _, dest: _38, bb: 28, stmt: 0 },
	node 1: (fn push) copy { src: node 0, dest: _2, bb: 0, stmt: 0 },
}
nodes_that_need_write = []


graph 13 {
	node 0: (fn main) copy { src: _, dest: _43, bb: 29, stmt: 9 },
}
nodes_that_need_write = []


graph 14 {
	node 0: (fn main) copy { src: _, dest: _46, bb: 31, stmt: 6 },
}
nodes_that_need_write = []


graph 15 {
	node 0: (fn main) copy { src: _, dest: _45, bb: 32, stmt: 0 },
	node 1: (fn main_0) copy { src: node 0, dest: _2, bb: 0, stmt: 0 },
}
nodes_that_need_write = []


graph 16 {
	node 0: (fn test_load_self_store_self) malloc(n = 1) { src: _, dest: _2, bb: 1, stmt: 2 },
	node 1: (fn test_load_self_store_self) copy { src: node 0, dest: _1, bb: 2, stmt: 3 },
	node 2: (fn test_load_self_store_self) field.3 { src: node 1, dest: _, bb: 2, stmt: 6 },
	node 3: (fn test_load_self_store_self) field.3 { src: node 2, dest: _6, bb: 2, stmt: 6 },
	node 4: (fn test_load_self_store_self) addr.load { src: node 3, dest: _, bb: 2, stmt: 6 },
	node 5: (fn test_load_self_store_self) field.3 { src: node 1, dest: _, bb: 2, stmt: 7 },
	node 6: (fn test_load_self_store_self) field.3 { src: node 5, dest: _, bb: 2, stmt: 7 },
	node 7: (fn test_load_self_store_self) addr.store { src: node 6, dest: _, bb: 2, stmt: 7 },
	node 8: (fn test_load_self_store_self) copy { src: node 1, dest: _9, bb: 2, stmt: 13 },
	node 9: (fn test_load_self_store_self) copy { src: node 8, dest: _8, bb: 2, stmt: 14 },
	node 10: (fn test_load_self_store_self) free { src: node 9, dest: _7, bb: 2, stmt: 15 },
}
nodes_that_need_write = [7, 6, 5, 1, 0]
```