### PR TITLE
Refactoring, cleanup, and generic testing script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,11 +292,11 @@ dependencies = [
 name = "c2rust-pdg"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bincode",
  "c2rust-analysis-rt",
  "env_logger",
  "indexed_vec",
- "lazy_static",
  "log",
  "serde",
 ]

--- a/analysis/runtime/src/lib.rs
+++ b/analysis/runtime/src/lib.rs
@@ -6,8 +6,14 @@ pub mod mir_loc;
 use std::env;
 
 /// List of functions we want hooked for the lifetime analyis runtime.
-pub const HOOK_FUNCTIONS: &[&'static str] =
-    &["malloc", "free", "calloc", "realloc", "reallocarray", "offset"];
+pub const HOOK_FUNCTIONS: &[&'static str] = &[
+    "malloc",
+    "free",
+    "calloc",
+    "realloc",
+    "reallocarray",
+    "offset",
+];
 
 pub use self::mir_loc::{DefPathHash, Metadata, MirLoc, MirLocId, MirPlace, MirProjection};
 

--- a/analysis/runtime/src/lib.rs
+++ b/analysis/runtime/src/lib.rs
@@ -23,3 +23,18 @@ pub fn initialize() {
 pub fn finalize() {
     backend::finalize();
 }
+
+pub struct Runtime;
+
+impl Runtime {
+    pub fn new() -> Self {
+        initialize();
+        Self
+    }
+}
+
+impl Drop for Runtime {
+    fn drop(&mut self) {
+        finalize();
+    }
+}

--- a/analysis/runtime/src/mir_loc.rs
+++ b/analysis/runtime/src/mir_loc.rs
@@ -40,7 +40,7 @@ pub enum MirProjection {
     Deref,
     Field(usize),
     Index(usize),
-    Unsupported
+    Unsupported,
 }
 
 #[derive(Eq, PartialEq, Hash, Clone, Serialize, Deserialize)]
@@ -66,8 +66,15 @@ pub struct DefPathHash(pub u64, pub u64);
 
 impl fmt::Debug for DefPathHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let entry = "unknown".to_string();
-        write!(f, "{}", MIR_LOCS.functions.get(self).unwrap_or(&entry))
+        write!(
+            f,
+            "{}",
+            MIR_LOCS
+                .functions
+                .get(self)
+                .map(|s| s.as_str())
+                .unwrap_or("unknown")
+        )
     }
 }
 
@@ -77,9 +84,9 @@ impl From<(u64, u64)> for DefPathHash {
     }
 }
 
