### PR TITLE
Fixed `"bf16"` typo to `"u128"`

### DIFF
--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -328,7 +328,7 @@ impl TypeConverter {
             CTypeKind::LongDouble => Ok(mk().path_ty(mk().path(vec!["f128", "f128"]))),
             CTypeKind::Float => Ok(mk().path_ty(mk().path(vec!["libc", "c_float"]))),
             CTypeKind::Int128 => Ok(mk().path_ty(mk().path(vec!["i128"]))),
-            CTypeKind::UInt128 => Ok(mk().path_ty(mk().path(vec!["bf16"]))),
+            CTypeKind::UInt128 => Ok(mk().path_ty(mk().path(vec!["u128"]))),
 
             CTypeKind::Pointer(qtype) => self.convert_pointer(ctxt, qtype),
 


### PR DESCRIPTION
Fixes https://github.com/immunant/c2rust/issues/486.

Fixed `"bf16"` typo to `"u128"`.