### PR TITLE
Refactor repeated `std_or_core` logic

### DIFF
--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -2,6 +2,7 @@ use crate::c_ast::CDeclId;
 use crate::c_ast::*;
 use crate::diagnostics::TranslationResult;
 use crate::renamer::*;
+use crate::translator::std_or_core;
 use c2rust_ast_builder::{mk, properties::*};
 use failure::format_err;
 use std::collections::{HashMap, HashSet};
@@ -300,8 +301,7 @@ impl TypeConverter {
         ctype: CTypeId,
     ) -> TranslationResult<Box<Type>> {
         if self.translate_valist && ctxt.is_va_list(ctype) {
-            let std_or_core = if self.emit_no_std { "core" } else { "std" };
-            let path = vec![std_or_core, "ffi", "VaList"];
+            let path = vec![std_or_core(self.emit_no_std), "ffi", "VaList"];
             let ty = mk().path_ty(mk().abs_path(path));
             return Ok(ty);
         }

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -1018,8 +1018,7 @@ impl<'c> Translation<'c> {
         }
 
         self.with_cur_file_item_store(|item_store| {
-            let std_or_core = if self.tcfg.emit_no_std { "core" } else { "std" }.to_string();
-            item_store.add_use(vec![std_or_core, "arch".into()], "asm");
+            item_store.add_use(vec![self.std_or_core().into(), "arch".into()], "asm");
         });
 
         let mac = mk().mac(

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -144,8 +144,11 @@ impl<'c> Translation<'c> {
 
                         self.use_feature("core_intrinsics");
 
-                        let atomic_store =
-                            mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", intrinsic_name]);
+                        let atomic_store = mk().abs_path_expr(vec![
+                            self.std_or_core(),
+                            "intrinsics",
+                            intrinsic_name,
+                        ]);
                         let val = if name == "__atomic_store" {
                             mk().unary_expr(UnOp::Deref(Default::default()), val)
                         } else {
@@ -184,8 +187,11 @@ impl<'c> Translation<'c> {
 
                         self.use_feature("core_intrinsics");
 
-                        let fn_path =
-                            mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", intrinsic_name]);
+                        let fn_path = mk().abs_path_expr(vec![
+                            self.std_or_core(),
+                            "intrinsics",
+                            intrinsic_name,
+                        ]);
                         let val = if name == "__atomic_exchange" {
                             mk().unary_expr(UnOp::Deref(Default::default()), val)
                         } else {
@@ -360,7 +366,8 @@ impl<'c> Translation<'c> {
         self.use_feature("core_intrinsics");
 
         // Emit `atomic_cxchg(a0, a1, a2).idx`
-        let atomic_cxchg = mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", intrinsic_name]);
+        let atomic_cxchg =
+            mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", intrinsic_name]);
         let call = mk().call_expr(atomic_cxchg, vec![dst, old_val, src_val]);
         let field_idx = if returns_val { 0 } else { 1 };
         let call_expr = mk().anon_field_expr(call, field_idx);

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -57,7 +57,6 @@ impl<'c> Translation<'c> {
             weak_id,
         } = args;
 
-        let std_or_core = if self.tcfg.emit_no_std { "core" } else { "std" };
         let ptr = self.convert_expr(ctx.used(), ptr_id)?;
         let order = self.convert_memordering(order_id);
         let val1 = val1_id
@@ -98,7 +97,7 @@ impl<'c> Translation<'c> {
                 self.use_feature("core_intrinsics");
 
                 let atomic_load =
-                    mk().abs_path_expr(vec![std_or_core, "intrinsics", intrinsic_name]);
+                    mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", intrinsic_name]);
                 let call = mk().call_expr(atomic_load, vec![ptr]);
                 if name == "__atomic_load" {
                     let ret = val1.expect("__atomic_load should have a ret argument");
@@ -146,7 +145,7 @@ impl<'c> Translation<'c> {
                         self.use_feature("core_intrinsics");
 
                         let atomic_store =
-                            mk().abs_path_expr(vec![std_or_core, "intrinsics", intrinsic_name]);
+                            mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", intrinsic_name]);
                         let val = if name == "__atomic_store" {
                             mk().unary_expr(UnOp::Deref(Default::default()), val)
                         } else {
@@ -186,7 +185,7 @@ impl<'c> Translation<'c> {
                         self.use_feature("core_intrinsics");
 
                         let fn_path =
-                            mk().abs_path_expr(vec![std_or_core, "intrinsics", intrinsic_name]);
+                            mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", intrinsic_name]);
                         let val = if name == "__atomic_exchange" {
                             mk().unary_expr(UnOp::Deref(Default::default()), val)
                         } else {
@@ -272,7 +271,7 @@ impl<'c> Translation<'c> {
                             };
 
                             let atomic_cxchg = mk().abs_path_expr(vec![
-                                std_or_core,
+                                self.std_or_core(),
                                 "intrinsics",
                                 &intrinsic_name,
                             ]);
@@ -359,10 +358,9 @@ impl<'c> Translation<'c> {
         returns_val: bool,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         self.use_feature("core_intrinsics");
-        let std_or_core = if self.tcfg.emit_no_std { "core" } else { "std" };
 
         // Emit `atomic_cxchg(a0, a1, a2).idx`
-        let atomic_cxchg = mk().abs_path_expr(vec![std_or_core, "intrinsics", intrinsic_name]);
+        let atomic_cxchg = mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", intrinsic_name]);
         let call = mk().call_expr(atomic_cxchg, vec![dst, old_val, src_val]);
         let field_idx = if returns_val { 0 } else { 1 };
         let call_expr = mk().anon_field_expr(call, field_idx);
@@ -382,10 +380,9 @@ impl<'c> Translation<'c> {
         fetch_first: bool,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         self.use_feature("core_intrinsics");
-        let std_or_core = if self.tcfg.emit_no_std { "core" } else { "std" };
 
         // Emit `atomic_func(a0, a1) (op a1)?`
-        let atomic_func = mk().abs_path_expr(vec![std_or_core, "intrinsics", func_name]);
+        let atomic_func = mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", func_name]);
 
         if fetch_first {
             let call_expr = mk().call_expr(atomic_func, vec![dst, src]);

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -32,38 +32,37 @@ impl<'c> Translation<'c> {
                 ))
             }
         };
-        let std_or_core = if self.tcfg.emit_no_std { "core" } else { "std" };
 
         match builtin_name {
             "__builtin_huge_valf" => Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                std_or_core,
+                self.std_or_core(),
                 "f32",
                 "INFINITY",
             ]))),
             "__builtin_huge_val" | "__builtin_huge_vall" => {
                 Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                    std_or_core,
+                    self.std_or_core(),
                     "f64",
                     "INFINITY",
                 ])))
             }
             "__builtin_inff" => Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                std_or_core,
+                self.std_or_core(),
                 "f32",
                 "INFINITY",
             ]))),
             "__builtin_inf" | "__builtin_infl" => Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                std_or_core,
+                self.std_or_core(),
                 "f64",
                 "INFINITY",
             ]))),
             "__builtin_nanf" => Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                std_or_core,
