### PR TITLE
Fixed some of the remaining `clippy` warnings that needed slightly more complex refactors.

### DIFF
--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -165,12 +165,13 @@ fn convert_module_list(
 ) -> Vec<Module> {
     modules.retain(|m| {
         let is_binary = tcfg.is_binary(m);
-        if is_binary && module_subset == ModuleSubset::Libraries {
+        let is_mod_binary = module_subset == ModuleSubset::Binaries;
+        if is_binary && !is_mod_binary {
             // Don't add binary modules to lib.rs, these are emitted to
             // standalone, separate binary modules.
             false
         } else {
-            is_binary || !(module_subset == ModuleSubset::Binaries)
+            is_binary || !is_mod_binary
         }
     });
 

--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -169,10 +169,8 @@ fn convert_module_list(
             // Don't add binary modules to lib.rs, these are emitted to
             // standalone, separate binary modules.
             false
-        } else if !is_binary && module_subset == ModuleSubset::Binaries {
-            false
         } else {
-            true
+            is_binary || !(module_subset == ModuleSubset::Binaries)
         }
     });
 

--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -168,7 +168,7 @@ fn convert_module_list(
         let is_mod_binary = module_subset == ModuleSubset::Binaries;
         // Don't add binary modules to lib.rs, these are emitted to
         // standalone, separate binary modules.
-        !(is_binary ^ is_mod_binary)
+        is_binary == is_mod_binary
     });
 
     let mut res = vec![];

