### PR TITLE
Fix the `clippy::large_enum_variant` warnings that are simple by `Box`ing them

### DIFF
--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -2120,7 +2120,8 @@ impl Builder {
 
     // Foreign Items
 
-    pub fn fn_foreign_item<D>(self, decl: D) -> ForeignItem
+    /// [`ForeignItem`] is large (472 bytes), so [`Box`] it.
+    pub fn fn_foreign_item<D>(self, decl: D) -> Box<ForeignItem>
     where
         D: Make<Box<FnDecl>>,
     {
@@ -2131,22 +2132,23 @@ impl Builder {
             generics: self.generics.clone(),
             ..decl.make(&self)
         };
-        ForeignItem::Fn(ForeignItemFn {
+        Box::new(ForeignItem::Fn(ForeignItemFn {
             attrs: self.attrs,
             vis: self.vis,
             sig,
             semi_token: token::Semi(self.span),
-        })
+        }))
     }
 
-    pub fn static_foreign_item<I, T>(self, name: I, ty: T) -> ForeignItem
+    /// [`ForeignItem`] is large (472 bytes), so [`Box`] it.
+    pub fn static_foreign_item<I, T>(self, name: I, ty: T) -> Box<ForeignItem>
     where
         I: Make<Ident>,
         T: Make<Box<Type>>,
     {
         let name = name.make(&self);
         let ty = ty.make(&self);
-        ForeignItem::Static(ForeignItemStatic {
+        Box::new(ForeignItem::Static(ForeignItemStatic {
             attrs: self.attrs,
             vis: self.vis,
             mutability: self.mutbl.to_token(),
@@ -2155,21 +2157,22 @@ impl Builder {
             static_token: token::Static(self.span),
             colon_token: token::Colon(self.span),
             semi_token: token::Semi(self.span),
-        })
+        }))
     }
 
-    pub fn ty_foreign_item<I>(self, name: I) -> ForeignItem
+    /// [`ForeignItem`] is large (472 bytes), so [`Box`] it.
+    pub fn ty_foreign_item<I>(self, name: I) -> Box<ForeignItem>
     where
         I: Make<Ident>,
     {
         let name = name.make(&self);
-        ForeignItem::Type(ForeignItemType {
+        Box::new(ForeignItem::Type(ForeignItemType {
             attrs: self.attrs,
             vis: self.vis,
             ident: name,
             type_token: token::Type(self.span),
             semi_token: token::Semi(self.span),
-        })
+        }))
     }
 
     pub fn mac_foreign_item<M>(self, mac: M) -> ForeignItem

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -657,7 +657,7 @@ pub fn translate(
                                 t.insert_item(item, decl);
                             }
                             ForeignItem(item) => {
-                                t.insert_foreign_item(item, decl);
+                                t.insert_foreign_item(*item, decl);
                             }
                             Items(items) => {
                                 for item in items {
@@ -744,7 +744,7 @@ pub fn translate(
                                 t.insert_item(item, decl);
                             }
                             ForeignItem(item) => {
-                                t.insert_foreign_item(item, decl);
+                                t.insert_foreign_item(*item, decl);
                             }
                             Items(items) => {
                                 for item in items {
@@ -1174,7 +1174,8 @@ pub enum ExprUse {
 /// into a single extern block at the end of translation.
 #[derive(Debug)]
 pub enum ConvertedDecl {
-    ForeignItem(ForeignItem), // 472 bytes
+    /// [`ForeignItem`] is large (472 bytes), so [`Box`] it.
+    ForeignItem(Box<ForeignItem>), // 472 bytes
     Item(Box<Item>),          // 24 bytes
     Items(Vec<Box<Item>>),    // 24 bytes
     NoItem,
@@ -2828,7 +2829,7 @@ impl<'c> Translation<'c> {
                     let items = match self.convert_decl(ctx, decl_id)? {
                         Item(item) => vec![item],
                         ForeignItem(item) => {
-                            vec![mk().extern_("C").foreign_items(vec![item])]
+                            vec![mk().extern_("C").foreign_items(vec![*item])]
                         }
                         Items(items) => items,
                         NoItem => return Ok(cfg::DeclStmtInfo::empty()),

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -1175,7 +1175,7 @@ pub enum ExprUse {
 #[derive(Debug)]
 pub enum ConvertedDecl {
     /// [`ForeignItem`] is large (472 bytes), so [`Box`] it.
-    ForeignItem(Box<ForeignItem>), // 472 bytes
+    ForeignItem(Box<ForeignItem>), // would be 472 bytes
     Item(Box<Item>),          // 24 bytes
     Items(Vec<Box<Item>>),    // 24 bytes
     NoItem,


### PR DESCRIPTION
This fixes 2/3 of the `clippy::large_enum_variant` warnings by simply `Box`ing their large variant (or field of that variant) when doing so causes minimal code changes (`Field`)/code changes that are still relatively simple and follow the style of existing code (`ForeignItem`).