### PR TITLE
Print `Graph` hashes instead of indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +302,7 @@ dependencies = [
 name = "c2rust-pdg"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "bincode",
  "c2rust-analysis-rt",
  "clap 3.2.8",

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -15,6 +15,7 @@ fs-err = "2"
 itertools = "0.10"
 linked_hash_set = "0.1"
 clap = { version = "3.2", features = ["derive"] }
+base64 = "0.13"
 
 [build-dependencies]
 rustc-private-link = { path = "../rustc-private-link" }

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -10,6 +10,8 @@ use std::{
 };
 
 use crate::util::pad_columns;
+use crate::util::DisplayHash;
+use crate::util::HashSize;
 use crate::util::ShortOption;
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
@@ -168,7 +170,8 @@ pub const _ROOT_NODE: NodeId = NodeId::from_u32(0);
 
 impl Display for NodeId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "n[{}]", self.as_usize())
+        let id = self.as_usize();
+        write!(f, "n[{id}]")
     }
 }
 
@@ -217,7 +220,8 @@ impl Display for Graph {
                 .to_string()
             })
             .collect::<Vec<_>>();
-        writeln!(f, "{{")?;
+        let id = DisplayHash::new(self, HashSize::U32);
+        writeln!(f, "g[{id}] {{")?;
         for line in pad_columns(&lines, sep, " ") {
             writeln!(f, "\t{line}")?;
         }
@@ -233,7 +237,8 @@ newtype_index!(
 
 impl Display for GraphId {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "g[{}]", self.as_usize())
+        let id = self.as_usize();
+        write!(f, "g[{id}]")
     }
 }
 
