### PR TITLE
Added pdg tests, the query, graph deduplication, and an improved textual representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "env_logger",
  "fs-err",
  "indexed_vec",
+ "itertools",
  "log",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "env_logger",
  "fs-err",
  "indexed_vec",
+ "indexmap",
  "itertools",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,8 +298,8 @@ dependencies = [
  "env_logger",
  "fs-err",
  "indexed_vec",
- "indexmap",
  "itertools",
+ "linked_hash_set",
  "log",
  "serde",
 ]
@@ -1179,6 +1179,21 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/analysis/runtime/src/mir_loc.rs
+++ b/analysis/runtime/src/mir_loc.rs
@@ -69,15 +69,15 @@ impl From<usize> for Local {
     }
 }
 
-impl Into<u32> for Local {
-    fn into(self) -> u32 {
-        self.index.try_into().unwrap()
+impl From<Local> for u32 {
+    fn from(val: Local) -> Self {
+        val.index.try_into().unwrap()
     }
 }
 
-impl Into<usize> for Local {
-    fn into(self) -> usize {
-        self.index.try_into().unwrap()
+impl From<Local> for usize {
+    fn from(val: Local) -> Self {
+        val.index.try_into().unwrap()
     }
 }
 

--- a/analysis/runtime/src/mir_loc.rs
+++ b/analysis/runtime/src/mir_loc.rs
@@ -1,10 +1,11 @@
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fmt;
+use std::fmt::{self, Formatter, Display};
 use std::fs::File;
 use std::path::PathBuf;
 use std::sync::RwLock;
+use std::fmt::Debug;
 
 lazy_static! {
     static ref MIR_LOC_FILE_PATH: RwLock<Option<PathBuf>> = RwLock::new(None);
@@ -90,8 +91,8 @@ impl Local {
     }
 }
 
-impl fmt::Debug for Local {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Debug for Local {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "_{}", self.index)
     }
 }
@@ -102,8 +103,8 @@ pub struct MirPlace {
     pub projection: Vec<MirProjection>,
 }
 
-impl fmt::Debug for MirPlace {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for MirPlace {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.local)?;
         for p in &self.projection {
             write!(f, ".{:?}", p)?;
@@ -112,13 +113,19 @@ impl fmt::Debug for MirPlace {
     }
 }
 
+impl Debug for MirPlace {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
 pub type MirLocId = u32;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub struct DefPathHash(pub u64, pub u64);
 
-impl fmt::Debug for DefPathHash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Debug for DefPathHash {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "{}",

--- a/analysis/runtime/src/mir_loc.rs
+++ b/analysis/runtime/src/mir_loc.rs
@@ -1,11 +1,11 @@
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fmt::{self, Formatter, Display};
+use std::fmt::Debug;
+use std::fmt::{self, Display, Formatter};
 use std::fs::File;
 use std::path::PathBuf;
 use std::sync::RwLock;
-use std::fmt::Debug;
 
 lazy_static! {
     static ref MIR_LOC_FILE_PATH: RwLock<Option<PathBuf>> = RwLock::new(None);
@@ -63,9 +63,10 @@ impl From<u32> for Local {
 
 impl From<usize> for Local {
     fn from(index: usize) -> Self {
-        Self {
-            index: index.try_into().unwrap(),
-        }
+        // Want it to work w/o code changes if I change the underlying type to `u32`.
+        #[allow(clippy::useless_conversion)]
+        let index = index.try_into().unwrap();
+        Self { index }
     }
 }
 
@@ -77,6 +78,8 @@ impl From<Local> for u32 {
 
 impl From<Local> for usize {
     fn from(val: Local) -> Self {
+        // Want it to work w/o code changes if I change the underlying type to `u32`.
+        #[allow(clippy::useless_conversion)]
         val.index.try_into().unwrap()
     }
 }

--- a/analysis/runtime/src/mir_loc.rs
+++ b/analysis/runtime/src/mir_loc.rs
@@ -83,11 +83,11 @@ impl From<Local> for usize {
 
 impl Local {
     pub fn as_u32(&self) -> u32 {
-        self.clone().into()
+        (*self).into()
     }
 
     pub fn as_usize(&self) -> usize {
-        self.clone().into()
+        (*self).into()
     }
 }
 

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -13,6 +13,7 @@ env_logger = "0.9"
 color-eyre = "0.6"
 fs-err = "2"
 itertools = "0.10"
+indexmap = "1"
 
 [build-dependencies]
 color-eyre = "0.6"

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -12,6 +12,7 @@ log = "0.4"
 env_logger = "0.9"
 color-eyre = "0.6"
 fs-err = "2"
+itertools = "0.10"
 
 [build-dependencies]
 color-eyre = "0.6"

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -13,7 +13,7 @@ env_logger = "0.9"
 color-eyre = "0.6"
 fs-err = "2"
 itertools = "0.10"
-indexmap = "1"
+linked_hash_set = "0.1"
 
 [build-dependencies]
 color-eyre = "0.6"

--- a/pdg/src/assert.rs
+++ b/pdg/src/assert.rs
@@ -1,8 +1,3 @@
-// * it would be nice to test properties like "an object is created in foo,
-// and its object graph contains a StoreAddr node".
-// essentially, if Stuart thinks the lighttpd example PDG looks good,
-// it would be nice to convert those mappings into test cases
-
 // * in that lighttpd map example I have a field for source which is a NodeId type,
 // but i'd like to confirm that the GraphId is always correct too.
 // we can go over this one if you want because it'll involve a small tweak to the pdg code
@@ -11,21 +6,6 @@
 //   it would be nice to have a test case that there are no duplicate objects
 
 // * all head of objects (node lists) have a source of None
-
-// Wanted to give you some more info about the query. It should basically say for each node in each object graph whether the node needs write permissions, based on whether or not there is a path to a StoreAddr node (within the same object graph, but there should be no paths out of the object graph anyway). The way the current representation of the PDG is, it's actually easiest to work backwards from StoreAddr nodes and mark all ancestor nodes as needing write permissions (I've avoided changing the representation and am aligning with Stuart's original as much as possible, but if there is a strong case for doing a forward search then I think tweaking the representation should be fine). We can also query on a per-object basis and only run the query for "the object that was created in fnode_init " for example . Essentially, the meat of the query might be something like
-// write_permissions_required:
-//   needs_write = []
-//   not_needs_write = []
-//   for node in nodes.reversed():
-//     if node not in needs_write and node not in not_needs_write
-//       if node.type == StoreAddr:
-//         cur = node
-//         # walk ancestry
-//         while let Some(parent) = cur.parent:
-//             needs_write.add(parent)
-//             cur = parent
-//       else: not_needs_write.add(node)
-//   return needs_write # or query_node in needs_write
 
 use crate::{graph::{Graph, Graphs}, util::Duplicates};
 

--- a/pdg/src/assert.rs
+++ b/pdg/src/assert.rs
@@ -22,7 +22,7 @@ impl Graphs {
 impl Graph {
     /// Assert that a graph's head has no source, as the head should be the root source.
     pub fn assert_head_has_no_source(&self) {
-        todo!()
+        assert_eq!(self.nodes[0usize.into()].source, None);
     }
 }
 

--- a/pdg/src/assert.rs
+++ b/pdg/src/assert.rs
@@ -1,0 +1,64 @@
+// * it would be nice to test properties like "an object is created in foo,
+// and its object graph contains a StoreAddr node".
+// essentially, if Stuart thinks the lighttpd example PDG looks good,
+// it would be nice to convert those mappings into test cases
+
+// * in that lighttpd map example I have a field for source which is a NodeId type,
+// but i'd like to confirm that the GraphId is always correct too.
+// we can go over this one if you want because it'll involve a small tweak to the pdg code
+
+// * this isn't implemented yet but when the graph deduplication is done,
+//   it would be nice to have a test case that there are no duplicate objects
+
+// * all head of objects (node lists) have a source of None
+
+// Wanted to give you some more info about the query. It should basically say for each node in each object graph whether the node needs write permissions, based on whether or not there is a path to a StoreAddr node (within the same object graph, but there should be no paths out of the object graph anyway). The way the current representation of the PDG is, it's actually easiest to work backwards from StoreAddr nodes and mark all ancestor nodes as needing write permissions (I've avoided changing the representation and am aligning with Stuart's original as much as possible, but if there is a strong case for doing a forward search then I think tweaking the representation should be fine). We can also query on a per-object basis and only run the query for "the object that was created in fnode_init " for example . Essentially, the meat of the query might be something like
+// write_permissions_required:
+//   needs_write = []
+//   not_needs_write = []
+//   for node in nodes.reversed():
+//     if node not in needs_write and node not in not_needs_write
+//       if node.type == StoreAddr:
+//         cur = node
+//         # walk ancestry
+//         while let Some(parent) = cur.parent:
+//             needs_write.add(parent)
+//             cur = parent
+//       else: not_needs_write.add(node)
+//   return needs_write # or query_node in needs_write
+
+use crate::{graph::{Graph, Graphs}, util::Duplicates};
+
+impl Graphs {
+    /// Assert that a graph has no duplicate objects.
+    ///
+    /// This is not necessary, but helps minimize the graphs.
+    /// Once when graph deduplication is implemented, we should implement and test this as well.
+    pub fn assert_no_duplicates(&self) {
+        Duplicates::find(&self.graphs).assert_empty();
+    }
+}
+
+impl Graph {
+    /// Assert that a graph's head has no source, as the head should be the root source.
+    pub fn assert_head_has_no_source(&self) {
+        todo!()
+    }
+}
+
+impl Graphs {
+    /// Assert [`Graph::assert_head_has_no_source`] for every [`Graph`].
+    pub fn assert_heads_have_no_sources(&self) {
+        for graph in &self.graphs {
+            graph.assert_head_has_no_source();
+        }
+    }
+}
+
+impl Graphs {
+    /// Assert all [`Graph`] tests.
+    pub fn assert_all_tests(&self) {
+        self.assert_no_duplicates();
+        self.assert_heads_have_no_sources();
+    }
+}

--- a/pdg/src/assert.rs
+++ b/pdg/src/assert.rs
@@ -38,7 +38,7 @@ impl Graphs {
 impl Graphs {
     /// Assert all [`Graph`] tests.
     pub fn assert_all_tests(&self) {
-        // self.assert_no_duplicates();
+        self.assert_no_duplicates();
         self.assert_heads_have_no_sources();
     }
 }

--- a/pdg/src/assert.rs
+++ b/pdg/src/assert.rs
@@ -38,7 +38,7 @@ impl Graphs {
 impl Graphs {
     /// Assert all [`Graph`] tests.
     pub fn assert_all_tests(&self) {
-        self.assert_no_duplicates();
+        // self.assert_no_duplicates();
         self.assert_heads_have_no_sources();
     }
 }

--- a/pdg/src/assert.rs
+++ b/pdg/src/assert.rs
@@ -1,11 +1,7 @@
-// * in that lighttpd map example I have a field for source which is a NodeId type,
+// TODO(kkysen, aneksteind)
+// in that lighttpd map example I have a field for source which is a NodeId type,
 // but i'd like to confirm that the GraphId is always correct too.
 // we can go over this one if you want because it'll involve a small tweak to the pdg code
-
-// * this isn't implemented yet but when the graph deduplication is done,
-//   it would be nice to have a test case that there are no duplicate objects
-
-// * all head of objects (node lists) have a source of None
 
 use crate::{graph::{Graph, Graphs}, util::Duplicates};
 

--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -178,10 +178,9 @@ pub fn add_node(
             .cloned();
         if !src.projection.is_empty() {
             if let Some((gid, _)) = latest_assignment {
-                for (nid, n) in graphs.graphs[gid].nodes.iter().enumerate().rev() {
-                    match n.kind {
-                        NodeKind::Field(..) => return Some((gid, nid.into())),
-                        _ => break,
+                if let Some((nid, n)) = graphs.graphs[gid].nodes.iter_enumerated().rev().next() {
+                    if let NodeKind::Field(..) = n.kind {
+                        return Some((gid, nid))
                     }
                 }
             }

--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -199,7 +199,7 @@ pub fn add_node(
     let node = Node {
         function: Func(dest_fn),
         block: basic_block_idx.into(),
-        index: statement_idx,
+        statement_index: statement_idx,
         kind: node_kind,
         source: source
             .and_then(|p| event.kind.parent(p))

--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -4,6 +4,7 @@ use c2rust_analysis_rt::mir_loc::{EventMetadata, Metadata, TransferKind};
 use c2rust_analysis_rt::{mir_loc, MirLoc};
 use color_eyre::eyre;
 use fs_err::File;
+use itertools::Itertools;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_hir::def_id::DefPathHash;
 use std::collections::HashMap;
@@ -245,6 +246,8 @@ pub fn construct_pdg(events: &[Event]) -> Graphs {
     for event in events {
         add_node(&mut graphs, &mut provenances, event);
     }
+    // TODO(kkysen) check if I have to remove any `GraphId`s from `graphs.latest_assignment`
+    graphs.graphs = graphs.graphs.into_iter().unique().collect();
 
     // for ((func, local), p) in &graphs.latest_assignment {
     //     let func = Func(*func);

--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -254,9 +254,9 @@ pub fn construct_pdg(events: &[Event]) -> Graphs {
         add_node(&mut graphs, &mut provenances, event);
     }
 
-    for ((func, local), p) in &graphs.latest_assignment {
-        let func = Func(*func);
-        println!("({func:?}:{local:?}) => {p:?}");
-    }
+    // for ((func, local), p) in &graphs.latest_assignment {
+    //     let func = Func(*func);
+    //     println!("({func:?}:{local:?}) => {p:?}");
+    // }
     graphs
 }

--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -199,7 +199,7 @@ pub fn add_node(
     let node = Node {
         function: Func(dest_fn),
         block: basic_block_idx.into(),
-        statement_index: statement_idx,
+        statement_idx,
         kind: node_kind,
         source: source
             .and_then(|p| event.kind.parent(p))

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -210,9 +210,15 @@ impl Display for Node {
     }
 }
 
+impl Display for GraphId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "graph {}", self.as_usize())
+    }
+}
+
 impl Display for Graph {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        writeln!(f, "graph {{")?;
+        writeln!(f, "{{")?;
         for (node_id, node) in self.nodes.iter_enumerated() {
             writeln!(f, "\t{node_id}: {node},")?;
         }
@@ -223,11 +229,11 @@ impl Display for Graph {
 
 impl Display for Graphs {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        for (i, graph) in self.graphs.iter().enumerate() {
-            if i != 0 {
+        for (graph_id, graph) in self.graphs.iter_enumerated() {
+            if graph_id.as_usize() != 0 {
                 write!(f, "\n\n")?;
             }
-            write!(f, "{graph}")?;
+            write!(f, "{graph_id} {graph}")?;
         }
         Ok(())
     }

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -81,7 +81,7 @@ pub struct Node {
     /// operation.  As in `rustc_middle::mir::Location`, an index less than the number of
     /// statements in the block refers to that statement, and an index equal to the number of
     /// statements refers to the terminator.
-    pub statement_index: usize,
+    pub statement_idx: usize,
     /// The MIR place where this operation stores its result.  This is `None` for operations that
     /// don't store anything and for operations whose result is a temporary not visible as a MIR
     /// place.
@@ -196,7 +196,7 @@ impl Display for Node {
         let Self {
             function,
             block,
-            statement_index,
+            statement_idx,
             dest,
             kind,
             source,
@@ -204,7 +204,7 @@ impl Display for Node {
         let src = ShortOption(source.as_ref());
         let dest = ShortOption(dest.as_ref());
         let bb = block.as_usize();
-        let stmt = statement_index;
+        let stmt = statement_idx;
         let fn_ = function;
         write!(f, "(fn {fn_}) {kind} {{ src: {src}, dest: {dest}, bb: {bb}, stmt: {stmt} }}")
     }

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -179,7 +179,7 @@ impl Display for NodeKind {
             Offset(offset) => write!(f, "offset[{offset}]"),
             AddrOfLocal(local) => write!(f, "&local {local:?}"),
             _AddrOfStatic(static_) => write!(f, "&static {static_:?}"),
-            Malloc(n) => write!(f, "malloc {n}"),
+            Malloc(n) => write!(f, "malloc(n = {n})"),
             Free => write!(f, "free"),
             PtrToInt => write!(f, "ptr_to_int"),
             IntToPtr => write!(f, "int_to_ptr"),

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -23,7 +23,7 @@ newtype_index!(
 pub const _ROOT_NODE: NodeId = NodeId::from_u32(0);
 
 /// A pointer derivation graph, which tracks the handling of one object throughout its lifetime.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Eq, PartialEq, Hash, Clone)]
 pub struct Graph {
     /// The nodes in the graph.  Nodes are stored in increasing order by timestamp.  The first
     /// node, called the "root node", creates the object described by this graph, and all other
@@ -39,6 +39,7 @@ impl Graph {
     }
 }
 
+#[derive(Eq, PartialEq, Hash, Clone)]
 pub struct Func(pub DefPathHash);
 
 impl Debug for Func {
@@ -55,7 +56,7 @@ impl Debug for Func {
 /// Each operation occurs at a point in time, but the timestamp is not stored explicitly.  Instead,
 /// nodes in each graph are stored in sequential order, and timing relationships can be identified
 /// by comparing `NodeId`s.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub struct Node {
     /// The function that contains this operation.
     ///
@@ -82,7 +83,7 @@ pub struct Node {
     pub source: Option<NodeId>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum NodeKind {
     /// A copy from one local to another.  This also covers casts such as `&mut T` to `&T` or `&T`
     /// to `*const T` that don't change the type or value of the pointer.
@@ -129,7 +130,7 @@ pub enum NodeKind {
 }
 
 /// A collection of graphs describing the handling of one or more objects within the program.
-#[derive(Default)]
+#[derive(Default, Eq, PartialEq)]
 pub struct Graphs {
     /// The graphs.  Each graph describes one object, or one group of objects that were all handled
     /// identically.

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -114,7 +114,7 @@ pub enum NodeKind {
     AddrOfLocal(Local),
     /// Get the address of a static.  These are treated the same as locals, with an
     /// `AddressOfStatic` attributed to the first statement.
-    AddrOfStatic(DefPathHash),
+    _AddrOfStatic(DefPathHash),
     /// Heap allocation.  The `usize` is the number of array elements allocated; for allocations of
     /// a single object, this value is 1.
     Malloc(usize),
@@ -178,7 +178,7 @@ impl Display for NodeKind {
             Field(field) => write!(f, "field.{}", field.as_usize()),
             Offset(offset) => write!(f, "offset[{offset}]"),
             AddrOfLocal(local) => write!(f, "&local {local:?}"),
-            AddrOfStatic(static_) => write!(f, "&static {static_:?}"),
+            _AddrOfStatic(static_) => write!(f, "&static {static_:?}"),
             Malloc(n) => write!(f, "malloc {n}"),
             Free => write!(f, "free"),
             PtrToInt => write!(f, "ptr_to_int"),
@@ -212,9 +212,9 @@ impl Display for Node {
 
 impl Display for Graph {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "graph {{\n")?;
+        writeln!(f, "graph {{")?;
         for (node_id, node) in self.nodes.iter_enumerated() {
-            write!(f, "\t{node_id}: {node},\n")?;
+            writeln!(f, "\t{node_id}: {node},")?;
         }
         write!(f, "}}")?;
         Ok(())

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -81,7 +81,7 @@ pub struct Node {
     /// operation.  As in `rustc_middle::mir::Location`, an index less than the number of
     /// statements in the block refers to that statement, and an index equal to the number of
     /// statements refers to the terminator.
-    pub index: usize,
+    pub statement_index: usize,
     /// The MIR place where this operation stores its result.  This is `None` for operations that
     /// don't store anything and for operations whose result is a temporary not visible as a MIR
     /// place.
@@ -196,7 +196,7 @@ impl Display for Node {
         let Self {
             function,
             block,
-            index,
+            statement_index,
             dest,
             kind,
             source,
@@ -204,9 +204,9 @@ impl Display for Node {
         let src = ShortOption(source.as_ref());
         let dest = ShortOption(dest.as_ref());
         let bb = block.as_usize();
-        let index_in_bb = index;
+        let stmt = statement_index;
         let fn_ = function;
-        write!(f, "(fn {fn_}) {kind} {{ src: {src}, dest: {dest}, bb: {bb}, bbi: {index_in_bb} }}")
+        write!(f, "(fn {fn_}) {kind} {{ src: {src}, dest: {dest}, bb: {bb}, stmt: {stmt} }}")
     }
 }
 

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> eyre::Result<()> {
 
     for (graph_id, graph) in pdg.graphs.iter_enumerated() {
         let needs_write = graph.needs_write_permission().map(|node_id| node_id.as_usize()).collect::<Vec<_>>();
-        println!("{graph_id}: {graph}");
+        println!("{graph_id} {graph}");
         println!("nodes_that_need_write = {needs_write:?}");
         println!("\n");
     }

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -44,19 +44,12 @@ fn main() -> eyre::Result<()> {
     // }
 
     let pdg = construct_pdg(&events);
-    // for (g, graph) in pdg.graphs.iter().enumerate() {
-    //     println!("-- Object {g:?} ---");
-    //     for (n, node) in graph.nodes.iter().enumerate() {
-    //         println!("{n:?}:{node:?}");
-    //     }
-    //     println!();
-    // }
-
     pdg.assert_all_tests();
 
-    for graph in pdg.graphs {
+    for (graph_id, graph) in pdg.graphs.iter_enumerated() {
+        let graph_id = graph_id.as_usize();
         let needs_write = graph.needs_write_permission().map(|node_id| node_id.as_usize()).collect::<Vec<_>>();
-        println!("{graph}");
+        println!("{graph_id}: {graph}");
         println!("node_that_need_write = {needs_write:?}");
         println!("___________________________________________");
     }

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -57,9 +57,9 @@ fn main() -> eyre::Result<()> {
     // pdg.assert_all_tests();
 
     for graph in pdg.graphs {
-        let needs_write = graph.needs_write_permission().collect::<Vec<_>>();
+        let needs_write = graph.needs_write_permission().map(|node_id| node_id.as_usize()).collect::<Vec<_>>();
         println!("{graph}");
-        println!("needs_write = {needs_write:?}");
+        println!("node_that_need_write = {needs_write:?}");
         println!("___________________________________________");
     }
 

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> eyre::Result<()> {
     //     println!();
     // }
 
-    // pdg.assert_all_tests();
+    pdg.assert_all_tests();
 
     for graph in pdg.graphs {
         let needs_write = graph.needs_write_permission().map(|node_id| node_id.as_usize()).collect::<Vec<_>>();

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -47,11 +47,10 @@ fn main() -> eyre::Result<()> {
     pdg.assert_all_tests();
 
     for (graph_id, graph) in pdg.graphs.iter_enumerated() {
-        let graph_id = graph_id.as_usize();
         let needs_write = graph.needs_write_permission().map(|node_id| node_id.as_usize()).collect::<Vec<_>>();
         println!("{graph_id}: {graph}");
-        println!("node_that_need_write = {needs_write:?}");
-        println!("___________________________________________");
+        println!("nodes_that_need_write = {needs_write:?}");
+        println!("\n");
     }
 
     Ok(())

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -19,6 +19,8 @@ extern crate rustc_target;
 
 mod builder;
 mod graph;
+mod assert;
+mod util;
 
 use builder::{construct_pdg, read_event_log};
 use c2rust_analysis_rt::{mir_loc, Runtime};
@@ -36,20 +38,22 @@ fn main() -> eyre::Result<()> {
         .expect("Expected event trace file path as the first argument");
     let events = read_event_log(Path::new(event_trace_path.as_str()))?;
 
-    for event in &events {
-        let mir_loc = mir_loc::get(event.mir_loc).unwrap();
-        let kind = &event.kind;
-        println!("{mir_loc:?} -> {kind:?}");
-    }
+    // for event in &events {
+    //     let mir_loc = mir_loc::get(event.mir_loc).unwrap();
+    //     let kind = &event.kind;
+    //     println!("{mir_loc:?} -> {kind:?}");
+    // }
 
     let pdg = construct_pdg(&events);
-    for (g, graph) in pdg.graphs.iter().enumerate() {
-        println!("-- Object {g:?} ---");
-        for (n, node) in graph.nodes.iter().enumerate() {
-            println!("{n:?}:{node:?}");
-        }
-        println!();
-    }
+    // for (g, graph) in pdg.graphs.iter().enumerate() {
+    //     println!("-- Object {g:?} ---");
+    //     for (n, node) in graph.nodes.iter().enumerate() {
+    //         println!("{n:?}:{node:?}");
+    //     }
+    //     println!();
+    // }
+
+    pdg.assert_all_tests();
 
     Ok(())
 }

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -53,5 +53,10 @@ fn main() -> eyre::Result<()> {
         println!("\n");
     }
 
+    let num_graphs = pdg.graphs.len();
+    let num_nodes = pdg.graphs.iter().map(|graph| graph.nodes.len()).sum::<usize>();
+    dbg!(num_graphs);
+    dbg!(num_nodes);
+
     Ok(())
 }

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -24,7 +24,7 @@ mod util;
 mod query;
 
 use builder::{construct_pdg, read_event_log};
-use c2rust_analysis_rt::{mir_loc, Runtime};
+use c2rust_analysis_rt::Runtime;
 use color_eyre::eyre;
 use std::{env, path::Path};
 

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -33,9 +33,7 @@ fn main() -> eyre::Result<()> {
     env_logger::init();
     let _runtime = Runtime::new();
 
-    let event_trace_path = env::args()
-        .skip(1)
-        .next()
+    let event_trace_path = env::args().nth(1)
         .expect("Expected event trace file path as the first argument");
     let events = read_event_log(Path::new(event_trace_path.as_str()))?;
 

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -21,6 +21,7 @@ mod builder;
 mod graph;
 mod assert;
 mod util;
+mod query;
 
 use builder::{construct_pdg, read_event_log};
 use c2rust_analysis_rt::{mir_loc, Runtime};
@@ -53,7 +54,14 @@ fn main() -> eyre::Result<()> {
     //     println!();
     // }
 
-    pdg.assert_all_tests();
+    // pdg.assert_all_tests();
+
+    for graph in pdg.graphs {
+        let needs_write = graph.needs_write_permission().collect::<Vec<_>>();
+        println!("{graph}");
+        println!("needs_write = {needs_write:?}");
+        println!("___________________________________________");
+    }
 
     Ok(())
 }

--- a/pdg/src/query.rs
+++ b/pdg/src/query.rs
@@ -1,0 +1,57 @@
+// * it would be nice to test properties like "an object is created in foo,
+// and its object graph contains a StoreAddr node".
+// essentially, if Stuart thinks the lighttpd example PDG looks good,
+// it would be nice to convert those mappings into test cases
+
+// Wanted to give you some more info about the query. It should basically say for each node in each object graph 
+// whether the node needs write permissions, based on whether or not there is a path to a StoreAddr node
+// (within the same object graph, but there should be no paths out of the object graph anyway).
+// The way the current representation of the PDG is, it's actually easiest to work backwards from StoreAddr nodes 
+// and mark all ancestor nodes as needing write permissions (I've avoided changing the representation 
+// and am aligning with Stuart's original as much as possible, but if there is a strong case for doing a forward search 
+// then I think tweaking the representation should be fine). We can also query on a per-object basis 
+// and only run the query for "the object that was created in fnode_init " for example . 
+// Essentially, the meat of the query might be something like
+// 
+// write_permissions_required:
+//   needs_write = []
+//   not_needs_write = []
+//   for node in nodes.reversed():
+//     if node not in needs_write and node not in not_needs_write
+//       if node.type == StoreAddr:
+//         cur = node
+//         # walk ancestry
+//         while let Some(parent) = cur.parent:
+//             needs_write.add(parent)
+//             cur = parent
+//       else: not_needs_write.add(node)
+//   return needs_write # or query_node in needs_write
+
+use indexmap::IndexSet;
+
+use crate::graph::{Graph, NodeId, NodeKind};
+
+impl Graph {
+    pub fn needs_write_permission(&self) -> impl Iterator<Item = NodeId> {
+        let mut needs_write: IndexSet<NodeId> = IndexSet::new();
+        let mut not_needs_write: IndexSet<NodeId> = IndexSet::new();
+        for (node_id, node) in self.nodes.iter_enumerated().rev() {
+            if !needs_write.contains(&node_id) && !not_needs_write.contains(&node_id) {
+                if let NodeKind::StoreAddr = node.kind {
+                    let mut cur = node_id;
+                    loop {
+                        needs_write.insert(cur);
+                        let source = match self.nodes[cur].source {
+                            None => break,
+                            Some(source) => source,
+                        };
+                        cur = source;
+                    }
+                } else {
+                    not_needs_write.insert(node_id);
+                }
+            }
+        }
+        needs_write.into_iter()
+    }
+}

--- a/pdg/src/query.rs
+++ b/pdg/src/query.rs
@@ -2,37 +2,25 @@ use linked_hash_set::LinkedHashSet;
 
 use crate::graph::{Graph, NodeId, NodeKind};
 
+// TODO(kkysen, aneksteind)
+// it would be nice to test properties like "an object is created in foo,
+// and its object graph contains a StoreAddr node".
+// essentially, if Stuart thinks the lighttpd example PDG looks good,
+// it would be nice to convert those mappings into test cases
+
 impl Graph {
-    /// it would be nice to test properties like "an object is created in foo,
-    /// and its object graph contains a StoreAddr node".
-    /// essentially, if Stuart thinks the lighttpd example PDG looks good,
-    /// it would be nice to convert those mappings into test cases
+    /// Query an object [`Graph`] to determine which of its [`Node`]s (returned as [`NodeId`]s)
+    /// need write permissions for future refactors into Rust references instead of raw pointers.
     ///
-    /// Wanted to give you some more info about the query. It should basically say for each node in each object graph 
-    /// whether the node needs write permissions, based on whether or not there is a path to a StoreAddr node
-    /// (within the same object graph, but there should be no paths out of the object graph anyway).
-    /// The way the current representation of the PDG is, it's actually easiest to work backwards from StoreAddr nodes 
-    /// and mark all ancestor nodes as needing write permissions (I've avoided changing the representation 
-    /// and am aligning with Stuart's original as much as possible, but if there is a strong case for doing a forward search 
-    /// then I think tweaking the representation should be fine). We can also query on a per-object basis 
-    /// and only run the query for "the object that was created in fnode_init " for example . 
-    /// Essentially, the meat of the query might be something like
+    /// This is calculated based on whether or not there is a path to a [`StoreAddr`] node,
+    /// which is a write, from the current [`Node`] we are testing
+    /// (in the same object [`Graph`], though there shouldn't be any paths out of an object [`Graph`] anyways).
+    ///
+    /// The way the PDG/[`Graph`]s is/are represented, it is actually easiest to work backwards from [`StoreAddr`] nodes
+    /// and mark all ancestor nodes as needing write permissions.
     /// 
-    /// ```psuedocode
-    /// write_permissions_required:
-    ///   needs_write = []
-    ///   not_needs_write = []
-    ///   for node in nodes.reversed():
-    ///     if node not in needs_write and node not in not_needs_write
-    ///       if node.type == StoreAddr:
-    ///         cur = node
-    ///         # walk ancestry
-    ///         while let Some(parent) = cur.parent:
-    ///             needs_write.add(parent)
-    ///             cur = parent
-    ///       else: not_needs_write.add(node)
-    ///   return needs_write # or query_node in needs_write
-    /// ```
+    /// [`StoreAddr`]: NodeKind::StoreAddr
+    /// [`Node`]: crate::graph::Node
     pub fn needs_write_permission(&self) -> impl Iterator<Item = NodeId> {
         let mut needs_write = LinkedHashSet::new();
         let mut not_needs_write = LinkedHashSet::new();

--- a/pdg/src/query.rs
+++ b/pdg/src/query.rs
@@ -1,37 +1,38 @@
-// * it would be nice to test properties like "an object is created in foo,
-// and its object graph contains a StoreAddr node".
-// essentially, if Stuart thinks the lighttpd example PDG looks good,
-// it would be nice to convert those mappings into test cases
-
-// Wanted to give you some more info about the query. It should basically say for each node in each object graph 
-// whether the node needs write permissions, based on whether or not there is a path to a StoreAddr node
-// (within the same object graph, but there should be no paths out of the object graph anyway).
-// The way the current representation of the PDG is, it's actually easiest to work backwards from StoreAddr nodes 
-// and mark all ancestor nodes as needing write permissions (I've avoided changing the representation 
-// and am aligning with Stuart's original as much as possible, but if there is a strong case for doing a forward search 
-// then I think tweaking the representation should be fine). We can also query on a per-object basis 
-// and only run the query for "the object that was created in fnode_init " for example . 
-// Essentially, the meat of the query might be something like
-// 
-// write_permissions_required:
-//   needs_write = []
-//   not_needs_write = []
-//   for node in nodes.reversed():
-//     if node not in needs_write and node not in not_needs_write
-//       if node.type == StoreAddr:
-//         cur = node
-//         # walk ancestry
-//         while let Some(parent) = cur.parent:
-//             needs_write.add(parent)
-//             cur = parent
-//       else: not_needs_write.add(node)
-//   return needs_write # or query_node in needs_write
-
 use indexmap::IndexSet;
 
 use crate::graph::{Graph, NodeId, NodeKind};
 
 impl Graph {
+    /// it would be nice to test properties like "an object is created in foo,
+    /// and its object graph contains a StoreAddr node".
+    /// essentially, if Stuart thinks the lighttpd example PDG looks good,
+    /// it would be nice to convert those mappings into test cases
+    ///
+    /// Wanted to give you some more info about the query. It should basically say for each node in each object graph 
+    /// whether the node needs write permissions, based on whether or not there is a path to a StoreAddr node
+    /// (within the same object graph, but there should be no paths out of the object graph anyway).
+    /// The way the current representation of the PDG is, it's actually easiest to work backwards from StoreAddr nodes 
+    /// and mark all ancestor nodes as needing write permissions (I've avoided changing the representation 
+    /// and am aligning with Stuart's original as much as possible, but if there is a strong case for doing a forward search 
+    /// then I think tweaking the representation should be fine). We can also query on a per-object basis 
+    /// and only run the query for "the object that was created in fnode_init " for example . 
+    /// Essentially, the meat of the query might be something like
+    /// 
+    /// ```psuedocode
+    /// write_permissions_required:
+    ///   needs_write = []
+    ///   not_needs_write = []
+    ///   for node in nodes.reversed():
+    ///     if node not in needs_write and node not in not_needs_write
+    ///       if node.type == StoreAddr:
+    ///         cur = node
+    ///         # walk ancestry
+    ///         while let Some(parent) = cur.parent:
+    ///             needs_write.add(parent)
+    ///             cur = parent
+    ///       else: not_needs_write.add(node)
+    ///   return needs_write # or query_node in needs_write
+    /// ```
     pub fn needs_write_permission(&self) -> impl Iterator<Item = NodeId> {
         let mut needs_write: IndexSet<NodeId> = IndexSet::new();
         let mut not_needs_write: IndexSet<NodeId> = IndexSet::new();

--- a/pdg/src/query.rs
+++ b/pdg/src/query.rs
@@ -1,12 +1,19 @@
+//! ## Future Plans for Queries
+//! TODO(kkysen, aneksteind)
+//! 
+//! It would be nice to test properties like "an object is create in `foo`,
+//! and its object [`Graph`] contains a [`StoreAddr`] node".
+//! 
+//! [`StoreAddr`]: NodeKind::StoreAddr.
+//! 
+//! For example PDGs that we have already (manually) confirmed are correct,
+//! we want to set up snapshot testing to make sure we don't introduce any regressions,
+//! and be able to test if certain changes have any effect on the PDG output.
+//! We are thinking about using [`insta`](https://insta.rs/) for this.
+
 use linked_hash_set::LinkedHashSet;
 
 use crate::graph::{Graph, NodeId, NodeKind};
-
-// TODO(kkysen, aneksteind)
-// it would be nice to test properties like "an object is created in foo,
-// and its object graph contains a StoreAddr node".
-// essentially, if Stuart thinks the lighttpd example PDG looks good,
-// it would be nice to convert those mappings into test cases
 
 impl Graph {
     /// Query an object [`Graph`] to determine which of its [`Node`]s (returned as [`NodeId`]s)

--- a/pdg/src/query.rs
+++ b/pdg/src/query.rs
@@ -1,4 +1,4 @@
-use indexmap::IndexSet;
+use linked_hash_set::LinkedHashSet;
 
 use crate::graph::{Graph, NodeId, NodeKind};
 
@@ -34,8 +34,8 @@ impl Graph {
     ///   return needs_write # or query_node in needs_write
     /// ```
     pub fn needs_write_permission(&self) -> impl Iterator<Item = NodeId> {
-        let mut needs_write: IndexSet<NodeId> = IndexSet::new();
-        let mut not_needs_write: IndexSet<NodeId> = IndexSet::new();
+        let mut needs_write = LinkedHashSet::new();
+        let mut not_needs_write = LinkedHashSet::new();
         for (node_id, node) in self.nodes.iter_enumerated().rev() {
             if !needs_write.contains(&node_id) && !not_needs_write.contains(&node_id) {
                 if let NodeKind::StoreAddr = node.kind {

--- a/pdg/src/util.rs
+++ b/pdg/src/util.rs
@@ -78,9 +78,14 @@ impl<T> Duplicates<T> {
         for (_, duplicates) in maybe_take(self.duplicates.iter(), n) {
             let duplicates = duplicates
                 .iter()
-                .map(|t| to_string(t))
+                .map(
+                    // not redundant; otherwise would require a `Copy` bound
+                    #[allow(clippy::redundant_closure)]
+                    |t| to_string(t),
+                )
                 .counts()
                 .into_iter()
+                .map(|(duplicate, count)| (duplicate.split('\n').join("\n\t"), count))
                 .map(|(duplicate, count)| match count {
                     0 => "".into(),
                     1 => duplicate,

--- a/pdg/src/util.rs
+++ b/pdg/src/util.rs
@@ -1,0 +1,85 @@
+use itertools::Itertools;
+
+use std::{
+    cmp::min,
+    collections::HashMap,
+    fmt::{self, Debug, Formatter},
+    hash::Hash,
+};
+
+pub fn maybe_take<T>(iter: impl Iterator<Item = T>, n: Option<usize>) -> impl Iterator<Item = T> {
+    iter.enumerate()
+        .take_while(move |(i, _)| n.map(|n| *i < n).unwrap_or(true))
+        .map(|(_, t)| t)
+}
+
+pub struct Duplicates<T> {
+    duplicates: HashMap<T, Vec<T>>,
+}
+
+impl<T: Eq + Hash + Clone> Duplicates<T> {
+    pub fn find(iter: impl IntoIterator<Item = T>) -> Self {
+        let duplicates = iter
+            .into_iter()
+            .into_group_map_by(|e| e.clone())
+            .into_iter()
+            .filter(|(_, duplicates)| duplicates.len() > 1)
+            .collect::<HashMap<_, _>>();
+        Self { duplicates }
+    }
+}
+
+impl<T> Duplicates<T> {
+    pub fn is_empty(&self) -> bool {
+        self.duplicates.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.duplicates.len()
+    }
+}
+
+impl<T: Debug> Duplicates<T> {
+    pub fn fmt_up_to_n(&self, f: &mut Formatter<'_>, n: Option<usize>) -> fmt::Result {
+        let num_remaining = |len: usize| {
+            let num_printed = match n {
+                Some(n) => min(n, len),
+                None => len,
+            };
+            len - num_printed
+        };
+
+        write!(f, "{} duplicates:\n", self.len())?;
+        for (_, duplicates) in maybe_take(self.duplicates.iter(), n) {
+            let duplicates = duplicates
+                .iter()
+                .map(|e| format!("{:?}", e))
+                .counts()
+                .into_iter()
+                .map(|(duplicate, count)| match count {
+                    0 => "".into(),
+                    1 => duplicate,
+                    _ => format!("({count}x) {duplicate}"),
+                })
+                .join(", ");
+            write!(f, "\t{}\n", duplicates)?;
+        }
+        write!(f, "and {} more...", num_remaining(self.len()))?;
+        Ok(())
+    }
+}
+
+impl<T: Debug> Debug for Duplicates<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.fmt_up_to_n(f, 10.into())
+    }
+}
+
+impl<T: Debug + Eq + Hash> Duplicates<T> {
+    pub fn assert_empty(&self) {
+        if self.is_empty() {
+            return;
+        }
+        panic!("unexpected duplicates: {:?}", self);
+    }
+}

--- a/pdg/src/util.rs
+++ b/pdg/src/util.rs
@@ -60,6 +60,8 @@ impl<T> Duplicates<T> {
 }
 
 impl<T> Duplicates<T> {
+    const DEFAULT_UP_TO_N: usize = 5;
+
     pub fn fmt_up_to_n(
         &self,
         f: &mut Formatter<'_>,
@@ -101,13 +103,13 @@ impl<T> Duplicates<T> {
 
 impl<T: Debug> Debug for Duplicates<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        self.fmt_up_to_n(f, 10.into(), |t| format!("{t:?}"))
+        self.fmt_up_to_n(f, Self::DEFAULT_UP_TO_N.into(), |t| format!("{t:?}"))
     }
 }
 
 impl<T: Display> Display for Duplicates<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        self.fmt_up_to_n(f, 10.into(), |t| format!("{t}"))
+        self.fmt_up_to_n(f, Self::DEFAULT_UP_TO_N.into(), |t| format!("{t}"))
     }
 }
 

--- a/pdg/src/util.rs
+++ b/pdg/src/util.rs
@@ -74,7 +74,7 @@ impl<T> Duplicates<T> {
             len - num_printed
         };
 
-        write!(f, "{} duplicates:\n", self.len())?;
+        writeln!(f, "{} duplicates:", self.len())?;
         for (_, duplicates) in maybe_take(self.duplicates.iter(), n) {
             let duplicates = duplicates
                 .iter()
@@ -87,7 +87,7 @@ impl<T> Duplicates<T> {
                     _ => format!("({count}x) {duplicate}"),
                 })
                 .join(", ");
-            write!(f, "\t{}\n", duplicates)?;
+            writeln!(f, "\t{}", duplicates)?;
         }
         write!(f, "and {} more...", num_remaining(self.len()))?;
         Ok(())


### PR DESCRIPTION
Added:
* pdg tests that check if:
    * there are no duplicate graphs
    * all graphs' first/head node has no source
* the pdg nodes that need write permissions query:
    * implemented with @aneksteind from his pseudocode
* graph deduplication:
    * ended up being very simple to do at the end with an `Itertools::unique` call
* an improved textual representation that's much more concise and readable
* a bunch of `clippy` fixes, mostly autofixes