### PR TITLE
[feat.pdg] dyninstr: make transformations of instrumentation operands explicit

### DIFF
--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -365,11 +365,13 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for CollectFunctionInstrumentationPoints<'a, 't
                     }
                     place_ref = cur_ref;
                 }
+
                 // Storing a raw pointer in an indirect destination; trace the destination
+                let base_dest_ty = base_dest.ty(&self.body.local_decls, self.tcx).ty;
                 self.add_instrumentation_point(
                     location,
                     store_fn,
-                    vec![InstrumentationOperand::RawPtr(Operand::Copy(base_dest))],
+                    vec![InstrumentationOperand::from_type(Operand::Copy(base_dest), &base_dest_ty)],
                     false,
                     false,
                     EventMetadata {

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -962,7 +962,8 @@ fn cast_ptr_to_usize<'tcx>(
     let ptr = match arg {
         // If we were given an address as a usize, no conversion is necessary
         InstrumentationOperand::AddressUsize(_arg) => {
-            assert!(arg_ty.is_integral());
+            assert!(arg_ty.is_integral() || arg_ty.is_unit(),
+                "{:?}: {:?} is not of integral or unit type", arg, arg_ty);
             return None;
         },
         // From a reference `r`, cast through raw ptr to usize: `r as *mut _ as usize`
@@ -993,7 +994,7 @@ fn cast_ptr_to_usize<'tcx>(
         },
         // From a raw pointer `r`, cast: `r as usize`
         InstrumentationOperand::RawPtr(arg) => {
-            assert!(arg_ty.is_unsafe_ptr());
+            assert!(arg_ty.is_unsafe_ptr(), "{:?}: {:?} is not an unsafe ptr", arg, arg_ty);
             arg.to_copy()
         },
     };


### PR DESCRIPTION
This is basically a semantic rebase of bf6040e981ab637a3759df704cad9abc18d660ad onto the current state of `feat.pdg`, except without the semantic changes associated with uncommenting the [block that deals with mutable references](https://github.com/immunant/c2rust/blob/62d48e220a68347b1394e001882d93ad540c7b19/dynamic_instrumentation/src/instrument_memory.rs#L459-L468). As a result, it does not have the `InstrumentationOperand::Place` variant--that variant is only needed for handling references.

[block that deals with mutable references](https://github.com/immunant/c2rust/blob/62d48e220a68347b1394e001882d93ad540c7b19/dynamic_instrumentation/src/instrument_memory.rs#L459-L468):

https://github.com/immunant/c2rust/blob/62d48e220a68347b1394e001882d93ad540c7b19/dynamic_instrumentation/src/instrument_memory.rs#L459-L468

This change documents what is traced at each instrumentation point, giving reasoning for classifying each operand as `AddressUsize` (no transformation), `RawPtr` (cast to usize), or `Reference` (cast through a raw pointer to usize).

This should be semantics-preserving; any change in behavior is a bug.

There's one change I'm concerned about (search `XXX`: it seems like we might accidentally pass arbitrary types used as field projection bases to our instrumentation functions, which are monomorphic), and one place I'm curious about (the handling of `after_call` when defining `ret_value` in `apply_instrumentation`: I'm not 100% sure that "returns unit or a raw ptr" is the right assumption to make about our hooked functions, nor 100% sure that it's OK to fully conflate `after_call` with the situation where we're instrumenting a call to a hooked function).

https://github.com/immunant/c2rust/blob/ce8f9654e04f34c6cbc8b17de06d618c942b10b5/dynamic_instrumentation/src/instrument_memory.rs#L278-L283

After this merges the reference instrumentation changes themselves should be self-contained and easily reviewable.