### PR TITLE
Append to event log

### DIFF
--- a/analysis/runtime/src/runtime/backend.rs
+++ b/analysis/runtime/src/runtime/backend.rs
@@ -44,10 +44,11 @@ pub enum Backend {
 impl Backend {
     fn write_all(&mut self, rx: Receiver<Event>) {
         for event in rx {
-            if matches!(event.kind, EventKind::Done) {
+            let done = matches!(event.kind, EventKind::Done);
+            self.write(event);
+            if done {
                 return;
             }
-            self.write(event);
         }
     }
 

--- a/analysis/runtime/src/runtime/backend.rs
+++ b/analysis/runtime/src/runtime/backend.rs
@@ -1,5 +1,5 @@
 use enum_dispatch::enum_dispatch;
-use fs_err::File;
+use fs_err::{File, OpenOptions};
 use std::env;
 use std::io::BufWriter;
 use std::sync::mpsc::Receiver;
@@ -76,7 +76,7 @@ impl LogBackend {
     pub fn detect() -> Result<Self, AnyError> {
         let path = env::var_os("INSTRUMENT_OUTPUT")
             .ok_or("Instrumentation requires the INSTRUMENT_OUTPUT environment variable be set")?;
-        let file = File::create(&path)?;
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
         let writer = BufWriter::new(file);
         Ok(Self { writer })
     }

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -77,8 +77,8 @@ main() {
         if [[ "${c2rust_instrument}" -nt "${metadata}" ]]; then
             cargo clean --profile dev # always dev/debug for now
 
-            if ! LD_LIBRARY_PATH="${toolchain_dir}/lib" \
-            "${c2rust}" instrument \
+            export LD_LIBRARY_PATH="${toolchain_dir}/lib"
+            if ! "${c2rust}" instrument \
                 "${metadata}" "${runtime}" \
                 -- "${profile_args[@]}"  \
             1> instrument.out.log \
@@ -90,7 +90,7 @@ main() {
         
         export INSTRUMENT_BACKEND=log
         export INSTRUMENT_OUTPUT=log.bc
-        rm -f "${INSTRUMENT_OUTPUT}"
+        export INSTRUMENT_OUTPUT_APPEND=false
         export METADATA_FILE="${metadata}"
         "${binary_path}" "${args[@]}"
     )

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -90,6 +90,7 @@ main() {
         
         export INSTRUMENT_BACKEND=log
         export INSTRUMENT_OUTPUT=log.bc
+        rm -f "${INSTRUMENT_OUTPUT}"
         export METADATA_FILE="${metadata}"
         "${binary_path}" "${args[@]}"
     )


### PR DESCRIPTION
Append to the event log in `c2rust_analysis_rt::runtime::backend::LogBackend` by opening the event log in append mode.  This lets us collect events from multiple, sequential runs of the same program.  This can be quite useful, as often tests, like for `lighttpd`, run the instrumented binary multiple times.  Note that parallel runs of the same program would not work at all.  For that case, each run should write to a different event log, which we can concatenate together at the end.

The event log, since it's split into separate `Graph`s for each object anyways, doesn't really matter if it represents multiple runs or not.  However, this PR also makes sure the `EventKind::Done` `Event` is written at the end, so that if we do want to split the event logs from different runs back apart, we can easily do so.

Now that we append, we need to delete the event log before running the `pdg.sh` script.