### PR TITLE
remove unused dependencies and features

### DIFF
--- a/c2rust-ast-builder/Cargo.toml
+++ b/c2rust-ast-builder/Cargo.toml
@@ -12,5 +12,5 @@ description = "Rust AST builder support crate for the C2Rust project"
 edition = "2021"
 
 [dependencies]
-proc-macro2 = { version = "1.0", features = ["span-locations"]}
-syn = { version = "1.0", features = ["full", "extra-traits", "printing"]}
+proc-macro2 = { version = "1.0", features = ["span-locations"], default-features = false }
+syn = { version = "1.0", features = ["full", "extra-traits", "printing"], default-features = false }

--- a/c2rust-ast-exporter/Cargo.toml
+++ b/c2rust-ast-exporter/Cargo.toml
@@ -20,7 +20,7 @@ serde_bytes = "0.11"
 serde_cbor = "0.11"
 
 [build-dependencies]
-bindgen = { version = "0.60", features = ["logging"] }
+bindgen = { version = "0.60", features = ["logging"], default-features = false }
 clang-sys = "1.3"
 # Pinning until https://github.com/rust-lang/cmake-rs/issues/131 is resolved
 # Fixed by https://github.com/rust-lang/cmake-rs/pull/146 on 5/12/2022; waiting for next release.
@@ -29,6 +29,5 @@ env_logger = "0.9"
 
 [features]
 default = []
-
 # Force static linking of LLVM
 llvm-static = []

--- a/c2rust-ast-printer/Cargo.toml
+++ b/c2rust-ast-printer/Cargo.toml
@@ -9,6 +9,6 @@ description = "Customized version of libsyntax rust pretty-printer"
 
 [dependencies]
 log = "0.4"
-syn = { version = "1.0", features = ["full", "proc-macro", "printing"] }
-proc-macro2 = "1.0"
+syn = { version = "1.0", features = ["full", "proc-macro", "printing"], default-features = false }
+proc-macro2 = { version = "1.0", default-features = false }
 prettyplease = "0.1.9"

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -16,8 +16,6 @@ edition = "2021"
 c2rust-ast-builder = { version = "0.16.0", path = "../c2rust-ast-builder" }
 c2rust-ast-exporter = { version = "0.16.0", path = "../c2rust-ast-exporter" }
 c2rust-ast-printer = { version = "0.16.0", path = "../c2rust-ast-printer" }
-c2rust-bitfields = { version = "0.3.0", path = "../c2rust-bitfields" }
-clap = {version = "2.34", features = ["yaml"]}
 colored = "2.0"
 dtoa = "1.0"
 failure = "0.1.5"
@@ -39,7 +37,7 @@ serde_json = "1.0"
 smallvec = "1.0"
 strum = "0.24"
 strum_macros = "0.24"
-syn = { version = "1.0", features = ["full", "extra-traits", "parsing", "printing"]}
+syn = { version = "1.0", features = ["full", "extra-traits", "parsing", "printing"], default-features = false}
 
 [features]
 # Force static linking of LLVM


### PR DESCRIPTION
Disable default features for dependencies where features are unused.
Remove `clap` and `c2rust-bitfields` from dependencies of `c2rust-transpile` (unused).