### PR TITLE
Improve the `c2rust_analysis_rt` env arg parser

### DIFF
--- a/analysis/runtime/src/lib.rs
+++ b/analysis/runtime/src/lib.rs
@@ -3,6 +3,7 @@ mod handlers;
 pub mod metadata;
 pub mod mir_loc;
 pub mod runtime;
+mod parse;
 
 pub use handlers::*;
 use runtime::{global_runtime::RUNTIME, skip::notify_if_events_were_skipped_before_main};

--- a/analysis/runtime/src/parse.rs
+++ b/analysis/runtime/src/parse.rs
@@ -1,0 +1,65 @@
+//! Don't want a huge depedency on `clap`.
+
+use std::{
+    error::Error,
+    fmt::{self, Debug, Display, Formatter},
+    marker::PhantomData,
+};
+
+pub trait AsStr {
+    fn as_str(&self) -> &'static str;
+}
+
+pub trait Choices
+where
+    Self: Sized,
+{
+    fn choices() -> &'static [Self];
+}
+
+impl AsStr for bool {
+    fn as_str(&self) -> &'static str {
+        match self {
+            true => "true",
+            false => "false",
+        }
+    }
+}
+
+impl Choices for bool {
+    fn choices() -> &'static [Self] {
+        &[true, false]
+    }
+}
+
+pub struct ChoiceError<T> {
+    pub found: String,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Choices + AsStr + 'static> Display for ChoiceError<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "found {}, but expected one of ", &self.found)?;
+        f.debug_list()
+            .entries(T::choices().iter().map(|choice| choice.as_str()));
+        Ok(())
+    }
+}
+
+impl<T: Choices + AsStr + 'static> Debug for ChoiceError<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl<T: Choices + AsStr + 'static> Error for ChoiceError<T> {}
+
+pub fn one_of<T: Choices + AsStr + 'static>(s: String) -> Result<&'static T, ChoiceError<T>> {
+    T::choices()
+        .iter()
+        .find(|choice| choice.as_str() == s.as_str())
+        .ok_or(ChoiceError {
+            found: s,
+            _phantom: Default::default(),
+        })
+}

--- a/analysis/runtime/src/parse.rs
+++ b/analysis/runtime/src/parse.rs
@@ -1,7 +1,7 @@
 //! Don't want a huge depedency on `clap`.
 
 use std::{
-    error::Error,
+    ffi::OsStr,
     fmt::{self, Debug, Display, Formatter},
     marker::PhantomData,
 };
@@ -10,11 +10,39 @@ pub trait AsStr {
     fn as_str(&self) -> &'static str;
 }
 
-pub trait Choices
+pub struct Choices<T> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Default for Choices<T> {
+    fn default() -> Self {
+        Self {
+            _phantom: Default::default(),
+        }
+    }
+}
+
+pub trait GetChoices
 where
     Self: Sized,
 {
     fn choices() -> &'static [Self];
+}
+
+impl<T: GetChoices + AsStr + 'static> Debug for Choices<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("one of ")?;
+        f.debug_list()
+            .entries(T::choices().iter().map(|choice| choice.as_str()))
+            .finish()?;
+        Ok(())
+    }
+}
+
+impl<T: GetChoices + AsStr + 'static> Display for Choices<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
 }
 
 impl AsStr for bool {
@@ -26,40 +54,44 @@ impl AsStr for bool {
     }
 }
 
-impl Choices for bool {
+impl GetChoices for bool {
     fn choices() -> &'static [Self] {
         &[true, false]
     }
 }
 
-pub struct ChoiceError<T> {
-    pub found: String,
-    _phantom: PhantomData<T>,
-}
-
-impl<T: Choices + AsStr + 'static> Display for ChoiceError<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "found {}, but expected one of ", &self.found)?;
-        f.debug_list()
-            .entries(T::choices().iter().map(|choice| choice.as_str()));
-        Ok(())
-    }
-}
-
-impl<T: Choices + AsStr + 'static> Debug for ChoiceError<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{self}")
-    }
-}
-
-impl<T: Choices + AsStr + 'static> Error for ChoiceError<T> {}
-
-pub fn one_of<T: Choices + AsStr + 'static>(s: String) -> Result<&'static T, ChoiceError<T>> {
+pub fn one_of<T: GetChoices + AsStr + 'static>(s: &OsStr) -> Result<&'static T, String> {
     T::choices()
         .iter()
-        .find(|choice| choice.as_str() == s.as_str())
-        .ok_or(ChoiceError {
-            found: s,
-            _phantom: Default::default(),
+        .find(|choice| s == OsStr::new(choice.as_str()))
+        .ok_or_else(|| {
+            let s = s.to_string_lossy().into_owned();
+            let choices = Choices::<T>::default();
+            format!("found {s}, but expected {choices}")
         })
+}
+
+pub mod env {
+    use std::{env, ffi::OsStr, path::PathBuf};
+
+    use super::{AsStr, Choices, GetChoices};
+
+    pub fn path<K: AsRef<OsStr>>(var: K) -> Result<PathBuf, String> {
+        let path = env::var_os(var.as_ref()).ok_or_else(|| {
+            let var = var.as_ref().to_string_lossy().into_owned();
+            format!("missing ${var}, must be a path")
+        })?;
+        Ok(path.into())
+    }
+
+    pub fn one_of<K: AsRef<OsStr>, T: GetChoices + AsStr + 'static>(
+        var: K,
+    ) -> Result<&'static T, String> {
+        let value = env::var_os(var.as_ref()).ok_or_else(|| {
+            let var = var.as_ref().to_string_lossy().into_owned();
+            let choices = Choices::<T>::default();
+            format!("missing ${var}, must be {choices}")
+        })?;
+        super::one_of(&value)
+    }
 }

--- a/analysis/runtime/src/parse.rs
+++ b/analysis/runtime/src/parse.rs
@@ -65,9 +65,9 @@ pub fn one_of<T: GetChoices + AsStr + 'static>(s: &OsStr) -> Result<&'static T, 
         .iter()
         .find(|choice| s == OsStr::new(choice.as_str()))
         .ok_or_else(|| {
-            let s = s.to_string_lossy().into_owned();
+            let s = s.to_string_lossy();
             let choices = Choices::<T>::default();
-            format!("found {s}, but expected {choices}")
+            format!("found \"{s}\", but expected {choices}")
         })
 }
 
