### PR TITLE
make build.rs scripts work without rustup

### DIFF
--- a/analysis/build.rs
+++ b/analysis/build.rs
@@ -3,13 +3,17 @@ use std::path::Path;
 use std::process::Command;
 use std::str;
 
-fn main() {
+fn main() -> std::io::Result<()> {
     // Add the toolchain lib/ directory to `-L`.  This fixes the linker error "cannot find
     // -lLLVM-13-rust-1.60.0-nightly".
     let out = Command::new("rustup")
         .args(&["which", "rustc"])
         .output()
-        .unwrap();
+        .or_else(|_| {
+            Command::new("which")
+            .args(&["rustc"])
+            .output()
+        })?;
     assert!(out.status.success());
     let rustc_path = Path::new(str::from_utf8(&out.stdout).unwrap().trim_end());
     let lib_dir = rustc_path.parent().unwrap().parent().unwrap().join("lib");
@@ -22,4 +26,5 @@ fn main() {
     assert!(out.status.success());
     let sysroot = str::from_utf8(&out.stdout).unwrap();
     println!("cargo:rustc-env=RUST_SYSROOT={}", sysroot)
+    Ok(())
 }

--- a/dynamic_instrumentation/build.rs
+++ b/dynamic_instrumentation/build.rs
@@ -3,13 +3,13 @@ use std::path::Path;
 use std::process::Command;
 use std::str;
 
-fn main() {
+fn main() -> std::io::Result<()> {
     // Add the toolchain lib/ directory to `-L`.  This fixes the linker error "cannot find
     // -lLLVM-13-rust-1.60.0-nightly".
     let out = Command::new("rustup")
         .args(&["which", "rustc"])
         .output()
-        .unwrap();
+        .or_else(|_| Command::new("which").args(&["rustc"]).output())?;
     assert!(out.status.success());
     let rustc_path = Path::new(str::from_utf8(&out.stdout).unwrap().trim_end());
     let lib_dir = rustc_path.parent().unwrap().parent().unwrap().join("lib");
@@ -21,5 +21,6 @@ fn main() {
         .expect("Could not invoke rustc to find rust sysroot");
     assert!(out.status.success());
     let sysroot = str::from_utf8(&out.stdout).unwrap();
-    println!("cargo:rustc-env=RUST_SYSROOT={}", sysroot)
+    println!("cargo:rustc-env=RUST_SYSROOT={}", sysroot);
+    Ok(())
 }

--- a/pdg/build.rs
+++ b/pdg/build.rs
@@ -9,7 +9,10 @@ fn main() -> eyre::Result<()> {
     color_eyre::install()?;
     // Add the toolchain lib/ directory to `-L`.  This fixes the linker error "cannot find
     // -lLLVM-13-rust-1.60.0-nightly".
-    let out = Command::new("rustup").args(&["which", "rustc"]).output()?;
+    let out = Command::new("rustup")
+        .args(&["which", "rustc"])
+        .output()
+        .or_else(|_| Command::new("which").args(&["rustc"]).output())?;
     assert!(out.status.success());
     let rustc_path = Path::new(str::from_utf8(&out.stdout)?.trim_end());
     let lib_dir = rustc_path


### PR DESCRIPTION
Fixes https://github.com/immunant/c2rust/issues/516.

Rustup is useful to install our dependencies at the versions we need, but we don't need to explicitly depend on it; users may install dependencies other ways, too.