### PR TITLE
Remove unused `inner_mut` (UB)

### DIFF
--- a/c2rust-transpile/src/rust_ast/mod.rs
+++ b/c2rust-transpile/src/rust_ast/mod.rs
@@ -47,8 +47,6 @@ pub trait SpanExt: Sized {
 
     fn inner(&self) -> (u32, u32);
 
-    fn inner_mut(&mut self) -> (&mut u32, &mut u32);
-
     #[inline(always)]
     fn lo(&self) -> BytePos {
         BytePos(self.inner().0)
@@ -145,15 +143,6 @@ fn validate_repr() {
     assert!(repr.hi == 0);
 }
 
-/** return a pair of mutable references to s.lo and s.hi */
-fn get_inner_mut(s: &mut Span) -> (&mut u32, &mut u32) {
-    validate_repr();
-    /* safety: safe if it is safe to transmute between `Span` and `SpanRepr`;
-    we call `validate_repr` to verify this. see doc comment on `validare_repr` */
-    let repr: &mut SpanRepr = unsafe { std::mem::transmute(s) };
-    (&mut repr.lo, &mut repr.hi)
-}
-
 /** return (s.lo, s.hi) */
 fn get_inner(s: &Span) -> (u32, u32) {
     validate_repr();
@@ -200,10 +189,6 @@ impl SpanExt for Span {
     fn inner(&self) -> (u32, u32) {
         get_inner(self)
     }
-
-    fn inner_mut(&mut self) -> (&mut u32, &mut u32) {
-        get_inner_mut(self)
-    }
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -231,9 +216,5 @@ impl SpanExt for MySpan {
 
     fn inner(&self) -> (u32, u32) {
         (self.lo, self.hi)
-    }
-
-    fn inner_mut(&mut self) -> (&mut u32, &mut u32) {
-        (&mut self.lo, &mut self.hi)
     }
 }


### PR DESCRIPTION
Removed `(get_)inner_mut` as it's unused and it's UB, so if we don't need it, we should remove it.