--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -166,13 +166,9 @@ fn convert_module_list(
     modules.retain(|m| {
         let is_binary = tcfg.is_binary(m);
         let is_mod_binary = module_subset == ModuleSubset::Binaries;
-        if is_binary && !is_mod_binary {
-            // Don't add binary modules to lib.rs, these are emitted to
-            // standalone, separate binary modules.
-            false
-        } else {
-            is_binary || !is_mod_binary
-        }
+        // Don't add binary modules to lib.rs, these are emitted to
+        // standalone, separate binary modules.
+        !(is_binary ^ is_mod_binary)
     });
 
     let mut res = vec![];

--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -165,10 +165,10 @@ fn convert_module_list(
 ) -> Vec<Module> {
     modules.retain(|m| {
         let is_binary = tcfg.is_binary(m);
-        let is_mod_binary = module_subset == ModuleSubset::Binaries;
+        let is_binary_subset = module_subset == ModuleSubset::Binaries;
         // Don't add binary modules to lib.rs, these are emitted to
         // standalone, separate binary modules.
-        is_binary == is_mod_binary
+        is_binary == is_binary_subset
     });
 
     let mut res = vec![];

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use log::warn;
-use syn::{spanned::Spanned as _, ExprBreak, ExprIf, ExprParen, ExprReturn, ExprUnary, Stmt};
+use syn::{spanned::Spanned as _, ExprBreak, ExprIf, ExprReturn, ExprUnary, Stmt};
 
 use crate::rust_ast::{comment_store, set_span::SetSpan, BytePos, SpanExt};
 

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -672,12 +672,6 @@ impl StructureState {
 ///   * Negating something of the form `!<expr>` produces `<expr>`
 ///
 fn not(bool_expr: &Box<Expr>) -> Box<Expr> {
-    fn unparen(expr: &Box<Expr>) -> &Box<Expr> {
-        match **expr {
-            Expr::Paren(ExprParen { ref expr, .. }) => expr,
-            _ => expr,
-        }
-    }
     match **bool_expr {
         Expr::Unary(ExprUnary {
             op: syn::UnOp::Not(_),

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -463,14 +463,18 @@ fn asm_is_att_syntax(asm: &str) -> bool {
         (Some(_intel), None) => false,
         (None, Some(_att)) => true,
         (None, None) => {
-            match () {
-                _ if asm.contains("word ptr") => false,
+            #[allow(clippy::needless_bool)]
+            if asm.contains("word ptr") {
+                false
+            } else if asm.contains('$') || asm.contains('%') || asm.contains('(') {
                 // Guess based on sigils used in AT&T assembly:
                 // $ for constants, % for registers, and ( for address calculations
-                _ if asm.contains('$') || asm.contains('%') || asm.contains('(') => true,
-                _ if asm.contains('[') => false,
+                true
+            } else if asm.contains('[') {
                 // default to true, because AT&T is the default for gcc inline asm
-                _ => true,
+                false
+            } else {
+                true
             }
         }
     }

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -453,26 +453,26 @@ fn asm_is_att_syntax(asm: &str) -> bool {
     // Look for syntax directives.
     let intel_directive = asm.find(".intel_syntax");
     let att_directive = asm.find(".att_syntax");
-    if let (Some(intel_pos), Some(att_pos)) = (intel_directive, att_directive) {
-        // Both directives are present; presumably this asm switches to one at
-        // its start and restores the default at the end. Whichever comes first
-        // should be what the asm uses.
-        att_pos < intel_pos
-    } else if intel_directive.is_some() {
-        false
-    } else if att_directive.is_some() {
-        true
-    } else if asm.contains("word ptr") {
-        false
-    } else if asm.contains('$') || asm.contains('%') || asm.contains('(') {
-        // Guess based on sigils used in AT&T assembly:
-        // $ for constants, % for registers, and ( for address calculations
-        true
-    } else if asm.contains('[') {
-        false
-    } else {
-        // default to true, because AT&T is the default for gcc inline asm
-        true
+    match (intel_directive, att_directive) {
+        (Some(intel_pos), Some(att_pos)) => {
+            // Both directives are present; presumably this asm switches to one at
+            // its start and restores the default at the end. Whichever comes first
+            // should be what the asm uses.
+            att_pos < intel_pos
+        }
+        (Some(_intel), None) => false,
+        (None, Some(_att)) => true,
+        (None, None) => {
+            match () {
+                _ if asm.contains("word ptr") => false,
+                // Guess based on sigils used in AT&T assembly:
+                // $ for constants, % for registers, and ( for address calculations
+                _ if asm.contains('$') || asm.contains('%') || asm.contains('(') => true,
+                _ if asm.contains('[') => false,
+                // default to true, because AT&T is the default for gcc inline asm
+                _ => true,
+            }
+        }
     }
 }
 

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -131,19 +131,15 @@ impl<'c> Translation<'c> {
             CLiteral::String(ref val, width) => {
                 let mut val = val.to_owned();
 
-                match self.ast_context.resolve_type(ty.ctype).kind {
-                    CTypeKind::ConstantArray(_elem_ty, size) => {
-                        // Match the literal size to the expected size padding with zeros as needed
-                        val.resize(size * (width as usize), 0)
-                    }
-
-                    // Add zero terminator
-                    _ => {
-                        for _ in 0..width {
-                            val.push(0);
-                        }
-                    }
+                let num_elems = match self.ast_context.resolve_type(ty.ctype).kind {
+                    // Match the literal size to the expected size padding with zeros as needed
+                    CTypeKind::ConstantArray(_elem_ty, size) => size,
+                    // zero terminator
+                    _ => 1,
                 };
+                let size = num_elems * (width as usize);
+                val.resize(size, 0);
+
                 let u8_ty = mk().path_ty(vec!["u8"]);
                 let width_lit = mk().lit_expr(mk().int_unsuffixed_lit(val.len() as u128));
                 let array_ty = mk().array_ty(u8_ty, width_lit);

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -1140,7 +1140,7 @@ fn item_attrs(item: &mut Item) -> Option<&mut Vec<syn::Attribute>> {
 }
 
 /// Unwrap a layer of parenthesization from an Expr, if present
-fn unparen(expr: &Box<Expr>) -> &Box<Expr> {
+pub(crate) fn unparen(expr: &Box<Expr>) -> &Box<Expr> {
     match **expr {
         Expr::Paren(ExprParen { ref expr, .. }) => expr,
         _ => expr,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -390,8 +390,7 @@ pub fn stmts_block(mut stmts: Vec<Stmt>) -> Box<Block> {
     mk().block(stmts)
 }
 
-/// Generate link attributes needed to ensure that the generated Rust libraries have the right symbol
-/// values.
+/// Generate link attributes needed to ensure that the generated Rust libraries have the right symbol values.
 fn mk_linkage(in_extern_block: bool, new_name: &str, old_name: &str) -> Builder {
     if new_name == old_name {
         if in_extern_block {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -375,27 +375,23 @@ fn vec_expr(val: Box<Expr>, count: Box<Expr>) -> Box<Expr> {
 }
 
 pub fn stmts_block(mut stmts: Vec<Stmt>) -> Box<Block> {
-    if let [Stmt::Expr(Expr::Block(ExprBlock {
-        block, label: None, ..
-    }))] = stmts.as_slice()
-    {
-        return Box::new(block.clone());
-    }
-
-    if !stmts.is_empty() {
-        let n = stmts.len() - 1;
-        let mut s = stmts.remove(n);
-        if let Stmt::Expr(e) = s {
-            s = Stmt::Semi(e, Default::default());
+    match stmts.pop() {
+        None => {}
+        Some(Stmt::Expr(Expr::Block(ExprBlock {
+            block, label: None, ..
+        }))) if stmts.is_empty() => return Box::new(block),
+        Some(mut s) => {
+            if let Stmt::Expr(e) = s {
+                s = Stmt::Semi(e, Default::default());
+            }
+            stmts.push(s);
         }
-        stmts.push(s)
     }
-
     mk().block(stmts)
 }
 
-// Generate link attributes needed to ensure that the generated Rust libraries have the right symbol
-// values.
+/// Generate link attributes needed to ensure that the generated Rust libraries have the right symbol
+/// values.
 fn mk_linkage(in_extern_block: bool, new_name: &str, old_name: &str) -> Builder {
     if new_name == old_name {
         if in_extern_block {


### PR DESCRIPTION
I fixed some of the remaining `clippy` warnings (from https://github.com/immunant/c2rust/pull/460) that needed slightly more complex refactors, which I want to have reviewed to make sure they're semantics-preserving.