### PR TITLE
Skip downloading `tinycbor` in docs.rs

### DIFF
--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -111,6 +111,11 @@ fn generate_bindings() -> Result<(), &'static str> {
 ///   - if `opt-level=0`                              then `CMAKE_BUILD_TYPE=Debug`
 ///   - if `opt-level={1,2,3}` and not `debug=false`, then `CMAKE_BUILD_TYPE=RelWithDebInfo`
 fn build_native(llvm_info: &LLVMInfo) {
+    if env::var("DOCS_RS").is_ok() {
+        // Don't build `cmake` things because it downloads `tinycbor`,
+        // and docs.rs has no network access
+        return;
+    }
     // Find where the (already built) LLVM lib dir is
     let llvm_lib_dir = &llvm_info.lib_dir;
 
@@ -119,12 +124,6 @@ fn build_native(llvm_info: &LLVMInfo) {
             println!("cargo:rustc-link-search=native={}", libdir);
         }
         _ => {
-            if env::var("DOCS_RS").is_ok() {
-                // Don't build `cmake` things because it downloads `tinycbor`, 
-                // and docs.rs has no network access
-                return;
-            }
-
             // Build libclangAstExporter.a with cmake
             let dst = Config::new("src")
                 // Where to find LLVM/Clang CMake files

--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -119,6 +119,12 @@ fn build_native(llvm_info: &LLVMInfo) {
             println!("cargo:rustc-link-search=native={}", libdir);
         }
         _ => {
+            if env::var("DOCS_RS").is_ok() {
+                // Don't build `cmake` things because it downloads `tinycbor`, 
+                // and docs.rs has no network access
+                return;
+            }
+
             // Build libclangAstExporter.a with cmake
             let dst = Config::new("src")
                 // Where to find LLVM/Clang CMake files

--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -11,8 +11,12 @@ fn main() {
 
     let llvm_info = LLVMInfo::new();
 
-    // Build the exporter library and link it (and its dependencies)
-    build_native(&llvm_info);
+    if env::var("DOCS_RS").is_err() {
+        // Build the exporter library and link it (and its dependencies)
+        // But only when not in `docs.rs`, as it has no network access
+        // and will try to download `tinycbor` and fail.
+        build_native(&llvm_info);
+    }
 
     // Generate ast_tags and ExportResult bindings
     if let Err(e) = generate_bindings() {
@@ -111,11 +115,6 @@ fn generate_bindings() -> Result<(), &'static str> {
 ///   - if `opt-level=0`                              then `CMAKE_BUILD_TYPE=Debug`
 ///   - if `opt-level={1,2,3}` and not `debug=false`, then `CMAKE_BUILD_TYPE=RelWithDebInfo`
 fn build_native(llvm_info: &LLVMInfo) {
-    if env::var("DOCS_RS").is_ok() {
-        // Don't build `cmake` things because it downloads `tinycbor`,
-        // and docs.rs has no network access
-        return;
-    }
     // Find where the (already built) LLVM lib dir is
     let llvm_lib_dir = &llvm_info.lib_dir;
 


### PR DESCRIPTION
Should fix https://github.com/immunant/c2rust/issues/470.

Skip doing `cmake` build (which includes downloading `tinycbor`) in docs.rs () because it restricts network access so otherwise our docs.rs build will fail.

According to https://docs.rs/about/builds#detecting-docsrs, we can check `env::var("DOCS_RS").is_ok()`.

It tested this with `DOCS_RS=1 cargo doc`, which builds fine.  `DOCS_RS=1 cargo build` fails with linker errors, but I *don't think* docs.rs does that, hopefully.

This is the simplest fix to get docs.rs working again for `c2rust`, but we should still f ix https://github.com/immunant/c2rust/issues/471 later.