### PR TITLE
Switched `tinycbor` to use `GIT_REPOSITORY` and `GIT_TAG` instead of `URL` and `URL_HASH` in `ExternalProject_Add`

### DIFF
--- a/c2rust-ast-exporter/src/CMakeLists.txt
+++ b/c2rust-ast-exporter/src/CMakeLists.txt
@@ -4,17 +4,16 @@ project(ASTExporter)
 #################################################
 # TinyCBOR                                      #
 #################################################
-set(TINYCBOR_URL "https://github.com/intel/tinycbor/archive/v0.5.3.tar.gz"
-    CACHE STRING "tinycbor download URL")
-set(TINYCBOR_MD5 "2cd3af70d8749a7ddd5a8d04d09ea8f6" CACHE STRING "tinycbor archive md5 sum")
+# v0.5.3 tag, but using the commit hash instead for integrity checks (worth it?)
+set(TINYCBOR_TAG "755f9ef932f9830a63a712fd2ac971d838b131f1" CACHE STRING "tinycbor git tag/branch/commit hash")
 set(TINYCBOR_PREFIX "${CMAKE_BINARY_DIR}/tinycbor" CACHE STRING "tinycbor install prefix")
 
 include(ExternalProject)
 ExternalProject_Add(tinycbor_build
             PREFIX ${TINYCBOR_PREFIX}
             INSTALL_DIR ${CMAKE_BINARY_DIR}
-            URL ${TINYCBOR_URL}
-            URL_HASH MD5=${TINYCBOR_MD5}
+            GIT_REPOSITORY https://github.com/intel/tinycbor.git
+            GIT_TAG ${TINYCBOR_TAG}
             # the fd redirection here fails when the build run inside Cargo.
             # patch from upstream:
             # https://github.com/intel/tinycbor/commit/6176e0a28d7c5ef3a5e9cbd02521999c412de72c

--- a/scripts/provision_dnf.sh
+++ b/scripts/provision_dnf.sh
@@ -16,6 +16,7 @@ dnf install --quiet --assumeyes \
     clang-devel \
     cmake \
     diffutils \
+    git \
     libquadmath-devel \
     llvm-devel \
     make \

--- a/scripts/provision_yum.sh
+++ b/scripts/provision_yum.sh
@@ -13,7 +13,7 @@ fi
 # required to install ninja-build
 yum install --quiet --assumeyes epel-release
 # NOTE: CentOS version of cmake is too old
-yum install --quiet --assumeyes which ninja-build make cmake libquadmath-devel
+yum install --quiet --assumeyes which git ninja-build make cmake libquadmath-devel
 
 yum install --quiet --assumeyes luarocks
 


### PR DESCRIPTION
Switched `tinycbor` to use `GIT_REPOSITORY` and `GIT_TAG` instead of `URL` and `URL_HASH` in `ExternalProject_Add`.

`tinycbor` is already downloaded from GitHub, so we can just use the built-in git support.  This makes upgrading `tinycbor` versions easier.  Also, we can use either git tags/branches or commit hashes.  I used a commit hash here so we keep the integrity checks (which are SHA-1 now vs. MD5), but we could use git tags for more flexibility (easy to upgrade and they could patch/update the tag).

I added this because I was thinking about upgrading the `tinycbor` version, as we might want to upstream a fix for https://github.com/immunant/c2rust/issues/353, where the `_POSIX_C_SOURCE` define causes `asprintf` to not be declared in BSD libc.  I found a workaround for that by appending to the generating `tinycbor/.config` to disable `cjson` and `json2cbor` support since we don't need it anyways, but I'm not sure if that's the best long-term approach.