### PR TITLE
Fixed remaining `clippy::borrowed_box` warnings

### DIFF
--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -19,7 +19,7 @@ pub mod properties {
         fn to_token(&self) -> Option<Self::Token>;
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Copy, Clone)]
     pub enum Mutability {
         Mutable,
         Immutable,

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -671,13 +671,13 @@ impl StructureState {
 ///
 ///   * Negating something of the form `!<expr>` produces `<expr>`
 ///
-fn not(bool_expr: &Box<Expr>) -> Box<Expr> {
-    match **bool_expr {
+fn not(bool_expr: &Expr) -> Box<Expr> {
+    match *bool_expr {
         Expr::Unary(ExprUnary {
             op: syn::UnOp::Not(_),
             ref expr,
             ..
-        }) => unparen(expr).clone(),
-        _ => mk().unary_expr("!", bool_expr.clone()),
+        }) => Box::new(unparen(expr).clone()),
+        _ => mk().unary_expr("!", Box::new(bool_expr.clone())),
     }
 }

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2990,7 +2990,7 @@ impl<'c> Translation<'c> {
 
     fn addr_lhs(
         &self,
-        lhs: &Box<Expr>,
+        lhs: Box<Expr>,
         lhs_type: CQualTypeId,
         write: bool,
     ) -> TranslationResult<Box<Expr>> {
@@ -2999,10 +2999,10 @@ impl<'c> Translation<'c> {
         } else {
             Mutability::Immutable
         };
-        let addr_lhs = match **lhs {
+        let addr_lhs = match *lhs {
             Expr::Unary(ExprUnary {
                 op: UnOp::Deref(_),
-                expr: ref e,
+                expr: e,
                 ..
             }) => {
                 if write == lhs_type.qualifiers.is_const {
@@ -3011,7 +3011,7 @@ impl<'c> Translation<'c> {
 
                     mk().cast_expr(e, ty)
                 } else {
-                    e.clone()
+                    e
                 }
             }
             _ => {
@@ -3029,7 +3029,7 @@ impl<'c> Translation<'c> {
     /// Write to a `lhs` that is volatile
     pub fn volatile_write(
         &self,
-        lhs: &Box<Expr>,
+        lhs: Box<Expr>,
         lhs_type: CQualTypeId,
         rhs: Box<Expr>,
     ) -> TranslationResult<Box<Expr>> {
@@ -3045,7 +3045,7 @@ impl<'c> Translation<'c> {
     /// Read from a `lhs` that is volatile
     pub fn volatile_read(
         &self,
-        lhs: &Box<Expr>,
+        lhs: Box<Expr>,
         lhs_type: CQualTypeId,
     ) -> TranslationResult<Box<Expr>> {
         let addr_lhs = self.addr_lhs(lhs, lhs_type, false)?;
@@ -3352,7 +3352,7 @@ impl<'c> Translation<'c> {
                 // If the variable is volatile and used as something that isn't an LValue, this
                 // constitutes a volatile read.
                 if lrvalue.is_rvalue() && qual_ty.qualifiers.is_volatile {
-                    val = self.volatile_read(&val, qual_ty)?;
+                    val = self.volatile_read(val, qual_ty)?;
                 }
 
                 // If the variable is actually an `EnumConstant`, we need to add a cast to the

--- a/c2rust-transpile/src/translator/named_references.rs
+++ b/c2rust-transpile/src/translator/named_references.rs
@@ -87,7 +87,7 @@ impl<'c> Translation<'c> {
             // Given the LHS access to a variable, produce the RHS one
             let read = |write: Box<Expr>| -> TranslationResult<Box<Expr>> {
                 if reference_ty.qualifiers.is_volatile {
-                    self.volatile_read(&write, reference_ty)
+                    self.volatile_read(write, reference_ty)
                 } else {
                     Ok(write)
                 }

--- a/c2rust-transpile/src/translator/named_references.rs
+++ b/c2rust-transpile/src/translator/named_references.rs
@@ -58,7 +58,7 @@ impl<'c> Translation<'c> {
             fn is_lvalue(e: &Box<Expr>) -> bool {
                 use Expr::*;
                 matches!(
-                    unparen(e).as_ref(),
+                    unparen(e),
                     Unary(ExprUnary {
                         op: syn::UnOp::Deref(_),
                         ..
@@ -70,15 +70,16 @@ impl<'c> Translation<'c> {
 
             // Check if something is a side-effect free Rust lvalue.
             fn is_simple_lvalue(e: &Box<Expr>) -> bool {
-                match **unparen(e) {
-                    Expr::Path(..) => true,
-                    Expr::Unary(ExprUnary {
+                use Expr::*;
+                match *unparen(e) {
+                    Path(..) => true,
+                    Unary(ExprUnary {
                         op: syn::UnOp::Deref(_),
                         ref expr,
                         ..
                     })
-                    | Expr::Field(ExprField { base: ref expr, .. })
-                    | Expr::Index(ExprIndex { ref expr, .. }) => is_simple_lvalue(expr),
+                    | Field(ExprField { base: ref expr, .. })
+                    | Index(ExprIndex { ref expr, .. }) => is_simple_lvalue(expr),
                     _ => false,
                 }
             }

--- a/c2rust-transpile/src/translator/named_references.rs
+++ b/c2rust-transpile/src/translator/named_references.rs
@@ -55,7 +55,7 @@ impl<'c> Translation<'c> {
         let reference = self.convert_expr(ctx.used(), reference)?;
         reference.and_then(|reference| {
             /// Check if something is a valid Rust lvalue. Inspired by `librustc::ty::expr_is_lval`.
-            fn is_lvalue(e: &Box<Expr>) -> bool {
+            fn is_lvalue(e: &Expr) -> bool {
                 use Expr::*;
                 matches!(
                     unparen(e),
@@ -69,7 +69,7 @@ impl<'c> Translation<'c> {
             }
 
             // Check if something is a side-effect free Rust lvalue.
-            fn is_simple_lvalue(e: &Box<Expr>) -> bool {
+            fn is_simple_lvalue(e: &Expr) -> bool {
                 use Expr::*;
                 match *unparen(e) {
                     Path(..) => true,

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -443,7 +443,7 @@ impl<'c> Translation<'c> {
                     // Regular (possibly volatile) assignment
                     Assign if !is_volatile => WithStmts::new_val(mk().assign_expr(&write, rhs)),
                     Assign => {
-                        WithStmts::new_val(self.volatile_write(&write, initial_lhs_type_id, rhs)?)
+                        WithStmts::new_val(self.volatile_write(write, initial_lhs_type_id, rhs)?)
                     }
 
                     // Anything volatile needs to be desugared into explicit reads and writes
@@ -501,7 +501,7 @@ impl<'c> Translation<'c> {
                         };
 
                         let write = if is_volatile {
-                            self.volatile_write(&write, initial_lhs_type_id, val)?
+                            self.volatile_write(write, initial_lhs_type_id, val)?
                         } else {
                             mk().assign_expr(write, val)
                         };
@@ -922,7 +922,7 @@ impl<'c> Translation<'c> {
 
                 // *p = *p + rhs
                 let assign_stmt = if ty.qualifiers.is_volatile {
-                    self.volatile_write(&write, ty, val)?
+                    self.volatile_write(write, ty, val)?
                 } else {
                     mk().assign_expr(&write, val)
                 };
@@ -1040,7 +1040,7 @@ impl<'c> Translation<'c> {
                                     // If the type on the other side of the pointer we are dereferencing is volatile and
                                     // this whole expression is not an LValue, we should make this a volatile read
                                     if lrvalue.is_rvalue() && cqual_type.qualifiers.is_volatile {
-                                        val = self.volatile_read(&val, cqual_type)?
+                                        val = self.volatile_read(val, cqual_type)?
                                     }
                                     Ok(val)
                                 }


### PR DESCRIPTION
Some of these were fixed by turning `&Box<Expr>`s into `&Expr`s and then re-adding explicit `Box::new`s where needed.  And some others were fixed by turning `&Box<Expr>` into `Box<Expr>` when all uses were `.clone()`ed anyways and call sites were supplied by `&arg` reference and were never otherwise moved out of.