### PR TITLE
Introduce a `path!` macro for creating items from simple paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
 name = "c2rust-bitfields-derive"
 version = "0.2.1"
 dependencies = [
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -315,8 +316,6 @@ dependencies = [
  "c2rust-ast-builder",
  "c2rust-ast-exporter",
  "c2rust-ast-printer",
- "c2rust-bitfields",
- "clap 2.34.0",
  "colored 2.0.0",
  "dtoa",
  "failure",

--- a/c2rust-ast-builder/Cargo.toml
+++ b/c2rust-ast-builder/Cargo.toml
@@ -12,5 +12,5 @@ description = "Rust AST builder support crate for the C2Rust project"
 edition = "2021"
 
 [dependencies]
-proc-macro2 = { version = "1.0", features = ["span-locations"]}
-syn = { version = "1.0", features = ["full", "extra-traits", "printing"]}
+proc-macro2 = { version = "1.0", features = ["span-locations"], default-features = false }
+syn = { version = "1.0", features = ["full", "extra-traits", "printing"], default-features = false }

--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -1,11 +1,13 @@
 //! Helpers for building AST nodes.  Normally used by calling `mk().some_node(args...)`.
 
+use std::default::Default;
+use std::iter::FromIterator;
 use std::str;
 
 use proc_macro2::{Span, TokenStream, TokenTree};
-use std::default::Default;
-use std::iter::FromIterator;
 use syn::{__private::ToTokens, punctuated::Punctuated, *};
+
+use self::properties::*;
 
 /// Produces an item corresponding to the provided path.
 ///
@@ -146,8 +148,6 @@ pub mod properties {
     }
 }
 
-use self::properties::*;
-
 pub type FnDecl = (Ident, Vec<FnArg>, Option<Variadic>, ReturnType);
 pub type BareFnTyParts = (Vec<BareFnArg>, Option<Variadic>, ReturnType);
 
@@ -197,12 +197,6 @@ pub trait Make<T> {
 impl<T> Make<T> for T {
     fn make(self, _mk: &Builder) -> T {
         self
-    }
-}
-
-impl<'a, T: Clone> Make<T> for &'a T {
-    fn make(self, _mk: &Builder) -> T {
-        self.clone()
     }
 }
 

--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -1176,7 +1176,7 @@ impl Builder {
     where
         I: Make<Ident>,
     {
-        self.path_expr(vec![name])
+        self.path_expr([name])
     }
 
     pub fn addr_of_expr<E>(self, e: E) -> Box<Expr>
@@ -1698,7 +1698,7 @@ impl Builder {
     where
         I: Make<Ident>,
     {
-        self.path_ty(vec![name])
+        self.path_ty([name])
     }
 
     pub fn infer_ty(self) -> Box<Type> {

--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -186,10 +186,6 @@ fn use_tree_with_prefix(prefix: Path, leaf: UseTree) -> UseTree {
     out
 }
 
-fn punct<T, P: Default>(x: Vec<T>) -> Punctuated<T, P> {
-    Punctuated::from_iter(x.into_iter())
-}
-
 fn punct_box<T, P: Default>(x: Vec<Box<T>>) -> Punctuated<T, P> {
     Punctuated::from_iter(x.into_iter().map(|x| *x))
 }
@@ -523,7 +519,7 @@ impl Make<Signature> for Box<FnDecl> {
             generics: mk.generics.clone(),
             abi: mk.get_abi_opt(),
             ident: name,
-            inputs: punct(inputs),
+            inputs: Punctuated::from_iter(inputs),
             variadic,
             output,
         }
@@ -745,7 +741,7 @@ impl Builder {
         let metalist = MetaList {
             path: func,
             paren_token: token::Paren(self.span),
-            nested: punct(arguments),
+            nested: Punctuated::from_iter(arguments),
         };
         let prepared = self.prepare_meta_list(metalist);
         self.prepared_attr(prepared)
@@ -855,12 +851,11 @@ impl Builder {
     }
 
     pub fn call_expr(self, func: Box<Expr>, args: Vec<Box<Expr>>) -> Box<Expr> {
-        let args = args.into_iter().map(|a| *a).collect();
         Box::new(parenthesize_if_necessary(Expr::Call(ExprCall {
             attrs: self.attrs,
             paren_token: token::Paren(self.span),
             func,
-            args,
+            args: punct_box(args),
         })))
     }
 
@@ -1113,7 +1108,7 @@ impl Builder {
             brace_token: token::Brace(self.span),
             dot2_token: None,
             path,
-            fields: punct(fields),
+            fields: Punctuated::from_iter(fields),
             rest: None,
         }))
     }
@@ -1134,7 +1129,7 @@ impl Builder {
             brace_token: token::Brace(self.span),
             dot2_token: Some(token::Dot2(self.span)),
             path,
-            fields: punct(fields),
+            fields: Punctuated::from_iter(fields),
             rest: base,
         }))
     }
@@ -1417,7 +1412,7 @@ impl Builder {
             paren_token: token::Paren(self.span),
             unsafety: self.unsafety.to_token(),
             abi,
-            inputs: punct(inputs),
+            inputs: Punctuated::from_iter(inputs),
             output,
             variadic,
             lifetimes: None,
@@ -1485,10 +1480,9 @@ impl Builder {
     }
 
     pub fn tuple_ty(self, elem_tys: Vec<Box<Type>>) -> Box<Type> {
-        let elem_tys = punct(elem_tys.into_iter().map(|ty| *ty).collect());
         Box::new(Type::Tuple(TypeTuple {
             paren_token: token::Paren(self.span),
-            elems: elem_tys,
+            elems: punct_box(elem_tys),
         }))
     }
 
@@ -1659,7 +1653,7 @@ impl Builder {
         let name = name.make(&self);
         let fields = FieldsNamed {
             brace_token: token::Brace(self.span),
-            named: punct(fields),
+            named: Punctuated::from_iter(fields),
         };
         Box::new(Item::Union(ItemUnion {
             attrs: self.attrs,
@@ -1682,7 +1676,7 @@ impl Builder {
             ident: name,
             enum_token: token::Enum(self.span),
             brace_token: token::Brace(self.span),
-            variants: punct(fields),
+            variants: Punctuated::from_iter(fields),
             generics: self.generics,
         }))
     }
@@ -2124,7 +2118,7 @@ impl Builder {
         GenericParam::Type(TypeParam {
             attrs: self.attrs,
             ident,
-            bounds: punct(vec![]),
+            bounds: Punctuated::new(),
             colon_token: None,
             eq_token: None,
             default: None,
@@ -2144,7 +2138,7 @@ impl Builder {
             attrs: self.attrs,
             lifetime,
             colon_token: None,
-            bounds: punct(vec![]),
+            bounds: Punctuated::new(),
         })
     }
 
@@ -2195,7 +2189,7 @@ impl Builder {
         Meta::List(MetaList {
             path,
             paren_token: token::Paren(self.span),
-            nested: punct(args),
+            nested: Punctuated::from_iter(args),
         })
     }
 

--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -244,13 +244,13 @@ impl<'a> Make<Visibility> for &'a str {
                 pub_token: token::Pub(mk_.span),
                 paren_token: token::Paren(mk_.span),
                 in_token: None,
-                path: Box::new(mk().path("crate")),
+                path: path![crate],
             }),
             "pub(super)" => Visibility::Restricted(VisRestricted {
                 pub_token: token::Pub(mk_.span),
                 paren_token: token::Paren(mk_.span),
                 in_token: None,
-                path: Box::new(mk().path("super")),
+                path: path![super],
             }),
             _ => panic!("unrecognized string for Visibility: {:?}", self),
         };

--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -526,15 +526,6 @@ impl Make<Signature> for Box<FnDecl> {
     }
 }
 
