### PR TITLE
Enabled `long double` test by default

### DIFF
--- a/scripts/provision_dnf.sh
+++ b/scripts/provision_dnf.sh
@@ -16,6 +16,7 @@ dnf install --quiet --assumeyes \
     clang-devel \
     cmake \
     diffutils \
+    libquadmath-devel \
     llvm-devel \
     make \
     ninja-build \

--- a/scripts/provision_yum.sh
+++ b/scripts/provision_yum.sh
@@ -13,7 +13,7 @@ fi
 # required to install ninja-build
 yum install --quiet --assumeyes epel-release
 # NOTE: CentOS version of cmake is too old
-yum install --quiet --assumeyes which ninja-build make cmake
+yum install --quiet --assumeyes which ninja-build make cmake libquadmath-devel
 
 yum install --quiet --assumeyes luarocks
 

--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -610,7 +610,7 @@ def get_testdirectories(
     dir = Path(directory)
     for path in dir.iterdir():
         if path.is_dir():
-            if path.name == "longdouble" and sys.platform == "darwin":
+            if path.name == "longdouble" and on_mac():
                 continue
             yield TestDirectory(str(path.absolute()), files, keep, logLevel)
 

--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -601,16 +601,15 @@ def readable_directory(directory: str) -> str:
 
 
 def get_testdirectories(
-        directory: str, files: str,
-        keep: List[str], test_longdoubles: bool,
-        logLevel: str) -> Generator[TestDirectory, None, None]:
+        directory: str,
+        files: str,
+        keep: List[str],
+        logLevel: str,
+) -> Generator[TestDirectory, None, None]:
     for entry in os.listdir(directory):
         path = os.path.abspath(os.path.join(directory, entry))
 
         if os.path.isdir(path):
-            if path.endswith("longdouble") and not test_longdoubles:
-                continue
-
             yield TestDirectory(path, files, keep, logLevel)
 
 
@@ -636,17 +635,13 @@ def main() -> None:
         choices=intermediate_files + ['all'], default=[],
         help="Which intermediate files to not clear"
     )
-    parser.add_argument(
-        '--test-longdoubles', dest='test_longdoubles',
-        default=False, action="store_true",
-        help="Enables testing of long double translation which requires gcc headers",
-    )
     c.add_args(parser)
 
     args = parser.parse_args()
     c.update_args(args)
-    test_directories = get_testdirectories(args.directory, args.regex_files,
-                                           args.keep, args.test_longdoubles,
+    test_directories = get_testdirectories(args.directory,
+                                           args.regex_files,
+                                           args.keep,
                                            args.logLevel)
     setup_logging(args.logLevel)
 

--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -2,6 +2,7 @@
 
 import errno
 import os
+from pathlib import Path
 import sys
 import logging
 import argparse
@@ -606,11 +607,12 @@ def get_testdirectories(
         keep: List[str],
         logLevel: str,
 ) -> Generator[TestDirectory, None, None]:
-    for entry in os.listdir(directory):
-        path = os.path.abspath(os.path.join(directory, entry))
-
-        if os.path.isdir(path):
-            yield TestDirectory(path, files, keep, logLevel)
+    dir = Path(directory)
+    for path in dir.iterdir():
+        if path.is_dir():
+            if path.name == "longdouble" and sys.platform == "darwin":
+                continue
+            yield TestDirectory(str(path.absolute()), files, keep, logLevel)
 
 
 def main() -> None:

--- a/tests/longdouble/src/test_long_double.rs
+++ b/tests/longdouble/src/test_long_double.rs
@@ -16,7 +16,7 @@ pub fn test_long_double_ops() {
 }
 
 pub fn test_long_double_casts() {
-    let mut input = f128::parse("4.41234567890123413322676295501878485").unwrap();
+    let input = f128::parse("4.41234567890123413322676295501878485").unwrap();
 
     let rust_ret = unsafe { rust_cast2double(input) };
 


### PR DESCRIPTION
`./scripts/test_translator.py tests/` previously skipped the `tests/longdouble` test unless `--test-longdoubles` was passed, because the `long double` test didn't always work.  It should be fixed now, so we can get rid of the `--test-longdoubles` option and have it be tested by default now.  The tests all work locally (Ubuntu/Linux), but I'm waiting to check if it works in CI on Darwin/macOS, too.