### PR TITLE
translator: remove `std_or_core()` function

### DIFF
--- a/c2rust-refactor/src/transform/externs.rs
+++ b/c2rust-refactor/src/transform/externs.rs
@@ -183,7 +183,7 @@ fn make_cast<'a, 'tcx>(
     }
 
     if needs_transmute {
-        mk().call_expr(mk().path_expr(vec!["", "std", "mem", "transmute"]), vec![expr])
+        mk().call_expr(mk().path_expr(vec!["", "core", "mem", "transmute"]), vec![expr])
     } else {
         let expr = if let ExprKind::AddrOf(_, mutability, _) = expr.kind {
             // We have to cast to *T where &T is the type of expr before casting

--- a/c2rust-refactor/src/transform/format.rs
+++ b/c2rust-refactor/src/transform/format.rs
@@ -302,6 +302,7 @@ impl CastType {
                 // CStr::from_ptr(e as *const libc::c_char).to_str().unwrap()
                 let e = mk().cast_expr(e, mk().ptr_ty(mk().path_ty(vec!["libc", "c_char"])));
                 let cs = mk().call_expr(
+                    // TODO(kkysen) change `"std"` to `"core"` after `#![feature(core_c_str)]` is stabilized in `1.63.0`
                     mk().path_expr(vec!["std", "ffi", "CStr", "from_ptr"]),
                     vec![e]);
                 let s = mk().method_call_expr(cs, "to_str", Vec::<P<Expr>>::new());

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -132,6 +132,12 @@ pub const RESERVED_NAMES: [&str; 103] = [
 ];
 
 impl TypeConverter {
+    // We don't provide a `Default` impl to simplify future compatibility:
+    // if `TypeConverter` ever gets fields incompatible with `Default`, then
+    // cleaning out the uses of `impl Default for TypeConverter` can be a pain.
+    // More practically, there is a single use of `TypeConverter::new` and no
+    // current plans to use a `Default` impl, so providing it isn't worth the
+    // potential breakage.
     #[allow(clippy::new_without_default)]
     pub fn new() -> TypeConverter {
         TypeConverter {

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -2,7 +2,6 @@ use crate::c_ast::CDeclId;
 use crate::c_ast::*;
 use crate::diagnostics::TranslationResult;
 use crate::renamer::*;
-use crate::translator::std_or_core;
 use c2rust_ast_builder::{mk, properties::*};
 use failure::format_err;
 use std::collections::{HashMap, HashSet};
@@ -21,7 +20,6 @@ pub struct TypeConverter {
     fields: HashMap<CDeclId, Renamer<FieldKey>>,
     suffix_names: HashMap<(CDeclId, &'static str), String>,
     features: HashSet<&'static str>,
-    pub emit_no_std: bool,
 }
 
 pub const RESERVED_NAMES: [&str; 103] = [
@@ -134,14 +132,14 @@ pub const RESERVED_NAMES: [&str; 103] = [
 ];
 
 impl TypeConverter {
-    pub fn new(emit_no_std: bool) -> TypeConverter {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> TypeConverter {
         TypeConverter {
             translate_valist: false,
             renamer: Renamer::new(&RESERVED_NAMES),
             fields: HashMap::new(),
             suffix_names: HashMap::new(),
             features: HashSet::new(),
-            emit_no_std,
         }
     }
 
@@ -301,7 +299,7 @@ impl TypeConverter {
         ctype: CTypeId,
     ) -> TranslationResult<Box<Type>> {
         if self.translate_valist && ctxt.is_va_list(ctype) {
-            let path = vec![std_or_core(self.emit_no_std), "ffi", "VaList"];
+            let path = vec!["core", "ffi", "VaList"];
             let ty = mk().path_ty(mk().abs_path(path));
             return Ok(ty);
         }

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -1018,7 +1018,7 @@ impl<'c> Translation<'c> {
         }
 
         self.with_cur_file_item_store(|item_store| {
-            item_store.add_use(vec![self.std_or_core().into(), "arch".into()], "asm");
+            item_store.add_use(vec!["core".into(), "arch".into()], "asm");
         });
 
         let mac = mk().mac(

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -96,8 +96,7 @@ impl<'c> Translation<'c> {
 
                 self.use_feature("core_intrinsics");
 
-                let atomic_load =
-                    mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", intrinsic_name]);
+                let atomic_load = mk().abs_path_expr(vec!["core", "intrinsics", intrinsic_name]);
                 let call = mk().call_expr(atomic_load, vec![ptr]);
                 if name == "__atomic_load" {
                     let ret = val1.expect("__atomic_load should have a ret argument");
@@ -144,11 +143,8 @@ impl<'c> Translation<'c> {
 
                         self.use_feature("core_intrinsics");
 
-                        let atomic_store = mk().abs_path_expr(vec![
-                            self.std_or_core(),
-                            "intrinsics",
-                            intrinsic_name,
-                        ]);
+                        let atomic_store =
+                            mk().abs_path_expr(vec!["core", "intrinsics", intrinsic_name]);
                         let val = if name == "__atomic_store" {
                             mk().unary_expr(UnOp::Deref(Default::default()), val)
                         } else {
@@ -187,11 +183,8 @@ impl<'c> Translation<'c> {
 
                         self.use_feature("core_intrinsics");
 
-                        let fn_path = mk().abs_path_expr(vec![
-                            self.std_or_core(),
-                            "intrinsics",
-                            intrinsic_name,
-                        ]);
+                        let fn_path =
+                            mk().abs_path_expr(vec!["core", "intrinsics", intrinsic_name]);
                         let val = if name == "__atomic_exchange" {
                             mk().unary_expr(UnOp::Deref(Default::default()), val)
                         } else {
@@ -276,11 +269,8 @@ impl<'c> Translation<'c> {
                                 mk().unary_expr(UnOp::Deref(Default::default()), desired)
                             };
 
-                            let atomic_cxchg = mk().abs_path_expr(vec![
-                                self.std_or_core(),
-                                "intrinsics",
-                                &intrinsic_name,
-                            ]);
+                            let atomic_cxchg =
+                                mk().abs_path_expr(vec!["core", "intrinsics", &intrinsic_name]);
                             let call =
                                 mk().call_expr(atomic_cxchg, vec![ptr, expected.clone(), desired]);
                             let res_name = self.renamer.borrow_mut().fresh();
@@ -366,8 +356,7 @@ impl<'c> Translation<'c> {
         self.use_feature("core_intrinsics");
 
         // Emit `atomic_cxchg(a0, a1, a2).idx`
-        let atomic_cxchg =
-            mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", intrinsic_name]);
+        let atomic_cxchg = mk().abs_path_expr(vec!["core", "intrinsics", intrinsic_name]);
         let call = mk().call_expr(atomic_cxchg, vec![dst, old_val, src_val]);
         let field_idx = if returns_val { 0 } else { 1 };
         let call_expr = mk().anon_field_expr(call, field_idx);
@@ -389,7 +378,7 @@ impl<'c> Translation<'c> {
         self.use_feature("core_intrinsics");
 
         // Emit `atomic_func(a0, a1) (op a1)?`
-        let atomic_func = mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", func_name]);
+        let atomic_func = mk().abs_path_expr(vec!["core", "intrinsics", func_name]);
 
         if fetch_first {
             let call_expr = mk().call_expr(atomic_func, vec![dst, src]);

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -174,7 +174,7 @@ impl<'c> Translation<'c> {
             "__builtin_bzero" => {
                 let ptr_stmts = self.convert_expr(ctx.used(), args[0])?;
                 let n_stmts = self.convert_expr(ctx.used(), args[1])?;
-                let write_bytes = mk().abs_path_expr(vec!["std", "ptr", "write_bytes"]);
+                let write_bytes = mk().abs_path_expr(vec!["core", "ptr", "write_bytes"]);
                 let zero = mk().lit_expr(mk().int_lit(0, "u8"));
                 ptr_stmts.and_then(|ptr| {
                     Ok(n_stmts.map(|n| mk().call_expr(write_bytes, vec![ptr, zero, n])))

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -34,38 +34,24 @@ impl<'c> Translation<'c> {
         };
 
         match builtin_name {
-            "__builtin_huge_valf" => Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                self.std_or_core(),
-                "f32",
-                "INFINITY",
-            ]))),
-            "__builtin_huge_val" | "__builtin_huge_vall" => {
-                Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                    self.std_or_core(),
-                    "f64",
-                    "INFINITY",
-                ])))
-            }
-            "__builtin_inff" => Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                self.std_or_core(),
-                "f32",
-                "INFINITY",
-            ]))),
-            "__builtin_inf" | "__builtin_infl" => Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                self.std_or_core(),
-                "f64",
-                "INFINITY",
-            ]))),
-            "__builtin_nanf" => Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                self.std_or_core(),
-                "f32",
-                "NAN",
-            ]))),
-            "__builtin_nan" => Ok(WithStmts::new_val(mk().abs_path_expr(vec![
-                self.std_or_core(),
-                "f64",
-                "NAN",
-            ]))),
+            "__builtin_huge_valf" => Ok(WithStmts::new_val(
+                mk().abs_path_expr(vec!["core", "f32", "INFINITY"]),
+            )),
+            "__builtin_huge_val" | "__builtin_huge_vall" => Ok(WithStmts::new_val(
+                mk().abs_path_expr(vec!["core", "f64", "INFINITY"]),
+            )),
+            "__builtin_inff" => Ok(WithStmts::new_val(
+                mk().abs_path_expr(vec!["core", "f32", "INFINITY"]),
+            )),
+            "__builtin_inf" | "__builtin_infl" => Ok(WithStmts::new_val(
+                mk().abs_path_expr(vec!["core", "f64", "INFINITY"]),
+            )),
+            "__builtin_nanf" => Ok(WithStmts::new_val(
+                mk().abs_path_expr(vec!["core", "f32", "NAN"]),
+            )),
+            "__builtin_nan" => Ok(WithStmts::new_val(
+                mk().abs_path_expr(vec!["core", "f64", "NAN"]),
+            )),
             "__builtin_nanl" => {
                 self.use_crate(ExternCrate::F128);
 
@@ -553,8 +539,7 @@ impl<'c> Translation<'c> {
             "__sync_synchronize" => {
                 self.use_feature("core_intrinsics");
 
-                let atomic_func =
-                    mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", "atomic_fence"]);
+                let atomic_func = mk().abs_path_expr(vec!["core", "intrinsics", "atomic_fence"]);
                 let call_expr = mk().call_expr(atomic_func, vec![] as Vec<Box<Expr>>);
                 self.convert_side_effects_expr(
                     ctx,
@@ -571,8 +556,7 @@ impl<'c> Translation<'c> {
                 self.use_feature("core_intrinsics");
 
                 // Emit `atomic_xchg_acq(arg0, arg1)`
-                let atomic_func =
-                    mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", "atomic_xchg_acq"]);
+                let atomic_func = mk().abs_path_expr(vec!["core", "intrinsics", "atomic_xchg_acq"]);
                 let arg0 = self.convert_expr(ctx.used(), args[0])?;
                 let arg1 = self.convert_expr(ctx.used(), args[1])?;
                 arg0.and_then(|arg0| {
@@ -596,7 +580,7 @@ impl<'c> Translation<'c> {
 
                 // Emit `atomic_store_rel(arg0, 0)`
                 let atomic_func =
-                    mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", "atomic_store_rel"]);
+                    mk().abs_path_expr(vec!["core", "intrinsics", "atomic_store_rel"]);
                 let arg0 = self.convert_expr(ctx.used(), args[0])?;
                 arg0.and_then(|arg0| {
                     let zero = mk().lit_expr(mk().int_lit(0, ""));
@@ -629,8 +613,7 @@ impl<'c> Translation<'c> {
                 self.use_feature("core_intrinsics");
 
                 // Emit `rotate_left(arg0, arg1)`
-                let rotate_func =
-                    mk().abs_path_expr(vec![self.std_or_core(), "intrinsics", "rotate_left"]);
+                let rotate_func = mk().abs_path_expr(vec!["core", "intrinsics", "rotate_left"]);
                 let arg0 = self.convert_expr(ctx.used(), args[0])?;
                 let arg1 = self.convert_expr(ctx.used(), args[1])?;
                 arg0.and_then(|arg0| {

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -151,8 +151,7 @@ impl<'c> Translation<'c> {
                 };
                 let target_ty = mk().set_mutbl(mutbl).ref_ty(self.convert_type(ty.ctype)?);
                 let byte_literal = mk().lit_expr(val);
-                let pointer =
-                    transmute_expr(source_ty, target_ty, byte_literal, self.tcfg.emit_no_std);
+                let pointer = transmute_expr(source_ty, target_ty, byte_literal);
                 let array = mk().unary_expr(UnOp::Deref(Default::default()), pointer);
                 Ok(WithStmts::new_unsafe_val(array))
             }

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -77,6 +77,7 @@ impl<'c> Translation<'c> {
                         vec![mk().method_call_expr(
                             mk().method_call_expr(
                                 mk().call_expr(
+                                    // TODO(kkysen) change `"std"` to `"alloc"` after `#![feature(alloc_c_string)]` is stabilized in `1.63.0`
                                     mk().abs_path_expr(vec!["std", "ffi", "CString", "new"]),
                                     vec![mk().path_expr(vec!["arg"])],
                                 ),
@@ -188,6 +189,7 @@ impl<'c> Translation<'c> {
                                         mk().method_call_expr(
                                             mk().call_expr(
                                                 mk().abs_path_expr(vec![
+                                                    // TODO(kkysen) change `"std"` to `"alloc"` after `#![feature(alloc_c_string)]` is stabilized in `1.63.0`
                                                     "std", "ffi", "CString", "new",
                                                 ]),
                                                 vec![mk().path_expr(vec!["var"])],

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -93,7 +93,7 @@ impl<'c> Translation<'c> {
                     mk().path_expr(vec!["args"]),
                     "push",
                     vec![mk().call_expr(
-                        mk().abs_path_expr(vec!["std", "ptr", "null_mut"]),
+                        mk().abs_path_expr(vec!["core", "ptr", "null_mut"]),
                         vec![] as Vec<Box<Expr>>,
                     )],
                 )));
@@ -208,7 +208,7 @@ impl<'c> Translation<'c> {
                     mk().path_expr(vec!["vars"]),
                     "push",
                     vec![mk().call_expr(
-                        mk().abs_path_expr(vec!["std", "ptr", "null_mut"]),
+                        mk().abs_path_expr(vec!["core", "ptr", "null_mut"]),
                         vec![] as Vec<Box<Expr>>,
                     )],
                 )));

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -280,20 +280,6 @@ pub struct Translation<'c> {
     cur_file: RefCell<Option<FileId>>,
 }
 
-pub fn std_or_core(emit_no_std: bool) -> &'static str {
-    if emit_no_std {
-        "core"
-    } else {
-        "std"
-    }
-}
-
-impl Translation<'_> {
-    pub fn std_or_core(&self) -> &'static str {
-        std_or_core(self.tcfg.emit_no_std)
-    }
-}
-
 fn simple_metaitem(name: &str) -> NestedMeta {
     let meta_item = mk().meta_path(name);
 
@@ -362,20 +348,12 @@ fn unwrap_function_pointer(ptr: Box<Expr>) -> Box<Expr> {
     mk().method_call_expr(ptr, "expect", vec![err_msg])
 }
 
-fn transmute_expr(
-    source_ty: Box<Type>,
-    target_ty: Box<Type>,
-    expr: Box<Expr>,
-    no_std: bool,
-) -> Box<Expr> {
+fn transmute_expr(source_ty: Box<Type>, target_ty: Box<Type>, expr: Box<Expr>) -> Box<Expr> {
     let type_args = match (&*source_ty, &*target_ty) {
         (Type::Infer(_), Type::Infer(_)) => Vec::new(),
         _ => vec![source_ty, target_ty],
     };
-    let mut path = vec![
-        mk().path_segment(std_or_core(no_std)),
-        mk().path_segment("mem"),
-    ];
+    let mut path = vec![mk().path_segment("core"), mk().path_segment("mem")];
 
     if type_args.is_empty() {
         path.push(mk().path_segment("transmute"));
@@ -1239,7 +1217,7 @@ impl<'c> Translation<'c> {
         main_file: &path::Path,
     ) -> Self {
         let comment_context = CommentContext::new(&mut ast_context);
-        let mut type_converter = TypeConverter::new(tcfg.emit_no_std);
+        let mut type_converter = TypeConverter::new();
 
         if tcfg.translate_valist {
             type_converter.translate_valist = true
@@ -1394,7 +1372,7 @@ impl<'c> Translation<'c> {
                     use CastKind::*;
                     match cast_kind {
                         IntegralToPointer | FunctionToPointerDecay | PointerToIntegral => {
-                            return true
+                            return true;
                         }
                         _ => {}
                     }
@@ -1805,7 +1783,7 @@ impl<'c> Translation<'c> {
                         _ => {
                             return Err(TranslationError::generic(
                                 "Found non-field in record field list",
-                            ))
+                            ));
                         }
                     }
                 }
@@ -1915,7 +1893,7 @@ impl<'c> Translation<'c> {
                                 decl_id,
                                 k
                             )
-                            .into())
+                            .into());
                         }
                     };
 
@@ -2742,7 +2720,7 @@ impl<'c> Translation<'c> {
                     // translate `va_list` variables to `VaListImpl`s and omit the initializer.
                     let pat_mut = mk().set_mutbl("mut").ident_pat(rust_name);
                     let ty = {
-                        let path = vec![self.std_or_core(), "ffi", "VaListImpl"];
+                        let path = vec!["core", "ffi", "VaListImpl"];
                         mk().path_ty(mk().abs_path(path))
                     };
                     let local_mut = mk().local::<_, _, Box<Expr>>(pat_mut, Some(ty), None);
@@ -3059,7 +3037,7 @@ impl<'c> Translation<'c> {
         let addr_lhs = self.addr_lhs(lhs, lhs_type, true)?;
 
         Ok(mk().call_expr(
-            mk().abs_path_expr(vec![self.std_or_core(), "ptr", "write_volatile"]),
+            mk().abs_path_expr(vec!["core", "ptr", "write_volatile"]),
             vec![addr_lhs, rhs],
         ))
     }
@@ -3076,7 +3054,7 @@ impl<'c> Translation<'c> {
         // in order to avoid omitted bit-casts to const from causing the
         // wrong type to be inferred via the result of the pointer.
         let mut path_parts: Vec<PathSegment> = vec![];
-        for elt in [self.std_or_core(), "ptr"] {
+        for elt in ["core", "ptr"] {
             path_parts.push(mk().path_segment(elt))
         }
         let elt_ty = self.convert_type(lhs_type.ctype)?;
@@ -3193,7 +3171,7 @@ impl<'c> Translation<'c> {
         let name = "size_of";
         let params = mk().angle_bracketed_args(vec![ty]);
         let path = vec![
-            mk().path_segment(self.std_or_core()),
+            mk().path_segment("core"),
             mk().path_segment("mem"),
             mk().path_segment_with_args(name, params),
         ];
@@ -3211,12 +3189,7 @@ impl<'c> Translation<'c> {
 
         let ty = self.convert_type(type_id)?;
         let tys = vec![ty];
-        let mut path = vec![];
-        if self.tcfg.emit_no_std {
-            path.push(mk().path_segment("core"));
-        } else {
-            path.push(mk().path_segment("std"));
-        }
+        let mut path = vec![mk().path_segment("core")];
         if preferred {
             self.use_feature("core_intrinsics");
             path.push(mk().path_segment("intrinsics"));
@@ -3409,7 +3382,7 @@ impl<'c> Translation<'c> {
                             if let Some(cur_file) = *self.cur_file.borrow() {
                                 self.import_type(qual_ty.ctype, cur_file);
                             }
-                            val = transmute_expr(actual_ty, ty, val, self.tcfg.emit_no_std);
+                            val = transmute_expr(actual_ty, ty, val);
                             set_unsafe = true;
                         } else {
                             val = mk().cast_expr(val, ty);
@@ -3758,7 +3731,7 @@ impl<'c> Translation<'c> {
                                             "Subscript applied to non-pointer: {:?}",
                                             lhs
                                         )
-                                        .into())
+                                        .into());
                                     }
                                 };
 
@@ -3785,16 +3758,16 @@ impl<'c> Translation<'c> {
                 let func = match self.ast_context[func].kind {
                     // Direct function call
                     CExprKind::ImplicitCast(_, fexp, CastKind::FunctionToPointerDecay, _, _)
-                        // Only a direct function call with pointer decay if the
-                        // callee is a declref
-                        if matches!(self.ast_context[fexp].kind, CExprKind::DeclRef(..)) =>
-                    {
-                        self.convert_expr(ctx.used(), fexp)?
-                    }
+                    // Only a direct function call with pointer decay if the
+                    // callee is a declref
+                    if matches!(self.ast_context[fexp].kind, CExprKind::DeclRef(..)) =>
+                        {
+                            self.convert_expr(ctx.used(), fexp)?
+                        }
 
                     // Builtin function call
                     CExprKind::ImplicitCast(_, fexp, CastKind::BuiltinFnToFnPtr, _, _) => {
-                        return self.convert_builtin(ctx, fexp, args)
+                        return self.convert_builtin(ctx, fexp, args);
                     }
 
                     // Function pointer call
@@ -3802,10 +3775,10 @@ impl<'c> Translation<'c> {
                         let callee = self.convert_expr(ctx.used(), func)?;
                         let make_fn_ty = |ret_ty: Box<Type>| {
                             let ret_ty = match *ret_ty {
-                                Type::Tuple(TypeTuple {elems: ref v, ..}) if v.is_empty() => ReturnType::Default,
+                                Type::Tuple(TypeTuple { elems: ref v, .. }) if v.is_empty() => ReturnType::Default,
                                 _ => ReturnType::Type(Default::default(), ret_ty),
                             };
-                            let bare_ty : (Vec<BareFnArg>, Option<Variadic>, ReturnType) = (
+                            let bare_ty: (Vec<BareFnArg>, Option<Variadic>, ReturnType) = (
                                 vec![mk().bare_arg(mk().infer_ty(), None::<Box<Ident>>); args.len()],
                                 None,
                                 ret_ty
@@ -3820,7 +3793,7 @@ impl<'c> Translation<'c> {
                                 let target_ty = make_fn_ty(ret_ty);
                                 callee.map(|fn_ptr| {
                                     let fn_ptr = unwrap_function_pointer(fn_ptr);
-                                    transmute_expr(mk().infer_ty(), target_ty, fn_ptr, self.tcfg.emit_no_std)
+                                    transmute_expr(mk().infer_ty(), target_ty, fn_ptr)
                                 })
                             }
                             None => {
@@ -3828,7 +3801,7 @@ impl<'c> Translation<'c> {
                                 let ret_ty = self.convert_type(call_expr_ty.ctype)?;
                                 let target_ty = make_fn_ty(ret_ty);
                                 callee.map(|fn_ptr| {
-                                    transmute_expr(mk().infer_ty(), target_ty, fn_ptr, self.tcfg.emit_no_std)
+                                    transmute_expr(mk().infer_ty(), target_ty, fn_ptr)
                                 })
                             }
                             Some(_) => {
@@ -4308,10 +4281,7 @@ impl<'c> Translation<'c> {
                         let source_ty = self.convert_type(source_ty.ctype)?;
                         let target_ty = self.convert_type(ty.ctype)?;
                         Ok(WithStmts::new_unsafe_val(transmute_expr(
-                            source_ty,
-                            target_ty,
-                            x,
-                            self.tcfg.emit_no_std,
+                            source_ty, target_ty, x,
                         )))
                     } else {
                         // Normal case
@@ -4327,10 +4297,7 @@ impl<'c> Translation<'c> {
                     let intptr_t = mk().path_ty(vec!["libc", "intptr_t"]);
                     let intptr = mk().cast_expr(x, intptr_t.clone());
                     Ok(WithStmts::new_unsafe_val(transmute_expr(
-                        intptr_t,
-                        target_ty,
-                        intptr,
-                        self.tcfg.emit_no_std,
+                        intptr_t, target_ty, intptr,
                     )))
                 })
             }
@@ -4365,10 +4332,7 @@ impl<'c> Translation<'c> {
                     val.and_then(|x| {
                         if self.ast_context.is_function_pointer(source_ty_ctype_id) {
                             Ok(WithStmts::new_unsafe_val(transmute_expr(
-                                source_ty,
-                                target_ty,
-                                x,
-                                self.tcfg.emit_no_std,
+                                source_ty, target_ty, x,
                             )))
                         } else {
                             Ok(WithStmts::new_val(mk().cast_expr(x, target_ty)))
@@ -4535,7 +4499,7 @@ impl<'c> Translation<'c> {
                     "Tried casting long double to unsupported type: {:?}",
                     target_ty_ctype
                 )
-                .into())
+                .into());
             }
         };
 
@@ -4575,7 +4539,7 @@ impl<'c> Translation<'c> {
                 return val.map(|x| match *unparen(&x) {
                     Expr::Cast(ExprCast { ref expr, .. }) => expr.clone(),
                     _ => panic!("DeclRef {:?} of enum {:?} is not cast", expr, enum_decl),
-                })
+                });
             }
 
             CExprKind::Literal(_, CLiteral::Integer(i, _)) => {
@@ -4608,7 +4572,7 @@ impl<'c> Translation<'c> {
 
         if self.ast_context.is_va_list(resolved_ty_id) {
             // generate MaybeUninit::uninit().assume_init()
-            let path = vec![self.std_or_core(), "mem", "MaybeUninit", "uninit"];
+            let path = vec!["core", "mem", "MaybeUninit", "uninit"];
             let call = mk().call_expr(mk().abs_path_expr(path), vec![] as Vec<Box<Expr>>);
             let call = mk().method_call_expr(call, "assume_init", vec![] as Vec<Box<Expr>>);
             return Ok(WithStmts::new_val(call));
@@ -4703,7 +4667,7 @@ impl<'c> Translation<'c> {
             CDeclKind::Struct { fields: None, .. } => {
                 return Err(TranslationError::generic(
                     "Attempted to zero-initialize forward-declared struct",
-                ))
+                ));
             }
 
             // Zero initialize the first field
@@ -4719,7 +4683,7 @@ impl<'c> Translation<'c> {
                     None => {
                         return Err(TranslationError::generic(
                             "Attempted to zero-initialize forward-declared struct",
-                        ))
+                        ));
                     }
                 };
 
@@ -4742,7 +4706,7 @@ impl<'c> Translation<'c> {
                     _ => {
                         return Err(TranslationError::generic(
                             "Found non-field in record field list",
-                        ))
+                        ));
                     }
                 };
 
@@ -4755,7 +4719,7 @@ impl<'c> Translation<'c> {
             _ => {
                 return Err(TranslationError::generic(
                     "Declaration is not associated with a type",
-                ))
+                ));
             }
         };
 

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -288,12 +288,7 @@ impl<'c> Translation<'c> {
                 .is_enum();
             let result_type = self.convert_type(lhs_ty.ctype)?;
             let val = if is_enum_result {
-                WithStmts::new_unsafe_val(transmute_expr(
-                    lhs_type,
-                    result_type,
-                    val,
-                    self.tcfg.emit_no_std,
-                ))
+                WithStmts::new_unsafe_val(transmute_expr(lhs_type, result_type, val))
             } else {
                 // We can't as-cast from a non primitive like f128 back to the result_type
                 if *resolved_computed_kind == CTypeKind::LongDouble {
@@ -497,12 +492,7 @@ impl<'c> Translation<'c> {
                                 let result_type = self.convert_type(qtype.ctype)?;
                                 let val = if is_enum_result {
                                     is_unsafe = true;
-                                    transmute_expr(
-                                        lhs_type,
-                                        result_type,
-                                        val,
-                                        self.tcfg.emit_no_std,
-                                    )
+                                    transmute_expr(lhs_type, result_type, val)
                                 } else {
                                     mk().cast_expr(val, result_type)
                                 };

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -106,12 +106,12 @@ impl<'c> Translation<'c> {
                         .pub_();
 
                     item_store.add_use_with_attr(
-                        vec![self.std_or_core().into(), "arch".into(), "x86".into()],
+                        vec!["core".into(), "arch".into(), "x86".into()],
                         name,
                         x86_attr,
                     );
                     item_store.add_use_with_attr(
-                        vec![self.std_or_core().into(), "arch".into(), "x86_64".into()],
+                        vec!["core".into(), "arch".into(), "x86_64".into()],
                         name,
                         x86_64_attr,
                     );
@@ -190,7 +190,7 @@ impl<'c> Translation<'c> {
                         .pub_();
 
                     item_store.add_use_with_attr(
-                        vec![self.std_or_core().into(), "arch".into(), "x86".into()],
+                        vec!["core".into(), "arch".into(), "x86".into()],
                         name,
                         x86_attr,
                     );
@@ -209,7 +209,7 @@ impl<'c> Translation<'c> {
                     .pub_();
 
                 item_store.add_use_with_attr(
-                    vec![self.std_or_core().into(), "arch".into(), "x86_64".into()],
+                    vec!["core".into(), "arch".into(), "x86_64".into()],
                     name,
                     x86_64_attr,
                 );
@@ -318,7 +318,6 @@ impl<'c> Translation<'c> {
                 mk().infer_ty(),
                 mk().infer_ty(),
                 expr,
-                self.tcfg.emit_no_std,
             )))
         } else {
             self.import_simd_function(fn_name)
@@ -346,12 +345,7 @@ impl<'c> Translation<'c> {
             let call = if ctx.is_static {
                 let tuple = mk().tuple_expr(params);
 
-                transmute_expr(
-                    mk().infer_ty(),
-                    mk().infer_ty(),
-                    tuple,
-                    self.tcfg.emit_no_std,
-                )
+                transmute_expr(mk().infer_ty(), mk().infer_ty(), tuple)
             } else {
                 let fn_call_name = match (&self.ast_context[ctype].kind, len) {
                     (Float, 4) => "_mm_setr_ps",

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -108,13 +108,8 @@ impl<'a> Translation<'a> {
                 // TODO: handle or panic on structs with more than one va_list?
                 let is_va_list = self.ast_context.is_va_list(ctype);
                 let mut ty = if is_va_list {
-                    let std_or_core = if self.type_converter.borrow().emit_no_std {
-                        "core"
-                    } else {
-                        "std"
-                    };
                     let path = vec![
-                        mk().path_segment(std_or_core),
+                        mk().path_segment("core"),
                         mk().path_segment("ffi"),
                         mk().path_segment_with_args(
                             "VaListImpl",

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -196,7 +196,7 @@ impl<'c> Translation<'c> {
                 } else {
                     let val = if have_fn_ptr {
                         // transmute result of call to `arg` when expecting a function pointer
-                        transmute_expr(mk().infer_ty(), mk().infer_ty(), val, self.tcfg.emit_no_std)
+                        transmute_expr(mk().infer_ty(), mk().infer_ty(), val)
                     } else {
                         val
                     };

--- a/pdg/src/util.rs
+++ b/pdg/src/util.rs
@@ -113,6 +113,17 @@ impl<T: Display> Display for Duplicates<T> {
     }
 }
 
+impl<T: Debug + Eq + Hash> Duplicates<T> {
+    // This function is sometimes used during debugging.
+    #[allow(dead_code)]
+    pub fn assert_empty_debug(&self) {
+        if self.is_empty() {
+            return;
+        }
+        panic!("unexpected duplicates: {:?}", self);
+    }
+}
+
 impl<T: Display + Eq + Hash> Duplicates<T> {
     pub fn assert_empty(&self) {
         if self.is_empty() {

--- a/pdg/src/util.rs
+++ b/pdg/src/util.rs
@@ -113,15 +113,6 @@ impl<T: Display> Display for Duplicates<T> {
     }
 }
 
-impl<T: Debug + Eq + Hash> Duplicates<T> {
-    pub fn assert_empty_debug(&self) {
-        if self.is_empty() {
-            return;
-        }
-        panic!("unexpected duplicates: {:?}", self);
-    }
-}
-
 impl<T: Display + Eq + Hash> Duplicates<T> {
     pub fn assert_empty(&self) {
         if self.is_empty() {


### PR DESCRIPTION
This is a redundant complication of translator source code: the `libcore` is always available,
whether the crate is `#![no_std]` or not. Using the imports from `core` or `std` is purely a
matter of code style, which should not be the responsibility of the transpiler.

If the transpiled crate should use `libstd` instead of `libcore` in imports, this can be fixed
by some refactoring tools, or possibly even `rustfmt`.

Also fixes https://github.com/immunant/c2rust/issues/480.