### PR TITLE
Initial (hacky) version of PDG snapshot testing for `analysis/test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
  "env_logger",
  "fs-err",
  "indexed_vec",
+ "insta",
  "itertools",
  "linked_hash_set",
  "log",
@@ -477,7 +478,7 @@ dependencies = [
  "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
- "yaml-rust",
+ "yaml-rust 0.3.5",
 ]
 
 [[package]]
@@ -606,6 +607,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "winapi",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +731,12 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enum_dispatch"
@@ -1089,6 +1109,20 @@ dependencies = [
  "autocfg",
  "hashbrown",
  "serde",
+]
+
+[[package]]
+name = "insta"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4126dd76ebfe2561486a1bd6738a33d2029ffb068a99ac446b7f8c77b2e58dbc"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "similar",
 ]
 
 [[package]]
@@ -1733,6 +1767,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec0091e1f5aa338283ce049bd9dfefd55e1f168ac233e85c1ffe0038fb48cbe"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust 0.4.5",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +1810,12 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "similar"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "sized-chunks"
@@ -1885,6 +1937,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2228,3 +2290,12 @@ name = "yaml-rust"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -355,37 +355,40 @@ pub unsafe extern "C" fn insertion_sort(n: libc::c_int, p: *mut libc::c_int) {
     }
 }
 unsafe fn main_0(mut argc: libc::c_int, mut argv: *mut *mut libc::c_char) -> libc::c_int {
-    // simple();
-    // exercise_allocator();
-    // simple_analysis();
-    // analysis2();
-    // inter_function_analysis();
-    // no_owner(0i32);
-    // no_owner(1i32);
-    // invalid();
-    // testing();
-    // simple1();
-    // lighttpd_test(std::ptr::null_mut());
+    simple();
+    exercise_allocator();
+    simple_analysis();
+    analysis2();
+    inter_function_analysis();
+    no_owner(0i32);
+    no_owner(1i32);
+    invalid();
+    testing();
+    simple1();
+    // segfault at:
+    // chunks[10].iov_base = ((*(*c).mem).ptr).offset((*c).offset as isize) as *mut libc::c_void;
+    // due to nullptr arg
+    lighttpd_test(std::ptr::null_mut());
 
-    // test_malloc_free();
-    // test_malloc_free_cast();
-    // test_arg();
-    // test_arg_rec();
-    // test_realloc_reassign();
-    // test_realloc_fresh();
-    // test_load_addr();
-    // test_overwrite();
-    // test_store_addr();
-    // test_load_other_store_self();
+    test_malloc_free();
+    test_malloc_free_cast();
+    test_arg();
+    test_arg_rec();
+    test_realloc_reassign();
+    test_realloc_fresh();
+    test_load_addr();
+    test_overwrite();
+    test_store_addr();
+    test_load_other_store_self();
     test_load_self_store_self();
-    // test_load_self_store_self_inter();
-    // test_ptr_int_ptr();
-    // test_load_value();
-    // test_store_value();
-    // test_store_value_field();
-    // test_load_value_store_value();
-    // let nums = &mut [2i32, 5i32, 3i32, 1i32, 6i32];
-    // insertion_sort(nums.len() as libc::c_int, nums as *mut libc::c_int);
+    test_load_self_store_self_inter();
+    test_ptr_int_ptr();
+    test_load_value();
+    test_store_value();
+    test_store_value_field();
+    test_load_value_store_value();
+    let nums = &mut [2i32, 5i32, 3i32, 1i32, 6i32];
+    insertion_sort(nums.len() as libc::c_int, nums as *mut libc::c_int);
     return 0i32;
 }
 pub fn main() {

--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -368,7 +368,7 @@ unsafe fn main_0(mut argc: libc::c_int, mut argv: *mut *mut libc::c_char) -> lib
     // segfault at:
     // chunks[10].iov_base = ((*(*c).mem).ptr).offset((*c).offset as isize) as *mut libc::c_void;
     // due to nullptr arg
-    lighttpd_test(std::ptr::null_mut());
+    // lighttpd_test(std::ptr::null_mut());
 
     test_malloc_free();
     test_malloc_free_cast();

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -19,5 +19,8 @@ clap = { version = "3.2", features = ["derive"] }
 [build-dependencies]
 color-eyre = "0.6"
 
+[dev-dependencies]
+insta = "1.15"
+
 [package.metadata.rust-analyzer] 
 rustc_private = true

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -130,3 +130,21 @@ fn main() -> eyre::Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{env, path::Path, process::Command};
+
+    use color_eyre::eyre;
+
+    #[test]
+    fn analysis_test_pdg_snapshot() -> eyre::Result<()> {
+        color_eyre::install()?;
+        env::set_current_dir("..")?;
+        let dir = Path::new("analysis/test");
+        Command::new("scripts/pdg.sh").arg(dir).status()?;
+        let pdg = fs_err::read_to_string(dir.join("pdg.log"))?;
+        insta::assert_display_snapshot!(pdg);
+        Ok(())
+    }
+}

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot.snap
@@ -1,0 +1,816 @@
+---
+source: pdg/src/main.rs
+expression: pdg
+---
+g[0] {
+	n[0]: copy _ => _10 @ bb5[4]: fn main;
+}
+nodes_that_need_write = []
+
+g[1] {
+	n[0]: copy _ => _9 @ bb5[5]: fn main;
+}
+nodes_that_need_write = []
+
+g[2] {
+	n[0]: copy _ => _19 @ bb8[11]: fn main;
+}
+nodes_that_need_write = []
+
+g[3] {
+	n[0]: copy _ => _18 @ bb8[12]: fn main;
+}
+nodes_that_need_write = []
+
+g[4] {
+	n[0]: copy _ => _27 @ bb8[22]: fn main;
+}
+nodes_that_need_write = []
+
+g[5] {
+	n[0]: copy _ => _26 @ bb8[23]: fn main;
+}
+nodes_that_need_write = []
+
+g[6] {
+	n[0]: copy _ => _23 @ bb13[4]: fn main;
+}
+nodes_that_need_write = []
+
+g[7] {
+	n[0]: copy _ => _22 @ bb13[5]: fn main;
+}
+nodes_that_need_write = []
+
+g[8] {
+	n[0]: copy _ => _29 @ bb15[11]: fn main;
+}
+nodes_that_need_write = []
+
+g[9] {
+	n[0]: copy _ => _34 @ bb16[5]: fn main;
+}
+nodes_that_need_write = []
+
+g[10] {
+	n[0]: copy _    => _30 @ bb18[0]: fn main;
+	n[1]: copy n[0] => _2  @ bb0[0]:  fn push;
+}
+nodes_that_need_write = []
+
+g[11] {
+	n[0]: copy _ => _37 @ bb27[4]: fn main;
+}
+nodes_that_need_write = []
+
+g[12] {
+	n[0]: copy        _    => _38       @ bb28[0]: fn main;   
+	n[1]: copy        n[0] => _2        @ bb0[0]:  fn push;   
+	n[2]: value.store _    => _20.Deref @ bb4[8]:  fn invalid;
+}
+nodes_that_need_write = []
+
+g[13] {
+	n[0]: copy _ => _43 @ bb29[9]: fn main;
+}
+nodes_that_need_write = []
+
+g[14] {
+	n[0]: copy _ => _46 @ bb31[6]: fn main;
+}
+nodes_that_need_write = []
+
+g[15] {
+	n[0]: copy _    => _45 @ bb32[0]: fn main;  
+	n[1]: copy n[0] => _2  @ bb0[0]:  fn main_0;
+}
+nodes_that_need_write = []
+
+g[16] {
+	n[0]: malloc(n = 1) _    => _2 @ bb1[2]: fn simple;
+	n[1]: copy          n[0] => _1 @ bb2[2]: fn simple;
+	n[2]: field.0       n[1] => _9 @ bb4[5]: fn simple;
+	n[3]: addr.load     n[2] => _  @ bb4[5]: fn simple;
+}
+nodes_that_need_write = []
+
+g[17] {
+	n[0]:  malloc(n = 1) _     => _6  @ bb3[2]:  fn simple;
+	n[1]:  copy          n[0]  => _5  @ bb4[2]:  fn simple;
+	n[2]:  copy          n[1]  => _10 @ bb4[9]:  fn simple;
+	n[3]:  copy          n[2]  => _1  @ bb4[10]: fn simple;
+	n[4]:  field.0       n[3]  => _   @ bb4[11]: fn simple;
+	n[5]:  addr.store    n[4]  => _   @ bb4[11]: fn simple;
+	n[6]:  field.0       n[3]  => _11 @ bb4[13]: fn simple;
+	n[7]:  addr.load     n[6]  => _   @ bb4[13]: fn simple;
+	n[8]:  field.0       n[1]  => _   @ bb4[14]: fn simple;
+	n[9]:  addr.store    n[8]  => _   @ bb4[14]: fn simple;
+	n[10]: field.1       n[3]  => _   @ bb4[16]: fn simple;
+	n[11]: addr.store    n[10] => _   @ bb4[16]: fn simple;
+	n[12]: field.0       n[3]  => _12 @ bb4[18]: fn simple;
+	n[13]: addr.load     n[12] => _   @ bb4[18]: fn simple;
+	n[14]: field.1       n[3]  => _13 @ bb4[21]: fn simple;
+	n[15]: addr.load     n[14] => _   @ bb4[21]: fn simple;
+	n[16]: addr.load     n[0]  => _   @ bb4[24]: fn simple;
+	n[17]: field.2       n[3]  => _   @ bb4[25]: fn simple;
+	n[18]: addr.store    n[17] => _   @ bb4[25]: fn simple;
+	n[19]: copy          n[3]  => _16 @ bb4[30]: fn simple;
+	n[20]: copy          n[19] => _2  @ bb0[0]:  fn recur; 
+	n[21]: copy          n[20] => _13 @ bb8[4]:  fn recur; 
+	n[22]: copy          n[21] => _2  @ bb0[0]:  fn recur; 
+	n[23]: copy          n[22] => _13 @ bb8[4]:  fn recur; 
+	n[24]: copy          n[23] => _2  @ bb0[0]:  fn recur; 
+	n[25]: copy          n[24] => _13 @ bb8[4]:  fn recur; 
+	n[26]: copy          n[25] => _2  @ bb0[0]:  fn recur; 
+	n[27]: copy          n[26] => _8  @ bb1[3]:  fn recur; 
+	n[28]: copy          n[27] => _7  @ bb1[4]:  fn recur; 
+	n[29]: free          n[28] => _0  @ bb1[5]:  fn recur; 
+	n[30]: copy          n[26] => _14 @ bb9[5]:  fn recur; 
+	n[31]: copy          n[26] => _14 @ bb9[5]:  fn recur; 
+	n[32]: copy          n[26] => _14 @ bb9[5]:  fn recur; 
+}
+nodes_that_need_write = [18, 17, 11, 10, 9, 8, 5, 4, 3, 2, 1, 0]
+
+g[18] {
+	n[0]: &_1 _ => _9 @ bb4[6]: fn simple;
+}
+nodes_that_need_write = []
+
+g[19] {
+	n[0]: &_1 _ => _13 @ bb4[22]: fn simple;
+}
+nodes_that_need_write = []
+
+g[20] {
+	n[0]: &_1         _    => _14               @ bb4[25]: fn simple;
+	n[1]: value.store n[0] => _1.Deref.Field(2) @ bb4[26]: fn simple;
+	n[2]: addr.load   n[0] => _                 @ bb5[3]:  fn simple;
+	n[3]: addr.store  n[0] => _                 @ bb5[7]:  fn simple;
+}
+nodes_that_need_write = [3, 0]
+
+g[21] {
+	n[0]: malloc(n = 1) _    => _2  @ bb1[2]:  fn exercise_allocator;
+	n[1]: copy          n[0] => _1  @ bb2[2]:  fn exercise_allocator;
+	n[2]: field.0       n[1] => _   @ bb2[5]:  fn exercise_allocator;
+	n[3]: addr.store    n[2] => _   @ bb2[5]:  fn exercise_allocator;
+	n[4]: field.0       n[1] => _10 @ bb2[18]: fn exercise_allocator;
+	n[5]: addr.load     n[4] => _   @ bb2[18]: fn exercise_allocator;
+	n[6]: copy          n[1] => _13 @ bb3[8]:  fn exercise_allocator;
+	n[7]: copy          n[6] => _12 @ bb3[9]:  fn exercise_allocator;
+	n[8]: free          n[7] => _11 @ bb5[2]:  fn exercise_allocator;
+}
+nodes_that_need_write = [3, 2, 1, 0]
+
+g[22] {
+	n[0]: &_9  _    => _8 @ bb2[13]: fn exercise_allocator;
+	n[1]: copy n[0] => _7 @ bb2[14]: fn exercise_allocator;
+	n[2]: copy n[1] => _6 @ bb2[16]: fn exercise_allocator;
+	n[3]: copy n[2] => _1 @ bb0[0]:  fn printf;            
+}
+nodes_that_need_write = []
+
+g[23] {
+	n[0]:  malloc(n = 1) _     => _11 @ bb5[2]:   fn exercise_allocator;
+	n[1]:  copy          n[0]  => _1  @ bb6[3]:   fn exercise_allocator;
+	n[2]:  copy          n[1]  => _19 @ bb6[7]:   fn exercise_allocator;
+	n[3]:  offset[0]     n[2]  => _18 @ bb6[7]:   fn exercise_allocator;
+	n[4]:  field.0       n[3]  => _   @ bb7[1]:   fn exercise_allocator;
+	n[5]:  addr.store    n[4]  => _   @ bb7[1]:   fn exercise_allocator;
+	n[6]:  copy          n[1]  => _21 @ bb7[6]:   fn exercise_allocator;
+	n[7]:  offset[1]     n[6]  => _20 @ bb7[6]:   fn exercise_allocator;
+	n[8]:  field.0       n[7]  => _   @ bb8[1]:   fn exercise_allocator;
+	n[9]:  addr.store    n[8]  => _   @ bb8[1]:   fn exercise_allocator;
+	n[10]: copy          n[1]  => _34 @ bb11[15]: fn exercise_allocator;
+	n[11]: offset[0]     n[10] => _33 @ bb11[20]: fn exercise_allocator;
+	n[12]: field.0       n[11] => _32 @ bb13[2]:  fn exercise_allocator;
+	n[13]: addr.load     n[12] => _   @ bb13[2]:  fn exercise_allocator;
+	n[14]: copy          n[1]  => _34 @ bb11[15]: fn exercise_allocator;
+	n[15]: offset[1]     n[14] => _33 @ bb11[20]: fn exercise_allocator;
+	n[16]: field.0       n[15] => _32 @ bb13[2]:  fn exercise_allocator;
+	n[17]: addr.load     n[16] => _   @ bb13[2]:  fn exercise_allocator;
+	n[18]: copy          n[1]  => _43 @ bb21[7]:  fn exercise_allocator;
+	n[19]: copy          n[18] => _42 @ bb21[8]:  fn exercise_allocator;
+}
+nodes_that_need_write = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+
+g[24] {
+	n[0]: &_31 _    => _30 @ bb11[7]:  fn exercise_allocator;
+	n[1]: copy n[0] => _29 @ bb11[8]:  fn exercise_allocator;
+	n[2]: copy n[1] => _28 @ bb11[10]: fn exercise_allocator;
+	n[3]: copy n[2] => _1  @ bb0[0]:   fn printf;            
+}
+nodes_that_need_write = []
+
+g[25] {
+	n[0]:  malloc(n = 1) _     => _41 @ bb22[2]:  fn exercise_allocator;
+	n[1]:  copy          n[0]  => _1  @ bb23[4]:  fn exercise_allocator;
+	n[2]:  copy          n[1]  => _48 @ bb23[8]:  fn exercise_allocator;
+	n[3]:  offset[0]     n[2]  => _47 @ bb23[8]:  fn exercise_allocator;
+	n[4]:  field.0       n[3]  => _   @ bb24[1]:  fn exercise_allocator;
+	n[5]:  addr.store    n[4]  => _   @ bb24[1]:  fn exercise_allocator;
+	n[6]:  copy          n[1]  => _50 @ bb24[6]:  fn exercise_allocator;
+	n[7]:  offset[1]     n[6]  => _49 @ bb24[6]:  fn exercise_allocator;
+	n[8]:  field.0       n[7]  => _   @ bb25[1]:  fn exercise_allocator;
+	n[9]:  addr.store    n[8]  => _   @ bb25[1]:  fn exercise_allocator;
+	n[10]: copy          n[1]  => _52 @ bb25[6]:  fn exercise_allocator;
+	n[11]: offset[2]     n[10] => _51 @ bb25[6]:  fn exercise_allocator;
+	n[12]: field.0       n[11] => _   @ bb26[1]:  fn exercise_allocator;
+	n[13]: addr.store    n[12] => _   @ bb26[1]:  fn exercise_allocator;
+	n[14]: copy          n[1]  => _64 @ bb29[15]: fn exercise_allocator;
+	n[15]: offset[0]     n[14] => _63 @ bb29[20]: fn exercise_allocator;
+	n[16]: field.0       n[15] => _62 @ bb31[2]:  fn exercise_allocator;
+	n[17]: addr.load     n[16] => _   @ bb31[2]:  fn exercise_allocator;
+	n[18]: copy          n[1]  => _64 @ bb29[15]: fn exercise_allocator;
+	n[19]: offset[1]     n[18] => _63 @ bb29[20]: fn exercise_allocator;
+	n[20]: field.0       n[19] => _62 @ bb31[2]:  fn exercise_allocator;
+	n[21]: addr.load     n[20] => _   @ bb31[2]:  fn exercise_allocator;
+	n[22]: copy          n[1]  => _64 @ bb29[15]: fn exercise_allocator;
+	n[23]: offset[2]     n[22] => _63 @ bb29[20]: fn exercise_allocator;
+	n[24]: field.0       n[23] => _62 @ bb31[2]:  fn exercise_allocator;
+	n[25]: addr.load     n[24] => _   @ bb31[2]:  fn exercise_allocator;
+	n[26]: copy          n[1]  => _73 @ bb39[7]:  fn exercise_allocator;
+	n[27]: copy          n[26] => _72 @ bb39[8]:  fn exercise_allocator;
+	n[28]: free          n[27] => _71 @ bb39[9]:  fn exercise_allocator;
+}
+nodes_that_need_write = [13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+
+g[26] {
+	n[0]: &_61 _    => _60 @ bb29[7]:  fn exercise_allocator;
+	n[1]: copy n[0] => _59 @ bb29[8]:  fn exercise_allocator;
+	n[2]: copy n[1] => _58 @ bb29[10]: fn exercise_allocator;
+	n[3]: copy n[2] => _1  @ bb0[0]:   fn printf;            
+}
+nodes_that_need_write = []
+
+g[27] {
+	n[0]:  malloc(n = 1) _     => _74  @ bb41[2]:  fn exercise_allocator;
+	n[1]:  copy          n[0]  => _1   @ bb42[3]:  fn exercise_allocator;
+	n[2]:  copy          n[1]  => _79  @ bb42[7]:  fn exercise_allocator;
+	n[3]:  offset[0]     n[2]  => _78  @ bb42[7]:  fn exercise_allocator;
+	n[4]:  field.0       n[3]  => _    @ bb43[1]:  fn exercise_allocator;
+	n[5]:  addr.store    n[4]  => _    @ bb43[1]:  fn exercise_allocator;
+	n[6]:  copy          n[1]  => _81  @ bb43[6]:  fn exercise_allocator;
+	n[7]:  offset[1]     n[6]  => _80  @ bb43[6]:  fn exercise_allocator;
+	n[8]:  field.0       n[7]  => _    @ bb44[1]:  fn exercise_allocator;
+	n[9]:  addr.store    n[8]  => _    @ bb44[1]:  fn exercise_allocator;
+	n[10]: copy          n[1]  => _83  @ bb44[6]:  fn exercise_allocator;
+	n[11]: offset[2]     n[10] => _82  @ bb44[6]:  fn exercise_allocator;
+	n[12]: field.0       n[11] => _    @ bb45[1]:  fn exercise_allocator;
+	n[13]: addr.store    n[12] => _    @ bb45[1]:  fn exercise_allocator;
+	n[14]: copy          n[1]  => _85  @ bb45[6]:  fn exercise_allocator;
+	n[15]: offset[3]     n[14] => _84  @ bb45[6]:  fn exercise_allocator;
+	n[16]: field.0       n[15] => _    @ bb46[1]:  fn exercise_allocator;
+	n[17]: addr.store    n[16] => _    @ bb46[1]:  fn exercise_allocator;
+	n[18]: copy          n[1]  => _97  @ bb49[15]: fn exercise_allocator;
+	n[19]: offset[0]     n[18] => _96  @ bb49[20]: fn exercise_allocator;
+	n[20]: field.0       n[19] => _95  @ bb51[2]:  fn exercise_allocator;
+	n[21]: addr.load     n[20] => _    @ bb51[2]:  fn exercise_allocator;
+	n[22]: copy          n[1]  => _97  @ bb49[15]: fn exercise_allocator;
+	n[23]: offset[1]     n[22] => _96  @ bb49[20]: fn exercise_allocator;
+	n[24]: field.0       n[23] => _95  @ bb51[2]:  fn exercise_allocator;
+	n[25]: addr.load     n[24] => _    @ bb51[2]:  fn exercise_allocator;
+	n[26]: copy          n[1]  => _97  @ bb49[15]: fn exercise_allocator;
+	n[27]: offset[2]     n[26] => _96  @ bb49[20]: fn exercise_allocator;
+	n[28]: field.0       n[27] => _95  @ bb51[2]:  fn exercise_allocator;
+	n[29]: addr.load     n[28] => _    @ bb51[2]:  fn exercise_allocator;
+	n[30]: copy          n[1]  => _97  @ bb49[15]: fn exercise_allocator;
+	n[31]: offset[3]     n[30] => _96  @ bb49[20]: fn exercise_allocator;
+	n[32]: field.0       n[31] => _95  @ bb51[2]:  fn exercise_allocator;
+	n[33]: addr.load     n[32] => _    @ bb51[2]:  fn exercise_allocator;
+	n[34]: copy          n[1]  => _106 @ bb59[7]:  fn exercise_allocator;
+	n[35]: copy          n[34] => _105 @ bb59[8]:  fn exercise_allocator;
+	n[36]: free          n[35] => _104 @ bb59[9]:  fn exercise_allocator;
+}
+nodes_that_need_write = [17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+
+g[28] {
+	n[0]: &_94 _    => _93 @ bb49[7]:  fn exercise_allocator;
+	n[1]: copy n[0] => _92 @ bb49[8]:  fn exercise_allocator;
+	n[2]: copy n[1] => _91 @ bb49[10]: fn exercise_allocator;
+	n[3]: copy n[2] => _1  @ bb0[0]:   fn printf;            
+}
+nodes_that_need_write = []
+
+g[29] {
+	n[0]: malloc(n = 1) _    => _2  @ bb1[2]:  fn simple_analysis;
+	n[1]: copy          n[0] => _1  @ bb2[2]:  fn simple_analysis;
+	n[2]: field.0       n[1] => _   @ bb2[5]:  fn simple_analysis;
+	n[3]: addr.store    n[2] => _   @ bb2[5]:  fn simple_analysis;
+	n[4]: field.0       n[1] => _10 @ bb2[18]: fn simple_analysis;
+	n[5]: addr.load     n[4] => _   @ bb2[18]: fn simple_analysis;
+	n[6]: copy          n[1] => _13 @ bb3[8]:  fn simple_analysis;
+	n[7]: copy          n[6] => _12 @ bb3[9]:  fn simple_analysis;
+	n[8]: free          n[7] => _11 @ bb3[10]: fn simple_analysis;
+}
+nodes_that_need_write = [3, 2, 1, 0]
+
+g[30] {
+	n[0]: &_9  _    => _8 @ bb2[13]: fn simple_analysis;
+	n[1]: copy n[0] => _7 @ bb2[14]: fn simple_analysis;
+	n[2]: copy n[1] => _6 @ bb2[16]: fn simple_analysis;
+	n[3]: copy n[2] => _1 @ bb0[0]:  fn printf;         
+}
+nodes_that_need_write = []
+
+g[31] {
+	n[0]:  malloc(n = 1) _    => _2 @ bb1[2]:  fn analysis2;       
+	n[1]:  copy          n[0] => _1 @ bb2[2]:  fn analysis2;       
+	n[2]:  field.0       n[1] => _  @ bb2[5]:  fn analysis2;       
+	n[3]:  addr.store    n[2] => _  @ bb2[5]:  fn analysis2;       
+	n[4]:  copy          n[1] => _6 @ bb2[9]:  fn analysis2;       
+	n[5]:  copy          n[4] => _1 @ bb0[0]:  fn analysis2_helper;
+	n[6]:  field.0       n[5] => _7 @ bb0[12]: fn analysis2_helper;
+	n[7]:  addr.load     n[6] => _  @ bb0[12]: fn analysis2_helper;
+	n[8]:  copy          n[5] => _9 @ bb3[6]:  fn analysis2;       
+	n[9]:  copy          n[8] => _8 @ bb3[7]:  fn analysis2;       
+	n[10]: free          n[9] => _7 @ bb3[8]:  fn analysis2;       
+}
+nodes_that_need_write = [3, 2, 1, 0]
+
+g[32] {
+	n[0]: &_6  _    => _5 @ bb0[7]:  fn analysis2_helper;
+	n[1]: copy n[0] => _4 @ bb0[8]:  fn analysis2_helper;
+	n[2]: copy n[1] => _3 @ bb0[10]: fn analysis2_helper;
+	n[3]: copy n[2] => _1 @ bb0[0]:  fn printf;          
+}
+nodes_that_need_write = []
+
+g[33] {
+	n[0]: malloc(n = 1) _    => _0  @ bb0[2]:  fn malloc_wrapper;         
+	n[1]: copy          n[0] => _2  @ bb2[0]:  fn inter_function_analysis;
+	n[2]: copy          n[1] => _1  @ bb2[2]:  fn inter_function_analysis;
+	n[3]: field.0       n[2] => _   @ bb2[5]:  fn inter_function_analysis;
+	n[4]: addr.store    n[3] => _   @ bb2[5]:  fn inter_function_analysis;
+	n[5]: field.0       n[2] => _10 @ bb2[18]: fn inter_function_analysis;
+	n[6]: addr.load     n[5] => _   @ bb2[18]: fn inter_function_analysis;
+	n[7]: copy          n[2] => _13 @ bb3[8]:  fn inter_function_analysis;
+	n[8]: copy          n[7] => _12 @ bb3[9]:  fn inter_function_analysis;
+	n[9]: free          n[8] => _11 @ bb3[10]: fn inter_function_analysis;
+}
+nodes_that_need_write = [4, 3, 2, 1, 0]
+
+g[34] {
+	n[0]: &_9  _    => _8 @ bb2[13]: fn inter_function_analysis;
+	n[1]: copy n[0] => _7 @ bb2[14]: fn inter_function_analysis;
+	n[2]: copy n[1] => _6 @ bb2[16]: fn inter_function_analysis;
+	n[3]: copy n[2] => _1 @ bb0[0]:  fn printf;                 
+}
+nodes_that_need_write = []
+
+g[35] {
+	n[0]: malloc(n = 1) _    => _2       @ bb1[2]: fn no_owner;
+	n[1]: value.store   n[0] => _5.Deref @ bb2[4]: fn no_owner;
+}
+nodes_that_need_write = []
+
+g[36] {
+	n[0]:  copy       _    => _5  @ bb2[3]:  fn no_owner;
+	n[1]:  addr.store n[0] => _   @ bb2[3]:  fn no_owner;
+	n[2]:  copy       _    => _5  @ bb2[3]:  fn no_owner;
+	n[3]:  addr.store n[0] => _   @ bb2[3]:  fn no_owner;
+	n[4]:  copy       _    => _12 @ bb3[5]:  fn no_owner;
+	n[5]:  addr.load  n[0] => _   @ bb3[5]:  fn no_owner;
+	n[6]:  copy       _    => _6  @ bb2[10]: fn invalid; 
+	n[7]:  addr.store n[0] => _   @ bb2[10]: fn invalid; 
+	n[8]:  copy       _    => _19 @ bb3[18]: fn invalid; 
+	n[9]:  field.0    n[8] => _18 @ bb3[18]: fn invalid; 
+	n[10]: addr.load  n[9] => _   @ bb3[18]: fn invalid; 
+	n[11]: copy       _    => _20 @ bb4[7]:  fn invalid; 
+	n[12]: addr.store n[0] => _   @ bb4[7]:  fn invalid; 
+}
+nodes_that_need_write = [12, 7, 3, 1, 0]
+
+g[37] {
+	n[0]: malloc(n = 1) _    => _2       @ bb1[2]: fn no_owner;
+	n[1]: value.store   n[0] => _5.Deref @ bb2[4]: fn no_owner;
+	n[2]: value.load    _    => _11      @ bb3[6]: fn no_owner;
+	n[3]: copy          n[2] => _10      @ bb3[7]: fn no_owner;
+	n[4]: free          n[3] => _9       @ bb3[8]: fn no_owner;
+}
+nodes_that_need_write = []
+
+g[38] {
+	n[0]:  malloc(n = 1) _    => _2       @ bb1[2]:  fn invalid;
+	n[1]:  copy          n[0] => _1       @ bb2[2]:  fn invalid;
+	n[2]:  field.0       n[1] => _        @ bb2[5]:  fn invalid;
+	n[3]:  addr.store    n[2] => _        @ bb2[5]:  fn invalid;
+	n[4]:  copy          n[1] => _5       @ bb2[8]:  fn invalid;
+	n[5]:  value.store   n[4] => _6.Deref @ bb2[11]: fn invalid;
+	n[6]:  field.0       n[1] => _12      @ bb2[25]: fn invalid;
+	n[7]:  addr.load     n[6] => _        @ bb2[25]: fn invalid;
+	n[8]:  copy          n[1] => _23      @ bb4[13]: fn invalid;
+	n[9]:  copy          n[8] => _22      @ bb4[14]: fn invalid;
+	n[10]: free          n[9] => _21      @ bb4[15]: fn invalid;
+}
+nodes_that_need_write = [3, 2, 1, 0]
+
+g[39] {
+	n[0]: &_11 _    => _10 @ bb2[20]: fn invalid;
+	n[1]: copy n[0] => _9  @ bb2[21]: fn invalid;
+	n[2]: copy n[1] => _8  @ bb2[23]: fn invalid;
+	n[3]: copy n[2] => _1  @ bb0[0]:  fn printf; 
+}
+nodes_that_need_write = []
+
+g[40] {
+	n[0]: &_17 _    => _16 @ bb3[11]: fn invalid;
+	n[1]: copy n[0] => _15 @ bb3[12]: fn invalid;
+	n[2]: copy n[1] => _14 @ bb3[14]: fn invalid;
+	n[3]: copy n[2] => _1  @ bb0[0]:  fn printf; 
+}
+nodes_that_need_write = []
+
+g[41] {
+	n[0]: copy _ => _4 @ bb0[8]: fn testing;
+}
+nodes_that_need_write = []
+
+g[42] {
+	n[0]: &_4  _    => _3 @ bb0[10]: fn testing;
+	n[1]: copy n[0] => _5 @ bb0[13]: fn testing;
+}
+nodes_that_need_write = []
+
+g[43] {
+	n[0]: copy _ => _7 @ bb0[16]: fn testing;
+}
+nodes_that_need_write = []
+
+g[44] {
+	n[0]: &_7         _    => _6       @ bb0[18]: fn testing;
+	n[1]: value.store n[0] => _5.Deref @ bb0[19]: fn testing;
+}
+nodes_that_need_write = []
+
+g[45] {
+	n[0]: addr.store _ => _ @ bb0[18]: fn testing;
+}
+nodes_that_need_write = [0]
+
+g[46] {
+	n[0]: malloc(n = 1) _    => _2  @ bb1[2]:  fn simple1;
+	n[1]: copy          n[0] => _1  @ bb2[2]:  fn simple1;
+	n[2]: copy          n[1] => _8  @ bb2[9]:  fn simple1;
+	n[3]: copy          n[2] => _7  @ bb2[10]: fn simple1;
+	n[4]: free          n[3] => _6  @ bb3[2]:  fn simple1;
+	n[5]: copy          n[1] => _16 @ bb4[21]: fn simple1;
+	n[6]: ptr_to_int    n[5] => _   @ bb4[21]: fn simple1;
+	n[7]: copy          n[1] => _21 @ bb4[34]: fn simple1;
+	n[8]: copy          n[7] => _20 @ bb4[35]: fn simple1;
+	n[9]: free          n[8] => _19 @ bb4[36]: fn simple1;
+}
+nodes_that_need_write = []
+
+g[47] {
+	n[0]: malloc(n = 1) _    => _6  @ bb3[2]:  fn simple1;
+	n[1]: copy          n[0] => _5  @ bb4[3]:  fn simple1;
+	n[2]: copy          n[1] => _11 @ bb4[7]:  fn simple1;
+	n[3]: field.0       n[2] => _   @ bb4[8]:  fn simple1;
+	n[4]: addr.store    n[3] => _   @ bb4[8]:  fn simple1;
+	n[5]: copy          n[1] => _12 @ bb4[11]: fn simple1;
+	n[6]: copy          n[2] => _13 @ bb4[14]: fn simple1;
+	n[7]: int_to_ptr    _    => _17 @ bb4[28]: fn simple1;
+}
+nodes_that_need_write = [4, 3, 2, 1, 0]
+
+g[48] {
+	n[0]: &_13 _ => _14 @ bb4[17]: fn simple1;
+}
+nodes_that_need_write = []
+
+g[49] {
+	n[0]: malloc(n = 1) _    => _1 @ bb1[2]: fn test_malloc_free;
+	n[1]: copy          n[0] => _5 @ bb2[5]: fn test_malloc_free;
+	n[2]: free          n[1] => _4 @ bb2[5]: fn test_malloc_free;
+}
+nodes_that_need_write = []
+
+g[50] {
+	n[0]: malloc(n = 1) _    => _2 @ bb1[2]:  fn test_malloc_free_cast;
+	n[1]: copy          n[0] => _1 @ bb2[2]:  fn test_malloc_free_cast;
+	n[2]: copy          n[1] => _7 @ bb2[8]:  fn test_malloc_free_cast;
+	n[3]: copy          n[2] => _6 @ bb2[9]:  fn test_malloc_free_cast;
+	n[4]: free          n[3] => _5 @ bb2[10]: fn test_malloc_free_cast;
+}
+nodes_that_need_write = []
+
+g[51] {
+	n[0]: malloc(n = 1) _    => _1 @ bb1[2]: fn test_arg;
+	n[1]: copy          n[0] => _5 @ bb2[5]: fn test_arg;
+	n[2]: copy          n[1] => _1 @ bb0[0]: fn foo;     
+	n[3]: copy          n[2] => _2 @ bb0[2]: fn foo;     
+	n[4]: copy          n[2] => _6 @ bb3[4]: fn test_arg;
+}
+nodes_that_need_write = []
+
+g[52] {
+	n[0]:  malloc(n = 1) _     => _1  @ bb1[2]: fn test_arg_rec;
+	n[1]:  copy          n[0]  => _5  @ bb2[5]: fn test_arg_rec;
+	n[2]:  copy          n[1]  => _2  @ bb0[0]: fn foo_rec;     
+	n[3]:  copy          n[2]  => _11 @ bb3[4]: fn foo_rec;     
+	n[4]:  copy          n[3]  => _2  @ bb0[0]: fn foo_rec;     
+	n[5]:  copy          n[4]  => _11 @ bb3[4]: fn foo_rec;     
+	n[6]:  copy          n[5]  => _2  @ bb0[0]: fn foo_rec;     
+	n[7]:  copy          n[6]  => _11 @ bb3[4]: fn foo_rec;     
+	n[8]:  copy          n[7]  => _2  @ bb0[0]: fn foo_rec;     
+	n[9]:  copy          n[8]  => _0  @ bb8[3]: fn foo_rec;     
+	n[10]: copy          n[9]  => _7  @ bb4[0]: fn foo_rec;     
+	n[11]: copy          n[10] => _12 @ bb4[5]: fn foo_rec;     
+	n[12]: copy          n[11] => _0  @ bb4[7]: fn foo_rec;     
+	n[13]: copy          n[12] => _7  @ bb4[0]: fn foo_rec;     
+	n[14]: copy          n[13] => _12 @ bb4[5]: fn foo_rec;     
+	n[15]: copy          n[14] => _0  @ bb4[7]: fn foo_rec;     
+	n[16]: copy          n[15] => _7  @ bb4[0]: fn foo_rec;     
+	n[17]: copy          n[16] => _12 @ bb4[5]: fn foo_rec;     
+	n[18]: copy          n[17] => _0  @ bb4[7]: fn foo_rec;     
+	n[19]: copy          n[18] => _4  @ bb3[0]: fn test_arg_rec;
+}
+nodes_that_need_write = []
+
+g[53] {
+	n[0]: malloc(n = 1) _    => _1 @ bb1[2]: fn test_realloc_reassign;
+	n[1]: copy          n[0] => _5 @ bb2[5]: fn test_realloc_reassign;
+	n[2]: free          n[1] => _4 @ bb4[2]: fn test_realloc_reassign;
+}
+nodes_that_need_write = []
+
+g[54] {
+	n[0]: malloc(n = 1) _    => _4  @ bb4[2]: fn test_realloc_reassign;
+	n[1]: copy          n[0] => _1  @ bb5[3]: fn test_realloc_reassign;
+	n[2]: copy          n[1] => _11 @ bb5[7]: fn test_realloc_reassign;
+	n[3]: free          n[2] => _10 @ bb5[7]: fn test_realloc_reassign;
+}
+nodes_that_need_write = []
+
+g[55] {
+	n[0]: malloc(n = 1) _    => _1 @ bb1[2]: fn test_realloc_fresh;
+	n[1]: copy          n[0] => _5 @ bb2[5]: fn test_realloc_fresh;
+	n[2]: free          n[1] => _4 @ bb3[2]: fn test_realloc_fresh;
+}
+nodes_that_need_write = []
+
+g[56] {
+	n[0]: malloc(n = 1) _    => _4 @ bb3[2]: fn test_realloc_fresh;
+	n[1]: copy          n[0] => _9 @ bb4[6]: fn test_realloc_fresh;
+	n[2]: free          n[1] => _8 @ bb4[6]: fn test_realloc_fresh;
+}
+nodes_that_need_write = []
+
+g[57] {
+	n[0]: malloc(n = 1) _    => _2 @ bb1[2]:  fn test_load_addr;
+	n[1]: copy          n[0] => _1 @ bb2[2]:  fn test_load_addr;
+	n[2]: addr.load     n[0] => _  @ bb2[5]:  fn test_load_addr;
+	n[3]: copy          n[1] => _8 @ bb2[11]: fn test_load_addr;
+	n[4]: copy          n[3] => _7 @ bb2[12]: fn test_load_addr;
+	n[5]: free          n[4] => _6 @ bb2[13]: fn test_load_addr;
+}
+nodes_that_need_write = []
+
+g[58] {
+	n[0]: malloc(n = 1) _ => _1 @ bb1[2]: fn test_overwrite;
+}
+nodes_that_need_write = []
+
+g[59] {
+	n[0]: malloc(n = 1) _    => _4 @ bb3[2]: fn test_overwrite;
+	n[1]: copy          n[0] => _7 @ bb4[4]: fn test_overwrite;
+	n[2]: copy          n[1] => _1 @ bb4[5]: fn test_overwrite;
+	n[3]: copy          n[2] => _9 @ bb4[9]: fn test_overwrite;
+	n[4]: free          n[3] => _8 @ bb4[9]: fn test_overwrite;
+}
+nodes_that_need_write = []
+
+g[60] {
+	n[0]: malloc(n = 1) _    => _2 @ bb1[2]:  fn test_store_addr;
+	n[1]: copy          n[0] => _1 @ bb2[2]:  fn test_store_addr;
+	n[2]: field.0       n[1] => _  @ bb2[4]:  fn test_store_addr;
+	n[3]: addr.store    n[2] => _  @ bb2[4]:  fn test_store_addr;
+	n[4]: copy          n[1] => _7 @ bb2[9]:  fn test_store_addr;
+	n[5]: copy          n[4] => _6 @ bb2[10]: fn test_store_addr;
+	n[6]: free          n[5] => _5 @ bb2[11]: fn test_store_addr;
+}
+nodes_that_need_write = [3, 2, 1, 0]
+
+g[61] {
+	n[0]: malloc(n = 1) _    => _2  @ bb1[2]:  fn test_load_other_store_self;
+	n[1]: copy          n[0] => _1  @ bb2[2]:  fn test_load_other_store_self;
+	n[2]: field.0       n[1] => _   @ bb4[4]:  fn test_load_other_store_self;
+	n[3]: addr.store    n[2] => _   @ bb4[4]:  fn test_load_other_store_self;
+	n[4]: field.0       n[1] => _9  @ bb4[6]:  fn test_load_other_store_self;
+	n[5]: addr.load     n[4] => _   @ bb4[6]:  fn test_load_other_store_self;
+	n[6]: copy          n[1] => _12 @ bb4[13]: fn test_load_other_store_self;
+	n[7]: copy          n[6] => _11 @ bb4[14]: fn test_load_other_store_self;
+	n[8]: free          n[7] => _10 @ bb4[15]: fn test_load_other_store_self;
+}
+nodes_that_need_write = [3, 2, 1, 0]
+
+g[62] {
+	n[0]: malloc(n = 1) _    => _6  @ bb3[2]: fn test_load_other_store_self;
+	n[1]: copy          n[0] => _5  @ bb4[2]: fn test_load_other_store_self;
+	n[2]: field.0       n[1] => _   @ bb4[7]: fn test_load_other_store_self;
+	n[3]: addr.store    n[2] => _   @ bb4[7]: fn test_load_other_store_self;
+	n[4]: copy          n[1] => _15 @ bb5[6]: fn test_load_other_store_self;
+	n[5]: copy          n[4] => _14 @ bb5[7]: fn test_load_other_store_self;
+	n[6]: free          n[5] => _13 @ bb5[8]: fn test_load_other_store_self;
+}
+nodes_that_need_write = [3, 2, 1, 0]
+
+g[63] {
+	n[0]:  malloc(n = 1) _    => _2 @ bb1[2]:  fn test_load_self_store_self;
+	n[1]:  copy          n[0] => _1 @ bb2[3]:  fn test_load_self_store_self;
+	n[2]:  field.3       n[1] => _  @ bb2[6]:  fn test_load_self_store_self;
+	n[3]:  field.3       n[2] => _6 @ bb2[6]:  fn test_load_self_store_self;
+	n[4]:  addr.load     n[3] => _  @ bb2[6]:  fn test_load_self_store_self;
+	n[5]:  field.3       n[1] => _  @ bb2[7]:  fn test_load_self_store_self;
+	n[6]:  field.3       n[5] => _  @ bb2[7]:  fn test_load_self_store_self;
+	n[7]:  addr.store    n[6] => _  @ bb2[7]:  fn test_load_self_store_self;
+	n[8]:  copy          n[1] => _9 @ bb2[13]: fn test_load_self_store_self;
+	n[9]:  copy          n[8] => _8 @ bb2[14]: fn test_load_self_store_self;
+	n[10]: free          n[9] => _7 @ bb2[15]: fn test_load_self_store_self;
+}
+nodes_that_need_write = [7, 6, 5, 1, 0]
+
+g[64] {
+	n[0]: malloc(n = 1) _    => _2  @ bb1[2]:  fn test_load_self_store_self_inter;
+	n[1]: copy          n[0] => _1  @ bb2[3]:  fn test_load_self_store_self_inter;
+	n[2]: field.0       n[1] => _6  @ bb2[6]:  fn test_load_self_store_self_inter;
+	n[3]: addr.load     n[2] => _   @ bb2[6]:  fn test_load_self_store_self_inter;
+	n[4]: field.0       n[1] => _   @ bb2[10]: fn test_load_self_store_self_inter;
+	n[5]: addr.store    n[4] => _   @ bb2[10]: fn test_load_self_store_self_inter;
+	n[6]: copy          n[1] => _10 @ bb2[16]: fn test_load_self_store_self_inter;
+	n[7]: copy          n[6] => _9  @ bb2[17]: fn test_load_self_store_self_inter;
+	n[8]: free          n[7] => _8  @ bb2[18]: fn test_load_self_store_self_inter;
+}
+nodes_that_need_write = [5, 4, 1, 0]
+
+g[65] {
+	n[0]: malloc(n = 1) _    => _1 @ bb1[2]:  fn test_ptr_int_ptr;
+	n[1]: copy          n[0] => _5 @ bb2[5]:  fn test_ptr_int_ptr;
+	n[2]: ptr_to_int    n[1] => _  @ bb2[5]:  fn test_ptr_int_ptr;
+	n[3]: int_to_ptr    _    => _1 @ bb2[11]: fn test_ptr_int_ptr;
+	n[4]: copy          n[3] => _8 @ bb2[15]: fn test_ptr_int_ptr;
+	n[5]: free          n[4] => _7 @ bb2[15]: fn test_ptr_int_ptr;
+}
+nodes_that_need_write = []
+
+g[66] {
+	n[0]: malloc(n = 1) _    => _1 @ bb1[2]: fn test_load_value;
+	n[1]: value.load    _    => _6 @ bb2[8]: fn test_load_value;
+	n[2]: free          n[1] => _5 @ bb2[8]: fn test_load_value;
+}
+nodes_that_need_write = []
+
+g[67] {
+	n[0]: &_1       _    => _4 @ bb2[4]: fn test_load_value;
+	n[1]: addr.load n[0] => _  @ bb2[7]: fn test_load_value;
+}
+nodes_that_need_write = []
+
+g[68] {
+	n[0]: malloc(n = 1) _    => _1       @ bb1[2]:  fn test_store_value;
+	n[1]: copy          n[0] => _4       @ bb2[4]:  fn test_store_value;
+	n[2]: copy          n[1] => _6       @ bb2[10]: fn test_store_value;
+	n[3]: value.store   n[2] => _5.Deref @ bb2[11]: fn test_store_value;
+	n[4]: copy          n[0] => _8       @ bb2[15]: fn test_store_value;
+	n[5]: free          n[4] => _7       @ bb2[15]: fn test_store_value;
+}
+nodes_that_need_write = []
+
+g[69] {
+	n[0]: &_1        _    => _5 @ bb2[7]:  fn test_store_value;
+	n[1]: addr.store n[0] => _  @ bb2[10]: fn test_store_value;
+}
+nodes_that_need_write = [1, 0]
+
+g[70] {
+	n[0]:  malloc(n = 1) _    => _2                @ bb1[2]:  fn test_store_value_field;
+	n[1]:  copy          n[0] => _1                @ bb2[2]:  fn test_store_value_field;
+	n[2]:  copy          n[1] => _9                @ bb4[6]:  fn test_store_value_field;
+	n[3]:  value.store   n[2] => _5.Deref.Field(2) @ bb4[7]:  fn test_store_value_field;
+	n[4]:  value.load    _    => _10               @ bb4[10]: fn test_store_value_field;
+	n[5]:  field.2       n[1] => _                 @ bb4[10]: fn test_store_value_field;
+	n[6]:  addr.store    n[5] => _                 @ bb4[10]: fn test_store_value_field;
+	n[7]:  value.store   n[4] => _1.Deref.Field(2) @ bb4[11]: fn test_store_value_field;
+	n[8]:  copy          n[1] => _13               @ bb4[16]: fn test_store_value_field;
+	n[9]:  copy          n[8] => _12               @ bb4[17]: fn test_store_value_field;
+	n[10]: free          n[9] => _11               @ bb4[18]: fn test_store_value_field;
+}
+nodes_that_need_write = [6, 5, 1, 0]
+
+g[71] {
+	n[0]: malloc(n = 1) _    => _6  @ bb3[2]: fn test_store_value_field;
+	n[1]: copy          n[0] => _5  @ bb4[2]: fn test_store_value_field;
+	n[2]: field.2       n[1] => _   @ bb4[6]: fn test_store_value_field;
+	n[3]: addr.store    n[2] => _   @ bb4[6]: fn test_store_value_field;
+	n[4]: field.2       n[1] => _10 @ bb4[9]: fn test_store_value_field;
+	n[5]: addr.load     n[4] => _   @ bb4[9]: fn test_store_value_field;
+}
+nodes_that_need_write = [3, 2, 1, 0]
+
+g[72] {
+	n[0]: malloc(n = 1) _    => _1       @ bb1[2]:  fn test_load_value_store_value;
+	n[1]: value.load    _    => _5       @ bb2[7]:  fn test_load_value_store_value;
+	n[2]: value.store   n[1] => _4.Deref @ bb2[8]:  fn test_load_value_store_value;
+	n[3]: value.load    _    => _7       @ bb2[12]: fn test_load_value_store_value;
+	n[4]: free          n[3] => _6       @ bb2[12]: fn test_load_value_store_value;
+}
+nodes_that_need_write = []
+
+g[73] {
+	n[0]: &_1        _    => _4 @ bb2[4]:  fn test_load_value_store_value;
+	n[1]: addr.load  n[0] => _  @ bb2[6]:  fn test_load_value_store_value;
+	n[2]: addr.store n[0] => _  @ bb2[7]:  fn test_load_value_store_value;
+	n[3]: addr.load  n[0] => _  @ bb2[11]: fn test_load_value_store_value;
+}
+nodes_that_need_write = [2, 0]
+
+g[74] {
+	n[0]: copy _ => _31 @ bb27[4]: fn main_0;
+}
+nodes_that_need_write = []
+
+g[75] {
+	n[0]: copy _ => _37 @ bb27[12]: fn main_0;
+}
+nodes_that_need_write = []
+
+g[76] {
+	n[0]:  &_31       _     => _39 @ bb28[6]:  fn main_0;        
+	n[1]:  copy       n[0]  => _38 @ bb28[7]:  fn main_0;        
+	n[2]:  copy       n[1]  => _2  @ bb0[0]:   fn insertion_sort;
+	n[3]:  copy       n[2]  => _10 @ bb3[4]:   fn insertion_sort;
+	n[4]:  offset[1]  n[3]  => _9  @ bb3[9]:   fn insertion_sort;
+	n[5]:  addr.load  n[4]  => _   @ bb5[2]:   fn insertion_sort;
+	n[6]:  copy       n[2]  => _22 @ bb9[5]:   fn insertion_sort;
+	n[7]:  offset[0]  n[6]  => _21 @ bb11[5]:  fn insertion_sort;
+	n[8]:  addr.load  n[7]  => _   @ bb12[2]:  fn insertion_sort;
+	n[9]:  copy       n[2]  => _47 @ bb24[8]:  fn insertion_sort;
+	n[10]: offset[1]  n[9]  => _46 @ bb24[13]: fn insertion_sort;
+	n[11]: addr.store n[10] => _   @ bb25[2]:  fn insertion_sort;
+	n[12]: copy       n[2]  => _10 @ bb3[4]:   fn insertion_sort;
+	n[13]: offset[2]  n[12] => _9  @ bb3[9]:   fn insertion_sort;
+	n[14]: addr.load  n[13] => _   @ bb5[2]:   fn insertion_sort;
+	n[15]: copy       n[2]  => _22 @ bb9[5]:   fn insertion_sort;
+	n[16]: offset[1]  n[15] => _21 @ bb11[5]:  fn insertion_sort;
+	n[17]: addr.load  n[16] => _   @ bb12[2]:  fn insertion_sort;
+	n[18]: copy       n[2]  => _31 @ bb13[4]:  fn insertion_sort;
+	n[19]: offset[1]  n[18] => _30 @ bb15[5]:  fn insertion_sort;
+	n[20]: addr.load  n[19] => _   @ bb16[2]:  fn insertion_sort;
+	n[21]: copy       n[2]  => _38 @ bb16[6]:  fn insertion_sort;
+	n[22]: offset[2]  n[21] => _37 @ bb16[11]: fn insertion_sort;
+	n[23]: addr.store n[22] => _   @ bb17[2]:  fn insertion_sort;
+	n[24]: copy       n[2]  => _22 @ bb9[5]:   fn insertion_sort;
+	n[25]: offset[0]  n[24] => _21 @ bb11[5]:  fn insertion_sort;
+	n[26]: addr.load  n[25] => _   @ bb12[2]:  fn insertion_sort;
+	n[27]: copy       n[2]  => _47 @ bb24[8]:  fn insertion_sort;
+	n[28]: offset[1]  n[27] => _46 @ bb24[13]: fn insertion_sort;
+	n[29]: addr.store n[28] => _   @ bb25[2]:  fn insertion_sort;
+	n[30]: copy       n[2]  => _10 @ bb3[4]:   fn insertion_sort;
+	n[31]: offset[3]  n[30] => _9  @ bb3[9]:   fn insertion_sort;
+	n[32]: addr.load  n[31] => _   @ bb5[2]:   fn insertion_sort;
+	n[33]: copy       n[2]  => _22 @ bb9[5]:   fn insertion_sort;
+	n[34]: offset[2]  n[33] => _21 @ bb11[5]:  fn insertion_sort;
+	n[35]: addr.load  n[34] => _   @ bb12[2]:  fn insertion_sort;
+	n[36]: copy       n[2]  => _31 @ bb13[4]:  fn insertion_sort;
+	n[37]: offset[2]  n[36] => _30 @ bb15[5]:  fn insertion_sort;
+	n[38]: addr.load  n[37] => _   @ bb16[2]:  fn insertion_sort;
+	n[39]: copy       n[2]  => _38 @ bb16[6]:  fn insertion_sort;
+	n[40]: offset[3]  n[39] => _37 @ bb16[11]: fn insertion_sort;
+	n[41]: addr.store n[40] => _   @ bb17[2]:  fn insertion_sort;
+	n[42]: copy       n[2]  => _22 @ bb9[5]:   fn insertion_sort;
+	n[43]: offset[1]  n[42] => _21 @ bb11[5]:  fn insertion_sort;
+	n[44]: addr.load  n[43] => _   @ bb12[2]:  fn insertion_sort;
+	n[45]: copy       n[2]  => _31 @ bb13[4]:  fn insertion_sort;
+	n[46]: offset[1]  n[45] => _30 @ bb15[5]:  fn insertion_sort;
+	n[47]: addr.load  n[46] => _   @ bb16[2]:  fn insertion_sort;
+	n[48]: copy       n[2]  => _38 @ bb16[6]:  fn insertion_sort;
+	n[49]: offset[2]  n[48] => _37 @ bb16[11]: fn insertion_sort;
+	n[50]: addr.store n[49] => _   @ bb17[2]:  fn insertion_sort;
+	n[51]: copy       n[2]  => _22 @ bb9[5]:   fn insertion_sort;
+	n[52]: offset[0]  n[51] => _21 @ bb11[5]:  fn insertion_sort;
+	n[53]: addr.load  n[52] => _   @ bb12[2]:  fn insertion_sort;
+	n[54]: copy       n[2]  => _31 @ bb13[4]:  fn insertion_sort;
+	n[55]: offset[0]  n[54] => _30 @ bb15[5]:  fn insertion_sort;
+	n[56]: addr.load  n[55] => _   @ bb16[2]:  fn insertion_sort;
+	n[57]: copy       n[2]  => _38 @ bb16[6]:  fn insertion_sort;
+	n[58]: offset[1]  n[57] => _37 @ bb16[11]: fn insertion_sort;
+	n[59]: addr.store n[58] => _   @ bb17[2]:  fn insertion_sort;
+	n[60]: copy       n[2]  => _47 @ bb24[8]:  fn insertion_sort;
+	n[61]: offset[0]  n[60] => _46 @ bb24[13]: fn insertion_sort;
+	n[62]: addr.store n[61] => _   @ bb25[2]:  fn insertion_sort;
+	n[63]: copy       n[2]  => _10 @ bb3[4]:   fn insertion_sort;
+	n[64]: offset[4]  n[63] => _9  @ bb3[9]:   fn insertion_sort;
+	n[65]: addr.load  n[64] => _   @ bb5[2]:   fn insertion_sort;
+	n[66]: copy       n[2]  => _22 @ bb9[5]:   fn insertion_sort;
+	n[67]: offset[3]  n[66] => _21 @ bb11[5]:  fn insertion_sort;
+	n[68]: addr.load  n[67] => _   @ bb12[2]:  fn insertion_sort;
+	n[69]: copy       n[2]  => _47 @ bb24[8]:  fn insertion_sort;
+	n[70]: offset[4]  n[69] => _46 @ bb24[13]: fn insertion_sort;
+	n[71]: addr.store n[70] => _   @ bb25[2]:  fn insertion_sort;
+}
+nodes_that_need_write = [71, 70, 69, 62, 61, 60, 59, 58, 57, 50, 49, 48, 41, 40, 39, 29, 28, 27, 23, 22, 21, 11, 10, 9, 2, 1, 0]
+
+num_graphs = 77
+num_nodes = 501
+


### PR DESCRIPTION
This is an initial (currently quite hacky) version of PDG snapshot testing for `analysis/test`.  Currently it just shells out to `./scripts/pdg.sh` and reads the produced (by `c2rust-pdg`) `analysis/test/pdg.log`.  I intend to improve this a lot (not shell out, but instead invoke library functions in `c2rust_pdg` and `c2rust_dynamic_instrumentation`), but I think it's useful to get a working version running so that we are aware of any PDG changes that occur and can unblock anyone else waiting for this to get more aggressive with changes.

Also, the `snapshots/*.snap` files need to be committed, right?