-pub trait LitStringable {
-    fn lit_string(self, _: &Builder) -> String;
-}
-
-impl LitStringable for &str {
-    fn lit_string(self, _: &Builder) -> String {
-        self.to_string()
-    }
-}
 #[derive(Clone, Debug)]
 pub struct Builder {
     // The builder holds a set of "modifiers", such as visibility and mutability.  Functions for
@@ -1213,28 +1204,16 @@ impl Builder {
 
     // Literals
 
-    pub fn int_lit<T>(self, i: u128, ty: T) -> Lit
-    where
-        T: LitStringable,
-    {
-        Lit::Int(LitInt::new(
-            &format!("{}{}", i, ty.lit_string(&self)),
-            self.span,
-        ))
+    pub fn int_lit(self, i: u128, ty: &str) -> Lit {
+        Lit::Int(LitInt::new(&format!("{}{}", i, ty), self.span))
     }
 
     pub fn int_unsuffixed_lit(self, i: u128) -> Lit {
         Lit::Int(LitInt::new(&format!("{}", i), self.span))
     }
 
-    pub fn float_lit<T>(self, s: &str, ty: T) -> Lit
-    where
-        T: LitStringable,
-    {
-        Lit::Float(LitFloat::new(
-            &format!("{}{}", s, ty.lit_string(&self)),
-            self.span,
-        ))
+    pub fn float_lit(self, s: &str, ty: &str) -> Lit {
+        Lit::Float(LitFloat::new(&format!("{}{}", s, ty), self.span))
     }
 
     pub fn float_unsuffixed_lit(self, s: &str) -> Lit {

--- a/c2rust-ast-builder/src/lib.rs
+++ b/c2rust-ast-builder/src/lib.rs
@@ -1,2 +1,5 @@
-mod builder;
+pub extern crate syn;
+
 pub use crate::builder::{mk, properties, Builder, Make};
+
+mod builder;

--- a/c2rust-ast-printer/Cargo.toml
+++ b/c2rust-ast-printer/Cargo.toml
@@ -9,6 +9,6 @@ description = "Customized version of libsyntax rust pretty-printer"
 
 [dependencies]
 log = "0.4"
-syn = { version = "1.0", features = ["full", "proc-macro", "printing"] }
-proc-macro2 = "1.0"
+syn = { version = "1.0", features = ["full", "proc-macro", "printing"], default-features = false }
+proc-macro2 = { version = "1.0", default-features = false }
 prettyplease = "0.1.9"

--- a/c2rust-bitfields-derive/Cargo.toml
+++ b/c2rust-bitfields-derive/Cargo.toml
@@ -13,6 +13,8 @@ description = "C-compatible struct bitfield derive implementation used in the C2
 readme = "README.md"
 
 [dependencies]
+
+itertools = "0.10.3"
 proc-macro2 = "1.0"
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -16,8 +16,6 @@ edition = "2021"
 c2rust-ast-builder = { version = "0.16.0", path = "../c2rust-ast-builder" }
 c2rust-ast-exporter = { version = "0.16.0", path = "../c2rust-ast-exporter" }
 c2rust-ast-printer = { version = "0.16.0", path = "../c2rust-ast-printer" }
-c2rust-bitfields = { version = "0.3.0", path = "../c2rust-bitfields" }
-clap = {version = "2.34", features = ["yaml"]}
 colored = "2.0"
 dtoa = "1.0"
 failure = "0.1.5"

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -602,9 +602,8 @@ impl Cfg<Label, StmtOrDecl> {
                             .push(StmtOrDecl::Stmt(mk().semi_stmt(mk().return_expr(ret_expr))));
                     }
                     ImplicitReturnType::Void => {
-                        wip.body.push(StmtOrDecl::Stmt(
-                            mk().semi_stmt(mk().return_expr(None as Option<Box<Expr>>)),
-                        ));
+                        wip.body
+                            .push(StmtOrDecl::Stmt(mk().semi_stmt(mk().return_expr(None))));
                     }
                     ImplicitReturnType::NoImplicitReturnType => {
                         // NOTE: emitting `ret_expr` is not necessarily an error. For instance,
@@ -2028,10 +2027,10 @@ impl CfgBuilder {
                 false,
             ),
 
-            Some(ImplicitReturnType::Void) => (mk().return_expr(None as Option<Box<Expr>>), false),
+            Some(ImplicitReturnType::Void) => (mk().return_expr(None), false),
 
             _ => (
-                mk().break_expr_value(Some(brk_lbl.pretty_print()), None as Option<Box<Expr>>),
+                mk().break_expr_value(Some(brk_lbl.pretty_print()), None),
                 true,
             ),
         };

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -491,7 +491,7 @@ impl StructureState {
                         let (stmts, span) = self.to_stmt(stmts, comment_store);
 
                         let body = mk().block_expr(mk().span(span).block(stmts));
-                        mk().arm(pat, None as Option<Box<Expr>>, body)
+                        mk().arm(pat, None, body)
                     })
                     .collect();
 
@@ -515,11 +515,8 @@ impl StructureState {
                 let mut if_stmt = match (then_stmts.is_empty(), els_stmts.is_empty()) {
                     (true, true) => mk().semi_stmt(cond),
                     (false, true) => {
-                        let if_expr = mk().ifte_expr(
-                            cond,
-                            mk().span(then_span).block(then_stmts),
-                            None as Option<Box<Expr>>,
-                        );
+                        let if_expr =
+                            mk().ifte_expr(cond, mk().span(then_span).block(then_stmts), None);
                         mk().expr_stmt(if_expr)
                     }
                     (true, false) => {
@@ -527,7 +524,7 @@ impl StructureState {
                         let if_expr = mk().ifte_expr(
                             negated_cond,
                             mk().span(els_span).block(els_stmts),
-                            None as Option<Box<Expr>>,
+                            None,
                         );
                         mk().expr_stmt(if_expr)
                     }
@@ -582,7 +579,7 @@ impl StructureState {
                         };
                         let pat = mk().lit_pat(lbl_expr);
                         let body = mk().block_expr(mk().span(stmts_span).block(stmts));
-                        mk().arm(pat, None as Option<Box<Expr>>, body)
+                        mk().arm(pat, None, body)
                     })
                     .collect();
 
@@ -590,7 +587,7 @@ impl StructureState {
 
                 arms.push(mk().arm(
                     mk().wild_pat(),
-                    None as Option<Box<Expr>>,
+                    None,
                     mk().block_expr(mk().span(then_span).block(then)),
                 ));
 

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -270,9 +270,7 @@ impl TypeConverter {
         match ctxt.resolve_type(qtype.ctype).kind {
             // While void converts to () in function returns, it converts to c_void
             // in the case of pointers.
-            CTypeKind::Void => Ok(mk()
-                .set_mutbl(mutbl)
-                .ptr_ty(mk().path_ty(vec!["libc", "c_void"]))),
+            CTypeKind::Void => Ok(mk().set_mutbl(mutbl).ptr_ty(path![::libc::c_void])),
 
             CTypeKind::VariableArray(mut elt, _len) => {
                 while let CTypeKind::VariableArray(elt_, _) = ctxt.resolve_type(elt).kind {

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -309,7 +309,7 @@ impl TypeConverter {
         }
 
         match ctxt.index(ctype).kind {
-            CTypeKind::Void => Ok(mk().tuple_ty(vec![] as Vec<Box<Type>>)),
+            CTypeKind::Void => Ok(mk().tuple_ty(vec![])),
             CTypeKind::Bool => Ok(path![bool]),
             CTypeKind::Short => Ok(path![::libc::c_short]),
             CTypeKind::Int => Ok(path![::libc::c_int]),

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -287,7 +287,7 @@ impl TypeConverter {
             CTypeKind::Function(..) => {
                 let fn_ty = self.convert(ctxt, qtype.ctype)?;
                 let param = mk().angle_bracketed_args(vec![fn_ty]);
-                Ok(mk().path_ty(vec![mk().path_segment_with_args("Option", param)]))
+                Ok(mk().path_ty([mk().path_segment_with_args("Option", param)]))
             }
 
             _ => {
@@ -341,22 +341,22 @@ impl TypeConverter {
                 let new_name = self
                     .resolve_decl_name(decl_id)
                     .ok_or_else(|| format_err!("Unknown decl id {:?}", decl_id))?;
-                Ok(mk().path_ty(mk().path(vec![new_name])))
+                Ok(mk().path_ty(mk().path([new_name])))
             }
 
             CTypeKind::Union(decl_id) => {
                 let new_name = self.resolve_decl_name(decl_id).unwrap();
-                Ok(mk().path_ty(mk().path(vec![new_name])))
+                Ok(mk().path_ty(mk().path([new_name])))
             }
 
             CTypeKind::Enum(decl_id) => {
                 let new_name = self.resolve_decl_name(decl_id).unwrap();
-                Ok(mk().path_ty(mk().path(vec![new_name])))
+                Ok(mk().path_ty(mk().path([new_name])))
             }
 
             CTypeKind::Typedef(decl_id) => {
                 let new_name = self.resolve_decl_name(decl_id).unwrap();
-                Ok(mk().path_ty(mk().path(vec![new_name])))
+                Ok(mk().path_ty(mk().path([new_name])))
             }
 
             CTypeKind::ConstantArray(element, count) => {

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -2,7 +2,7 @@ use crate::c_ast::CDeclId;
 use crate::c_ast::*;
 use crate::diagnostics::TranslationResult;
 use crate::renamer::*;
-use c2rust_ast_builder::{mk, properties::*};
+use c2rust_ast_builder::{mk, path, properties::*};
 use failure::format_err;
 use std::collections::{HashMap, HashSet};
 use std::ops::Index;
@@ -305,31 +305,29 @@ impl TypeConverter {
         ctype: CTypeId,
     ) -> TranslationResult<Box<Type>> {
         if self.translate_valist && ctxt.is_va_list(ctype) {
-            let path = vec!["core", "ffi", "VaList"];
-            let ty = mk().path_ty(mk().abs_path(path));
-            return Ok(ty);
+            return Ok(path![::core::ffi::VaList]);
         }
 
         match ctxt.index(ctype).kind {
             CTypeKind::Void => Ok(mk().tuple_ty(vec![] as Vec<Box<Type>>)),
-            CTypeKind::Bool => Ok(mk().path_ty(mk().path(vec!["bool"]))),
-            CTypeKind::Short => Ok(mk().path_ty(mk().path(vec!["libc", "c_short"]))),
-            CTypeKind::Int => Ok(mk().path_ty(mk().path(vec!["libc", "c_int"]))),
-            CTypeKind::Long => Ok(mk().path_ty(mk().path(vec!["libc", "c_long"]))),
-            CTypeKind::LongLong => Ok(mk().path_ty(mk().path(vec!["libc", "c_longlong"]))),
-            CTypeKind::UShort => Ok(mk().path_ty(mk().path(vec!["libc", "c_ushort"]))),
-            CTypeKind::UInt => Ok(mk().path_ty(mk().path(vec!["libc", "c_uint"]))),
-            CTypeKind::ULong => Ok(mk().path_ty(mk().path(vec!["libc", "c_ulong"]))),
-            CTypeKind::ULongLong => Ok(mk().path_ty(mk().path(vec!["libc", "c_ulonglong"]))),
-            CTypeKind::SChar => Ok(mk().path_ty(mk().path(vec!["libc", "c_schar"]))),
-            CTypeKind::UChar => Ok(mk().path_ty(mk().path(vec!["libc", "c_uchar"]))),
-            CTypeKind::Char => Ok(mk().path_ty(mk().path(vec!["libc", "c_char"]))),
-            CTypeKind::Double => Ok(mk().path_ty(mk().path(vec!["libc", "c_double"]))),
-            CTypeKind::LongDouble => Ok(mk().path_ty(mk().path(vec!["f128", "f128"]))),
-            CTypeKind::Float => Ok(mk().path_ty(mk().path(vec!["libc", "c_float"]))),
-            CTypeKind::Int128 => Ok(mk().path_ty(mk().path(vec!["i128"]))),
-            CTypeKind::UInt128 => Ok(mk().path_ty(mk().path(vec!["u128"]))),
-            CTypeKind::BFloat16 => Ok(mk().path_ty(mk().path(vec!["bf16"]))),
+            CTypeKind::Bool => Ok(path![bool]),
+            CTypeKind::Short => Ok(path![::libc::c_short]),
+            CTypeKind::Int => Ok(path![::libc::c_int]),
+            CTypeKind::Long => Ok(path![::libc::c_long]),
+            CTypeKind::LongLong => Ok(path![::libc::c_longlong]),
+            CTypeKind::UShort => Ok(path![::libc::c_ushort]),
+            CTypeKind::UInt => Ok(path![::libc::c_uint]),
+            CTypeKind::ULong => Ok(path![::libc::c_ulong]),
+            CTypeKind::ULongLong => Ok(path![::libc::c_ulonglong]),
+            CTypeKind::SChar => Ok(path![::libc::c_schar]),
+            CTypeKind::UChar => Ok(path![::libc::c_uchar]),
+            CTypeKind::Char => Ok(path![::libc::c_char]),
+            CTypeKind::Double => Ok(path![::libc::c_double]),
+            CTypeKind::LongDouble => Ok(path![::f128::f128]),
+            CTypeKind::Float => Ok(path![::libc::c_float]),
+            CTypeKind::Int128 => Ok(path![i128]),
+            CTypeKind::UInt128 => Ok(path![u128]),
+            CTypeKind::BFloat16 => Ok(path![bf16]),
 
             CTypeKind::Pointer(qtype) => self.convert_pointer(ctxt, qtype),
 

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -850,18 +850,14 @@ impl<'c> Translation<'c> {
                     let output_name = self.renamer.borrow_mut().fresh();
                     let output_local = mk().local(
                         mk().ident_pat(&output_name),
-                        None as Option<Box<Type>>,
+                        None,
                         Some(mk().mutbl().addr_of_expr(out_expr)),
                     );
                     stmts.push(mk().local_stmt(Box::new(output_local)));
 
                     // `let mut freshN;`
                     let inner_name = self.renamer.borrow_mut().fresh();
-                    let inner_local = mk().local(
-                        mk().ident_pat(&inner_name),
-                        None as Option<Box<Type>>,
-                        None as Option<Box<Expr>>,
-                    );
+                    let inner_local = mk().local(mk().ident_pat(&inner_name), None, None);
                     stmts.push(mk().local_stmt(Box::new(inner_local)));
 
                     out_expr = mk().ident_expr(&inner_name);
@@ -892,11 +888,7 @@ impl<'c> Translation<'c> {
                     let (output_name, inner_name) = operand_renames.get(tied_operand).unwrap();
 
                     let input_name = self.renamer.borrow_mut().fresh();
-                    let input_local = mk().local(
-                        mk().ident_pat(&input_name),
-                        None as Option<Box<Type>>,
-                        Some(in_expr),
-                    );
+                    let input_local = mk().local(mk().ident_pat(&input_name), None, Some(in_expr));
                     stmts.push(mk().local_stmt(Box::new(input_local)));
 
                     // Replace `in_expr` with

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -1022,7 +1022,7 @@ impl<'c> Translation<'c> {
         });
 
         let mac = mk().mac(
-            vec!["asm"],
+            path![asm],
             tokens.into_iter().collect::<TokenStream>(),
             MacroDelimiter::Paren(Default::default()),
         );

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -496,23 +496,22 @@ fn map_input_op_idx(
     if let Some(adj_idx) = idx.checked_sub(num_output_operands) {
         // will only be Some(idx) if it was an input operand
         match tied_operands.get(&(adj_idx, false)) {
-            Some(&out_idx) => {
-                return out_idx;
-            }
+            Some(&out_idx) => out_idx,
             None => {
                 // get number of tied inputs before this index
                 // TODO: can calculate this once before the call, not once for each input
                 let num_tied_before = tied_operands
                     .keys()
-                    .filter(|&&(iidx, is_out)| !is_out && iidx < adj_idx)
+                    .copied()
+                    .filter(|&(iidx, is_out)| !is_out && iidx < adj_idx)
                     .count();
                 // shift the original index by the number of tied input operands prior to the current one
-                return idx - num_tied_before;
+                idx - num_tied_before
             }
-        };
+        }
+    } else {
+        idx
     }
-
-    idx
 }
 
 /// Rewrite a LLVM inline assembly template string into an asm!-compatible one

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -893,16 +893,20 @@ impl<'c> Translation<'c> {
 
                     // Replace `in_expr` with
                     // `c2rust_asm_casts::AsmCast::cast_in(output, input)`
-                    let path_expr = mk().path_expr(vec!["c2rust_asm_casts", "AsmCast", "cast_in"]);
                     let output = mk().ident_expr(output_name);
                     let input = mk().ident_expr(input_name);
-                    in_expr = mk().call_expr(path_expr, vec![output.clone(), input.clone()]);
+                    in_expr = mk().call_expr(
+                        path![::c2rust_asm_casts::AsmCast::cast_in],
+                        vec![output.clone(), input.clone()],
+                    );
 
                     // Append the cast-out call after the assembly macro:
                     // `c2rust_asm_casts::AsmCast::cast_out(output, input, inner);`
-                    let path_expr = mk().path_expr(vec!["c2rust_asm_casts", "AsmCast", "cast_out"]);
                     let inner = mk().ident_expr(inner_name);
-                    let cast_out = mk().call_expr(path_expr, vec![output, input, inner]);
+                    let cast_out = mk().call_expr(
+                        path![::c2rust_asm_casts::AsmCast::cast_out],
+                        vec![output, input, inner],
+                    );
                     post_stmts.push(mk().semi_stmt(cast_out));
                 }
                 Some(in_expr)

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -276,7 +276,7 @@ impl<'c> Translation<'c> {
                             let res_name = self.renamer.borrow_mut().fresh();
                             let res_let = mk().local_stmt(Box::new(mk().local(
                                 mk().ident_pat(&res_name),
-                                None as Option<Box<Type>>,
+                                None,
                                 Some(call),
                             )));
                             let assignment = mk().semi_stmt(mk().assign_expr(
@@ -410,14 +410,14 @@ impl<'c> Translation<'c> {
             let arg0_name = self.renamer.borrow_mut().fresh();
             let arg0_let = mk().local_stmt(Box::new(mk().local(
                 mk().ident_pat(&arg0_name),
-                None as Option<Box<Type>>,
+                None,
                 Some(dst),
             )));
 
             let arg1_name = self.renamer.borrow_mut().fresh();
             let arg1_let = mk().local_stmt(Box::new(mk().local(
                 mk().ident_pat(&arg1_name),
-                None as Option<Box<Type>>,
+                None,
                 Some(src),
             )));
 

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -34,30 +34,20 @@ impl<'c> Translation<'c> {
         };
 
         match builtin_name {
-            "__builtin_huge_valf" => Ok(WithStmts::new_val(
-                mk().abs_path_expr(vec!["core", "f32", "INFINITY"]),
-            )),
-            "__builtin_huge_val" | "__builtin_huge_vall" => Ok(WithStmts::new_val(
-                mk().abs_path_expr(vec!["core", "f64", "INFINITY"]),
-            )),
-            "__builtin_inff" => Ok(WithStmts::new_val(
-                mk().abs_path_expr(vec!["core", "f32", "INFINITY"]),
-            )),
-            "__builtin_inf" | "__builtin_infl" => Ok(WithStmts::new_val(
-                mk().abs_path_expr(vec!["core", "f64", "INFINITY"]),
-            )),
-            "__builtin_nanf" => Ok(WithStmts::new_val(
-                mk().abs_path_expr(vec!["core", "f32", "NAN"]),
-            )),
-            "__builtin_nan" => Ok(WithStmts::new_val(
-                mk().abs_path_expr(vec!["core", "f64", "NAN"]),
-            )),
+            "__builtin_huge_valf" => Ok(WithStmts::new_val(path![::core::f32::INFINITY])),
+            "__builtin_huge_val" | "__builtin_huge_vall" => {
+                Ok(WithStmts::new_val(path![::core::f64::INFINITY]))
+            }
+            "__builtin_inff" => Ok(WithStmts::new_val(path![::core::f32::INFINITY])),
+            "__builtin_inf" | "__builtin_infl" => {
+                Ok(WithStmts::new_val(path![::core::f64::INFINITY]))
+            }
+            "__builtin_nanf" => Ok(WithStmts::new_val(path![::core::f32::NAN])),
+            "__builtin_nan" => Ok(WithStmts::new_val(path![::core::f64::NAN])),
             "__builtin_nanl" => {
                 self.use_crate(ExternCrate::F128);
 
-                Ok(WithStmts::new_val(
-                    mk().path_expr(vec!["f128", "f128", "NAN"]),
-                ))
+                Ok(WithStmts::new_val(path![::f128::f128::NAN]))
             }
             "__builtin_signbit" | "__builtin_signbitf" | "__builtin_signbitl" => {
                 // Long doubles require the Float trait from num_traits to call this method

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -688,7 +688,7 @@ impl<'c> Translation<'c> {
         args: &[CExprId],
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let name = &builtin_name[10..];
-        let mem = mk().path_expr(vec!["libc", name]);
+        let mem: Box<Expr> = mk().path_expr(["libc", name]);
         let args = self.convert_exprs(ctx.used(), args)?;
         args.and_then(|args| {
             let mut args = args.into_iter();

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -589,7 +589,7 @@ impl<'c> Translation<'c> {
             "__builtin_unwind_init" => Ok(WithStmts::new_val(self.panic_or_err("no value"))),
             "__builtin_unreachable" => Ok(WithStmts::new(
                 vec![mk().semi_stmt(mk().mac_expr(mk().mac(
-                    vec!["unreachable"],
+                    path![unreachable],
                     vec![],
                     MacroDelimiter::Paren(Default::default()),
                 )))],

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -60,8 +60,7 @@ impl<'c> Translation<'c> {
                 let val = self.convert_expr(ctx.used(), args[0])?;
 
                 Ok(val.map(|v| {
-                    let val =
-                        mk().method_call_expr(v, "is_sign_negative", vec![] as Vec<Box<Expr>>);
+                    let val = mk().method_call_expr(v, "is_sign_negative", vec![]);
 
                     mk().cast_expr(val, mk().path_ty(vec!["libc", "c_int"]))
                 }))
@@ -104,11 +103,11 @@ impl<'c> Translation<'c> {
             }
             "__builtin_bswap16" | "__builtin_bswap32" | "__builtin_bswap64" => {
                 let val = self.convert_expr(ctx.used(), args[0])?;
-                Ok(val.map(|x| mk().method_call_expr(x, "swap_bytes", vec![] as Vec<Box<Expr>>)))
+                Ok(val.map(|x| mk().method_call_expr(x, "swap_bytes", vec![])))
             }
             "__builtin_fabs" | "__builtin_fabsf" | "__builtin_fabsl" => {
                 let val = self.convert_expr(ctx.used(), args[0])?;
-                Ok(val.map(|x| mk().method_call_expr(x, "abs", vec![] as Vec<Box<Expr>>)))
+                Ok(val.map(|x| mk().method_call_expr(x, "abs", vec![])))
             }
             "__builtin_isfinite" | "__builtin_isnan" => {
                 let val = self.convert_expr(ctx.used(), args[0])?;
@@ -127,11 +126,7 @@ impl<'c> Translation<'c> {
                 // isinf_sign(x) -> fabs(x) == infinity ? (signbit(x) ? -1 : 1) : 0
                 let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|x| {
-                    let inner_cond = mk().method_call_expr(
-                        x.clone(),
-                        "is_sign_positive",
-                        vec![] as Vec<Box<Expr>>,
-                    );
+                    let inner_cond = mk().method_call_expr(x.clone(), "is_sign_positive", vec![]);
                     let one = mk().lit_expr(mk().int_lit(1, ""));
                     let minus_one = mk().unary_expr(
                         UnOp::Neg(Default::default()),
@@ -140,8 +135,7 @@ impl<'c> Translation<'c> {
                     let one_block = mk().block(vec![mk().expr_stmt(one)]);
                     let inner_ifte = mk().ifte_expr(inner_cond, one_block, Some(minus_one));
                     let zero = mk().lit_expr(mk().int_lit(0, ""));
-                    let outer_cond =
-                        mk().method_call_expr(x, "is_infinite", vec![] as Vec<Box<Expr>>);
+                    let outer_cond = mk().method_call_expr(x, "is_infinite", vec![]);
                     let inner_ifte_block = mk().block(vec![mk().expr_stmt(inner_ifte)]);
                     mk().ifte_expr(outer_cond, inner_ifte_block, Some(zero))
                 }))
@@ -262,11 +256,8 @@ impl<'c> Translation<'c> {
                             let fn_ctx = self.function_context.borrow();
                             let src = fn_ctx.get_va_list_arg_name();
 
-                            let call_expr = mk().method_call_expr(
-                                mk().ident_expr(src),
-                                "clone",
-                                vec![] as Vec<Box<Expr>>,
-                            );
+                            let call_expr =
+                                mk().method_call_expr(mk().ident_expr(src), "clone", vec![]);
                             let assign_expr = mk().assign_expr(dst.to_expr(), call_expr);
                             let stmt = mk().semi_stmt(assign_expr);
 
@@ -285,8 +276,7 @@ impl<'c> Translation<'c> {
                         let dst = self.convert_expr(ctx.expect_valistimpl().used(), args[0])?;
                         let src = self.convert_expr(ctx.expect_valistimpl().used(), args[1])?;
 
-                        let call_expr =
-                            mk().method_call_expr(src.to_expr(), "clone", vec![] as Vec<Box<Expr>>);
+                        let call_expr = mk().method_call_expr(src.to_expr(), "clone", vec![]);
                         let assign_expr = mk().assign_expr(dst.to_expr(), call_expr);
                         let stmt = mk().semi_stmt(assign_expr);
 
@@ -316,14 +306,10 @@ impl<'c> Translation<'c> {
                     Ok(WithStmts::new(
                         vec![mk().local_stmt(Box::new(mk().local(
                             mk().mutbl().ident_pat(&alloca_name),
-                            None as Option<Box<Type>>,
+                            None,
                             Some(vec_expr(zero_elem, cast_int(count, "usize", false))),
                         )))],
-                        mk().method_call_expr(
-                            mk().ident_expr(&alloca_name),
-                            "as_mut_ptr",
-                            vec![] as Vec<Box<Expr>>,
-                        ),
+                        mk().method_call_expr(mk().ident_expr(&alloca_name), "as_mut_ptr", vec![]),
                     ))
                 })
             }
@@ -654,7 +640,7 @@ impl<'c> Translation<'c> {
                     mk().ident_pat(&sum_name),
                     mk().ident_pat(over_name.clone()),
                 ]),
-                None as Option<Box<Type>>,
+                None,
                 Some(overflowing),
             )));
 

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -52,7 +52,7 @@ impl<'c> Translation<'c> {
                         if let Some(cur_file) = *self.cur_file.borrow() {
                             self.add_import(cur_file, variant_id, &name);
                         }
-                        return mk().path_expr(vec![name]);
+                        return mk().path_expr([name]);
                     }
                 }
                 _ => panic!("{:?} does not point to an enum variant", variant_id),
@@ -231,7 +231,7 @@ impl<'c> Translation<'c> {
                         .resolve_decl_name(struct_id)
                         .unwrap();
 
-                    let outer_path = mk().path_expr(vec![outer_name]);
+                    let outer_path = mk().path_expr([outer_name]);
                     literal = literal
                         .map(|lit_ws| lit_ws.map(|lit| mk().call_expr(outer_path, vec![lit])));
                 };

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -140,7 +140,7 @@ impl<'c> Translation<'c> {
                 let size = num_elems * (width as usize);
                 val.resize(size, 0);
 
-                let u8_ty = mk().path_ty(vec!["u8"]);
+                let u8_ty: Box<Type> = path![u8];
                 let width_lit = mk().lit_expr(mk().int_unsuffixed_lit(val.len() as u128));
                 let array_ty = mk().array_ty(u8_ty, width_lit);
                 let source_ty = mk().ref_ty(array_ty);

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -85,11 +85,7 @@ impl<'c> Translation<'c> {
             CLiteral::Character(val) => {
                 let val = val as u32;
                 let expr = match char::from_u32(val) {
-                    Some(c) => {
-                        let expr = mk().lit_expr(c);
-                        let i32_type = mk().path_ty(vec!["i32"]);
-                        mk().cast_expr(expr, i32_type)
-                    }
+                    Some(c) => mk().cast_expr(mk().lit_expr(c), path![i32]),
                     None => {
                         // Fallback for characters outside of the valid Unicode range
                         if (val as i32) < 0 {
@@ -116,7 +112,7 @@ impl<'c> Translation<'c> {
                     CTypeKind::LongDouble => {
                         self.use_crate(ExternCrate::F128);
 
-                        let fn_path = mk().path_expr(vec!["f128", "f128", "new"]);
+                        let fn_path: Box<Expr> = path![::f128::f128::new];
                         let args = vec![mk().lit_expr(mk().float_unsuffixed_lit(&str))];
 
                         mk().call_expr(fn_path, args)

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -39,9 +39,9 @@ impl<'c> Translation<'c> {
 
             let main_fn = mk().path_expr([main_fn_name]);
 
-            let exit_fn = mk().abs_path_expr(vec!["std", "process", "exit"]);
-            let args_fn = mk().abs_path_expr(vec!["std", "env", "args"]);
-            let vars_fn = mk().abs_path_expr(vec!["std", "env", "vars"]);
+            let exit_fn: Box<Expr> = path![::std::process::exit];
+            let args_fn: Box<Expr> = path![::std::env::args];
+            let vars_fn: Box<Expr> = path![::std::env::vars];
 
             let no_args: Vec<Box<Expr>> = vec![];
 

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -131,57 +131,56 @@ impl<'c> Translation<'c> {
                     ]),
                     mk().call_expr(vars_fn, vec![]),
                     mk().block(vec![
-                                mk().local_stmt(Box::new(
-                                    mk().local(
-                                        mk().ident_pat("var"),
-                                        Some(path![String]),
-                                        Some(
-                                            mk().mac_expr(
-                                                mk().mac(
-                                                    path![format],
-                                                    vec![
-                                                        TokenTree::Literal(
-                                                            proc_macro2::Literal::string("{}={}"),
-                                                        ),
-                                                        TokenTree::Punct(Punct::new(
-                                                            ',',
-                                                            proc_macro2::Spacing::Alone,
-                                                        )),
-                                                        TokenTree::Ident(var_name_ident),
-                                                        TokenTree::Punct(Punct::new(
-                                                            ',',
-                                                            proc_macro2::Spacing::Alone,
-                                                        )),
-                                                        TokenTree::Ident(var_value_ident),
-                                                    ]
-                                                    .into_iter()
-                                                    .collect::<TokenStream>(),
-                                                    MacroDelimiter::Paren(Default::default()),
+                        mk().local_stmt(Box::new(
+                            mk().local(
+                                mk().ident_pat("var"),
+                                Some(path![String]),
+                                Some(
+                                    mk().mac_expr(
+                                        mk().mac(
+                                            path![format],
+                                            vec![
+                                                TokenTree::Literal(
+                                                    proc_macro2::Literal::string("{}={}"),
                                                 ),
-                                            ),
+                                                TokenTree::Punct(Punct::new(
+                                                    ',',
+                                                    proc_macro2::Spacing::Alone,
+                                                )),
+                                                TokenTree::Ident(var_name_ident),
+                                                TokenTree::Punct(Punct::new(
+                                                    ',',
+                                                    proc_macro2::Spacing::Alone,
+                                                )),
+                                                TokenTree::Ident(var_value_ident),
+                                            ]
+                                            .into_iter()
+                                            .collect::<TokenStream>(),
+                                            MacroDelimiter::Paren(Default::default()),
                                         ),
                                     ),
-                                )),
-                                mk().semi_stmt(mk().method_call_expr(
-                                    path![vars],
-                                    "push",
-                                    vec![mk().method_call_expr(
-                                        mk().method_call_expr(
-                                            mk().call_expr(
-                                                // TODO(kkysen) change `"std"` to `"alloc"` after `#![feature(alloc_c_string)]` is stabilized in `1.63.0`
-                                                path![::std::ffi::CString::new],
-                                                vec![path![var]],
-                                            ),
-                                            "expect",
-                                            vec![mk().lit_expr(
-                                            "Failed to convert environment variable into CString."
-                                        )],
-                                        ),
-                                        "into_raw",
-                                        vec![],
+                                ),
+                            ),
+                        )),
+                        mk().semi_stmt(mk().method_call_expr(
+                            path![vars],
+                            "push",
+                            vec![mk().method_call_expr(
+                                mk().method_call_expr(
+                                    mk().call_expr(
+                                        path![::std::ffi::CString::new],
+                                        vec![path![var]],
+                                    ),
+                                    "expect",
+                                    vec![mk().lit_expr(
+                                        "Failed to convert environment variable into CString."
                                     )],
-                                )),
-                            ]),
+                                ),
+                                "into_raw",
+                                vec![],
+                            )],
+                        )),
+                    ]),
                     None as Option<Ident>,
                 )));
                 stmts.push(mk().semi_stmt(mk().method_call_expr(

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -37,7 +37,7 @@ impl<'c> Translation<'c> {
 
             let decl = mk().fn_decl("main", vec![], None, ReturnType::Default);
 
-            let main_fn = mk().path_expr(vec![main_fn_name]);
+            let main_fn = mk().path_expr([main_fn_name]);
 
             let exit_fn = mk().abs_path_expr(vec!["std", "process", "exit"]);
             let args_fn = mk().abs_path_expr(vec!["std", "env", "args"]);
@@ -55,7 +55,7 @@ impl<'c> Translation<'c> {
 
                 stmts.push(mk().local_stmt(Box::new(mk().local(
                     mk().mutbl().ident_pat("args"),
-                    Some(mk().path_ty(vec![mk().path_segment_with_args(
+                    Some(mk().path_ty([mk().path_segment_with_args(
                         "Vec",
                         mk().angle_bracketed_args(vec![
                             mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_char"])),
@@ -129,7 +129,7 @@ impl<'c> Translation<'c> {
 
                 stmts.push(mk().local_stmt(Box::new(mk().local(
                     mk().mutbl().ident_pat("vars"),
-                    Some(mk().path_ty(vec![mk().path_segment_with_args(
+                    Some(mk().path_ty([mk().path_segment_with_args(
                         "Vec",
                         mk().angle_bracketed_args(vec![
                             mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_char"])),

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -158,7 +158,7 @@ impl<'c> Translation<'c> {
                                         Some(
                                             mk().mac_expr(
                                                 mk().mac(
-                                                    vec!["format"],
+                                                    path![format],
                                                     vec![
                                                         TokenTree::Literal(
                                                             proc_macro2::Literal::string("{}={}"),

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -70,7 +70,7 @@ impl<'c> Translation<'c> {
                 ))));
                 stmts.push(mk().semi_stmt(mk().for_expr(
                     mk().ident_pat("arg"),
-                    mk().call_expr(args_fn, vec![] as Vec<Box<Expr>>),
+                    mk().call_expr(args_fn, vec![]),
                     mk().block(vec![mk().semi_stmt(mk().method_call_expr(
                         mk().path_expr(vec!["args"]),
                         "push",
@@ -85,7 +85,7 @@ impl<'c> Translation<'c> {
                                 vec![mk().lit_expr("Failed to convert argument into CString.")],
                             ),
                             "into_raw",
-                            vec![] as Vec<Box<Expr>>,
+                            vec![],
                         )],
                     ))]),
                     None as Option<Ident>,
@@ -149,7 +149,7 @@ impl<'c> Translation<'c> {
                         mk().ident_pat("var_name"),
                         mk().ident_pat("var_value"),
                     ]),
-                    mk().call_expr(vars_fn, vec![] as Vec<Box<Expr>>),
+                    mk().call_expr(vars_fn, vec![]),
                     mk().block(vec![
                                 mk().local_stmt(Box::new(
                                     mk().local(
@@ -200,7 +200,7 @@ impl<'c> Translation<'c> {
                                         )],
                                         ),
                                         "into_raw",
-                                        vec![] as Vec<Box<Expr>>,
+                                        vec![],
                                     )],
                                 )),
                             ]),

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -57,30 +57,20 @@ impl<'c> Translation<'c> {
                     mk().mutbl().ident_pat("args"),
                     Some(mk().path_ty([mk().path_segment_with_args(
                         "Vec",
-                        mk().angle_bracketed_args(vec![
-                            mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_char"])),
-                        ]),
+                        mk().angle_bracketed_args(vec![mk().mutbl().ptr_ty(path![::libc::c_char])]),
                     )])),
-                    Some(
-                        mk().call_expr(
-                            mk().path_expr(vec!["Vec", "new"]),
-                            vec![] as Vec<Box<Expr>>,
-                        ),
-                    ),
+                    Some(mk().call_expr(path![Vec::new], vec![])),
                 ))));
                 stmts.push(mk().semi_stmt(mk().for_expr(
                     mk().ident_pat("arg"),
                     mk().call_expr(args_fn, vec![]),
                     mk().block(vec![mk().semi_stmt(mk().method_call_expr(
-                        mk().path_expr(vec!["args"]),
+                        path![args],
                         "push",
                         vec![mk().method_call_expr(
                             mk().method_call_expr(
-                                mk().call_expr(
-                                    // TODO(kkysen) change `"std"` to `"alloc"` after `#![feature(alloc_c_string)]` is stabilized in `1.63.0`
-                                    mk().abs_path_expr(vec!["std", "ffi", "CString", "new"]),
-                                    vec![mk().path_expr(vec!["arg"])],
-                                ),
+                                // TODO(kkysen) change `"std"` to `"alloc"` after `#![feature(alloc_c_string)]` is stabilized in `1.63.0`
+                                mk().call_expr(path![::std::ffi::CString::new], vec![path![arg]]),
                                 "expect",
                                 vec![mk().lit_expr("Failed to convert argument into CString.")],
                             ),
@@ -91,12 +81,9 @@ impl<'c> Translation<'c> {
                     None as Option<Ident>,
                 )));
                 stmts.push(mk().semi_stmt(mk().method_call_expr(
-                    mk().path_expr(vec!["args"]),
+                    path![args],
                     "push",
-                    vec![mk().call_expr(
-                        mk().abs_path_expr(vec!["core", "ptr", "null_mut"]),
-                        vec![] as Vec<Box<Expr>>,
-                    )],
+                    vec![mk().call_expr(path![::core::ptr::null_mut], vec![])],
                 )));
 
                 let argc_ty: Box<Type> = match self.ast_context.index(parameters[0]).kind {
@@ -131,16 +118,9 @@ impl<'c> Translation<'c> {
                     mk().mutbl().ident_pat("vars"),
                     Some(mk().path_ty([mk().path_segment_with_args(
                         "Vec",
-                        mk().angle_bracketed_args(vec![
-                            mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_char"])),
-                        ]),
+                        mk().angle_bracketed_args(vec![mk().mutbl().ptr_ty(path![::libc::c_char])]),
                     )])),
-                    Some(
-                        mk().call_expr(
-                            mk().path_expr(vec!["Vec", "new"]),
-                            vec![] as Vec<Box<Expr>>,
-                        ),
-                    ),
+                    Some(mk().call_expr(path![Vec::new], vec![])),
                 ))));
                 let var_name_ident = mk().ident("var_name");
                 let var_value_ident = mk().ident("var_value");
@@ -154,7 +134,7 @@ impl<'c> Translation<'c> {
                                 mk().local_stmt(Box::new(
                                     mk().local(
                                         mk().ident_pat("var"),
-                                        Some(mk().path_ty(vec!["String"])),
+                                        Some(path![String]),
                                         Some(
                                             mk().mac_expr(
                                                 mk().mac(
@@ -183,16 +163,14 @@ impl<'c> Translation<'c> {
                                     ),
                                 )),
                                 mk().semi_stmt(mk().method_call_expr(
-                                    mk().path_expr(vec!["vars"]),
+                                    path![vars],
                                     "push",
                                     vec![mk().method_call_expr(
                                         mk().method_call_expr(
                                             mk().call_expr(
-                                                mk().abs_path_expr(vec![
-                                                    // TODO(kkysen) change `"std"` to `"alloc"` after `#![feature(alloc_c_string)]` is stabilized in `1.63.0`
-                                                    "std", "ffi", "CString", "new",
-                                                ]),
-                                                vec![mk().path_expr(vec!["var"])],
+                                                // TODO(kkysen) change `"std"` to `"alloc"` after `#![feature(alloc_c_string)]` is stabilized in `1.63.0`
+                                                path![::std::ffi::CString::new],
+                                                vec![path![var]],
                                             ),
                                             "expect",
                                             vec![mk().lit_expr(
@@ -207,12 +185,9 @@ impl<'c> Translation<'c> {
                     None as Option<Ident>,
                 )));
                 stmts.push(mk().semi_stmt(mk().method_call_expr(
-                    mk().path_expr(vec!["vars"]),
+                    path![vars],
                     "push",
-                    vec![mk().call_expr(
-                        mk().abs_path_expr(vec!["core", "ptr", "null_mut"]),
-                        vec![] as Vec<Box<Expr>>,
-                    )],
+                    vec![mk().call_expr(path![::core::ptr::null_mut], vec![])],
                 )));
 
                 let envp_ty: Box<Type> = match self.ast_context.index(parameters[2]).kind {
@@ -247,10 +222,7 @@ impl<'c> Translation<'c> {
 
                 stmts.push(mk().semi_stmt(call_exit));
             } else {
-                let call_main = mk().cast_expr(
-                    mk().call_expr(main_fn, main_args),
-                    mk().path_ty(vec!["i32"]),
-                );
+                let call_main = mk().cast_expr(mk().call_expr(main_fn, main_args), path![i32]);
 
                 let call_exit = mk().call_expr(exit_fn, vec![call_main]);
                 let unsafe_block = mk().unsafe_block(vec![mk().expr_stmt(call_exit)]);

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -59,7 +59,7 @@ impl<'c> Translation<'c> {
                         "Vec",
                         mk().angle_bracketed_args(vec![mk().mutbl().ptr_ty(path![::libc::c_char])]),
                     )])),
-                    Some(mk().call_expr(path![Vec::new], vec![])),
+                    Some(mk().call_expr(path![::alloc::vec::Vec::new], vec![])),
                 ))));
                 stmts.push(mk().semi_stmt(mk().for_expr(
                     mk().ident_pat("arg"),
@@ -120,7 +120,7 @@ impl<'c> Translation<'c> {
                         "Vec",
                         mk().angle_bracketed_args(vec![mk().mutbl().ptr_ty(path![::libc::c_char])]),
                     )])),
-                    Some(mk().call_expr(path![Vec::new], vec![])),
+                    Some(mk().call_expr(path![::alloc::vec::Vec::new], vec![])),
                 ))));
                 let var_name_ident = mk().ident("var_name");
                 let var_value_ident = mk().ident("var_value");
@@ -134,7 +134,7 @@ impl<'c> Translation<'c> {
                         mk().local_stmt(Box::new(
                             mk().local(
                                 mk().ident_pat("var"),
-                                Some(path![String]),
+                                Some(path![::alloc::string::String]),
                                 Some(
                                     mk().mac_expr(
                                         mk().mac(

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3358,7 +3358,7 @@ impl<'c> Translation<'c> {
                 // Most references to the va_list should refer to the VaList
                 // type, not VaListImpl
                 if !ctx.expecting_valistimpl && self.ast_context.is_va_list(qual_ty.ctype) {
-                    val = mk().method_call_expr(val, "as_va_list", Vec::<Box<Expr>>::new());
+                    val = mk().method_call_expr(val, "as_va_list", vec![]);
                 }
 
                 // If we are referring to a function and need its address, we
@@ -3887,9 +3887,7 @@ impl<'c> Translation<'c> {
                     // Most references to the va_list should refer to the VaList
                     // type, not VaListImpl
                     if !ctx.expecting_valistimpl && self.ast_context.is_va_list(qual_ty.ctype) {
-                        val = val.map(|v| {
-                            mk().method_call_expr(v, "as_va_list", Vec::<Box<Expr>>::new())
-                        });
+                        val = val.map(|v| mk().method_call_expr(v, "as_va_list", vec![]));
                     }
 
                     Ok(val)
@@ -4499,9 +4497,9 @@ impl<'c> Translation<'c> {
         };
 
         Ok(val.map(|val| {
-            let to_call = mk().method_call_expr(val, to_method_name, Vec::<Box<Expr>>::new());
+            let to_call = mk().method_call_expr(val, to_method_name, vec![]);
 
-            mk().method_call_expr(to_call, "unwrap", Vec::<Box<Expr>>::new())
+            mk().method_call_expr(to_call, "unwrap", vec![])
         }))
     }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -25,7 +25,7 @@ use crate::rust_ast::{pos_to_span, SpanExt, DUMMY_SP};
 use crate::translator::atomics::ConvertAtomicArgs;
 use crate::translator::named_references::NamedReference;
 use crate::translator::operators::ConvertBinaryExprArgs;
-use c2rust_ast_builder::{mk, properties::*, Builder};
+use c2rust_ast_builder::{mk, path, properties::*, Builder};
 use c2rust_ast_printer::pprust::{self};
 
 use crate::c_ast::iterators::{DFExpr, SomeId};
@@ -1726,7 +1726,7 @@ impl<'c> Translation<'c> {
                         .borrow_mut()
                         .resolve_decl_suffix_name(decl_id, PADDING_SUFFIX)
                         .to_owned();
-                    let padding_ty = mk().path_ty(vec!["usize"]);
+                    let padding_ty: Box<Type> = path![usize];
                     let outer_size = self.compute_size_of_ty(outer_ty)?.to_expr();
                     let inner_size = self.compute_size_of_ty(inner_ty)?.to_expr();
                     let padding_value =
@@ -2969,7 +2969,7 @@ impl<'c> Translation<'c> {
     /// function pointers, and normal pointers.
     fn null_ptr(&self, type_id: CTypeId, is_static: bool) -> TranslationResult<Box<Expr>> {
         if self.ast_context.is_function_pointer(type_id) {
-            return Ok(mk().path_expr(vec!["None"]));
+            return Ok(path![None]);
         }
 
         let pointee = match self.ast_context.resolve_type(type_id).kind {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3437,24 +3437,22 @@ impl<'c> Translation<'c> {
                         .ok_or_else(|| {
                             format_err!("Expected Variable offsetof to be a side-effect free")
                         })?;
-                    let expr = mk().cast_expr(expr, mk().ident_ty("usize"));
+                    let expr = mk().cast_expr(expr, path![usize]);
                     use syn::__private::ToTokens;
                     let index_expr = expr.to_token_stream();
 
                     // offset_of!(Struct, field[expr as usize]) as ty
-                    let macro_body = vec![
-                        TokenTree::Ident(ty_ident),
-                        TokenTree::Punct(Punct::new(',', Alone)),
-                        TokenTree::Ident(field_ident),
-                        TokenTree::Group(proc_macro2::Group::new(
-                            proc_macro2::Delimiter::Bracket,
-                            index_expr,
-                        )),
-                    ];
-                    let path: Path = path![offset_of];
                     let mac = mk().mac_expr(mk().mac(
-                        path,
-                        macro_body,
+                        path![::memoffset::offset_of],
+                        vec![
+                            TokenTree::Ident(ty_ident),
+                            TokenTree::Punct(Punct::new(',', Alone)),
+                            TokenTree::Ident(field_ident),
+                            TokenTree::Group(proc_macro2::Group::new(
+                                proc_macro2::Delimiter::Bracket,
+                                index_expr,
+                            )),
+                        ],
                         MacroDelimiter::Paren(Default::default()),
                     ));
 
@@ -4340,7 +4338,7 @@ impl<'c> Translation<'c> {
             CastKind::LValueToRValue | CastKind::ToVoid | CastKind::ConstCast => Ok(val),
 
             CastKind::FunctionToPointerDecay | CastKind::BuiltinFnToFnPtr => {
-                Ok(val.map(|x| mk().call_expr(mk().ident_expr("Some"), vec![x])))
+                Ok(val.map(|x| mk().call_expr(path![Some], vec![x])))
             }
 
             CastKind::ArrayToPointerDecay => {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -456,10 +456,10 @@ fn clean_path(mod_names: &RefCell<IndexMap<String, PathBuf>>, path: Option<&path
     let mut file_path: String = path.map_or("internal".to_string(), path_to_str);
     let path = path.unwrap_or_else(|| path::Path::new(""));
     let mut mod_names = mod_names.borrow_mut();
-    if !mod_names.contains_key(&file_path.clone()) {
+    if !mod_names.contains_key(&file_path) {
         mod_names.insert(file_path.clone(), path.to_path_buf());
     } else {
-        let mod_path = mod_names.get(&file_path.clone()).unwrap();
+        let mod_path = mod_names.get(&file_path).unwrap();
         // A collision in the module names has occured.
         // Ex: types.h can be included from
         // /usr/include/bits and /usr/include/sys

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -309,7 +309,7 @@ fn cast_int(val: Box<Expr>, name: &str, need_lit_suffix: bool) -> Box<Expr> {
     match opt_literal_val {
         Some(i) if !need_lit_suffix => mk().lit_expr(mk().int_unsuffixed_lit(i)),
         Some(i) => mk().lit_expr(mk().int_lit(i, name)),
-        None => mk().cast_expr(val, mk().path_ty(vec![name])),
+        None => mk().cast_expr(val, mk().path_ty([name])),
     }
 }
 
@@ -1513,7 +1513,7 @@ impl<'c> Translation<'c> {
 
         std::mem::swap(init, &mut default_init);
 
-        let root_lhs_expr = mk().path_expr(vec![name]);
+        let root_lhs_expr = mk().path_expr([name]);
         let assign_expr = mk().assign_expr(root_lhs_expr, default_init);
         let stmt = mk().expr_stmt(assign_expr);
 
@@ -1575,7 +1575,7 @@ impl<'c> Translation<'c> {
             mk().unsafe_().extern_("C").barefn_ty(fn_bare_decl),
             static_array_size,
         );
-        let static_val = mk().array_expr(vec![mk().path_expr(vec![fn_name])]);
+        let static_val = mk().array_expr(vec![mk().path_expr([fn_name])]);
         let static_item = static_attributes.static_item("INIT_ARRAY", static_ty, static_val);
 
         (fn_item, static_item)
@@ -1695,7 +1695,7 @@ impl<'c> Translation<'c> {
                     // would significantly complicate the implementation
                     assert!(self.ast_context.has_inner_struct_decl(decl_id));
                     let inner_name = self.resolve_decl_inner_name(decl_id);
-                    let inner_ty = mk().path_ty(vec![inner_name.clone()]);
+                    let inner_ty = mk().path_ty([inner_name.clone()]);
                     let inner_repr_attr = mk().meta_list("repr", reprs);
                     let inner_struct = mk()
                         .span(span)
@@ -1705,7 +1705,7 @@ impl<'c> Translation<'c> {
                         .struct_item(inner_name.clone(), field_entries, false);
 
                     // https://github.com/rust-lang/rust/issues/33626
-                    let outer_ty = mk().path_ty(vec![name.clone()]);
+                    let outer_ty = mk().path_ty([name.clone()]);
                     let outer_reprs = vec![
                         simple_metaitem("C"),
                         int_arg_metaitem("align", alignment as u128),
@@ -1850,7 +1850,7 @@ impl<'c> Translation<'c> {
                 if let Some(cur_file) = *self.cur_file.borrow() {
                     self.add_import(cur_file, enum_id, &enum_name);
                 }
-                let ty = mk().path_ty(mk().path(vec![enum_name]));
+                let ty = mk().path_ty(mk().path([enum_name]));
                 let val = match value {
                     ConstIntExpr::I(value) => signed_int_expr(value),
                     ConstIntExpr::U(value) => mk().lit_expr(mk().int_unsuffixed_lit(value as u128)),
@@ -2942,9 +2942,7 @@ impl<'c> Translation<'c> {
         {
             elt = self.variable_array_base_type(elt);
             let ty = self.convert_type(elt)?;
-            mk().path_ty(vec![
-                mk().path_segment_with_args("Vec", mk().angle_bracketed_args(vec![ty]))
-            ])
+            mk().path_ty([mk().path_segment_with_args("Vec", mk().angle_bracketed_args(vec![ty]))])
         } else {
             self.convert_type(typ.ctype)?
         };
@@ -3080,7 +3078,7 @@ impl<'c> Translation<'c> {
                     .borrow()
                     .get(&CDeclId(counts.0))
                     .expect("Failed to lookup VLA expression");
-                let csize = mk().path_expr(vec![csize_name]);
+                let csize = mk().path_expr([csize_name]);
 
                 let val = match opt_esize {
                     None => csize,
@@ -3345,7 +3343,7 @@ impl<'c> Translation<'c> {
                     }
                 }
 
-                let mut val = mk().path_expr(vec![rustname]);
+                let mut val = mk().path_expr([rustname]);
 
                 // If the variable is volatile and used as something that isn't an LValue, this
                 // constitutes a volatile read.
@@ -4029,7 +4027,7 @@ impl<'c> Translation<'c> {
                     self.add_import(*cur_file, *macro_id, &rustname);
                 }
 
-                let val = WithStmts::new_val(mk().path_expr(vec![rustname]));
+                let val = WithStmts::new_val(mk().path_expr([rustname]));
 
                 let expr_kind = &self.ast_context[expr_id].kind;
                 if let Some(expr_ty) = expr_kind.get_qual_type() {
@@ -4436,7 +4434,7 @@ impl<'c> Translation<'c> {
                     .expect("field name required");
 
                 Ok(val.map(|x| {
-                    mk().struct_expr(mk().path(vec![union_name]), vec![mk().field(field_name, x)])
+                    mk().struct_expr(mk().path([union_name]), vec![mk().field(field_name, x)])
                 }))
             }
 
@@ -4737,7 +4735,7 @@ impl<'c> Translation<'c> {
                 .resolve_decl_name(name_decl_id)
                 .unwrap();
 
-            let outer_path = mk().path_expr(vec![outer_name]);
+            let outer_path = mk().path_expr([outer_name]);
             init = init.map(|i| mk().call_expr(outer_path, vec![i]));
         };
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4067,7 +4067,7 @@ impl<'c> Translation<'c> {
 
         let ts: TokenStream = syn::parse_str(args).ok()?;
         Some(WithStmts::new_val(mk().mac_expr(mk().mac(
-            ident,
+            mk().path(ident),
             ts,
             MacroDelimiter::Paren(Default::default()),
         ))))

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -299,18 +299,17 @@ fn int_arg_metaitem(name: &str, arg: u128) -> NestedMeta {
 }
 
 fn cast_int(val: Box<Expr>, name: &str, need_lit_suffix: bool) -> Box<Expr> {
-    let opt_literal_val = match &*val {
-        Expr::Lit(ref l) => match &l.lit {
-            Lit::Int(i) => Some(i.base10_digits().parse().unwrap()),
-            _ => None,
-        },
-        _ => None,
-    };
-    match opt_literal_val {
-        Some(i) if !need_lit_suffix => mk().lit_expr(mk().int_unsuffixed_lit(i)),
-        Some(i) => mk().lit_expr(mk().int_lit(i, name)),
-        None => mk().cast_expr(val, mk().path_ty([name])),
+    if let Expr::Lit(l) = &*val {
+        if let Lit::Int(i) = &l.lit {
+            let lit = i.base10_digits().parse().unwrap();
+            return if need_lit_suffix {
+                mk().lit_expr(mk().int_lit(lit, name))
+            } else {
+                val
+            };
+        }
     }
+    mk().cast_expr(val, mk().path_ty([name]))
 }
 
 /// Pointer offset that casts its argument to isize

--- a/c2rust-transpile/src/translator/named_references.rs
+++ b/c2rust-transpile/src/translator/named_references.rs
@@ -127,7 +127,7 @@ impl<'c> Translation<'c> {
                 // let ref mut p = lhs;
                 let compute_ref = mk().local_stmt(Box::new(mk().local(
                     mk().mutbl().ident_ref_pat(&ptr_name),
-                    None as Option<Box<Type>>,
+                    None,
                     Some(reference),
                 )));
 

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -261,7 +261,7 @@ impl<'c> Translation<'c> {
             let lhs = if *resolved_computed_kind == CTypeKind::LongDouble {
                 self.use_crate(ExternCrate::F128);
 
-                let fn_path = mk().path_expr(vec!["f128", "f128", "from"]);
+                let fn_path = path![::f128::f128::from];
                 let args = vec![read];
 
                 mk().call_expr(fn_path, args)
@@ -818,7 +818,7 @@ impl<'c> Translation<'c> {
             CTypeKind::LongDouble => {
                 self.use_crate(ExternCrate::F128);
 
-                let fn_path = mk().path_expr(vec!["f128", "f128", "new"]);
+                let fn_path = path![::f128::f128::new];
                 let args = vec![mk().lit_expr(mk().float_unsuffixed_lit("1."))];
 
                 mk().call_expr(fn_path, args)
@@ -883,10 +883,10 @@ impl<'c> Translation<'c> {
                     CTypeKind::LongDouble => {
                         self.use_crate(ExternCrate::F128);
 
-                        let fn_path = mk().path_expr(vec!["f128", "f128", "new"]);
-                        let args = vec![mk().lit_expr(mk().float_unsuffixed_lit("1."))];
-
-                        mk().call_expr(fn_path, args)
+                        mk().call_expr(
+                            path![::f128::f128::new],
+                            vec![mk().lit_expr(mk().float_unsuffixed_lit("1."))],
+                        )
                     }
                     _ => mk().lit_expr(mk().int_unsuffixed_lit(1)),
                 };
@@ -1078,7 +1078,7 @@ impl<'c> Translation<'c> {
 
             c_ast::UnOp::Not => {
                 let val = self.convert_condition(ctx, false, arg)?;
-                Ok(val.map(|x| mk().cast_expr(x, mk().path_ty(vec!["libc", "c_int"]))))
+                Ok(val.map(|x| mk().cast_expr(x, path![::libc::c_int])))
             }
             c_ast::UnOp::Extension => {
                 let arg = self.convert_expr(ctx, arg)?;

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -438,7 +438,9 @@ impl<'c> Translation<'c> {
                     use c_ast::BinOp::*;
                     let assign_stmt = match op {
                         // Regular (possibly volatile) assignment
-                        Assign if !is_volatile => WithStmts::new_val(mk().assign_expr(&write, rhs)),
+                        Assign if !is_volatile => {
+                            WithStmts::new_val(mk().assign_expr(write.clone(), rhs))
+                        }
                         Assign => WithStmts::new_val(self.volatile_write(
                             write,
                             initial_lhs_type_id,
@@ -515,12 +517,12 @@ impl<'c> Translation<'c> {
                         AssignAdd if pointer_lhs.is_some() => {
                             let mul = self.compute_size_of_expr(pointer_lhs.unwrap().ctype);
                             let ptr = pointer_offset(write.clone(), rhs, mul, false, false);
-                            WithStmts::new_val(mk().assign_expr(&write, ptr))
+                            WithStmts::new_val(mk().assign_expr(write.clone(), ptr))
                         }
                         AssignSubtract if pointer_lhs.is_some() => {
                             let mul = self.compute_size_of_expr(pointer_lhs.unwrap().ctype);
                             let ptr = pointer_offset(write.clone(), rhs, mul, true, false);
-                            WithStmts::new_val(mk().assign_expr(&write, ptr))
+                            WithStmts::new_val(mk().assign_expr(write.clone(), ptr))
                         }
 
                         _ => {
@@ -535,7 +537,7 @@ impl<'c> Translation<'c> {
                                     op == AssignSubtract,
                                     false,
                                 );
-                                WithStmts::new_val(mk().assign_expr(&write, ptr))
+                                WithStmts::new_val(mk().assign_expr(write.clone(), ptr))
                             } else {
                                 fn eq<Token: Default, F: Fn(Token) -> BinOp>(f: F) -> BinOp {
                                     f(Default::default())
@@ -929,7 +931,7 @@ impl<'c> Translation<'c> {
                 let assign_stmt = if ty.qualifiers.is_volatile {
                     self.volatile_write(write, ty, val)?
                 } else {
-                    mk().assign_expr(&write, val)
+                    mk().assign_expr(write.clone(), val)
                 };
 
                 Ok(WithStmts::new(

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -7,7 +7,7 @@ fn neg_expr(arg: Box<Expr>) -> Box<Expr> {
 }
 
 fn wrapping_neg_expr(arg: Box<Expr>) -> Box<Expr> {
-    mk().method_call_expr(arg, "wrapping_neg", vec![] as Vec<Box<Expr>>)
+    mk().method_call_expr(arg, "wrapping_neg", vec![])
 }
 
 impl From<c_ast::BinOp> for BinOp {
@@ -665,9 +665,9 @@ impl<'c> Translation<'c> {
                         && self.ast_context.is_null_expr(lhs_expr_id);
 
                     if fn_eq_null {
-                        mk().method_call_expr(lhs, "is_none", vec![] as Vec<Box<Expr>>)
+                        mk().method_call_expr(lhs, "is_none", vec![])
                     } else if null_eq_fn {
-                        mk().method_call_expr(rhs, "is_none", vec![] as Vec<Box<Expr>>)
+                        mk().method_call_expr(rhs, "is_none", vec![])
                     } else {
                         mk().binary_expr(BinOp::Eq(Default::default()), lhs, rhs)
                     }
@@ -687,9 +687,9 @@ impl<'c> Translation<'c> {
                         && self.ast_context.is_null_expr(lhs_expr_id);
 
                     if fn_eq_null {
-                        mk().method_call_expr(lhs, "is_some", vec![] as Vec<Box<Expr>>)
+                        mk().method_call_expr(lhs, "is_some", vec![])
                     } else if null_eq_fn {
-                        mk().method_call_expr(rhs, "is_some", vec![] as Vec<Box<Expr>>)
+                        mk().method_call_expr(rhs, "is_some", vec![])
                     } else {
                         mk().binary_expr(BinOp::Ne(Default::default()), lhs, rhs)
                     }
@@ -870,7 +870,7 @@ impl<'c> Translation<'c> {
                 let val_name = self.renamer.borrow_mut().fresh();
                 let save_old_val = mk().local_stmt(Box::new(mk().local(
                     mk().ident_pat(&val_name),
-                    None as Option<Box<Type>>,
+                    None,
                     Some(read.clone()),
                 )));
 

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -323,10 +323,9 @@ impl<'c> Translation<'c> {
             self.import_simd_function(fn_name)
                 .expect("None of these fns should be unsupported in rust");
 
-            Ok(WithStmts::new_val(mk().call_expr(
-                mk().ident_expr(fn_name),
-                Vec::new() as Vec<Box<Expr>>,
-            )))
+            Ok(WithStmts::new_val(
+                mk().call_expr(mk().ident_expr(fn_name), vec![]),
+            ))
         }
     }
 

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -572,8 +572,7 @@ impl<'a> Translation<'a> {
             .collect::<WithStmts<Vec<syn::FieldValue>>>()
             .and_then(|fields| {
                 let struct_expr = mk().struct_expr(name.as_str(), fields);
-                let local_variable =
-                    Box::new(mk().local(local_pat, None as Option<Box<Type>>, Some(struct_expr)));
+                let local_variable = Box::new(mk().local(local_pat, None, Some(struct_expr)));
 
                 let mut is_unsafe = false;
                 let mut stmts = vec![mk().local_stmt(local_variable)];
@@ -790,11 +789,7 @@ impl<'a> Translation<'a> {
                     _ if contains_block(&param_expr) => {
                         let name = self.renamer.borrow_mut().pick_name("rhs");
                         let name_ident = mk().mutbl().ident_pat(name.clone());
-                        let temporary_stmt = mk().local(
-                            name_ident,
-                            None as Option<Box<Type>>,
-                            Some(param_expr.clone()),
-                        );
+                        let temporary_stmt = mk().local(name_ident, None, Some(param_expr.clone()));
                         let assignment_expr = mk().method_call_expr(
                             lhs_expr,
                             setter_name,

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -717,8 +717,7 @@ impl<'a> Translation<'a> {
                     .resolve_field_name(None, field_id)
                     .ok_or("Could not find bitfield name")?;
                 let setter_name = format!("set_{}", field_name);
-                let lhs_expr_read =
-                    mk().method_call_expr(lhs_expr.clone(), field_name, Vec::<Box<Expr>>::new());
+                let lhs_expr_read = mk().method_call_expr(lhs_expr.clone(), field_name, vec![]);
                 // Allow the value of this assignment to be used as the RHS of other assignments
                 let val = lhs_expr_read.clone();
                 let param_expr = match op {

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -160,7 +160,7 @@ impl<'a> Translation<'a> {
                                 .unwrap();
 
                             let inner_name = self.resolve_decl_inner_name(decl_id);
-                            ty = mk().path_ty(mk().path(vec![inner_name]));
+                            ty = mk().path_ty(mk().path([inner_name]));
 
                             use_inner_type = true;
 

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -175,7 +175,7 @@ impl<'c> Translation<'c> {
                 })
             {
                 real_arg_ty = Some(arg_ty.clone());
-                arg_ty = mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_void"]));
+                arg_ty = mk().mutbl().ptr_ty(path![::libc::c_void]);
             }
 
             val.and_then(|val| {

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -183,7 +183,7 @@ impl<'c> Translation<'c> {
                     mk().ident("arg"),
                     mk().angle_bracketed_args(vec![arg_ty]),
                 );
-                let mut val = mk().method_call_expr(val, path, vec![] as Vec<Box<Expr>>);
+                let mut val = mk().method_call_expr(val, path, vec![]);
                 if let Some(ty) = real_arg_ty {
                     val = mk().cast_expr(val, ty);
                 }

--- a/tests/statics/src/test_sections.rs
+++ b/tests/statics/src/test_sections.rs
@@ -38,7 +38,7 @@ pub fn test_sectioned_used_static() {
 
         let pos = lines
             .iter()
-            .position(|&x| x == "static mut rust_used_static4: libc::c_int = 1 as libc::c_int;")
+            .position(|&x| x == "static mut rust_used_static4: ::libc::c_int = 1 as ::libc::c_int;")
             .expect("Did not find expected static string in source");
         // The ordering of these attributes is not stable between LLVM versions
         assert!(
@@ -47,7 +47,7 @@ pub fn test_sectioned_used_static() {
         );
 
         // This static is pub, but we want to ensure it has attributes applied
-        assert!(src.contains("#[link_section = \"fb\"]\npub static mut rust_initialized_extern: libc::c_int = 1 as libc::c_int;"));
-        assert!(src.contains("extern \"C\" {\n    #[link_name = \"no_attrs\"]\n    static mut rust_aliased_static: libc::c_int;"))
+        assert!(src.contains("#[link_section = \"fb\"]\npub static mut rust_initialized_extern: ::libc::c_int = 1 as ::libc::c_int;"));
+        assert!(src.contains("extern \"C\" {\n    #[link_name = \"no_attrs\"]\n    static mut rust_aliased_static: ::libc::c_int;"))
     }
 }


### PR DESCRIPTION
This PR introduces the `path!` macro which can be used like

```rust
let p: syn::Path = path![::core::ptr::null_mut];
let e: syn::Expr = path![Vec::new];
let t: syn::Type = path![::libc::c_char];
```

It can output any type `T` which has `impl Make<T> for Path`. Currently this means `Path`, `Type` and `Expr`. Currently the macro supports only simple raw paths, i.e. no variable interpolation (only literal identifiers), no qualified self and no generic parameters. The restriction on simple interpolation of variables may be lifted in a later PR. The restriction on qualified self and generics will likely no be lifted, since they seem far beyond the capabilities of reasonable declarative macros.

This PR also adds `impl Make<Path>` for slices and arrays. This allows to avoid unnecessary allocations when creating paths (almost all paths created by the transpiler have a statically known size). As an extra benefit, switching from `vec![..]` to `[..]` construction looks more lightweight, and allows processing of the array by rustfmt (vec! calls are not formatted properly in general).

This PR also specializes the methods of `Builder` with respect to most generic parameters. Those generics were redundant since each position could be occupied only by a single specific type. E.g. `Make<Box<Expr>>` is implemented only by `Box<Expr>`, so that is always the type of `impl Make<Box<Expr>>` arguments.

Specializing those generic parameters has no restriction on the practical usability of the API, and it in fact makes it more flexible: generic parameters break type inference. If I have `fn foo<T: Trait>(t: T)` and `fn bar<R>() -> R`, then `foo(bar())` will result in a compile error since the type of `R` is generally impossible to infer. The type inference is heavily used by the `path!` macro to overload on the return type.

As a bonus, specializing the parameters allows to remove a significant number of redundant explicit type casts. It also results in better compile speed (generics aren't fully compiled in the defining crate, and are instantiated separately in each codegen unit). The speed benefit is minor, but a nice touch.