### PR TITLE
Add a `c2rust-pdg --print TO_PRINT` option

### DIFF
--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -253,10 +253,5 @@ pub fn construct_pdg(events: &[Event], metadata: &Metadata) -> Graphs {
     }
     // TODO(kkysen) check if I have to remove any `GraphId`s from `graphs.latest_assignment`
     graphs.graphs = graphs.graphs.into_iter().unique().collect();
-
-    // for ((func_hash, local), p) in &graphs.latest_assignment {
-    //     let func = &metadata.functions[func_hash];
-    //     println!("({func}:{local:?}) => {p:?}");
-    // }
     graphs
 }

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -71,14 +71,14 @@ fn main() -> eyre::Result<()> {
     env_logger::init();
     let args = Args::parse();
 
-    let print = args.print.iter().collect::<HashSet<_>>();
-    let print = |to_print| print.contains(&to_print);
+    let print_args = args.print.iter().collect::<HashSet<_>>();
+    let should_print = |to_print| print_args.contains(&to_print);
 
     let events = read_event_log(Path::new(&args.event_log))?;
     let metadata = read_metadata(Path::new(&args.metadata))?;
     let metadata = &metadata;
 
-    if print(ToPrint::Events) {
+    if should_print(ToPrint::Events) {
         for event in &events {
             let mir_loc = metadata.get(event.mir_loc);
             let kind = &event.kind;
@@ -89,7 +89,7 @@ fn main() -> eyre::Result<()> {
     let pdg = construct_pdg(&events, metadata);
     pdg.assert_all_tests();
 
-    if print(ToPrint::LatestAssignments) {
+    if should_print(ToPrint::LatestAssignments) {
         for ((func_hash, local), p) in &pdg.latest_assignment {
             let func = &metadata.functions[func_hash];
             println!("({func}:{local:?}) => {p:?}");
@@ -101,18 +101,18 @@ fn main() -> eyre::Result<()> {
             .needs_write_permission()
             .map(|node_id| node_id.as_usize())
             .collect::<Vec<_>>();
-        if print(ToPrint::Graphs) {
+        if should_print(ToPrint::Graphs) {
             println!("{graph_id} {graph}");
         }
-        if print(ToPrint::WritePermissions) {
+        if should_print(ToPrint::WritePermissions) {
             println!("nodes_that_need_write = {needs_write:?}");
         }
-        if print(ToPrint::Graphs) || print(ToPrint::WritePermissions) {
+        if should_print(ToPrint::Graphs) || should_print(ToPrint::WritePermissions) {
             println!();
         }
     }
 
-    if print(ToPrint::Counts) {
+    if should_print(ToPrint::Counts) {
         let num_graphs = pdg.graphs.len();
         let num_nodes = pdg
             .graphs

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -24,34 +24,46 @@ mod query;
 mod util;
 
 use builder::{construct_pdg, read_event_log};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use color_eyre::eyre;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    fmt::{self, Display, Formatter},
+    path::{Path, PathBuf},
+};
 
 use crate::builder::read_metadata;
 
-/// Construct and query a PDG from an instrumented program's event log.
-#[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
-struct Args {
-    /// Path to an event log from a run of an instrumented program.
-    #[clap(long, value_parser)]
-    event_log: PathBuf,
-    /// Path to the instrumented program's metadata generated at compile/instrumentation time.
-    #[clap(long, value_parser)]
-    metadata: PathBuf,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
+enum ToPrint {
+    Graphs,
+    Counts,
+    Events,
+    LatestAssignments,
+    WritePermissions,
+}
+
+impl Display for ToPrint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.to_possible_value().unwrap().get_name())
+    }
 }
 
 /// Construct and query a PDG from an instrumented program's event log.
-#[derive(Parser, Debug)]
+#[derive(Debug, Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// Path to an event log from a run of an instrumented program.
     #[clap(long, value_parser)]
     event_log: PathBuf,
+
     /// Path to the instrumented program's metadata generated at compile/instrumentation time.
     #[clap(long, value_parser)]
     metadata: PathBuf,
+
+    /// What to print.
+    #[clap(long, value_parser)]
+    print: Vec<ToPrint>,
 }
 
 fn main() -> eyre::Result<()> {
@@ -59,36 +71,57 @@ fn main() -> eyre::Result<()> {
     env_logger::init();
     let args = Args::parse();
 
+    let print = args.print.iter().collect::<HashSet<_>>();
+    let print = |to_print| print.contains(&to_print);
+
     let events = read_event_log(Path::new(&args.event_log))?;
     let metadata = read_metadata(Path::new(&args.metadata))?;
+    let metadata = &metadata;
 
-    // for event in &events {
-    //     let mir_loc = metadata.get(event.mir_loc);
-    //     let kind = &event.kind;
-    //     println!("{mir_loc:?} -> {kind:?}");
-    // }
+    if print(ToPrint::Events) {
+        for event in &events {
+            let mir_loc = metadata.get(event.mir_loc);
+            let kind = &event.kind;
+            println!("{mir_loc:?} -> {kind:?}");
+        }
+    }
 
-    let pdg = construct_pdg(&events, &metadata);
+    let pdg = construct_pdg(&events, metadata);
     pdg.assert_all_tests();
+
+    if print(ToPrint::LatestAssignments) {
+        for ((func_hash, local), p) in &pdg.latest_assignment {
+            let func = &metadata.functions[func_hash];
+            println!("({func}:{local:?}) => {p:?}");
+        }
+    }
 
     for (graph_id, graph) in pdg.graphs.iter_enumerated() {
         let needs_write = graph
             .needs_write_permission()
             .map(|node_id| node_id.as_usize())
             .collect::<Vec<_>>();
-        println!("{graph_id} {graph}");
-        println!("nodes_that_need_write = {needs_write:?}");
-        println!("\n");
+        if print(ToPrint::Graphs) {
+            println!("{graph_id} {graph}");
+        }
+        if print(ToPrint::WritePermissions) {
+            println!("nodes_that_need_write = {needs_write:?}");
+        }
+        if print(ToPrint::Graphs) || print(ToPrint::WritePermissions) {
+            println!();
+        }
     }
 
-    let num_graphs = pdg.graphs.len();
-    let num_nodes = pdg
-        .graphs
-        .iter()
-        .map(|graph| graph.nodes.len())
-        .sum::<usize>();
-    dbg!(num_graphs);
-    dbg!(num_nodes);
+    if print(ToPrint::Counts) {
+        let num_graphs = pdg.graphs.len();
+        let num_nodes = pdg
+            .graphs
+            .iter()
+            .map(|graph| graph.nodes.len())
+            .sum::<usize>();
+        println!("num_graphs = {num_graphs}");
+        println!("num_nodes = {num_nodes}");
+    }
 
     Ok(())
 }

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -41,6 +41,7 @@ enum ToPrint {
     Events,
     LatestAssignments,
     WritePermissions,
+    Metadata,
 }
 
 impl Display for ToPrint {
@@ -77,6 +78,10 @@ fn main() -> eyre::Result<()> {
     let events = read_event_log(Path::new(&args.event_log))?;
     let metadata = read_metadata(Path::new(&args.metadata))?;
     let metadata = &metadata;
+
+    if should_print(ToPrint::Metadata) {
+        println!("{metadata:#?}");
+    }
 
     if should_print(ToPrint::Events) {
         for event in &events {

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -62,7 +62,7 @@ struct Args {
     metadata: PathBuf,
 
     /// What to print.
-    #[clap(long, value_parser)]
+    #[clap(long, value_parser, default_value = "graphs")]
     print: Vec<ToPrint>,
 }
 

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -42,6 +42,18 @@ struct Args {
     metadata: PathBuf,
 }
 
+/// Construct and query a PDG from an instrumented program's event log.
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Path to an event log from a run of an instrumented program.
+    #[clap(long, value_parser)]
+    event_log: PathBuf,
+    /// Path to the instrumented program's metadata generated at compile/instrumentation time.
+    #[clap(long, value_parser)]
+    metadata: PathBuf,
+}
+
 fn main() -> eyre::Result<()> {
     color_eyre::install()?;
     env_logger::init();

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -101,6 +101,9 @@ main() {
             -- \
             --event-log "../${test_dir}/log.bc" \
             --metadata "${metadata}" \
+            --print graphs \
+            --print write-permissions \
+            --print counts \
         > "../${test_dir}/pdg.log"
     )
 }


### PR DESCRIPTION
Added a `c2rust-pdg --print TO_PRINT` option that can be any of
* `graphs`
* `counts`
* `events`
* `latest-assignments`
* `write-permissions`

and can be repeated to print more of them.  This
* brings some control to all the ad-hoc things that were printed before
* makes sure we don't have code that's commented out that has to be maintained
* lets us easily change what we want to be printed without re-compiling, as @fw-immunant came across once