@@ -256,11 +261,11 @@ impl Graphs {
 
 impl Display for Graphs {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        for (graph_id, graph) in self.graphs.iter_enumerated() {
-            if graph_id.as_usize() != 0 {
+        for (i, graph) in self.graphs.iter().enumerate() {
+            if i != 0 {
                 write!(f, "\n\n")?;
             }
-            write!(f, "{graph_id} {graph}")?;
+            write!(f, "{graph}")?;
         }
         Ok(())
     }

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -101,13 +101,13 @@ fn main() -> eyre::Result<()> {
         }
     }
 
-    for (graph_id, graph) in pdg.graphs.iter_enumerated() {
+    for graph in &pdg.graphs {
         let needs_write = graph
             .needs_write_permission()
             .map(|node_id| node_id.as_usize())
             .collect::<Vec<_>>();
         if should_print(ToPrint::Graphs) {
-            println!("{graph_id} {graph}");
+            println!("{graph}");
         }
         if should_print(ToPrint::WritePermissions) {
             println!("nodes_that_need_write = {needs_write:?}");

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot.snap
@@ -1,92 +1,93 @@
 ---
 source: pdg/src/main.rs
+assertion_line: 150
 expression: pdg
 ---
-g[0] {
+g[UWYHPA] {
 	n[0]: copy _ => _10 @ bb5[4]: fn main;
 }
 nodes_that_need_write = []
 
-g[1] {
+g[h3iWPA] {
 	n[0]: copy _ => _9 @ bb5[5]: fn main;
 }
 nodes_that_need_write = []
 
-g[2] {
+g[xV2iuA] {
 	n[0]: copy _ => _19 @ bb8[11]: fn main;
 }
 nodes_that_need_write = []
 
-g[3] {
+g[tY+EoA] {
 	n[0]: copy _ => _18 @ bb8[12]: fn main;
 }
 nodes_that_need_write = []
 
-g[4] {
+g[qR1hcw] {
 	n[0]: copy _ => _27 @ bb8[22]: fn main;
 }
 nodes_that_need_write = []
 
-g[5] {
+g[nFToHA] {
 	n[0]: copy _ => _26 @ bb8[23]: fn main;
 }
 nodes_that_need_write = []
 
-g[6] {
+g[Mx7yHw] {
 	n[0]: copy _ => _23 @ bb13[4]: fn main;
 }
 nodes_that_need_write = []
 
-g[7] {
+g[UT8mPQ] {
 	n[0]: copy _ => _22 @ bb13[5]: fn main;
 }
 nodes_that_need_write = []
 
-g[8] {
+g[G3F1LQ] {
 	n[0]: copy _ => _29 @ bb15[11]: fn main;
 }
 nodes_that_need_write = []
 
-g[9] {
+g[eV+gxg] {
 	n[0]: copy _ => _34 @ bb16[5]: fn main;
 }
 nodes_that_need_write = []
 
-g[10] {
+g[zD10nw] {
 	n[0]: copy _    => _30 @ bb18[0]: fn main;
 	n[1]: copy n[0] => _2  @ bb0[0]:  fn push;
 }
 nodes_that_need_write = []
 
-g[11] {
+g[tSGxlw] {
 	n[0]: copy _ => _37 @ bb27[4]: fn main;
 }
 nodes_that_need_write = []
 
-g[12] {
+g[G/E50Q] {
 	n[0]: copy        _    => _38       @ bb28[0]: fn main;   
 	n[1]: copy        n[0] => _2        @ bb0[0]:  fn push;   
 	n[2]: value.store _    => _20.Deref @ bb4[8]:  fn invalid;
 }
 nodes_that_need_write = []
 
-g[13] {
+g[3/xp2w] {
 	n[0]: copy _ => _43 @ bb29[9]: fn main;
 }
 nodes_that_need_write = []
 
-g[14] {
+g[/S2qBw] {
 	n[0]: copy _ => _46 @ bb31[6]: fn main;
 }
 nodes_that_need_write = []
 
-g[15] {
+g[L3UJ7w] {
 	n[0]: copy _    => _45 @ bb32[0]: fn main;  
 	n[1]: copy n[0] => _2  @ bb0[0]:  fn main_0;
 }
 nodes_that_need_write = []
 
-g[16] {
+g[fssh3g] {
 	n[0]: malloc(n = 1) _    => _2 @ bb1[2]: fn simple;
 	n[1]: copy          n[0] => _1 @ bb2[2]: fn simple;
 	n[2]: field.0       n[1] => _9 @ bb4[5]: fn simple;
@@ -94,7 +95,7 @@ g[16] {
 }
 nodes_that_need_write = []
 
-g[17] {
+g[+TO0PA] {
 	n[0]:  malloc(n = 1) _     => _6  @ bb3[2]:  fn simple;
 	n[1]:  copy          n[0]  => _5  @ bb4[2]:  fn simple;
 	n[2]:  copy          n[1]  => _10 @ bb4[9]:  fn simple;
@@ -131,17 +132,17 @@ g[17] {
 }
 nodes_that_need_write = [18, 17, 11, 10, 9, 8, 5, 4, 3, 2, 1, 0]
 
-g[18] {
+g[5pMeQw] {
 	n[0]: &_1 _ => _9 @ bb4[6]: fn simple;
 }
 nodes_that_need_write = []
 
-g[19] {
+g[oDi+iQ] {
 	n[0]: &_1 _ => _13 @ bb4[22]: fn simple;
 }
 nodes_that_need_write = []
 
-g[20] {
+g[KqUXIA] {
 	n[0]: &_1         _    => _14               @ bb4[25]: fn simple;
 	n[1]: value.store n[0] => _1.Deref.Field(2) @ bb4[26]: fn simple;
 	n[2]: addr.load   n[0] => _                 @ bb5[3]:  fn simple;
@@ -149,7 +150,7 @@ g[20] {
 }
 nodes_that_need_write = [3, 0]
 
-g[21] {
+g[NyH3Fw] {
 	n[0]: malloc(n = 1) _    => _2  @ bb1[2]:  fn exercise_allocator;
 	n[1]: copy          n[0] => _1  @ bb2[2]:  fn exercise_allocator;
 	n[2]: field.0       n[1] => _   @ bb2[5]:  fn exercise_allocator;
@@ -162,7 +163,7 @@ g[21] {
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
-g[22] {
+g[/9qaCQ] {
 	n[0]: &_9  _    => _8 @ bb2[13]: fn exercise_allocator;
 	n[1]: copy n[0] => _7 @ bb2[14]: fn exercise_allocator;
 	n[2]: copy n[1] => _6 @ bb2[16]: fn exercise_allocator;
@@ -170,7 +171,7 @@ g[22] {
 }
 nodes_that_need_write = []
 
-g[23] {
+g[EvDfig] {
 	n[0]:  malloc(n = 1) _     => _11 @ bb5[2]:   fn exercise_allocator;
 	n[1]:  copy          n[0]  => _1  @ bb6[3]:   fn exercise_allocator;
 	n[2]:  copy          n[1]  => _19 @ bb6[7]:   fn exercise_allocator;
@@ -194,7 +195,7 @@ g[23] {
 }
 nodes_that_need_write = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
-g[24] {
+g[4k2qGg] {
 	n[0]: &_31 _    => _30 @ bb11[7]:  fn exercise_allocator;
 	n[1]: copy n[0] => _29 @ bb11[8]:  fn exercise_allocator;
 	n[2]: copy n[1] => _28 @ bb11[10]: fn exercise_allocator;
@@ -202,7 +203,7 @@ g[24] {
 }
 nodes_that_need_write = []
 
-g[25] {
+g[zqy5ZQ] {
 	n[0]:  malloc(n = 1) _     => _41 @ bb22[2]:  fn exercise_allocator;
 	n[1]:  copy          n[0]  => _1  @ bb23[4]:  fn exercise_allocator;
 	n[2]:  copy          n[1]  => _48 @ bb23[8]:  fn exercise_allocator;
@@ -235,7 +236,7 @@ g[25] {
 }
 nodes_that_need_write = [13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
-g[26] {
+g[mbbXvA] {
 	n[0]: &_61 _    => _60 @ bb29[7]:  fn exercise_allocator;
 	n[1]: copy n[0] => _59 @ bb29[8]:  fn exercise_allocator;
 	n[2]: copy n[1] => _58 @ bb29[10]: fn exercise_allocator;
@@ -243,7 +244,7 @@ g[26] {
 }
 nodes_that_need_write = []
 
-g[27] {
+g[dGsV1Q] {
 	n[0]:  malloc(n = 1) _     => _74  @ bb41[2]:  fn exercise_allocator;
 	n[1]:  copy          n[0]  => _1   @ bb42[3]:  fn exercise_allocator;
 	n[2]:  copy          n[1]  => _79  @ bb42[7]:  fn exercise_allocator;
@@ -284,7 +285,7 @@ g[27] {
 }
 nodes_that_need_write = [17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
-g[28] {
+g[x9DyEQ] {
 	n[0]: &_94 _    => _93 @ bb49[7]:  fn exercise_allocator;
 	n[1]: copy n[0] => _92 @ bb49[8]:  fn exercise_allocator;
 	n[2]: copy n[1] => _91 @ bb49[10]: fn exercise_allocator;
@@ -292,7 +293,7 @@ g[28] {
 }
 nodes_that_need_write = []
 
-g[29] {
+g[MheTHQ] {
 	n[0]: malloc(n = 1) _    => _2  @ bb1[2]:  fn simple_analysis;
 	n[1]: copy          n[0] => _1  @ bb2[2]:  fn simple_analysis;
 	n[2]: field.0       n[1] => _   @ bb2[5]:  fn simple_analysis;
@@ -305,7 +306,7 @@ g[29] {
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
-g[30] {
+g[ONj9gQ] {
 	n[0]: &_9  _    => _8 @ bb2[13]: fn simple_analysis;
 	n[1]: copy n[0] => _7 @ bb2[14]: fn simple_analysis;
 	n[2]: copy n[1] => _6 @ bb2[16]: fn simple_analysis;
@@ -313,7 +314,7 @@ g[30] {
 }
 nodes_that_need_write = []
 
-g[31] {
+g[+xSS7g] {
 	n[0]:  malloc(n = 1) _    => _2 @ bb1[2]:  fn analysis2;       
 	n[1]:  copy          n[0] => _1 @ bb2[2]:  fn analysis2;       
 	n[2]:  field.0       n[1] => _  @ bb2[5]:  fn analysis2;       
@@ -328,7 +329,7 @@ g[31] {
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
-g[32] {
+g[i+RqhQ] {
 	n[0]: &_6  _    => _5 @ bb0[7]:  fn analysis2_helper;
 	n[1]: copy n[0] => _4 @ bb0[8]:  fn analysis2_helper;
 	n[2]: copy n[1] => _3 @ bb0[10]: fn analysis2_helper;
@@ -336,7 +337,7 @@ g[32] {
 }
 nodes_that_need_write = []
 
-g[33] {
+g[5ZNRqg] {
 	n[0]: malloc(n = 1) _    => _0  @ bb0[2]:  fn malloc_wrapper;         
 	n[1]: copy          n[0] => _2  @ bb2[0]:  fn inter_function_analysis;
 	n[2]: copy          n[1] => _1  @ bb2[2]:  fn inter_function_analysis;
@@ -350,7 +351,7 @@ g[33] {
 }
 nodes_that_need_write = [4, 3, 2, 1, 0]
 
-g[34] {
+g[4ck0tA] {
 	n[0]: &_9  _    => _8 @ bb2[13]: fn inter_function_analysis;
 	n[1]: copy n[0] => _7 @ bb2[14]: fn inter_function_analysis;
 	n[2]: copy n[1] => _6 @ bb2[16]: fn inter_function_analysis;
@@ -358,13 +359,13 @@ g[34] {
 }
 nodes_that_need_write = []
 
-g[35] {
+g[7N9OoQ] {
 	n[0]: malloc(n = 1) _    => _2       @ bb1[2]: fn no_owner;
 	n[1]: value.store   n[0] => _5.Deref @ bb2[4]: fn no_owner;
 }
 nodes_that_need_write = []
 
-g[36] {
+g[u1jwkA] {
 	n[0]:  copy       _    => _5  @ bb2[3]:  fn no_owner;
 	n[1]:  addr.store n[0] => _   @ bb2[3]:  fn no_owner;
 	n[2]:  copy       _    => _5  @ bb2[3]:  fn no_owner;
@@ -381,7 +382,7 @@ g[36] {
 }
 nodes_that_need_write = [12, 7, 3, 1, 0]
 
-g[37] {
+g[GUadMA] {
 	n[0]: malloc(n = 1) _    => _2       @ bb1[2]: fn no_owner;
 	n[1]: value.store   n[0] => _5.Deref @ bb2[4]: fn no_owner;
 	n[2]: value.load    _    => _11      @ bb3[6]: fn no_owner;
@@ -390,7 +391,7 @@ g[37] {
 }
 nodes_that_need_write = []
 
-g[38] {
+g[Uo6Mug] {
 	n[0]:  malloc(n = 1) _    => _2       @ bb1[2]:  fn invalid;
 	n[1]:  copy          n[0] => _1       @ bb2[2]:  fn invalid;
 	n[2]:  field.0       n[1] => _        @ bb2[5]:  fn invalid;
@@ -405,7 +406,7 @@ g[38] {
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
-g[39] {
+g[M6gBSg] {
 	n[0]: &_11 _    => _10 @ bb2[20]: fn invalid;
 	n[1]: copy n[0] => _9  @ bb2[21]: fn invalid;
 	n[2]: copy n[1] => _8  @ bb2[23]: fn invalid;
@@ -413,7 +414,7 @@ g[39] {
 }
 nodes_that_need_write = []
 
-g[40] {
+g[ymS8XA] {
 	n[0]: &_17 _    => _16 @ bb3[11]: fn invalid;
 	n[1]: copy n[0] => _15 @ bb3[12]: fn invalid;
 	n[2]: copy n[1] => _14 @ bb3[14]: fn invalid;
@@ -421,34 +422,34 @@ g[40] {
 }
 nodes_that_need_write = []
 
-g[41] {
+g[QwqAwA] {
 	n[0]: copy _ => _4 @ bb0[8]: fn testing;
 }
 nodes_that_need_write = []
 
-g[42] {
+g[nELiVQ] {
 	n[0]: &_4  _    => _3 @ bb0[10]: fn testing;
 	n[1]: copy n[0] => _5 @ bb0[13]: fn testing;
 }
 nodes_that_need_write = []
 
-g[43] {
+g[H0OeBg] {
 	n[0]: copy _ => _7 @ bb0[16]: fn testing;
 }
 nodes_that_need_write = []
 
-g[44] {
+g[+99ALQ] {
 	n[0]: &_7         _    => _6       @ bb0[18]: fn testing;
 	n[1]: value.store n[0] => _5.Deref @ bb0[19]: fn testing;
 }
 nodes_that_need_write = []
 
-g[45] {
+g[olnAuw] {
 	n[0]: addr.store _ => _ @ bb0[18]: fn testing;
 }
 nodes_that_need_write = [0]
 
-g[46] {
+g[zVfWig] {
 	n[0]: malloc(n = 1) _    => _2  @ bb1[2]:  fn simple1;
 	n[1]: copy          n[0] => _1  @ bb2[2]:  fn simple1;
 	n[2]: copy          n[1] => _8  @ bb2[9]:  fn simple1;
@@ -462,7 +463,7 @@ g[46] {
 }
 nodes_that_need_write = []
 
-g[47] {
+g[XQkGVg] {
 	n[0]: malloc(n = 1) _    => _6  @ bb3[2]:  fn simple1;
 	n[1]: copy          n[0] => _5  @ bb4[3]:  fn simple1;
 	n[2]: copy          n[1] => _11 @ bb4[7]:  fn simple1;
@@ -474,19 +475,19 @@ g[47] {
 }
 nodes_that_need_write = [4, 3, 2, 1, 0]
 
-g[48] {
+g[ThQC4Q] {
 	n[0]: &_13 _ => _14 @ bb4[17]: fn simple1;
 }
 nodes_that_need_write = []
 
-g[49] {
+g[rw80kQ] {
 	n[0]: malloc(n = 1) _    => _1 @ bb1[2]: fn test_malloc_free;
 	n[1]: copy          n[0] => _5 @ bb2[5]: fn test_malloc_free;
 	n[2]: free          n[1] => _4 @ bb2[5]: fn test_malloc_free;
 }
 nodes_that_need_write = []
 
-g[50] {
+g[f7Y+Fg] {
 	n[0]: malloc(n = 1) _    => _2 @ bb1[2]:  fn test_malloc_free_cast;
 	n[1]: copy          n[0] => _1 @ bb2[2]:  fn test_malloc_free_cast;
 	n[2]: copy          n[1] => _7 @ bb2[8]:  fn test_malloc_free_cast;
@@ -495,7 +496,7 @@ g[50] {
 }
 nodes_that_need_write = []
 
-g[51] {
+g[ECmLMQ] {
 	n[0]: malloc(n = 1) _    => _1 @ bb1[2]: fn test_arg;
 	n[1]: copy          n[0] => _5 @ bb2[5]: fn test_arg;
 	n[2]: copy          n[1] => _1 @ bb0[0]: fn foo;     
@@ -504,7 +505,7 @@ g[51] {
 }
 nodes_that_need_write = []
 
-g[52] {
+g[rqof6w] {
 	n[0]:  malloc(n = 1) _     => _1  @ bb1[2]: fn test_arg_rec;
 	n[1]:  copy          n[0]  => _5  @ bb2[5]: fn test_arg_rec;
 	n[2]:  copy          n[1]  => _2  @ bb0[0]: fn foo_rec;     
@@ -528,14 +529,14 @@ g[52] {
 }
 nodes_that_need_write = []
 
-g[53] {
+g[DdZzRA] {
 	n[0]: malloc(n = 1) _    => _1 @ bb1[2]: fn test_realloc_reassign;
 	n[1]: copy          n[0] => _5 @ bb2[5]: fn test_realloc_reassign;
 	n[2]: free          n[1] => _4 @ bb4[2]: fn test_realloc_reassign;
 }
 nodes_that_need_write = []
 
-g[54] {
+g[amZubA] {
 	n[0]: malloc(n = 1) _    => _4  @ bb4[2]: fn test_realloc_reassign;
 	n[1]: copy          n[0] => _1  @ bb5[3]: fn test_realloc_reassign;
 	n[2]: copy          n[1] => _11 @ bb5[7]: fn test_realloc_reassign;
@@ -543,21 +544,21 @@ g[54] {
 }
 nodes_that_need_write = []
 
-g[55] {
+g[g9TXSg] {
 	n[0]: malloc(n = 1) _    => _1 @ bb1[2]: fn test_realloc_fresh;
 	n[1]: copy          n[0] => _5 @ bb2[5]: fn test_realloc_fresh;
 	n[2]: free          n[1] => _4 @ bb3[2]: fn test_realloc_fresh;
 }
 nodes_that_need_write = []
 
-g[56] {
+g[kSfC3Q] {
 	n[0]: malloc(n = 1) _    => _4 @ bb3[2]: fn test_realloc_fresh;
 	n[1]: copy          n[0] => _9 @ bb4[6]: fn test_realloc_fresh;
 	n[2]: free          n[1] => _8 @ bb4[6]: fn test_realloc_fresh;
 }
 nodes_that_need_write = []
 
-g[57] {
+g[vcauRQ] {
 	n[0]: malloc(n = 1) _    => _2 @ bb1[2]:  fn test_load_addr;
 	n[1]: copy          n[0] => _1 @ bb2[2]:  fn test_load_addr;
 	n[2]: addr.load     n[0] => _  @ bb2[5]:  fn test_load_addr;
@@ -567,12 +568,12 @@ g[57] {
 }
 nodes_that_need_write = []
 
-g[58] {
+g[p1MB9Q] {
 	n[0]: malloc(n = 1) _ => _1 @ bb1[2]: fn test_overwrite;
 }
 nodes_that_need_write = []
 
-g[59] {
+g[0LuCLw] {
 	n[0]: malloc(n = 1) _    => _4 @ bb3[2]: fn test_overwrite;
 	n[1]: copy          n[0] => _7 @ bb4[4]: fn test_overwrite;
 	n[2]: copy          n[1] => _1 @ bb4[5]: fn test_overwrite;
@@ -581,7 +582,7 @@ g[59] {
 }
 nodes_that_need_write = []
 
-g[60] {
+g[tzmHGg] {
 	n[0]: malloc(n = 1) _    => _2 @ bb1[2]:  fn test_store_addr;
 	n[1]: copy          n[0] => _1 @ bb2[2]:  fn test_store_addr;
 	n[2]: field.0       n[1] => _  @ bb2[4]:  fn test_store_addr;
@@ -592,7 +593,7 @@ g[60] {
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
-g[61] {
+g[9eh/kA] {
 	n[0]: malloc(n = 1) _    => _2  @ bb1[2]:  fn test_load_other_store_self;
 	n[1]: copy          n[0] => _1  @ bb2[2]:  fn test_load_other_store_self;
 	n[2]: field.0       n[1] => _   @ bb4[4]:  fn test_load_other_store_self;
@@ -605,7 +606,7 @@ g[61] {
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
-g[62] {
+g[Y1dU1A] {
 	n[0]: malloc(n = 1) _    => _6  @ bb3[2]: fn test_load_other_store_self;
 	n[1]: copy          n[0] => _5  @ bb4[2]: fn test_load_other_store_self;
 	n[2]: field.0       n[1] => _   @ bb4[7]: fn test_load_other_store_self;
@@ -616,7 +617,7 @@ g[62] {
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
-g[63] {
+g[Ek6y2w] {
 	n[0]:  malloc(n = 1) _    => _2 @ bb1[2]:  fn test_load_self_store_self;
 	n[1]:  copy          n[0] => _1 @ bb2[3]:  fn test_load_self_store_self;
 	n[2]:  field.3       n[1] => _  @ bb2[6]:  fn test_load_self_store_self;
@@ -631,7 +632,7 @@ g[63] {
 }
 nodes_that_need_write = [7, 6, 5, 1, 0]
 
-g[64] {
+g[jhTNdQ] {
 	n[0]: malloc(n = 1) _    => _2  @ bb1[2]:  fn test_load_self_store_self_inter;
 	n[1]: copy          n[0] => _1  @ bb2[3]:  fn test_load_self_store_self_inter;
 	n[2]: field.0       n[1] => _6  @ bb2[6]:  fn test_load_self_store_self_inter;
@@ -644,7 +645,7 @@ g[64] {
 }
 nodes_that_need_write = [5, 4, 1, 0]
 
-g[65] {
+g[tkOyHg] {
 	n[0]: malloc(n = 1) _    => _1 @ bb1[2]:  fn test_ptr_int_ptr;
 	n[1]: copy          n[0] => _5 @ bb2[5]:  fn test_ptr_int_ptr;
 	n[2]: ptr_to_int    n[1] => _  @ bb2[5]:  fn test_ptr_int_ptr;
@@ -654,20 +655,20 @@ g[65] {
 }
 nodes_that_need_write = []
 
-g[66] {
+g[GrMFdw] {
 	n[0]: malloc(n = 1) _    => _1 @ bb1[2]: fn test_load_value;
 	n[1]: value.load    _    => _6 @ bb2[8]: fn test_load_value;
 	n[2]: free          n[1] => _5 @ bb2[8]: fn test_load_value;
 }
 nodes_that_need_write = []
 
-g[67] {
+g[FzitsA] {
 	n[0]: &_1       _    => _4 @ bb2[4]: fn test_load_value;
 	n[1]: addr.load n[0] => _  @ bb2[7]: fn test_load_value;
 }
 nodes_that_need_write = []
 
-g[68] {
+g[sadkqQ] {
 	n[0]: malloc(n = 1) _    => _1       @ bb1[2]:  fn test_store_value;
 	n[1]: copy          n[0] => _4       @ bb2[4]:  fn test_store_value;
 	n[2]: copy          n[1] => _6       @ bb2[10]: fn test_store_value;
@@ -677,13 +678,13 @@ g[68] {
 }
 nodes_that_need_write = []
 
-g[69] {
+g[JfFq+w] {
 	n[0]: &_1        _    => _5 @ bb2[7]:  fn test_store_value;
 	n[1]: addr.store n[0] => _  @ bb2[10]: fn test_store_value;
 }
 nodes_that_need_write = [1, 0]
 
-g[70] {
+g[1HEc2g] {
 	n[0]:  malloc(n = 1) _    => _2                @ bb1[2]:  fn test_store_value_field;
 	n[1]:  copy          n[0] => _1                @ bb2[2]:  fn test_store_value_field;
 	n[2]:  copy          n[1] => _9                @ bb4[6]:  fn test_store_value_field;
@@ -698,7 +699,7 @@ g[70] {
 }
 nodes_that_need_write = [6, 5, 1, 0]
 
-g[71] {
+g[uWnoLg] {
 	n[0]: malloc(n = 1) _    => _6  @ bb3[2]: fn test_store_value_field;
 	n[1]: copy          n[0] => _5  @ bb4[2]: fn test_store_value_field;
 	n[2]: field.2       n[1] => _   @ bb4[6]: fn test_store_value_field;
@@ -708,7 +709,7 @@ g[71] {
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
-g[72] {
+g[JwVNCw] {
 	n[0]: malloc(n = 1) _    => _1       @ bb1[2]:  fn test_load_value_store_value;
 	n[1]: value.load    _    => _5       @ bb2[7]:  fn test_load_value_store_value;
 	n[2]: value.store   n[1] => _4.Deref @ bb2[8]:  fn test_load_value_store_value;
@@ -717,7 +718,7 @@ g[72] {
 }
 nodes_that_need_write = []
 
-g[73] {
+g[ugP49Q] {
 	n[0]: &_1        _    => _4 @ bb2[4]:  fn test_load_value_store_value;
 	n[1]: addr.load  n[0] => _  @ bb2[6]:  fn test_load_value_store_value;
 	n[2]: addr.store n[0] => _  @ bb2[7]:  fn test_load_value_store_value;
@@ -725,17 +726,17 @@ g[73] {
 }
 nodes_that_need_write = [2, 0]
 
-g[74] {
+g[mD52ng] {
 	n[0]: copy _ => _31 @ bb27[4]: fn main_0;
 }
 nodes_that_need_write = []
 
-g[75] {
+g[TlrwBg] {
 	n[0]: copy _ => _37 @ bb27[12]: fn main_0;
 }
 nodes_that_need_write = []
 
-g[76] {
+g[RpQKtw] {
 	n[0]:  &_31       _     => _39 @ bb28[6]:  fn main_0;        
 	n[1]:  copy       n[0]  => _38 @ bb28[7]:  fn main_0;        
 	n[2]:  copy       n[1]  => _2  @ bb0[0]:   fn insertion_sort;


### PR DESCRIPTION
When pretty-printing a `Graph`, instead of the `GraphId` index, print the `Graph`'s hash.

The reason we print the hash instead of the index is so that `Graph`s remain stable when their position changes,
 so when changes cause a new `Graph` to be emitted,
 it doesn't cause a snapshot diff on all subsequent `Graph`s, only the new one.

As for the actual hash printed, the hash (a `u64`) is turned into a `u32` and then printed as base64 to be succinct and readable.