### PR TITLE
Refactor `build.rs`s into `rustc-private-link` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "git-testament",
  "log",
  "regex",
+ "rustc-private-link",
  "shlex",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-private-link"
+version = "0.1.0"
+
+[[package]]
 name = "rustc-workspace-hack"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "log",
+ "rustc-private-link",
 ]
 
 [[package]]
@@ -305,6 +306,7 @@ dependencies = [
  "itertools",
  "linked_hash_set",
  "log",
+ "rustc-private-link",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "analysis/runtime",
     "dynamic_instrumentation",
     "pdg",
+    "rustc-private-link",
 ]
 exclude = [
     "cross-checks/pointer-tracer",

--- a/c2rust/Cargo.toml
+++ b/c2rust/Cargo.toml
@@ -27,6 +27,8 @@ shlex = "1.1"
 c2rust-transpile = { version = "0.16.0", path = "../c2rust-transpile" }
 c2rust-dynamic-instrumentation = { version = "0.1.0", path = "../dynamic_instrumentation", optional = true }
 
+[build-dependencies]
+rustc-private-link = { path = "../rustc-private-link" }
 
 [[bin]]
 name = "c2rust-instrument"

--- a/c2rust/build.rs
+++ b/c2rust/build.rs
@@ -1,25 +1,6 @@
-use std::env;
-use std::path::PathBuf;
-use std::process::Command;
+use rustc_private_link::SysRoot;
 
 fn main() {
-    let sysroot = Command::new(env::var("RUSTC").unwrap())
-        .arg("--print=sysroot")
-        .output()
-        .expect("Could not invoke rustc to find rust sysroot");
-    let sysroot = String::from_utf8(sysroot.stdout)
-        .expect("Rust sysroot path contains a non-UTF8 character")
-        .trim()
-        .to_string();
-
-    let mut rustlib_path = PathBuf::new();
-    rustlib_path.push(sysroot);
-    rustlib_path.push("lib/rustlib");
-    rustlib_path.push(env::var("TARGET").unwrap());
-    rustlib_path.push("lib");
-    let path_string = rustlib_path
-        .into_os_string()
-        .into_string()
-        .expect("Unexpected non-Unicode character in rustlib path");
-    println!("cargo:rustc-env=RUSTLIB={}", path_string);
+    let sysroot = SysRoot::resolve();
+    sysroot.set_env_rustlib();
 }

--- a/dynamic_instrumentation/Cargo.toml
+++ b/dynamic_instrumentation/Cargo.toml
@@ -13,5 +13,8 @@ indexmap = "1.8"
 lazy_static = "1.4"
 log = "0.4"
 
+[build-dependencies]
+rustc-private-link = { path = "../rustc-private-link" }
+
 [package.metadata.rust-analyzer] 
 rustc_private=true

--- a/dynamic_instrumentation/build.rs
+++ b/dynamic_instrumentation/build.rs
@@ -1,25 +1,7 @@
-use std::env;
-use std::path::Path;
-use std::process::Command;
-use std::str;
+use rustc_private_link::SysRoot;
 
 fn main() {
-    // Add the toolchain lib/ directory to `-L`.  This fixes the linker error "cannot find
-    // -lLLVM-13-rust-1.60.0-nightly".
-    let out = Command::new("rustup")
-        .args(&["which", "rustc"])
-        .output()
-        .unwrap();
-    assert!(out.status.success());
-    let rustc_path = Path::new(str::from_utf8(&out.stdout).unwrap().trim_end());
-    let lib_dir = rustc_path.parent().unwrap().parent().unwrap().join("lib");
-    println!("cargo:rustc-link-search={}", lib_dir.display());
-
-    let out = Command::new(env::var("RUSTC").unwrap())
-        .arg("--print=sysroot")
-        .output()
-        .expect("Could not invoke rustc to find rust sysroot");
-    assert!(out.status.success());
-    let sysroot = str::from_utf8(&out.stdout).unwrap();
-    println!("cargo:rustc-env=RUST_SYSROOT={}", sysroot)
+    let sysroot = SysRoot::resolve();
+    sysroot.link_rustc_private();
+    sysroot.set_env();
 }

--- a/dynamic_instrumentation/build.rs
+++ b/dynamic_instrumentation/build.rs
@@ -3,5 +3,5 @@ use rustc_private_link::SysRoot;
 fn main() {
     let sysroot = SysRoot::resolve();
     sysroot.link_rustc_private();
-    sysroot.set_env();
+    sysroot.set_env_rust_sysroot();
 }

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -17,7 +17,7 @@ linked_hash_set = "0.1"
 clap = { version = "3.2", features = ["derive"] }
 
 [build-dependencies]
-color-eyre = "0.6"
+rustc-private-link = { path = "../rustc-private-link" }
 
 [dev-dependencies]
 insta = "1.15"

--- a/pdg/build.rs
+++ b/pdg/build.rs
@@ -1,23 +1,6 @@
-use std::path::Path;
-use std::process::Command;
-use std::str;
+use rustc_private_link::SysRoot;
 
-use color_eyre::eyre;
-use color_eyre::eyre::eyre;
-
-fn main() -> eyre::Result<()> {
-    color_eyre::install()?;
-    // Add the toolchain lib/ directory to `-L`.  This fixes the linker error "cannot find
-    // -lLLVM-13-rust-1.60.0-nightly".
-    let out = Command::new("rustup").args(&["which", "rustc"]).output()?;
-    assert!(out.status.success());
-    let rustc_path = Path::new(str::from_utf8(&out.stdout)?.trim_end());
-    let lib_dir = rustc_path
-        .parent()
-        .ok_or(eyre!("`which rustc` has no parent directory"))?
-        .parent()
-        .ok_or(eyre!("`which rustc` has no 2nd parent directory"))?
-        .join("lib");
-    println!("cargo:rustc-link-search={}", lib_dir.display());
-    Ok(())
+fn main() {
+    let sysroot = SysRoot::resolve();
+    sysroot.link_rustc_private();
 }

--- a/rustc-private-link/Cargo.toml
+++ b/rustc-private-link/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rustc-private-link"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rustc-private-link/src/lib.rs
+++ b/rustc-private-link/src/lib.rs
@@ -13,6 +13,7 @@ impl SysRoot {
             .expect("could not invoke `rustc` to find rust sysroot");
         let path = String::from_utf8(output.stdout)
             .expect("`rustc --print sysroot` is not UTF-8")
+            .trim_end()
             .into();
         Self { path }
     }

--- a/rustc-private-link/src/lib.rs
+++ b/rustc-private-link/src/lib.rs
@@ -1,0 +1,28 @@
+use std::{env, path::PathBuf, process::Command};
+
+pub struct SysRoot {
+    path: PathBuf,
+}
+
+impl SysRoot {
+    pub fn resolve() -> Self {
+        let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let output = Command::new(rustc)
+            .args(&["--print", "sysroot"])
+            .output()
+            .expect("could not invoke `rustc` to find rust sysroot");
+        let path = String::from_utf8(output.stdout)
+            .expect("`rustc --print sysroot` is not UTF-8")
+            .into();
+        Self { path }
+    }
+
+    pub fn set_env(&self) {
+        println!("cargo:rustc-env=RUST_SYSROOT={}", self.path.display());
+    }
+
+    pub fn link_rustc_private(&self) {
+        let lib_dir = self.path.join("lib");
+        println!("cargo:rustc-link-search={}", lib_dir.display());
+    }
+}

--- a/rustc-private-link/src/lib.rs
+++ b/rustc-private-link/src/lib.rs
@@ -1,4 +1,8 @@
-use std::{env, path::PathBuf, process::Command};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 pub struct SysRoot {
     path: PathBuf,
@@ -18,12 +22,36 @@ impl SysRoot {
         Self { path }
     }
 
-    pub fn set_env(&self) {
-        println!("cargo:rustc-env=RUST_SYSROOT={}", self.path.display());
+    pub fn sysroot(&self) -> &Path {
+        self.path.as_path()
+    }
+
+    pub fn lib(&self) -> PathBuf {
+        self.sysroot().join("lib")
+    }
+
+    pub fn rustlib(&self) -> PathBuf {
+        let target = env::var_os("TARGET").expect("cargo should set $TARGET");
+        [
+            self.sysroot(),
+            Path::new("lib"),
+            Path::new("rustlib"),
+            Path::new(&target),
+            Path::new("lib"),
+        ]
+        .iter()
+        .collect()
+    }
+
+    pub fn set_env_rust_sysroot(&self) {
+        println!("cargo:rustc-env=RUST_SYSROOT={}", self.sysroot().display());
+    }
+
+    pub fn set_env_rustlib(&self) {
+        println!("cargo:rustc-env=RUSTLIB={}", self.rustlib().display());
     }
 
     pub fn link_rustc_private(&self) {
-        let lib_dir = self.path.join("lib");
-        println!("cargo:rustc-link-search={}", lib_dir.display());
+        println!("cargo:rustc-link-search={}", self.lib().display());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/immunant/c2rust/issues/516.

This refactors the `build.rs`s in `dynamic-instrumentation`, `pdg`, and `c2rust` into a separate library crate, `rustc-private-link`, to avoid duplication as we're going to add a bunch of fixes/improvements to it now.

It keeps most of the same logic currently used in the `build.rs`s (no improvements yet, look for later PRs on top of this), except for two things:
* Where `color-eyre` was used in `pdg/build.rs`, it drops that as it's a bit overkill for a `build.rs`.
* `$RUSTC` is looked up using `env::var_os` instead of `env::var` and a default of `"rustc"` is used.
* To determine where the `rustc_private` crate dynamic libraries are, it uses `rustc --print sysroot` instead of using any of `rustup which rustc`, `which rustc`, or `$CARGO` and then looking up 2 directories from that.  Those are both the same directories (then the libraries are in `lib/` under the sysroot), and we already use `rustc --print sysroot` in `dynamic-instrumentation/build.rs`).  Thus, this fixes https://github.com/immunant/c2rust/issues/516.

Also, any thoughts on the naming?  Initially I chose `rustc-private-link`, though maybe `link-rustc-private` would be better, but I'm not sure if that's accurate enough, since some of the uses are more sysroot related (`set_env_{rust_sysroot,rustlib}`).