@@ -88,7 +88,7 @@ pub mod env {
         var: K,
     ) -> Result<&'static T, String> {
         let value = env::var_os(var.as_ref()).ok_or_else(|| {
-            let var = var.as_ref().to_string_lossy().into_owned();
+            let var = var.as_ref().to_string_lossy();
             let choices = Choices::<T>::default();
             format!("missing ${var}, must be {choices}")
         })?;

--- a/analysis/runtime/src/parse.rs
+++ b/analysis/runtime/src/parse.rs
@@ -1,4 +1,4 @@
-//! Don't want a huge depedency on `clap`.
+//! Don't want a huge dependency on `clap`.
 
 use std::{
     ffi::OsStr,

--- a/analysis/runtime/src/runtime/backend.rs
+++ b/analysis/runtime/src/runtime/backend.rs
@@ -99,8 +99,7 @@ impl Backend {
 
 impl DetectBackend for DebugBackend {
     fn detect() -> Result<Self, AnyError> {
-        let path =
-            parse::env::path("METADATA_FILE").map_err(|s| format!("instrumentation: {s}"))?;
+        let path = parse::env::path("METADATA_FILE")?;
         // TODO may want to deduplicate this with [`pdg::builder::read_metadata`] in [`Metadata::read`],
         // but that may require adding `color-eyre`/`eyre` as a dependency
         let bytes = fs_err::read(path)?;
@@ -111,10 +110,8 @@ impl DetectBackend for DebugBackend {
 
 impl DetectBackend for LogBackend {
     fn detect() -> Result<Self, AnyError> {
-        let path =
-            parse::env::path("INSTRUMENT_OUTPUT").map_err(|s| format!("instrumentation: {s}"))?;
-        let append: bool = *parse::env::one_of("INSTRUMENT_OUTPUT_APPEND")
-            .map_err(|s| format!("instrumentation: {s}"))?;
+        let path = parse::env::path("INSTRUMENT_OUTPUT")?;
+        let append: bool = *parse::env::one_of("INSTRUMENT_OUTPUT_APPEND")?;
         let file = OpenOptions::new()
             .create(true)
             .write(true)

--- a/analysis/runtime/src/runtime/global_runtime.rs
+++ b/analysis/runtime/src/runtime/global_runtime.rs
@@ -1,3 +1,5 @@
+use std::process;
+
 use once_cell::sync::OnceCell;
 
 use crate::events::Event;
@@ -57,11 +59,15 @@ impl GlobalRuntime {
         self.runtime.get_or_try_init(Runtime::try_init)
     }
 
-    /// Same as [`GlobalRuntime::try_init`] except the [`Result`] is `.unwrap()`ed.
+    /// Same as [`GlobalRuntime::try_init`], if there is an error,
+    /// it is [`eprintln!`]ed [`std::process::exit`] called.
     ///
     /// This (or [`GlobalRuntime::try_init`]), on [`RUNTIME`], should be called at the top of `main`.
     pub fn init(&self) {
-        self.try_init().unwrap();
+        if let Err(e) = self.try_init() {
+            eprintln!("{e}");
+            process::exit(1);
+        }
     }
 
     /// Finalize the [`GlobalRuntime`] by finalizing the [`Runtime`] if it has been initialized.


### PR DESCRIPTION
This improves the environment variable argument parsing in `c2rust_analysis_rt`.  Ideally, we could use something nice like `clap`, but that's a huge dependency (compile-time and size-wise) to add to the runtime (currently it is recompiled on every `c2rust instrument` and already takes 15 seconds on `donna`).

Instead, I added `mod parse`, which contains a manually re-implemented version of something similar to `clap::ArgEnum`, as well as a few wrappers around parsing arguments from environment variables and printing nice, standardized error messages.

Furthermore, instead of calling `GlobalRuntime::try_init().unwrap()` in `initialize`, which prints the `Debug` `impl` of the `Error` and the `.unwrap()` source location (not very useful, as it's not where the error occurs, and backtraces using something like `eyre` might be too heavy for the runtime), we print the `Display` `impl` of the `Error` only and then `exit(1)`.