+                self.std_or_core(),
                 "f32",
                 "NAN",
             ]))),
             "__builtin_nan" => Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                std_or_core,
+                self.std_or_core(),
                 "f64",
                 "NAN",
             ]))),
@@ -555,7 +554,7 @@ impl<'c> Translation<'c> {
                 self.use_feature("core_intrinsics");
 
                 let atomic_func =
-                    mk().abs_path_expr(vec![std_or_core, "intrinsics", "atomic_fence"]);
+                    mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", "atomic_fence"]);
                 let call_expr = mk().call_expr(atomic_func, vec![] as Vec<Box<Expr>>);
                 self.convert_side_effects_expr(
                     ctx,
@@ -573,7 +572,7 @@ impl<'c> Translation<'c> {
 
                 // Emit `atomic_xchg_acq(arg0, arg1)`
                 let atomic_func =
-                    mk().abs_path_expr(vec![std_or_core, "intrinsics", "atomic_xchg_acq"]);
+                    mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", "atomic_xchg_acq"]);
                 let arg0 = self.convert_expr(ctx.used(), args[0])?;
                 let arg1 = self.convert_expr(ctx.used(), args[1])?;
                 arg0.and_then(|arg0| {
@@ -597,7 +596,7 @@ impl<'c> Translation<'c> {
 
                 // Emit `atomic_store_rel(arg0, 0)`
                 let atomic_func =
-                    mk().abs_path_expr(vec![std_or_core, "intrinsics", "atomic_store_rel"]);
+                    mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", "atomic_store_rel"]);
                 let arg0 = self.convert_expr(ctx.used(), args[0])?;
                 arg0.and_then(|arg0| {
                     let zero = mk().lit_expr(mk().int_lit(0, ""));
@@ -631,7 +630,7 @@ impl<'c> Translation<'c> {
 
                 // Emit `rotate_left(arg0, arg1)`
                 let rotate_func =
-                    mk().abs_path_expr(vec![std_or_core, "intrinsics", "rotate_left"]);
+                    mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", "rotate_left"]);
                 let arg0 = self.convert_expr(ctx.used(), args[0])?;
                 let arg1 = self.convert_expr(ctx.used(), args[1])?;
                 arg0.and_then(|arg0| {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4608,13 +4608,7 @@ impl<'c> Translation<'c> {
 
         if self.ast_context.is_va_list(resolved_ty_id) {
             // generate MaybeUninit::uninit().assume_init()
-            let name = "uninit";
-            let path = vec![
-                mk().path_segment(self.std_or_core()),
-                mk().path_segment("mem"),
-                mk().path_segment("MaybeUninit"),
-                mk().path_segment(name),
-            ];
+            let path = vec![self.std_or_core(), "mem", "MaybeUninit", "uninit"];
             let call = mk().call_expr(mk().abs_path_expr(path), vec![] as Vec<Box<Expr>>);
             let call = mk().method_call_expr(call, "assume_init", vec![] as Vec<Box<Expr>>);
             return Ok(WithStmts::new_val(call));

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -281,7 +281,11 @@ pub struct Translation<'c> {
 }
 
 pub fn std_or_core(emit_no_std: bool) -> &'static str {
-    if emit_no_std { "core" } else { "std" }
+    if emit_no_std {
+        "core"
+    } else {
+        "std"
+    }
 }
 
 impl Translation<'_> {
@@ -368,7 +372,10 @@ fn transmute_expr(
         (Type::Infer(_), Type::Infer(_)) => Vec::new(),
         _ => vec![source_ty, target_ty],
     };
-    let mut path = vec![mk().path_segment(std_or_core(no_std)), mk().path_segment("mem")];
+    let mut path = vec![
+        mk().path_segment(std_or_core(no_std)),
+        mk().path_segment("mem"),
+    ];
 
     if type_args.is_empty() {
         path.push(mk().path_segment("transmute"));
@@ -2967,11 +2974,7 @@ impl<'c> Translation<'c> {
             Mutability::Mutable
         };
 
-        Ok(ConvertedVariable {
-            ty,
-            mutbl,
-            init,
-        })
+        Ok(ConvertedVariable { ty, mutbl, init })
     }
 
     fn convert_type(&self, type_id: CTypeId) -> TranslationResult<Box<Type>> {

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -428,7 +428,8 @@ impl<'c> Translation<'c> {
             self.name_reference_write_read(ctx, lhs)?
         } else {
             self.name_reference_write(ctx, lhs)?.map(|named_ref| {
-                named_ref.map_rvalue(|()| self.panic_or_err("Volatile value is not supposed to be read"))
+                named_ref
+                    .map_rvalue(|()| self.panic_or_err("Volatile value is not supposed to be read"))
             })
         };
 

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -104,16 +104,14 @@ impl<'c> Translation<'c> {
                             ),
                         )
                         .pub_();
-                    let std_or_core =
-                        if self.tcfg.emit_no_std { "core" } else { "std" }.to_string();
 
                     item_store.add_use_with_attr(
-                        vec![std_or_core.clone(), "arch".into(), "x86".into()],
+                        vec![self.std_or_core().into(), "arch".into(), "x86".into()],
                         name,
                         x86_attr,
                     );
                     item_store.add_use_with_attr(
-                        vec![std_or_core, "arch".into(), "x86_64".into()],
+                        vec![self.std_or_core().into(), "arch".into(), "x86_64".into()],
                         name,
                         x86_64_attr,
                     );
@@ -179,8 +177,6 @@ impl<'c> Translation<'c> {
             self.use_feature("stdsimd");
 
             self.with_cur_file_item_store(|item_store| {
-                let std_or_core = if self.tcfg.emit_no_std { "core" } else { "std" }.to_string();
-
                 // REVIEW: Also a linear lookup
                 if !SIMD_X86_64_ONLY.contains(&name) {
                     let x86_attr = mk()
@@ -194,7 +190,7 @@ impl<'c> Translation<'c> {
                         .pub_();
 
                     item_store.add_use_with_attr(
-                        vec![std_or_core.clone(), "arch".into(), "x86".into()],
+                        vec![self.std_or_core().into(), "arch".into(), "x86".into()],
                         name,
                         x86_attr,
                     );
@@ -213,7 +209,7 @@ impl<'c> Translation<'c> {
                     .pub_();
 
                 item_store.add_use_with_attr(
-                    vec![std_or_core, "arch".into(), "x86_64".into()],
+                    vec![self.std_or_core().into(), "arch".into(), "x86_64".into()],
                     name,
                     x86_64_attr,
                 );


### PR DESCRIPTION
Refactored out `std_or_core = if self.tcfg.emit_no_std { "core" } else { "std" }` into `Translation::std_or_core(&self)` and `fn std_or_core(emit_no_std: bool)`.  This was repeated in lots of places all over the transpiler.  There are lots of similar de-duplication refactors we could do, but this one was simple and I did while working on another PR first.