### PR TITLE
remove `c2rust-macros` from the workspace as it's unused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,15 +284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "c2rust-macros"
-version = "0.16.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "c2rust-pdg"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
     "c2rust-ast-exporter",
     "c2rust-ast-printer",
     "c2rust-bitfields",
-    "c2rust-macros",
     "c2rust-asm-casts",
     "analysis/runtime",
     "dynamic_instrumentation",
@@ -14,6 +13,7 @@ members = [
     "rustc-private-link",
 ]
 exclude = [
+    "c2rust-macros",
     "cross-checks/pointer-tracer",
     "cross-checks/zero-malloc",
     "cross-checks/rust-checks",


### PR DESCRIPTION
This crate is used only in c2rust-refactor, which is itself excluded.