### PR TITLE
Transpiler cleanup 15.07

### DIFF
--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -147,7 +147,7 @@ fn use_tree_with_prefix(prefix: Path, leaf: UseTree) -> UseTree {
 }
 
 fn punct<T, P: Default>(x: Vec<T>) -> Punctuated<T, P> {
-    Punctuated::from_iter(x.into_iter())
+    Punctuated::from_iter(x)
 }
 
 fn punct_box<T, P: Default>(x: Vec<Box<T>>) -> Punctuated<T, P> {
@@ -562,13 +562,9 @@ impl Builder {
         let mut tokens = TokenStream::new();
         let comma_token = token::Comma(self.span);
         let mut it = list.nested.into_iter();
-        tokens.extend(
-            Some(proc_macro2::TokenTree::Punct(proc_macro2::Punct::new(
-                '(',
-                proc_macro2::Spacing::Alone,
-            )))
-            .into_iter(),
-        );
+        tokens.extend(Some(proc_macro2::TokenTree::Punct(
+            proc_macro2::Punct::new('(', proc_macro2::Spacing::Alone),
+        )));
         if let Some(value) = it.next() {
             value.to_tokens(&mut tokens);
         }
@@ -576,13 +572,9 @@ impl Builder {
             comma_token.to_tokens(&mut tokens);
             value.to_tokens(&mut tokens);
         }
-        tokens.extend(
-            Some(proc_macro2::TokenTree::Punct(proc_macro2::Punct::new(
-                ')',
-                proc_macro2::Spacing::Alone,
-            )))
-            .into_iter(),
-        );
+        tokens.extend(Some(proc_macro2::TokenTree::Punct(
+            proc_macro2::Punct::new(')', proc_macro2::Spacing::Alone),
+        )));
         PreparedMetaItem {
             path: list.path,
             tokens,
@@ -1640,7 +1632,7 @@ impl Builder {
     pub fn cvar_args_ty(self) -> Box<Type> {
         let dot = TokenTree::Punct(proc_macro2::Punct::new('.', proc_macro2::Spacing::Joint));
         let dots = vec![dot.clone(), dot.clone(), dot];
-        Box::new(Type::Verbatim(TokenStream::from_iter(dots.into_iter())))
+        Box::new(Type::Verbatim(TokenStream::from_iter(dots)))
     }
 
     // Stmts

--- a/c2rust-ast-exporter/src/clang_ast.rs
+++ b/c2rust-ast-exporter/src/clang_ast.rs
@@ -202,7 +202,7 @@ pub fn process(items: Value) -> error::Result<AstContext> {
         })
         .collect::<Vec<_>>();
 
-    for mut entry in all_nodes.into_iter() {
+    for mut entry in all_nodes {
         let entry_id: u64 = from_value(entry.pop_front().unwrap()).unwrap();
         let tag = from_value(entry.pop_front().unwrap()).unwrap();
 

--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -119,7 +119,7 @@ impl ModuleTree {
     /// Convert the tree representation into a linear vector
     /// and push it into `res`
     fn linearize(&self, res: &mut Vec<Module>) {
-        for (name, child) in self.0.iter() {
+        for (name, child) in &self.0 {
             child.linearize_internal(name, res);
         }
     }
@@ -299,8 +299,7 @@ fn emit_cargo_toml<'lcmd>(
             crate_json
                 .as_object()
                 .cloned() // FIXME: we need to clone it because there's no `into_object`
-                .unwrap()
-                .into_iter(),
+                .unwrap(),
         );
     }
 

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -172,7 +172,7 @@ fn parse_attributes(attributes: Vec<Value>) -> IndexSet<Attribute> {
     let mut expect_alias_value = false;
     let mut expect_visibility_value = false;
 
-    for attr in attributes.into_iter() {
+    for attr in attributes {
         let attr_str = from_value::<String>(attr).expect("Decl attributes should be strings");
 
         match attr_str.as_str() {
@@ -1928,13 +1928,11 @@ impl ConversionContext {
                         ident
                     );
 
-                    let initializer = node
-                        .children
-                        .get(0)
-                        .into_iter()
-                        .flatten()
-                        .map(|id| self.visit_expr(*id))
-                        .next();
+                    let initializer = if let Some(Some(id)) = node.children.get(0) {
+                        Some(self.visit_expr(*id))
+                    } else {
+                        None
+                    };
 
                     let typ_id = node
                         .type_id

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -2,6 +2,7 @@ use crate::c_ast::*;
 use crate::diagnostics::diag;
 use c2rust_ast_exporter::clang_ast::*;
 use failure::err_msg;
+use itertools::izip;
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -1091,9 +1092,7 @@ impl ConversionContext {
                     let (input_children, output_children) =
                         node.children.split_at(raw_inputs.len());
 
-                    let inputs: Vec<AsmOperand> = raw_inputs
-                        .into_iter()
-                        .zip(input_children)
+                    let inputs: Vec<AsmOperand> = izip!(raw_inputs, input_children)
                         .map(|(c, e)| {
                             let constraints = from_value(c).expect("constraint string");
                             let expression = self.visit_expr(e.expect("expression"));
@@ -1104,9 +1103,7 @@ impl ConversionContext {
                         })
                         .collect();
 
-                    let outputs: Vec<AsmOperand> = raw_outputs
-                        .into_iter()
-                        .zip(output_children)
+                    let outputs: Vec<AsmOperand> = izip!(raw_outputs, output_children)
                         .map(|(c, e)| {
                             let constraints = from_value(c).expect("constraint string");
                             let expression = self.visit_expr(e.expect("expression"));

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1,5 +1,6 @@
 use c2rust_ast_exporter::clang_ast::LRValue;
 use indexmap::{IndexMap, IndexSet};
+use itertools::izip;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
@@ -211,9 +212,9 @@ impl TypedAstContext {
         fn cmp_pos(a: &SrcLoc, b: &SrcLoc) -> Ordering {
             (a.line, a.column).cmp(&(b.line, b.column))
         }
-        let path_a = self.include_map[self.file_map[a.fileid as usize]].clone();
-        let path_b = self.include_map[self.file_map[b.fileid as usize]].clone();
-        for (include_a, include_b) in path_a.iter().zip(path_b.iter()) {
+        let path_a = &self.include_map[self.file_map[a.fileid as usize]];
+        let path_b = &self.include_map[self.file_map[b.fileid as usize]];
+        for (include_a, include_b) in izip!(path_a, path_b) {
             if include_a.fileid != include_b.fileid {
                 return cmp_pos(include_a, include_b);
             }

--- a/c2rust-transpile/src/c_ast/print.rs
+++ b/c2rust-transpile/src/c_ast/print.rs
@@ -56,7 +56,7 @@ impl<W: Write> Printer<W> {
     }
 
     pub fn print(&mut self, context: &TypedAstContext) -> Result<()> {
-        for top_decl in context.c_decls_top.iter() {
+        for top_decl in &context.c_decls_top {
             self.print_decl(*top_decl, true, true, context)?;
             self.writer.write_all(b"\n")?;
         }

--- a/c2rust-transpile/src/cfg/loops.rs
+++ b/c2rust-transpile/src/cfg/loops.rs
@@ -111,7 +111,7 @@ pub fn heuristic_loop_body(
                     break;
                 }
 
-                following = succs.iter().next().unwrap().clone();
+                following = succs.first().unwrap().clone();
             }
         }
     }

--- a/c2rust-transpile/src/cfg/loops.rs
+++ b/c2rust-transpile/src/cfg/loops.rs
@@ -87,9 +87,7 @@ pub fn heuristic_loop_body(
     follow_entries: &mut IndexSet<Label>,
 ) {
     if follow_entries.len() > 1 {
-        for follow_entry in follow_entries.clone().iter() {
-            let mut following: Label = follow_entry.clone();
-
+        for mut following in follow_entries.clone() {
             loop {
                 // If this block might have come from 2 places, give up
                 if predecessor_map[&following].len() != 1 {
@@ -202,7 +200,7 @@ impl<Lbl: Hash + Eq + Clone> LoopInfo<Lbl> {
     /// Filter out any nodes which need to be pruned from the entire CFG due to being unreachable.
     pub fn filter_unreachable(&mut self, reachable: &IndexSet<Lbl>) {
         self.node_loops.retain(|lbl, _| reachable.contains(lbl));
-        for (_, &mut (ref mut set, _)) in self.loops.iter_mut() {
+        for (_, (set, _)) in &mut self.loops {
             set.retain(|lbl| reachable.contains(lbl));
         }
     }
@@ -211,7 +209,7 @@ impl<Lbl: Hash + Eq + Clone> LoopInfo<Lbl> {
     /// going to be very much _not_ injective - the whole point of remapping is to merge some nodes.
     pub fn rewrite_blocks(&mut self, rewrites: &IndexMap<Lbl, Lbl>) {
         self.node_loops.retain(|lbl, _| rewrites.get(lbl).is_none());
-        for (_, &mut (ref mut set, _)) in self.loops.iter_mut() {
+        for (_, (set, _)) in &mut self.loops {
             set.retain(|lbl| rewrites.get(lbl).is_none());
         }
     }

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -1133,7 +1133,7 @@ struct WipBlock {
 
 impl Extend<Stmt> for WipBlock {
     fn extend<T: IntoIterator<Item = Stmt>>(&mut self, iter: T) {
-        for stmt in iter.into_iter() {
+        for stmt in iter {
             self.body.push(StmtOrDecl::Stmt(stmt))
         }
     }
@@ -2153,7 +2153,7 @@ impl Cfg<Label, StmtOrDecl> {
         file.write_fmt(format_args!("  entry -> {};\n", self.entries.debug_print()))?;
 
         // Rest of graph
-        for (lbl, bb) in self.nodes.iter() {
+        for (lbl, bb) in &self.nodes {
             let pretty_terminator = match bb.terminator {
                 End | Jump(_) => String::from(""),
                 Branch(ref cond, _, _) => format!("\n{}", pprust::expr_to_string(cond.deref())),

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -655,6 +655,7 @@ impl Cfg<Label, StmtOrDecl> {
     }
 }
 
+use itertools::Itertools;
 use std::fmt::Debug;
 use std::rc::Rc;
 
@@ -2167,9 +2168,7 @@ impl Cfg<Label, StmtOrDecl> {
                     "\\ldefined: {{{}}}",
                     bb.defined
                         .iter()
-                        .filter_map(|decl| ctx.index(*decl).kind.get_name())
-                        .cloned()
-                        .collect::<Vec<_>>()
+                        .filter_map(|decl| ctx.index(*decl).kind.get_name().cloned())
                         .join(", "),
                 )
             };
@@ -2181,9 +2180,7 @@ impl Cfg<Label, StmtOrDecl> {
                     "\\llive in: {{{}}}",
                     bb.live
                         .iter()
-                        .filter_map(|decl| ctx.index(*decl).kind.get_name())
-                        .cloned()
-                        .collect::<Vec<_>>()
+                        .filter_map(|decl| ctx.index(*decl).kind.get_name().cloned())
                         .join(", "),
                 )
             };
@@ -2226,7 +2223,6 @@ impl Cfg<Label, StmtOrDecl> {
                             bb.body
                                 .iter()
                                 .flat_map(|sd: &StmtOrDecl| -> Vec<String> { sd.to_string(store) })
-                                .collect::<Vec<String>>()
                                 .join("\n"),
                         )
                     }

--- a/c2rust-transpile/src/cfg/relooper.rs
+++ b/c2rust-transpile/src/cfg/relooper.rs
@@ -2,6 +2,7 @@
 //! simplifying the latter.
 
 use super::*;
+use itertools::chain;
 
 /// Convert the CFG into a sequence of structures
 pub fn reloop(
@@ -364,7 +365,7 @@ impl RelooperState {
             // Try to match an existing loop (from the initial C)
             let mut matched_existing_loop = false;
             if let Some(ref loop_info) = self.loop_info {
-                let must_be_in_loop = entries.iter().chain(new_returns.iter()).cloned();
+                let must_be_in_loop = chain!(&entries, &new_returns).cloned();
                 if let Some(loop_id) = loop_info.tightest_common_loop(must_be_in_loop) {
                     // Construct the target group of labels
                     let mut desired_body: IndexSet<Label> =

--- a/c2rust-transpile/src/cfg/relooper.rs
+++ b/c2rust-transpile/src/cfg/relooper.rs
@@ -187,8 +187,7 @@ impl RelooperState {
         // Simple blocks
         if none_branch_to.len() == 1 && some_branch_to.is_empty() {
             let entry = none_branch_to
-                .iter()
-                .next()
+                .first()
                 .expect("Should find exactly one entry");
 
             if let Some(bb) = blocks.swap_remove(entry) {

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -313,8 +313,7 @@ fn structured_cfg_help<S: StructuredStatement<E = Box<Expr>, P = Box<Pat>, L = L
 
             Loop { body, entries } => {
                 let label = entries
-                    .iter()
-                    .next()
+                    .first()
                     .ok_or_else(|| format_err!("The loop {:?} has no entry", structure))?;
 
                 let mut these_exits = IndexMap::new();

--- a/c2rust-transpile/src/rust_ast/mod.rs
+++ b/c2rust-transpile/src/rust_ast/mod.rs
@@ -16,9 +16,8 @@ fn raise_span_limit(_new_limit: u32) {
     if new_limit >= limit {
         let delta = new_limit - limit;
         let s = str::repeat("        ", (delta as usize + 7) / 8);
-        use std::str::FromStr;
         /* used only for its side-effect of expanding the source map */
-        let _ = proc_macro2::TokenStream::from_str(&s);
+        let _ = s.parse::<proc_macro2::TokenStream>();
         SPAN_LIMIT.store(new_limit, Ordering::Relaxed);
     }
 }
@@ -139,9 +138,9 @@ struct SpanRepr {
 /// On the plus side, the `fallback::Span` payload is a POD pair of two u32s, so that case is trivial.
 fn validate_repr() {
     let repr: SpanRepr = unsafe { std::mem::transmute(Span::call_site()) };
-    assert!(repr.compiler_or_fallback == 1);
-    assert!(repr.lo == 0);
-    assert!(repr.hi == 0);
+    assert_eq!(repr.compiler_or_fallback, 1);
+    assert_eq!(repr.lo, 0);
+    assert_eq!(repr.hi, 0);
 }
 
 /** return a pair of mutable references to s.lo and s.hi */

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -2,6 +2,7 @@
 //! This module provides basic support for converting inline assembly statements.
 
 use crate::diagnostics::TranslationResult;
+use itertools::chain;
 
 use super::*;
 use log::warn;
@@ -713,9 +714,7 @@ impl<'c> Translation<'c> {
             |idx: usize| map_input_op_idx(idx, outputs.len(), &tied_operands),
             |ref_str: &str| {
                 if let Ok(idx) = ref_str.parse::<usize>() {
-                    outputs
-                        .iter()
-                        .chain(inputs)
+                    chain!(outputs, inputs)
                         .nth(idx)
                         .map_or(false, operand_is_mem_only)
                 } else {

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -26,9 +26,9 @@ impl<'c> Translation<'c> {
     fn convert_memordering(&self, expr: CExprId) -> Option<Ordering> {
         let memorder = &self.ast_context[expr];
         let i = match memorder.kind {
-            CExprKind::Literal(_, CLiteral::Integer(i, _)) => Some(i),
-            _ => None,
-        }?;
+            CExprKind::Literal(_, CLiteral::Integer(i, _)) => i,
+            _ => return None,
+        };
         use Ordering::*;
         let ordering = match i {
             0 => Relaxed,

--- a/c2rust-transpile/src/with_stmts.rs
+++ b/c2rust-transpile/src/with_stmts.rs
@@ -160,7 +160,7 @@ impl<T> FromIterator<WithStmts<T>> for WithStmts<Vec<T>> {
         let mut stmts = vec![];
         let mut res = vec![];
         let mut is_unsafe = false;
-        for mut val in value.into_iter() {
+        for mut val in value {
             is_unsafe |= val.is_unsafe();
             stmts.append(val.stmts_mut());
             res.push(val.into_value());

--- a/pdg/src/util.rs
+++ b/pdg/src/util.rs
@@ -1,4 +1,4 @@
-use itertools::Itertools;
+use itertools::{izip, Itertools};
 
 use std::{
     cmp::min,
@@ -175,9 +175,7 @@ pub fn pad_columns(lines: &[String], split_sep: char, join_sep: &str) -> Vec<Str
         .collect::<Vec<_>>();
     rows.iter()
         .map(|cells| {
-            cells
-                .iter()
-                .zip(column_max_lengths.iter())
+            izip!(cells, &column_max_lengths)
                 .map(|(&cell, &max_length)| Padded {
                     to_pad: cell,
                     pad_len: max_length - cell.len(),


### PR DESCRIPTION
* remove UB const DUMMY_SP, use safe `Span::call_site()` instead;
* simplify argument parsing chains `it.next().unwrap().parse().unwrap()` into a single pattern match;
* extract common logic for adding architecture-dependent item usage in simd.rs into a separate function;
* various minor cleanups.