### PR TITLE
Fixed the `clippy::if_same_then_else` warning

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2405,9 +2405,7 @@ impl<'c> Translation<'c> {
                 // Only add linkage attributes if the function is `extern`
                 let mut mk_ = if is_main {
                     mk()
-                } else if is_global && !is_inline {
-                    mk_linkage(false, new_name, name).extern_("C").pub_()
-                } else if is_extern_inline {
+                } else if (is_global && !is_inline) || is_extern_inline {
                     mk_linkage(false, new_name, name).extern_("C").pub_()
                 } else if self.cur_file.borrow().is_some() {
                     mk().extern_("C").pub_()

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2398,15 +2398,16 @@ impl<'c> Translation<'c> {
                     block.set_span(span);
                 }
 
+                // c99 extern inline functions should be pub, but not gnu_inline attributed
+                // extern inlines, which become subject to their gnu89 visibility (private)
+                let is_extern_inline = is_inline && is_extern && !attrs.contains(&c_ast::Attribute::GnuInline);
+
                 // Only add linkage attributes if the function is `extern`
                 let mut mk_ = if is_main {
                     mk()
                 } else if is_global && !is_inline {
                     mk_linkage(false, new_name, name).extern_("C").pub_()
-                } else if is_inline && is_extern && !attrs.contains(&c_ast::Attribute::GnuInline) {
-                    // c99 extern inline functions should be pub, but not gnu_inline attributed
-                    // extern inlines, which become subject to their gnu89 visibility (private)
-
+                } else if is_extern_inline {
                     mk_linkage(false, new_name, name).extern_("C").pub_()
                 } else if self.cur_file.borrow().is_some() {
                     mk().extern_("C").pub_()


### PR DESCRIPTION
This fixes the `clippy::if_same_then_else` warning here:

https://github.com/immunant/c2rust/blob/2113c3e93bdcb866e975079668e4427dc520f29b/c2rust-transpile/src/translator/mod.rs#L2374-L2388

It would be a trivial fix, except there is a comment in only one of the equivalent branches, so I wasn't sure if they should be merged or not.  No one's said anything about it, so I decided to extract the branch condition with the comment into a separate `bool` variable, move the comment there, and then combine the branches.

