### PR TITLE
Require `INSTRUMENT_BACKEND` to be `debug` or `log`

### DIFF
--- a/analysis/runtime/src/runtime/backend.rs
+++ b/analysis/runtime/src/runtime/backend.rs
@@ -125,9 +125,7 @@ impl DetectBackend for LogBackend {
 
 impl DetectBackend for BackendKind {
     fn detect() -> Result<Self, AnyError> {
-        Ok(parse::env::one_of("INSTRUMENT_BACKEND")
-            .cloned()
-            .unwrap_or_default())
+        Ok(parse::env::one_of("INSTRUMENT_BACKEND").cloned()?)
     }
 }
 


### PR DESCRIPTION
Require `INSTRUMENT_BACKEND` to be `debug` or `log` instead of silently swallowing errors and defaulting to `debug`.