### PR TITLE
Disable building `json2cbor.c` in `tinycbor`, and which doesn't build on macOS/BSDs when `cjson` is installed

### DIFF
--- a/c2rust-ast-exporter/src/CMakeLists.txt
+++ b/c2rust-ast-exporter/src/CMakeLists.txt
@@ -19,7 +19,7 @@ ExternalProject_Add(tinycbor_build
             # patch from upstream:
             # https://github.com/intel/tinycbor/commit/6176e0a28d7c5ef3a5e9cbd02521999c412de72c
             PATCH_COMMAND patch --forward -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/tinycbor_fix_build.patch || true
-            CONFIGURE_COMMAND ""
+            CONFIGURE_COMMAND make .config && cat ${CMAKE_CURRENT_SOURCE_DIR}/tinycbor.config >> .config
             BUILD_COMMAND make --quiet prefix=<INSTALL_DIR> CFLAGS=-fPIC
             INSTALL_COMMAND make --quiet prefix=<INSTALL_DIR> install            
             BUILD_IN_SOURCE 1

--- a/c2rust-ast-exporter/src/tinycbor.config
+++ b/c2rust-ast-exporter/src/tinycbor.config
@@ -1,4 +1,4 @@
 # Disable json2cbor by disabling cjson.
 # We don't need json2cbor and it doesn't compile on BSD.
-system-cjson-pass := 0
-cjson-pass := 0
+system-cjson-pass := 
+cjson-pass := 

--- a/c2rust-ast-exporter/src/tinycbor.config
+++ b/c2rust-ast-exporter/src/tinycbor.config
@@ -1,0 +1,4 @@
+# Disable json2cbor by disabling cjson.
+# We don't need json2cbor and it doesn't compile on BSD.
+system-cjson-pass := 0
+cjson-pass := 0


### PR DESCRIPTION
Fixes https://github.com/immunant/c2rust/issues/353.

This unconditionally disables building `tools/json2cbor/` in [`tinycbor`](https://github.com/intel/tinycbor), which isn't needed for our uses of `tinycbor` and is an optional dependency.  Normally it is autodetected when [`cjson`](https://github.com/DaveGamble/cJSON) is found, and it still is, but now we append to the generated `.config` file to explicitly disable it.

On macOS/BSD, `tools/json2cbor/json2cbor.c` doesn't build because it defines `_POSIX_C_SOURCE`, which in BSD libc, prevents `asprintf` from being declared, which is used by `tools/json2cbor/json2cbor.c`.  This can be fixed by removing the `_POSIX_C_SOURCE` define, but that'd have to be fixed in a patch or upstream in https://github.com/intel/tinycbor, which it probably should be, but the fix would take longer.

However, either way, we don't need `json2cbor`, so we can just always disable it, and it's better to be explicit about our dependencies than unknowingly having an optional dependency on `cjson` that affects the build.