-impl Into<(u64, u64)> for DefPathHash {
-    fn into(self) -> (u64, u64) {
-        (self.0, self.1)
+impl From<DefPathHash> for (u64, u64) {
+    fn from(other: DefPathHash) -> Self {
+        (other.0, other.1)
     }
 }
 

--- a/c2rust/src/bin/c2rust-instrument.rs
+++ b/c2rust/src/bin/c2rust-instrument.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use c2rust_dynamic_instrumentation::instrument;
-use clap::{load_yaml, App, Values};
+use clap::{load_yaml, App};
 
 fn main() -> anyhow::Result<()> {
     env_logger::init();

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -9,7 +9,7 @@ use rustc_index::vec::IndexVec;
 use rustc_middle::mir::visit::{MutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{
     BasicBlock, BasicBlockData, Body, CastKind, Constant, Local, LocalDecl, Location, Operand,
-    Place, PlaceElem, PlaceRef, ProjectionElem, Rvalue, SourceInfo, SourceScopeData, Statement,
+    Place, PlaceElem, ProjectionElem, Rvalue, SourceInfo, Statement,
     StatementKind, Terminator, TerminatorKind, START_BLOCK,
 };
 use rustc_middle::ty::{self, ParamEnv, TyCtxt};
@@ -213,7 +213,7 @@ fn rv_place<'tcx>(rv: &'tcx Rvalue) -> Option<Place<'tcx>> {
 impl<'a, 'tcx: 'a> Visitor<'tcx> for FunctionInstrumenter<'a, 'tcx> {
     fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, location: Location) {
         self.super_place(place, context, location);
-        let field_fn = self
+        let _field_fn = self
             .find_instrumentation_def(Symbol::intern("ptr_field"))
             .expect("Could not find pointer field hook");
         let load_fn = self
@@ -280,7 +280,7 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for FunctionInstrumenter<'a, 'tcx> {
         let copy_fn = self
             .find_instrumentation_def(Symbol::intern("ptr_copy"))
             .expect("Could not find pointer copy hook");
-        let ref_copy_fn = self
+        let _ref_copy_fn = self
             .find_instrumentation_def(Symbol::intern("ref_copy"))
             .expect("Could not find ref copy hook");
         let addr_local_fn = self
@@ -728,7 +728,7 @@ fn do_instrumentation<'tcx>(
 ) {
     for point in points {
         let &InstrumentationPoint {
-            id,
+            id: _id,
             loc,
             func,
             ref args,

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -9,8 +9,8 @@ use rustc_index::vec::IndexVec;
 use rustc_middle::mir::visit::{MutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{
     BasicBlock, BasicBlockData, Body, CastKind, Constant, Local, LocalDecl, Location, Operand,
-    Place, PlaceElem, ProjectionElem, Rvalue, SourceInfo, Statement,
-    StatementKind, Terminator, TerminatorKind, START_BLOCK,
+    Place, PlaceElem, ProjectionElem, Rvalue, SourceInfo, Statement, StatementKind, Terminator,
+    TerminatorKind, START_BLOCK,
 };
 use rustc_middle::ty::{self, ParamEnv, TyCtxt};
 use rustc_span::def_id::{DefId, DefPathHash, CRATE_DEF_INDEX};

--- a/dynamic_instrumentation/src/lib.rs
+++ b/dynamic_instrumentation/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(rustc_private)]
 extern crate rustc_ast;
 extern crate rustc_const_eval;
+extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_index;
 extern crate rustc_interface;
@@ -10,7 +11,6 @@ extern crate rustc_mir_transform;
 extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_target;
-extern crate rustc_data_structures;
 
 mod instrument_memory;
 use instrument_memory::InstrumentMemoryOps;

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -8,9 +8,12 @@ bincode = "1.0.1"
 c2rust-analysis-rt = { path = "../analysis/runtime"}
 indexed_vec = "1.2.1"
 serde = { version = "1.0", features = ["derive"] }
-lazy_static = "1.4"
 log = "0.4"
 env_logger = "0.9"
+anyhow = "1"
+
+[build-dependencies]
+anyhow = "1"
 
 [package.metadata.rust-analyzer] 
-rustc_private=true
+rustc_private = true

--- a/pdg/build.rs
+++ b/pdg/build.rs
@@ -1,15 +1,20 @@
+use anyhow::anyhow;
 use std::path::Path;
 use std::process::Command;
 use std::str;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     // Add the toolchain lib/ directory to `-L`.  This fixes the linker error "cannot find
     // -lLLVM-13-rust-1.60.0-nightly".
-    let out = Command::new("rustup")
-        .args(&["which", "rustc"])
-        .output().unwrap();
+    let out = Command::new("rustup").args(&["which", "rustc"]).output()?;
     assert!(out.status.success());
-    let rustc_path = Path::new(str::from_utf8(&out.stdout).unwrap().trim_end());
-    let lib_dir = rustc_path.parent().unwrap().parent().unwrap().join("lib");
+    let rustc_path = Path::new(str::from_utf8(&out.stdout)?.trim_end());
+    let lib_dir = rustc_path
+        .parent()
+        .ok_or(anyhow!("`which rustc` has no parent directory"))?
+        .parent()
+        .ok_or(anyhow!("`which rustc` has no 2nd parent directory"))?
+        .join("lib");
     println!("cargo:rustc-link-search={}", lib_dir.display());
+    Ok(())
 }

--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -1,135 +1,148 @@
 use crate::graph::{Func, Graph, GraphId, Graphs, Node, NodeId, NodeKind};
 use bincode;
-use c2rust_analysis_rt::events::{Event, EventKind};
+use c2rust_analysis_rt::events::{Event, EventKind, Pointer};
 use c2rust_analysis_rt::mir_loc::{EventMetadata, Metadata, TransferKind};
 use c2rust_analysis_rt::{mir_loc, MirLoc};
 use log;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_hir::def_id::DefPathHash;
-use rustc_middle::mir::Local;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::BufReader;
+use std::fs::{self, File};
+use std::io::{self, BufReader};
+use std::iter;
+use std::path::Path;
 
-pub fn read_event_log(path: String) -> Vec<Event> {
-    let file = File::open(path).unwrap();
-    let mut events = vec![];
+pub fn read_event_log(path: &Path) -> io::Result<Vec<Event>> {
+    let file = File::open(path)?;
     let mut reader = BufReader::new(file);
-    loop {
-        match bincode::deserialize_from(&mut reader) {
-            Ok(e) => events.push(e),
-            _ => break,
+    let events = iter::from_fn(|| bincode::deserialize_from(&mut reader).ok()).collect::<Vec<_>>();
+    Ok(events)
+}
+
+pub fn _read_metadata(path: &Path) -> anyhow::Result<Metadata> {
+    let bytes = fs::read(path)?;
+    let metadata = bincode::deserialize(&bytes)?;
+    Ok(metadata)
+}
+
+pub trait EventKindExt {
+    fn ptr(&self, metadata: &EventMetadata) -> Option<Pointer>;
+    fn has_parent(&self) -> bool;
+    fn parent(&self, obj: (GraphId, NodeId)) -> Option<(GraphId, NodeId)>;
+    fn to_node_kind(&self) -> Option<NodeKind>;
+}
+
+impl EventKindExt for EventKind {
+    /// return the ptr of interest for a particular event
+    fn ptr(&self, _metadata: &EventMetadata) -> Option<Pointer> {
+        use EventKind::*;
+        Some(match *self {
+            CopyPtr(lhs) => lhs,
+            Field(ptr, ..) => ptr,
+            Free { ptr } => ptr,
+            Ret(ptr) => ptr,
+            LoadAddr(ptr) => ptr,
+            StoreAddr(ptr) => ptr,
+            LoadValue(ptr) => ptr,
+            StoreValue(ptr) => ptr,
+            CopyRef => return None, // FIXME
+            ToInt(ptr) => ptr,
+            Realloc { old_ptr, .. } => old_ptr,
+            FromInt(lhs) => lhs,
+            Alloc { ptr, .. } => ptr,
+            AddrOfLocal(lhs, _) => lhs,
+            Offset(ptr, _, _) => ptr,
+            Done => return None,
+        })
+    }
+
+    fn has_parent(&self) -> bool {
+        use EventKind::*;
+        match self {
+            Realloc { new_ptr: _, .. } => false,
+            Alloc { ptr: _, .. } => false,
+            AddrOfLocal(_ptr, _) => false,
+            Done => false,
+            _ => true,
         }
     }
-    events
-}
 
-pub fn _read_metadata(path: String) -> Metadata {
-    let file = File::open(path).unwrap();
-    bincode::deserialize_from(file).unwrap()
-}
+    fn parent(&self, obj: (GraphId, NodeId)) -> Option<(GraphId, NodeId)> {
+        if self.has_parent() {
+            None
+        } else {
+            Some(obj)
+        }
+    }
 
-/** return the ptr of interest for a particular event */
-fn get_ptr(kind: &EventKind, _metadata: &EventMetadata) -> Option<usize> {
-    Some(match kind {
-        EventKind::CopyPtr(lhs) => *lhs,
-        EventKind::Field(ptr, ..) => *ptr,
-        EventKind::Free { ptr } => *ptr,
-        EventKind::Ret(ptr) => *ptr,
-
-        EventKind::LoadAddr(ptr) => *ptr,
-        EventKind::StoreAddr(ptr) => *ptr,
-        EventKind::LoadValue(ptr) => *ptr,
-        EventKind::StoreValue(ptr) => *ptr,
-        EventKind::CopyRef => return None, // FIXME
-        EventKind::ToInt(ptr) => *ptr,
-        EventKind::Realloc { old_ptr, .. } => *old_ptr,
-        EventKind::FromInt(lhs) => *lhs,
-        EventKind::Alloc { ptr, .. } => *ptr,
-        EventKind::AddrOfLocal(lhs, _) => *lhs,
-        EventKind::Offset(ptr, _, _) => *ptr,
-        EventKind::Done => return None,
-    })
-}
-
-fn get_parent_object(kind: &EventKind, obj: (GraphId, NodeId)) -> Option<(GraphId, NodeId)> {
-    Some(match kind {
-        EventKind::Realloc { new_ptr: _new_ptr, .. } => return None,
-        EventKind::Alloc { ptr: _ptr, .. } => return None,
-        EventKind::AddrOfLocal(_ptr, _) => return None,
-        EventKind::Done => return None,
-        _ => obj,
-    })
-}
-
-pub fn event_to_node_kind(event: &Event) -> Option<NodeKind> {
-    Some(match event.kind {
-        EventKind::Alloc { .. } => NodeKind::Malloc(1),
-        EventKind::Realloc { .. } => NodeKind::Malloc(1),
-        EventKind::Free { .. } => NodeKind::Free,
-        EventKind::CopyPtr(..) | EventKind::CopyRef => NodeKind::Copy,
-        EventKind::Field(_, field) => NodeKind::Field(field.into()),
-        EventKind::LoadAddr(..) => NodeKind::LoadAddr,
-        EventKind::StoreAddr(..) => NodeKind::StoreAddr,
-        EventKind::LoadValue(..) => NodeKind::LoadValue,
-        EventKind::StoreValue(..) => NodeKind::StoreValue,
-        EventKind::AddrOfLocal(_, l) => NodeKind::AddrOfLocal(Local::from(l)),
-        EventKind::ToInt(_) => NodeKind::PtrToInt,
-        EventKind::FromInt(_) => NodeKind::IntToPtr,
-        EventKind::Ret(_) => return None,
-        EventKind::Offset(_, offset, _) => NodeKind::Offset(offset),
-        EventKind::Done => return None,
-    })
+    fn to_node_kind(&self) -> Option<NodeKind> {
+        use EventKind::*;
+        Some(match *self {
+            Alloc { .. } => NodeKind::Malloc(1),
+            Realloc { .. } => NodeKind::Malloc(1),
+            Free { .. } => NodeKind::Free,
+            CopyPtr(..) | CopyRef => NodeKind::Copy,
+            Field(_, field) => NodeKind::Field(field.into()),
+            LoadAddr(..) => NodeKind::LoadAddr,
+            StoreAddr(..) => NodeKind::StoreAddr,
+            LoadValue(..) => NodeKind::LoadValue,
+            StoreValue(..) => NodeKind::StoreValue,
+            AddrOfLocal(_, local) => NodeKind::AddrOfLocal(local.into()),
+            ToInt(_) => NodeKind::PtrToInt,
+            FromInt(_) => NodeKind::IntToPtr,
+            Ret(_) => return None,
+            Offset(_, offset, _) => NodeKind::Offset(offset),
+            Done => return None,
+        })
+    }
 }
 
 fn update_provenance(
-    provenances: &mut HashMap<usize, (GraphId, NodeId)>,
+    provenances: &mut HashMap<Pointer, (GraphId, NodeId)>,
     event_kind: &EventKind,
     metadata: &EventMetadata,
     mapping: (GraphId, NodeId),
 ) {
-    match event_kind {
-        EventKind::Alloc { ptr, .. } => {
-            provenances.insert(*ptr, mapping);
+    use EventKind::*;
+    match *event_kind {
+        Alloc { ptr, .. } => {
+            provenances.insert(ptr, mapping);
         }
-        EventKind::CopyPtr(ptr) => {
+        CopyPtr(ptr) => {
             // only insert if not already there
-            if let Err(..) = provenances.try_insert(*ptr, mapping) {
-                log::warn!("{:p} doesn't have a source", ptr);
+            if let Err(..) = provenances.try_insert(ptr, mapping) {
+                log::warn!("{:x} doesn't have a source", ptr);
             }
         }
-        EventKind::Realloc { new_ptr, .. } => {
-            provenances.insert(*new_ptr, mapping);
+        Realloc { new_ptr, .. } => {
+            provenances.insert(new_ptr, mapping);
         }
-        EventKind::Offset(_, _, new_ptr) => {
-            provenances.insert(*new_ptr, mapping);
+        Offset(_, _, new_ptr) => {
+            provenances.insert(new_ptr, mapping);
         }
-        EventKind::CopyRef => {
+        CopyRef => {
             provenances.insert(metadata.destination.clone().unwrap().local.clone(), mapping);
         }
-        EventKind::AddrOfLocal(ptr, _) => {
-            provenances.insert(*ptr, mapping);
+        AddrOfLocal(ptr, _) => {
+            provenances.insert(ptr, mapping);
         }
-        _ => (),
+        _ => {}
     }
 }
 
 pub fn add_node(
     graphs: &mut Graphs,
-    provenances: &mut HashMap<usize, (GraphId, NodeId)>,
+    provenances: &mut HashMap<Pointer, (GraphId, NodeId)>,
     event: &Event,
 ) -> Option<NodeId> {
-    let node_kind = match event_to_node_kind(event) {
-        Some(kind) => kind,
-        None => return None,
-    };
+    let node_kind = event.kind.to_node_kind()?;
 
     let MirLoc {
         body_def,
         mut basic_block_idx,
         mut statement_idx,
         metadata,
-    } = mir_loc::get(event.mir_loc).unwrap().clone();
+    } = mir_loc::get(event.mir_loc).unwrap();
 
     let this_func_hash = DefPathHash(Fingerprint::new(body_def.0, body_def.1).into());
     let (src_fn, dest_fn) = match metadata.transfer_kind {
@@ -150,7 +163,10 @@ pub fn add_node(
         statement_idx = 0;
     }
 
-    let head = get_ptr(&event.kind, &metadata).and_then(|p| provenances.get(&p).cloned());
+    let head = event
+        .kind
+        .ptr(&metadata)
+        .and_then(|ptr| provenances.get(&ptr).cloned());
     let ptr = head.and_then(|(gid, _last_nid_ref)| {
         graphs.graphs[gid]
             .nodes
@@ -170,12 +186,13 @@ pub fn add_node(
             .latest_assignment
             .get(&(src_fn, src.local.clone()))
             .cloned();
-        if latest_assignment.is_some() && !src.projection.is_empty() {
-            let (gid, _) = latest_assignment.unwrap();
-            for (nid, n) in graphs.graphs[gid].nodes.iter().enumerate().rev() {
-                match n.kind {
-                    NodeKind::Field(..) => return Some((gid, nid.into())),
-                    _ => break,
+        if !src.projection.is_empty() {
+            if let Some((gid, _)) = latest_assignment {
+                for (nid, n) in graphs.graphs[gid].nodes.iter().enumerate().rev() {
+                    match n.kind {
+                        NodeKind::Field(..) => return Some((gid, nid.into())),
+                        _ => break,
+                    }
                 }
             }
         }
@@ -191,15 +208,19 @@ pub fn add_node(
 
     let node = Node {
         function: Func(dest_fn),
-        block: basic_block_idx.clone().into(),
-        index: statement_idx.clone().into(),
+        block: basic_block_idx.into(),
+        index: statement_idx.into(),
         kind: node_kind,
-        source: source.and_then(|p| get_parent_object(&event.kind, p)).map(|n| n.1),
+        source: source
+            .and_then(|p| event.kind.parent(p))
+            .map(|(_, nid)| nid),
         dest: metadata.destination.clone(),
     };
 
-    let graph_id = source.or(ptr)
-        .or(head).and_then(|p| get_parent_object(&event.kind, p))
+    let graph_id = source
+        .or(ptr)
+        .or(head)
+        .and_then(|p| event.kind.parent(p))
         .map(|(gid, _)| gid)
         .unwrap_or_else(|| graphs.graphs.push(Graph::new()));
     let node_id = graphs.graphs[graph_id].nodes.push(node);
@@ -229,15 +250,16 @@ pub fn add_node(
     Some(node_id)
 }
 
-pub fn construct_pdg(events: &Vec<Event>) -> Graphs {
+pub fn construct_pdg(events: &[Event]) -> Graphs {
     let mut graphs = Graphs::new();
-    let mut provenances = HashMap::<usize, (GraphId, NodeId)>::new();
+    let mut provenances = HashMap::new();
     for event in events {
         add_node(&mut graphs, &mut provenances, event);
     }
 
-    for ((f, l), p) in &graphs.latest_assignment {
-        println!("({:?}:_{:?}) => {:?}", Func(*f), l, p);
+    for ((func, line), p) in &graphs.latest_assignment {
+        let func = Func(*func);
+        println!("({func:?}:_{line:?}) => {p:?}");
     }
     graphs
 }

--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -2,12 +2,11 @@ use crate::graph::{Func, Graph, GraphId, Graphs, Node, NodeId, NodeKind};
 use bincode;
 use c2rust_analysis_rt::events::{Event, EventKind};
 use c2rust_analysis_rt::mir_loc::{EventMetadata, Metadata, TransferKind};
-use c2rust_analysis_rt::{mir_loc, MirLoc, MirPlace, MirProjection};
+use c2rust_analysis_rt::{mir_loc, MirLoc};
 use log;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_hir::def_id::DefPathHash;
-use rustc_middle::mir::{Field, Local};
-use std::borrow::Borrow;
+use rustc_middle::mir::Local;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
@@ -25,13 +24,13 @@ pub fn read_event_log(path: String) -> Vec<Event> {
     events
 }
 
-pub fn read_metadata(path: String) -> Metadata {
+pub fn _read_metadata(path: String) -> Metadata {
     let file = File::open(path).unwrap();
     bincode::deserialize_from(file).unwrap()
 }
 
 /** return the ptr of interest for a particular event */
-fn get_ptr(kind: &EventKind, metadata: &EventMetadata) -> Option<usize> {
+fn get_ptr(kind: &EventKind, _metadata: &EventMetadata) -> Option<usize> {
     Some(match kind {
         EventKind::CopyPtr(lhs) => *lhs,
         EventKind::Field(ptr, ..) => *ptr,
@@ -55,9 +54,9 @@ fn get_ptr(kind: &EventKind, metadata: &EventMetadata) -> Option<usize> {
 
 fn get_parent_object(kind: &EventKind, obj: (GraphId, NodeId)) -> Option<(GraphId, NodeId)> {
     Some(match kind {
-        EventKind::Realloc { new_ptr, .. } => return None,
-        EventKind::Alloc { ptr, .. } => return None,
-        EventKind::AddrOfLocal(ptr, _) => return None,
+        EventKind::Realloc { new_ptr: _new_ptr, .. } => return None,
+        EventKind::Alloc { ptr: _ptr, .. } => return None,
+        EventKind::AddrOfLocal(_ptr, _) => return None,
         EventKind::Done => return None,
         _ => obj,
     })
@@ -152,7 +151,7 @@ pub fn add_node(
     }
 
     let head = get_ptr(&event.kind, &metadata).and_then(|p| provenances.get(&p).cloned());
-    let ptr = head.and_then(|(gid, last_nid_ref)| {
+    let ptr = head.and_then(|(gid, _last_nid_ref)| {
         graphs.graphs[gid]
             .nodes
             .iter()

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -1,25 +1,29 @@
+use c2rust_analysis_rt::MirPlace;
 use rustc_index::newtype_index;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{BasicBlock, Field, Local};
 use rustc_span::def_id::DefPathHash;
-use c2rust_analysis_rt::MirPlace;
-use std::{collections::HashMap, fmt::Debug};
+use std::{
+    collections::HashMap,
+    fmt::{self, Debug, Formatter},
+    ops::{Index, IndexMut},
+};
 
-// Implement `Idx` and other traits like MIR indices (`Local`, `BasicBlock`, etc.)
 newtype_index!(
+    /// Implement `Idx` and other traits like MIR indices (`Local`, `BasicBlock`, etc.)
     pub struct GraphId { DEBUG_FORMAT = "GraphId({})" }
 );
 
-// Implement `Idx` and other traits like MIR indices (`Local`, `BasicBlock`, etc.)
 newtype_index!(
+    /// Implement `Idx` and other traits like MIR indices (`Local`, `BasicBlock`, etc.)
     pub struct NodeId { DEBUG_FORMAT = "NodeId({})" }
 );
 
-// Implement `Idx` and other traits like MIR indices (`Local`, `BasicBlock`, etc.)
+/// Implement `Idx` and other traits like MIR indices (`Local`, `BasicBlock`, etc.)
 pub const _ROOT_NODE: NodeId = NodeId::from_u32(0);
 
 /// A pointer derivation graph, which tracks the handling of one object throughout its lifetime.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Graph {
     /// The nodes in the graph.  Nodes are stored in increasing order by timestamp.  The first
     /// node, called the "root node", creates the object described by this graph, and all other
@@ -38,8 +42,8 @@ impl Graph {
 pub struct Func(pub DefPathHash);
 
 impl Debug for Func {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let x = c2rust_analysis_rt::DefPathHash::from(self.0.0.as_value());
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let x = c2rust_analysis_rt::DefPathHash::from(self.0 .0.as_value());
         x.fmt(f)
     }
 }
@@ -125,6 +129,7 @@ pub enum NodeKind {
 }
 
 /// A collection of graphs describing the handling of one or more objects within the program.
+#[derive(Default)]
 pub struct Graphs {
     /// The graphs.  Each graph describes one object, or one group of objects that were all handled
     /// identically.
@@ -144,7 +149,7 @@ impl Graphs {
 }
 
 impl Debug for Graphs {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", self.graphs)
     }
 }

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -2,7 +2,7 @@ use rustc_index::newtype_index;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{BasicBlock, Field, Local};
 use rustc_span::def_id::DefPathHash;
-use c2rust_analysis_rt::{MirPlace, mir_loc::EventMetadata};
+use c2rust_analysis_rt::MirPlace;
 use std::{collections::HashMap, fmt::Debug};
 
 // Implement `Idx` and other traits like MIR indices (`Local`, `BasicBlock`, etc.)
@@ -16,7 +16,7 @@ newtype_index!(
 );
 
 // Implement `Idx` and other traits like MIR indices (`Local`, `BasicBlock`, etc.)
-pub const ROOT_NODE: NodeId = NodeId::from_u32(0);
+pub const _ROOT_NODE: NodeId = NodeId::from_u32(0);
 
 /// A pointer derivation graph, which tracks the handling of one object throughout its lifetime.
 #[derive(Debug)]
@@ -75,7 +75,7 @@ pub struct Node {
     /// The kind of operation that was performed.
     pub kind: NodeKind,
     /// The `Node` that produced the input to this operation.
-    pub source: Option<(NodeId)>,
+    pub source: Option<NodeId>,
 }
 
 #[derive(Debug)]
@@ -100,7 +100,7 @@ pub enum NodeKind {
     AddrOfLocal(Local),
     /// Get the address of a static.  These are treated the same as locals, with an
     /// `AddressOfStatic` attributed to the first statement.
-    AddrOfStatic(DefPathHash),
+    _AddrOfStatic(DefPathHash),
     /// Heap allocation.  The `usize` is the number of array elements allocated; for allocations of
     /// a single object, this value is 1.
     Malloc(usize),

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -1,9 +1,12 @@
 #![feature(min_specialization)]
 #![feature(rustc_private)]
 #![feature(map_try_insert)]
+
 extern crate rustc_ast;
 extern crate rustc_const_eval;
+extern crate rustc_data_structures;
 extern crate rustc_driver;
+extern crate rustc_hir;
 extern crate rustc_index;
 extern crate rustc_interface;
 extern crate rustc_middle;
@@ -13,46 +16,38 @@ extern crate rustc_serialize;
 extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_target;
-extern crate rustc_hir;
-extern crate rustc_data_structures;
 
 mod builder;
 mod graph;
 
+use builder::{construct_pdg, read_event_log};
+use c2rust_analysis_rt::{mir_loc, Runtime};
+use std::{env, path::Path};
 
-use builder::{read_event_log, construct_pdg};
-use c2rust_analysis_rt::mir_loc;
-use lazy_static::lazy_static;
-use std::env;
-
-lazy_static! {
-    static ref EVENT_TRACE_FILE_PATH: String = {
-        env::args()
-            .skip(1)
-            .next()
-            .expect("Expected event trace file path as the first argument")
-    };
-}
-
-fn main() {
+fn main() -> anyhow::Result<()> {
     env_logger::init();
-    c2rust_analysis_rt::initialize();
+    let _runtime = Runtime::new();
 
-    let events = read_event_log(EVENT_TRACE_FILE_PATH.to_string());
+    let event_trace_path = env::args()
+        .skip(1)
+        .next()
+        .expect("Expected event trace file path as the first argument");
+    let events = read_event_log(Path::new(event_trace_path.as_str()))?;
 
     for event in &events {
         let mir_loc = mir_loc::get(event.mir_loc).unwrap();
-        println!("{:?} -> {:?}", mir_loc, event.kind);
+        let kind = &event.kind;
+        println!("{mir_loc:?} -> {kind:?}");
     }
 
     let pdg = construct_pdg(&events);
     for (g, graph) in pdg.graphs.iter().enumerate() {
-        println!("-- Object {:?} ---", g);
+        println!("-- Object {g:?} ---");
         for (n, node) in graph.nodes.iter().enumerate() {
-            println!("{:?}:{:?}", n, node)
+            println!("{n:?}:{node:?}");
         }
-        println!()
+        println!();
     }
 
-    c2rust_analysis_rt::finalize();
+    Ok(())
 }

--- a/scripts/get-binary-names-from-cargo-metadata.mjs
+++ b/scripts/get-binary-names-from-cargo-metadata.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+import * as fs from "fs";
+import assert from "node:assert/strict";
+
+const [_nodePath, _scriptPath, ...args] = process.argv;
+assert(args.length <= 1);
+const isDefault = args[0] === "default";
+
+const cargoMetadataString = fs.readFileSync("/dev/stdin");
+const cargoMetadata = JSON.parse(cargoMetadataString);
+const binaryNames = cargoMetadata
+    .workspace_members
+    .map(id => cargoMetadata.packages.find(e => e.id === id))
+    .flatMap(package_ => {
+        const useDefault = isDefault && package_.default_run;
+        return package_
+            .targets
+            .filter(target => target.kind.includes("bin"))
+            .filter(target => !useDefault ? true : target.name === package_.default_run)
+            ;
+    })
+    .map(e => e.name)
+    ;
+for (const binaryName of binaryNames) {
+    console.log(binaryName);
+}

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euox pipefail
+
+cargo() {
+    command cargo "${1}" --profile "${CARGO_PROFILE}" "${@:2}"
+}
+
+main() {
+    local profile_dir_name="${1:-debug}"
+    if [[ "${profile_dir_name}" != "debug" ]]; then
+        echo >&2 "only debug works right now, see https://github.com/immunant/c2rust/issues/448"
+        return 1
+    fi
+
+    local profile_dir="target/${profile_dir_name}"
+    local profile="${profile_dir_name}"
+    if [[ "${profile}" == "debug" ]]; then
+        profile=dev
+    fi
+    export CARGO_PROFILE="${profile}"
+
+    test_dir=analysis/test
+
+    cargo build --features dynamic-instrumentation
+
+    export RUST_BACKTRACE=1
+    unset RUSTC_WRAPPER
+
+    rustc_path="$(rustup which rustc)"
+    toolchain_dir="$(dirname "$(dirname "${rustc_path}")")"
+
+    (cd "${test_dir}"
+        cargo clean
+        LD_LIBRARY_PATH="${toolchain_dir}/lib" ../../${profile_dir}/c2rust instrument metadata.bc ../runtime/ -- --profile "${CARGO_PROFILE}"
+        INSTRUMENT_BACKEND=log INSTRUMENT_OUTPUT=log.bc METADATA_FILE=metadata.bc ${profile_dir}/c2rust-analysis-test
+    )
+    return
+
+    (cd pdg
+        RUST_LOG=info METADATA_FILE="../${test_dir}/metadata.bc" cargo run -- "../${test_dir}/log.bc"
+    )
+}
+
+main "${@}"

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -37,12 +37,12 @@ main() {
 
     (cd "${test_dir}"
         cargo clean
-        LD_LIBRARY_PATH="${toolchain_dir}/lib" "${c2rust}" instrument metadata.bc "${runtime}" -- --profile "${CARGO_PROFILE}"
+        LD_LIBRARY_PATH="${toolchain_dir}/lib" "${c2rust}" instrument metadata.bc "${runtime}" -- --profile "${CARGO_PROFILE}" 1> instrument.out.log 2> instrument.err.log
         INSTRUMENT_BACKEND=log INSTRUMENT_OUTPUT=log.bc METADATA_FILE=metadata.bc cargo run
     )
 
     (cd pdg
-        RUST_LOG=info METADATA_FILE="../${test_dir}/metadata.bc" cargo run -- "../${test_dir}/log.bc"
+        RUST_LOG=info METADATA_FILE="../${test_dir}/metadata.bc" cargo run -- "../${test_dir}/log.bc" &> "../${test_dir}/pdg.log"
     )
 }
 

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -37,8 +37,19 @@ main() {
 
     (cd "${test_dir}"
         cargo clean
-        LD_LIBRARY_PATH="${toolchain_dir}/lib" "${c2rust}" instrument metadata.bc "${runtime}" -- --profile "${CARGO_PROFILE}" 1> instrument.out.log 2> instrument.err.log
-        INSTRUMENT_BACKEND=log INSTRUMENT_OUTPUT=log.bc METADATA_FILE=metadata.bc cargo run
+        
+        LD_LIBRARY_PATH="${toolchain_dir}/lib" \
+        "${c2rust}" instrument \
+            metadata.bc "${runtime}" \
+            -- --profile "${CARGO_PROFILE}" \
+        1> instrument.out.log \
+        2> instrument.err.log
+        
+        RUSTFLAGS=" ${RUSTFLAGS:-} -Awarnings " \
+        INSTRUMENT_BACKEND=log \
+        INSTRUMENT_OUTPUT=log.bc \
+        METADATA_FILE=metadata.bc \
+        cargo run
     )
 
     (cd pdg

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -7,7 +7,11 @@ cargo() {
 }
 
 main() {
-    local profile_dir_name="${1:-debug}"
+    local test_dir="${1}"
+
+    local profile_dir_name="${PROFILE:-debug}"
+    local cwd="${PWD}"
+
     if [[ "${profile_dir_name}" != "debug" ]]; then
         echo >&2 "only debug works right now, see https://github.com/immunant/c2rust/issues/448"
         return 1
@@ -20,22 +24,22 @@ main() {
     fi
     export CARGO_PROFILE="${profile}"
 
-    test_dir=analysis/test
-
     cargo build --features dynamic-instrumentation
 
     export RUST_BACKTRACE=1
     unset RUSTC_WRAPPER
 
-    rustc_path="$(rustup which rustc)"
-    toolchain_dir="$(dirname "$(dirname "${rustc_path}")")"
+    local rustc_path="$(rustup which rustc)"
+    local toolchain_dir="$(dirname "$(dirname "${rustc_path}")")"
+
+    local c2rust="${cwd}/${profile_dir}/c2rust"
+    local runtime="${cwd}/analysis/runtime/"
 
     (cd "${test_dir}"
         cargo clean
-        LD_LIBRARY_PATH="${toolchain_dir}/lib" ../../${profile_dir}/c2rust instrument metadata.bc ../runtime/ -- --profile "${CARGO_PROFILE}"
-        INSTRUMENT_BACKEND=log INSTRUMENT_OUTPUT=log.bc METADATA_FILE=metadata.bc ${profile_dir}/c2rust-analysis-test
+        LD_LIBRARY_PATH="${toolchain_dir}/lib" "${c2rust}" instrument metadata.bc "${runtime}" -- --profile "${CARGO_PROFILE}"
+        INSTRUMENT_BACKEND=log INSTRUMENT_OUTPUT=log.bc METADATA_FILE=metadata.bc cargo run
     )
-    return
 
     (cd pdg
         RUST_LOG=info METADATA_FILE="../${test_dir}/metadata.bc" cargo run -- "../${test_dir}/log.bc"

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -39,7 +39,7 @@ main() {
     local metadata="${cwd}/${test_dir}/metadata.bc"
 
     (cd "${test_dir}"
-        if [[ "${c2rust}" -nt "${metadata}" ]] || [[ "${c2rust_instrument}" -nt "${metadata}" ]]; then
+        if [[ "${c2rust_instrument}" -nt "${metadata}" ]]; then
             cargo clean
 
             LD_LIBRARY_PATH="${toolchain_dir}/lib" \

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -8,6 +8,7 @@ cargo() {
 
 main() {
     local test_dir="${1}"
+    local args="${@:2}"
 
     local profile_dir_name="${PROFILE:-debug}"
     local cwd="${PWD}"
@@ -53,7 +54,7 @@ main() {
         INSTRUMENT_BACKEND=log \
         INSTRUMENT_OUTPUT=log.bc \
         METADATA_FILE="${metadata}" \
-        cargo run
+        cargo run -- "${args[@]}"
     )
 
     (cd pdg


### PR DESCRIPTION
I added a script, `./scripts/pdg.sh <test crate root> <args...>`, that instruments and runs a test crate, such as `analysis/test` or `lighttpd`.  This is a more generic version of @aneksteind's saved command.
* It only re-builds/instruments if the `c2rust-instrument` binary is newer than `metadata.bc`.
* It saves the `c2rust instrument` output to `instrument.{out,err}.log` and the `pdg` output to `pdg.log`.
* It supresses the many warnings from the test crate with `RUSTFLAGS="-Awarnings"`.
* It uses `./scripts/get-get-binary-names-from-cargo-metadata.mjs` to parse `cargo metadata` to know what default binary targets to run (because `cargo run` doesn't work with the instrumented binary).

Then I cleaned up a bunch of things:
* Removed unused imports.
* `_`-prefixed unused variables, functions, types, etc.
* Ran `rustfmt`.
Now everything builds without warnings.

And then I refactored some things in `c2rust_pdg`:
* Switched to using the RAII `c2rust_analysis_rt::Runtime` instead of `initialize` and `finalize` calls.
* Added `anyhow` for error-handling instead of `.unwrap()`ing everywhere.
* Made `EVENT_TRACE_FILE_PATH` a normal variable in `fn main` instead of a `lazy_static!`, since it's only used once.
* Gave some variables more expressive names.
* Used new inline formatting strings (e.x. `"{x:?}"`).
* Skipped some `String` allocs that were unneeded.
* Switched an `Into` `impl` to a `From` one.
* Fixed doc comments on `newtype_index!` types.
* `#[derive(Default)]`ed some structs that had similar `new` methods.
* Refactored `read_event_log` to use `iter::from_fn`, which is way cleaner.
* Added `use EventKind::*` wildcard imports right before large `match`es to reduce boilerplate.
* Added a `trait EventKindExt` `impl`ed for `EventKind` for all the functions that took an `&EventKind` that were method-like.
* Refactored `has_parent` out of `parent` (previously `get_parent_object`), since it only returned `None` or `Some(obj)`.
* Replaced uses of `usize` that were really `Pointer` (`c2rust_analysis_rt::Pointer`) with `Pointer` for clarity.
* Removed some unnecessary `.clone()`s (as in they were no-ops).
* Switched `&Vec<_>` args to `&[_]`.

