### PR TITLE
Use `syn::parse_quote!` to reimplement the generation of `fn main()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,19 +677,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -1676,18 +1663,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -20,7 +20,7 @@ c2rust-bitfields = { version = "0.3.0", path = "../c2rust-bitfields" }
 clap = {version = "2.34", features = ["yaml"]}
 colored = "2.0"
 dtoa = "1.0"
-failure = "0.1.5"
+failure = { version = "0.1.5", default-features = false, features = ["std"] }
 fern = { version = "0.6", features = ["colored"] }
 handlebars = "4.2"
 indexmap = { version = "1.0.1", features = ["serde-1"] }

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -3,56 +3,81 @@
 //! a helper that can be called from a generated main function in
 //! Rust.
 
-use super::*;
 use failure::format_err;
-use proc_macro2::{TokenStream, TokenTree};
+use proc_macro2::Span;
+
+use crate::translator::{Translation, TranslationError};
+use crate::{CDeclId, CDeclKind, CParamId, CTypeKind};
 
 impl<'c> Translation<'c> {
-    pub fn convert_main(&self, main_id: CDeclId) -> Result<Box<Item>, TranslationError> {
-        if let CDeclKind::Function {
-            ref parameters,
-            typ,
-            ..
-        } = self.ast_context.index(main_id).kind
+    pub fn convert_main(&self, main_id: CDeclId) -> Result<Box<syn::Item>, TranslationError> {
+        let (parameters, typ) = if let CDeclKind::Function {
+            parameters, typ, ..
+        } = &self.ast_context[main_id].kind
         {
-            let ret: CTypeKind = match self.ast_context.resolve_type(typ).kind {
-                CTypeKind::Function(ret, _, _, _, _) => {
-                    self.ast_context.resolve_type(ret.ctype).kind.clone()
-                }
-                ref k => Err(format_err!(
+            (parameters, typ)
+        } else {
+            return Err(TranslationError::generic(
+                "Cannot translate non-function main entry point",
+            ));
+        };
+
+        let ret: CTypeKind = match &self.ast_context.resolve_type(*typ).kind {
+            CTypeKind::Function(ret, _, _, _, _) => {
+                self.ast_context.resolve_type(ret.ctype).kind.clone()
+            }
+            k => {
+                return Err(format_err!(
                     "Type of main function {:?} was not a function type, got {:?}",
                     main_id,
                     k
-                ))?,
-            };
+                )
+                .into())
+            }
+        };
 
-            let main_fn_name = self
-                .renamer
-                .borrow()
-                .get(&main_id)
-                .expect("Could not find main function in renamer");
+        let main_fn_name = self
+            .renamer
+            .borrow()
+            .get(&main_id)
+            .expect("Could not find main function in renamer");
 
-            let main_fn = syn::Ident::new(&main_fn_name, Span::dummy());
+        let main_fn = syn::Ident::new(&main_fn_name, Span::call_site());
 
-            let mut stmts: Vec<Stmt> = vec![];
-            let mut main_args: Vec<Box<Expr>> = vec![];
+        let get_arg_ty = |idx: &CParamId, name: &str| match &self.ast_context[*idx].kind {
+            CDeclKind::Variable { typ, .. } => self.convert_type(typ.ctype),
+            _ => {
+                Err(format_err!("Cannot find type of '{}' argument in main function", name).into())
+            }
+        };
 
-            let get_arg_ty = |idx: CParamId, name: &str| match self.ast_context[idx].kind {
-                CDeclKind::Variable { ref typ, .. } => self.convert_type(typ.ctype),
-                _ => Err(TranslationError::generic(
-                    format!("Cannot find type of '{}' argument in main function", name),
-                )),
-            };
+        match parameters.as_slice() {
+            [] => {
+                if let CTypeKind::Void = ret {
+                    Ok(syn::parse_quote! {
+                        pub fn main() {
+                            unsafe { #main_fn() };
+                            ::std::process::exit(0_i32);
+                        }
+                    })
+                } else {
+                    Ok(syn::parse_quote! {
+                        pub fn main() {
+                            let main_result = unsafe { #main_fn() };
+                            ::std::process::exit(main_result as i32);
+                        }
+                    })
+                }
+            }
 
-            let n = parameters.len();
+            [argc_id, argv_id, rest @ ..] if rest.len() <= 1 => {
+                let mut stmts: Vec<syn::Stmt> = vec![];
+                let mut main_args: Vec<syn::Expr> = vec![];
 
-            if n >= 2 {
                 // `argv` and `argc`
 
-                stmts.push(syn::parse_quote! {
+                stmts.append(&mut syn::parse_quote! {
                     let mut args: Vec<*mut ::libc::c_char> = Vec::new();
-                });
-                stmts.push(syn::parse_quote! {
                     for arg in ::std::env::args() {
                         args.push(
                             ::std::ffi::CString::new(arg)
@@ -60,72 +85,60 @@ impl<'c> Translation<'c> {
                                 .into_raw()
                         );
                     }
-                });
-                stmts.push(syn::parse_quote! {
                     args.push(::std::ptr::null_mut());
                 });
 
-                let argc_ty: Box<Type> = get_arg_ty(parameters[0], "argc")?;
-                let argv_ty: Box<Type> = get_arg_ty(parameters[1], "argv")?;
+                let argc_ty: Box<syn::Type> = get_arg_ty(argc_id, "argc")?;
+                let argv_ty: Box<syn::Type> = get_arg_ty(argv_id, "argv")?;
 
-                main_args.push(syn::parse_quote!((args.len() - 1) as #argc_ty));
-                main_args.push(syn::parse_quote!(args.as_mut_ptr() as #argv_ty));
-            }
+                main_args.push(syn::parse_quote! { (args.len() - 1) as #argc_ty });
+                main_args.push(syn::parse_quote! { args.as_mut_ptr() as #argv_ty });
 
-            if n >= 3 {
-                // non-standard `envp`
+                if let [envp_id] = rest {
+                    // non-standard `envp`
 
-                stmts.push(syn::parse_quote! {
-                    let mut vars: Vec<*mut ::libc::c_char> = Vec::new();
-                });
-                stmts.push(syn::parse_quote! {
-                    for (var_name, var_value) in ::std::env::vars() {
-                        let var: String = format!("{}={}", var_name, var_value);
-                        vars.push(
-                            ::std::ffi::CString::new(var)
-                                .expect("Failed to convert environment variable into CString.")
-                                .into_raw()
-                        );
-                    }
-                });
-                stmts.push(syn::parse_quote! {
-                    vars.push(::std::ptr::null_mut);
-                });
+                    stmts.append(&mut syn::parse_quote! {
+                        let mut vars: Vec<*mut ::libc::c_char> = Vec::new();
+                        for (var_name, var_value) in ::std::env::vars() {
+                            let var: String = format!("{}={}", var_name, var_value);
+                            vars.push(
+                                ::std::ffi::CString::new(var)
+                                    .expect("Failed to convert environment variable into CString.")
+                                    .into_raw()
+                            );
+                        }
+                        vars.push(::std::ptr::null_mut);
+                    });
 
-                let envp_ty: Box<Type> = get_arg_ty(parameters[2], "envp")?;
+                    let envp_ty: Box<syn::Type> = get_arg_ty(envp_id, "envp")?;
 
-                main_args.push(syn::parse_quote!(vars.as_mut_ptr() as #envp_ty));
-            }
-
-            // Check `main` has the right form
-            if n != 0 && n != 2 && n != 3 {
-                Err(format_err!(
-                    "Main function should have 0, 2, or 3 parameters, not {}.",
-                    n
-                ))?;
-            };
-
-            if let CTypeKind::Void = ret {
-                stmts.append(&mut syn::parse_quote! {
-                    unsafe { #main_fn( #(#main_args),* ) };
-                    ::std::process::exit(0_i32);
-                });
-            } else {
-                stmts.append(&mut syn::parse_quote! {
-                    let main_result = unsafe { #main_fn( #(#main_args),* ) };
-                    ::std::process::exit(main_result as i32);
-                });
-            };
-
-            Ok(syn::parse_quote! {
-                pub fn main() {
-                    #(#stmts)*
+                    main_args.push(syn::parse_quote! { vars.as_mut_ptr() as #envp_ty });
                 }
-            })
-        } else {
-            Err(TranslationError::generic(
-                "Cannot translate non-function main entry point",
-            ))
+
+                if let CTypeKind::Void = ret {
+                    stmts.append(&mut syn::parse_quote! {
+                        unsafe { #main_fn( #(#main_args),* ) };
+                        ::std::process::exit(0_i32);
+                    });
+                } else {
+                    stmts.append(&mut syn::parse_quote! {
+                        let main_result = unsafe { #main_fn( #(#main_args),* ) };
+                        ::std::process::exit(main_result as i32);
+                    });
+                };
+
+                Ok(syn::parse_quote! {
+                    pub fn main() {
+                        #(#stmts)*
+                    }
+                })
+            }
+
+            _ => Err(format_err!(
+                "Main function should have 0, 2, or 3 parameters, not {}.",
+                parameters.len(),
+            )
+            .into()),
         }
     }
 }


### PR DESCRIPTION
This PR reimplements `c2rust_transpile::translator::main_function` using `syn::parse_quote!` macro instead of explicitly constructed AST via c2rust-ast-builder. The PR consists of two commits. The first one purely swaps usages of `mk()` for `syn::parse_quote!`. The second restructures `convert_main` into a more idiomatic form, leveraging slice patterns and avoiding panicking item accesses.

This PR is intended foremost as a test drive of the `syn::parse_quote!` in the context of the transpiler. It is meant to showcase on a relatively simple and compact test case the benefits of that approach, and to gain experience with porting code to `parse_quote!`.

In my view, the benefits of `parse_quote!`-based solution are obvious. The code is much more compact, it doesn't require any redundant boxing of AST nodes, the API is familiar to any Rust programmer (it's just the usual Rust code), and the output of code generation is immediately visible. There is also some mild help available from the IDEs with regard to interpolated code (mostly related to syntax highlighting and brace matching).

The only downside that I have encountered is that the code is no longer typechecked at compile time: while the builder explicitly constructs the well-typed AST, turning any syntax errors into compile errors, the `parse_quote!` invocation is parsed only at runtime. This means that if the code within the macro is not well-formed, it will be uncovered only at runtime, and the errors may be confusing (the exact position of the error is not provided by the macro). Unfortunately, `parse_quote!` relies heavily on Rust's trait system, and const traits are still very unstable, so this will not improve in the foreseeable future.

On the other hand, the possibility of purely syntactic errors is quite low, since the code snippets within the macro are usually very short and natural. There was only one case which stumped me: the return type of function signature. I have tried to write `fn foo() -> #ret`, while the correct syntax is `fn foo() #ret`, with `ret` an `Option<ReturnType>`. In retrospect, it should have been obvious since otherwise `->` would be dangling, but it's lack in the correct syntax is still mildly disturbing for me.

In all other cases during my experiments (which included not just `convert_main`), I have not encountered any confusing behaviour.

Another potential issue is that `parse_quote!` is less amenable to incremental construction of AST than the builder. This may be side-stepped with intermediate well-typed parses, or with `quote!` macro (but it increases the likelihood of runtime errors). However, I have generally experienced that `parse_quote!` makes AST generation simple enough that some minor code duplication is a nice alternative to incremental builders.

If this PR is acceptable, I would like to gradually switch most code to the `syn::parse_quote!` API. I plan to do it in several PRs, since such sweeping changes are likely to cause merge conflicts with branches. Also, it's hard to test such sweeping changes, and I'm not sure that I would like to migrate _all_ usages of c2rust-ast-builder (some cases look simpler with the builder API, but they are rare).