### PR TITLE
Fixed bare URL warnings in `cargo doc`

### DIFF
--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -2626,7 +2626,7 @@ fn expr_precedence(e: &Expr) -> u8 {
     }
 }
 
-/// See https://doc.rust-lang.org/reference/expressions.html
+/// See <https://doc.rust-lang.org/reference/expressions.html>
 fn binop_precedence(b: &BinOp) -> u8 {
     match b {
         BinOp::Add(_) => 8,

--- a/c2rust-ast-exporter/src/ast_tags.hpp
+++ b/c2rust-ast-exporter/src/ast_tags.hpp
@@ -152,45 +152,45 @@ enum StringTypeTag {
     TagUTF32,
 };
 
-// From clang/Basic/TargetInfo.h
-/// The different kinds of __builtin_va_list types defined by
+// From `clang/Basic/TargetInfo.h`
+/// The different kinds of `__builtin_va_list` types defined by
 /// the target implementation.
 enum BuiltinVaListKind {
-    /// typedef char* __builtin_va_list;
+    /// `typedef char* __builtin_va_list;`
     CharPtrBuiltinVaList = 0,
 
-    /// typedef void* __builtin_va_list;
+    /// `typedef void* __builtin_va_list;`
     VoidPtrBuiltinVaList,
 
-    /// __builtin_va_list as defined by the AArch64 ABI
-    /// http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055a/IHI0055A_aapcs64.pdf
+    /// `__builtin_va_list` as defined by the AArch64 ABI
+    /// <http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055a/IHI0055A_aapcs64.pdf>
     AArch64ABIBuiltinVaList,
 
-    /// __builtin_va_list as defined by the PNaCl ABI:
-    /// http://www.chromium.org/nativeclient/pnacl/bitcode-abi#TOC-Machine-Types
+    /// `__builtin_va_list` as defined by the PNaCl ABI:
+    /// <http://www.chromium.org/nativeclient/pnacl/bitcode-abi#TOC-Machine-Types>
     PNaClABIBuiltinVaList,
 
-    /// __builtin_va_list as defined by the Power ABI:
-    /// https://www.power.org
-    ///        /resources/downloads/Power-Arch-32-bit-ABI-supp-1.0-Embedded.pdf
+    /// `__builtin_va_list` as defined by the Power ABI:
+    /// <https://www.power.org/resources/downloads/Power-Arch-32-bit-ABI-supp-1.0-Embedded.pdf>
     PowerABIBuiltinVaList,
 
-    /// __builtin_va_list as defined by the x86-64 ABI:
-    /// http://refspecs.linuxbase.org/elf/x86_64-abi-0.21.pdf
+    /// `__builtin_va_list` as defined by the x86-64 ABI:
+    /// <http://refspecs.linuxbase.org/elf/x86_64-abi-0.21.pdf>
     X86_64ABIBuiltinVaList,
 
-    /// __builtin_va_list as defined by ARM AAPCS ABI
-    /// http://infocenter.arm.com
-    //        /help/topic/com.arm.doc.ihi0042d/IHI0042D_aapcs.pdf
+    /// `__builtin_va_list` as defined by ARM AAPCS ABI
+    /// <http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042d/IHI0042D_aapcs.pdf>
     AAPCSABIBuiltinVaList,
 
-    // typedef struct __va_list_tag
-    //   {
-    //     long __gpr;
-    //     long __fpr;
-    //     void *__overflow_arg_area;
-    //     void *__reg_save_area;
-    //   } va_list[1];
+    /// ```C
+    /// typedef struct __va_list_tag
+    ///   {
+    ///     long __gpr;
+    ///     long __fpr;
+    ///     void *__overflow_arg_area;
+    ///     void *__reg_save_area;
+    ///   } va_list[1];
+    /// ```
     SystemZBuiltinVaList
 };
 

--- a/c2rust-ast-exporter/src/ast_tags.hpp
+++ b/c2rust-ast-exporter/src/ast_tags.hpp
@@ -162,34 +162,28 @@ enum BuiltinVaListKind {
     /// `typedef void* __builtin_va_list;`
     VoidPtrBuiltinVaList,
 
-    /// `__builtin_va_list` as defined by the AArch64 ABI
-    /// <http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055a/IHI0055A_aapcs64.pdf>
+    /// `__builtin_va_list` as defined by the [AArch64 ABI](http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055a/IHI0055A_aapcs64.pdf)
     AArch64ABIBuiltinVaList,
 
-    /// `__builtin_va_list` as defined by the PNaCl ABI:
-    /// <http://www.chromium.org/nativeclient/pnacl/bitcode-abi#TOC-Machine-Types>
+    /// `__builtin_va_list` as defined by the [PNaCl ABI](http://www.chromium.org/nativeclient/pnacl/bitcode-abi#TOC-Machine-Types)
     PNaClABIBuiltinVaList,
 
-    /// `__builtin_va_list` as defined by the Power ABI:
-    /// <https://www.power.org/resources/downloads/Power-Arch-32-bit-ABI-supp-1.0-Embedded.pdf>
+    /// `__builtin_va_list` as defined by the [Power ABI](https://www.power.org/resources/downloads/Power-Arch-32-bit-ABI-supp-1.0-Embedded.pdf)
     PowerABIBuiltinVaList,
 
-    /// `__builtin_va_list` as defined by the x86-64 ABI:
-    /// <http://refspecs.linuxbase.org/elf/x86_64-abi-0.21.pdf>
+    /// `__builtin_va_list` as defined by the [x86-64 ABI](http://refspecs.linuxbase.org/elf/x86_64-abi-0.21.pdf)
     X86_64ABIBuiltinVaList,
 
-    /// `__builtin_va_list` as defined by ARM AAPCS ABI
-    /// <http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042d/IHI0042D_aapcs.pdf>
+    /// `__builtin_va_list` as defined by the [ARM AAPCS ABI](http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042d/IHI0042D_aapcs.pdf)
     AAPCSABIBuiltinVaList,
 
     /// ```C
-    /// typedef struct __va_list_tag
-    ///   {
+    /// typedef struct __va_list_tag {
     ///     long __gpr;
     ///     long __fpr;
     ///     void *__overflow_arg_area;
     ///     void *__reg_save_area;
-    ///   } va_list[1];
+    /// } va_list[1];
     /// ```
     SystemZBuiltinVaList
 };

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -543,7 +543,7 @@ pub enum ImplicitReturnType {
     NoImplicitReturnType,
 
     /// This is for handling GNU C statement expressions
-    /// https://gcc.gnu.org/onlinedocs/gcc-3.2.3/gcc/Statement-Exprs.html
+    /// <https://gcc.gnu.org/onlinedocs/gcc-3.2.3/gcc/Statement-Exprs.html>
     ///
     /// TODO: document
     StmtExpr(ExprContext, CExprId, Label),

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -200,9 +200,9 @@ fn is_regname_or_int(parsed_constraint: &str) -> bool {
 /// Translate an architecture-specific assembly constraint from llvm/gcc
 /// to those accepted by the Rust asm! macro. "Simple" (arch-independent)
 /// constraints are handled in `parse_constraints`, not here.
-/// See https://gcc.gnu.org/onlinedocs/gcc/Machine-Constraints.html,
-/// https://llvm.org/docs/LangRef.html#constraint-codes, and
-/// https://doc.rust-lang.org/nightly/reference/inline-assembly.html#register-operands
+/// See <https://gcc.gnu.org/onlinedocs/gcc/Machine-Constraints.html>,
+/// <https://llvm.org/docs/LangRef.html#constraint-codes>, and
+/// <https://doc.rust-lang.org/nightly/reference/inline-assembly.html#register-operands>
 fn translate_machine_constraint(constraint: &str, arch: Arch) -> Option<(&str, bool)> {
     let mem = &mut false;
     // Many constraints are not handled here, because rustc does. The best we can
@@ -286,7 +286,7 @@ fn translate_machine_constraint(constraint: &str, arch: Arch) -> Option<(&str, b
 /// Translate a template modifier from llvm/gcc asm template argument modifiers
 /// to those accepted by the Rust asm! macro. This is arch-dependent, so we need
 /// to know which architecture the asm targets.
-/// See https://doc.rust-lang.org/nightly/reference/inline-assembly.html#template-modifiers
+/// See <https://doc.rust-lang.org/nightly/reference/inline-assembly.html#template-modifiers>
 fn translate_modifier(modifier: char, arch: Arch) -> Option<char> {
     Some(match arch {
         Arch::X86OrX86_64 => match modifier {
@@ -444,7 +444,7 @@ fn remove_comments(mut asm: &str) -> String {
     without_comments
 }
 
-/// Detect whether an x86[_64] gcc inline asm string uses Intel or AT&T syntax.
+/// Detect whether an x86(_64) gcc inline asm string uses Intel or AT&T syntax.
 /// For gcc, AT&T syntax is default... unless `-masm=intel` is passed. This
 /// means we can hope but not guarantee that x86 asm with no syntax directive
 /// uses AT&T syntax.

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -10,7 +10,7 @@ use crate::c_ast::CTypeKind::{Char, Double, Float, Int, LongLong, Short};
 use crate::c_ast::CastKind::{BitCast, IntegralCast};
 
 /// As of rustc 1.29, rust is known to be missing some SIMD functions.
-/// See https://github.com/rust-lang-nursery/stdsimd/issues/579
+/// See <https://github.com/rust-lang-nursery/stdsimd/issues/579>
 static MISSING_SIMD_FUNCTIONS: [&str; 36] = [
     "_mm_and_si64",
     "_mm_andnot_si64",


### PR DESCRIPTION
When running `cargo doc` and `cargo doc --document-private-items`, there were warnings about bare URLs in doc comments, which don't turn into hyperlinks in the generated documentation.  This fixes all of those by either making them named `[name](link)` links or surrounding them with `<>`.  Now `cargo doc` runs without warnings except for a clash between the `c2rust-transpile` library crate in the `c2rust-transpile` package and the `c2rust-transpile` binary crate in the `c2rust` package, which is harder to fix easily/might not be worth it.