### PR TITLE
Set rpath to find rustc private crates at runtime

### DIFF
--- a/c2rust/build.rs
+++ b/c2rust/build.rs
@@ -3,4 +3,5 @@ use rustc_private_link::SysRoot;
 fn main() {
     let sysroot = SysRoot::resolve();
     sysroot.set_env_rustlib();
+    sysroot.link_rustc_private();
 }

--- a/c2rust/build.rs
+++ b/c2rust/build.rs
@@ -2,6 +2,5 @@ use rustc_private_link::SysRoot;
 
 fn main() {
     let sysroot = SysRoot::resolve();
-    sysroot.set_env_rustlib();
     sysroot.link_rustc_private();
 }

--- a/c2rust/src/main.rs
+++ b/c2rust/src/main.rs
@@ -38,11 +38,6 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    let mut ld_library_path = String::from(env!("RUSTLIB"));
-    if let Ok(old_library_path) = env::var("LD_LIBRARY_PATH") {
-        ld_library_path = format!("{}:{}", ld_library_path, old_library_path);
-    }
-
     // Assumes the subcommand executable is in the same directory as this driver
     // program.
     let cmd_path = std::env::current_exe().expect("Cannot get current executable path");
@@ -53,7 +48,6 @@ where
     exit(
         Command::new(cmd_path.into_os_string())
             .args(args)
-            .env("LD_LIBRARY_PATH", ld_library_path)
             .status()
             .expect("SubCommand failed to start")
             .code()

--- a/dynamic_instrumentation/build.rs
+++ b/dynamic_instrumentation/build.rs
@@ -2,6 +2,8 @@ use rustc_private_link::SysRoot;
 
 fn main() {
     let sysroot = SysRoot::resolve();
-    sysroot.link_rustc_private();
     sysroot.set_env_rust_sysroot();
+    // Not strictly needed here since this is not used as this is a library crate (it's needed in `c2rust`),
+    // but it doesn't hurt, and in case this ever adds a binary crate, it's useful.
+    sysroot.link_rustc_private();
 }

--- a/rustc-private-link/src/lib.rs
+++ b/rustc-private-link/src/lib.rs
@@ -52,6 +52,8 @@ impl SysRoot {
     }
 
     pub fn link_rustc_private(&self) {
-        println!("cargo:rustc-link-search={}", self.lib().display());
+        let lib = self.lib();
+        println!("cargo:rustc-link-search={}", lib.display());
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{}", lib.display());
     }
 }

--- a/rustc-private-link/src/lib.rs
+++ b/rustc-private-link/src/lib.rs
@@ -69,10 +69,6 @@ impl SysRoot {
         print_cargo_path("rustc-env=RUST_SYSROOT=", self.sysroot());
     }
 
-    pub fn set_env_rustlib(&self) {
-        print_cargo_path("rustc-env=RUSTLIB=", &self.rustlib());
-    }
-
     pub fn link_rustc_private(&self) {
         let lib = self.lib();
         print_cargo_path("rustc-link-search=", &lib);

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -60,9 +60,6 @@ main() {
     export RUST_BACKTRACE=1
     unset RUSTC_WRAPPER
 
-    local rustc_path="$(rustup which rustc)"
-    local toolchain_dir="$(dirname "$(dirname "${rustc_path}")")"
-
     local c2rust="${cwd}/${profile_dir}/c2rust"
     local c2rust_instrument="${cwd}/${profile_dir}/c2rust-instrument"
     local runtime="${cwd}/analysis/runtime/"
@@ -77,7 +74,6 @@ main() {
         if [[ "${c2rust_instrument}" -nt "${metadata}" ]]; then
             cargo clean --profile dev # always dev/debug for now
 
-            export LD_LIBRARY_PATH="${toolchain_dir}/lib"
             if ! "${c2rust}" instrument \
                 "${metadata}" "${runtime}" \
                 -- "${profile_args[@]}"  \


### PR DESCRIPTION
Fixes https://github.com/immunant/c2rust/issues/514.

Now `c2rust-pdg` and `c2rust-instrument` work without needing to set `LD_LIBRARY_PATH`.