### PR TITLE
Locally allow `clippy::vec_box` warnings

### DIFF
--- a/c2rust-transpile/src/rust_ast/item_store.rs
+++ b/c2rust-transpile/src/rust_ast/item_store.rs
@@ -67,6 +67,8 @@ impl PathedMultiImports {
 
 #[derive(Debug, Default)]
 pub struct ItemStore {
+    // Fixing this would require major refactors for marginal benefit.
+    #[allow(clippy::vec_box)]
     items: Vec<Box<Item>>,
     foreign_items: Vec<ForeignItem>,
     uses: PathedMultiImports,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -1051,6 +1051,8 @@ fn make_submodule(
 
 // TODO(kkysen) shouldn't need `extern crate`
 /// Pretty-print the leading pragmas and extern crate declarations
+// Fixing this would require major refactors for marginal benefit.
+#[allow(clippy::vec_box)]
 fn arrange_header(t: &Translation, is_binary: bool) -> (Vec<syn::Attribute>, Vec<Box<Item>>) {
     let mut out_attrs = vec![];
     let mut out_items = vec![];
@@ -3229,6 +3231,8 @@ impl<'c> Translation<'c> {
         Ok(WithStmts::new_val(call))
     }
 
+    // Fixing this would require major refactors for marginal benefit.
+    #[allow(clippy::vec_box)]
     fn convert_exprs(
         &self,
         ctx: ExprContext,


### PR DESCRIPTION
Locally `#[allow(clippy::vec_box)]`, as fixing this would require major refactoring for marginal, if any, benefit.  Fixing this would require unboxing much of the codebase, and as many of these types can be quite large (~400 bytes), I wasn't sure if the copy overhead would be worth it vs. the allocation overhead.  It's simpler to just keep the code as is and allow the few (3) instances of `Vec<Box<_>>`.