### PR TITLE
Switched to a `clap` 3 parser for `c2rust-pdg`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap 3.1.18",
+ "clap 3.2.8",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -296,6 +296,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "c2rust-analysis-rt",
+ "clap 3.2.8",
  "color-eyre",
  "env_logger",
  "fs-err",
@@ -350,7 +351,7 @@ dependencies = [
  "bytesize",
  "cargo-platform",
  "cargo-util",
- "clap 3.1.18",
+ "clap 3.2.8",
  "crates-io",
  "crossbeam-utils",
  "curl",
@@ -481,24 +482,39 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "indexmap",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
 ]
 
 [[package]]
-name = "clap_lex"
-version = "0.2.0"
+name = "clap_derive"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1477,6 +1493,30 @@ checksum = "f28f53e8b192565862cf99343194579a022eb9c7dd3a8d03134734803c7b3125"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bincode = "1.0.1"
+bincode = "1.0"
 c2rust-analysis-rt = { path = "../analysis/runtime"}
-indexed_vec = "1.2.1"
+indexed_vec = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 env_logger = "0.9"
@@ -14,6 +14,7 @@ color-eyre = "0.6"
 fs-err = "2"
 itertools = "0.10"
 linked_hash_set = "0.1"
+clap = { version = "3.2", features = ["derive"] }
 
 [build-dependencies]
 color-eyre = "0.6"

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -24,24 +24,31 @@ mod query;
 mod util;
 
 use builder::{construct_pdg, read_event_log};
+use clap::Parser;
 use color_eyre::eyre;
-use std::{env, path::Path};
+use std::path::{Path, PathBuf};
 
 use crate::builder::read_metadata;
+
+/// Construct and query a PDG from an instrumented program's event log.
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Path to an event log from a run of an instrumented program.
+    #[clap(long, value_parser)]
+    event_log: PathBuf,
+    /// Path to the instrumented program's metadata generated at compile/instrumentation time.
+    #[clap(long, value_parser)]
+    metadata: PathBuf,
+}
 
 fn main() -> eyre::Result<()> {
     color_eyre::install()?;
     env_logger::init();
+    let args = Args::parse();
 
-    let metadata_path = env::args_os()
-        .nth(2)
-        .expect("Expected metadata file path as the 1st argument");
-    let event_trace_path = env::args_os()
-        .nth(1)
-        .expect("Expected event trace file path as the 2nd argument");
-
-    let metadata = read_metadata(Path::new(&metadata_path))?;
-    let events = read_event_log(Path::new(&event_trace_path))?;
+    let events = read_event_log(Path::new(&args.event_log))?;
+    let metadata = read_metadata(Path::new(&args.metadata))?;
 
     // for event in &events {
     //     let mir_loc = metadata.get(event.mir_loc);

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -98,7 +98,9 @@ main() {
         export RUST_LOG=info
         cargo run \
             "${profile_args[@]}" \
-            -- "../${test_dir}/log.bc" "${metadata}" \
+            -- \
+            --event-log "../${test_dir}/log.bc" \
+            --metadata "${metadata}" \
         > "../${test_dir}/pdg.log"
     )
 }


### PR DESCRIPTION
`c2rust-pdg` now uses `clap` 3 for its CLI arguments, which makes help and error messages much nicer and gives names to arguments.  Now the usage is:

```shell
c2rust-pdg --event-log <EVENT_LOG> --metadata <METADATA>
```

This f ixes https://github.com/immunant/c2rust/issues/395 for `c2rust-pdg`, though the existing `c2rust-*` parsers still have to be upgraded.