### PR TITLE
transpile: simplify dynamic argument parsing

### DIFF
--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -646,16 +646,9 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let args = self.convert_exprs(ctx.used(), args)?;
         args.and_then(|args| {
-            let mut args = args.into_iter();
-            let a = args
-                .next()
-                .ok_or("Missing first argument to convert_overflow_arith")?;
-            let b = args
-                .next()
-                .ok_or("Missing second argument to convert_overflow_arith")?;
-            let c = args
-                .next()
-                .ok_or("Missing third argument to convert_overflow_arith")?;
+            let [a, b, c]: [_; 3] = args
+                .try_into()
+                .map_err(|_| "`convert_overflow_arith` must have exactly 3 arguments")?;
             let overflowing = mk().method_call_expr(a, method_name, vec![b]);
             let sum_name = self.renamer.borrow_mut().fresh();
             let over_name = self.renamer.borrow_mut().fresh();
@@ -691,16 +684,9 @@ impl<'c> Translation<'c> {
         let mem = mk().path_expr(vec!["libc", name]);
         let args = self.convert_exprs(ctx.used(), args)?;
         args.and_then(|args| {
-            let mut args = args.into_iter();
-            let dst = args
-                .next()
-                .ok_or("Missing dst argument to convert_libc_fns")?;
-            let c = args
-                .next()
-                .ok_or("Missing c argument to convert_libc_fns")?;
-            let len = args
-                .next()
-                .ok_or("Missing len argument to convert_libc_fns")?;
+            let [dst, c, len]: [_; 3] = args
+                .try_into()
+                .map_err(|_| "`convert_libc_fns` must have exactly 3 arguments: [dst, c, len]")?;
             let size_t = mk().path_ty(vec!["libc", "size_t"]);
             let len1 = mk().cast_expr(len, size_t);
             let mem_expr = mk().call_expr(mem, vec![dst, c, len1]);

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -428,16 +428,9 @@ impl<'c> Translation<'c> {
         let param_translation =
             self.convert_exprs(ctx.used(), &[first_expr_id, second_expr_id, mask_expr_id])?;
         param_translation.and_then(|params| {
-            let mut params = params.into_iter();
-            let first = params
-                .next()
-                .ok_or("Missing first param in convert_shuffle_vector")?;
-            let second = params
-                .next()
-                .ok_or("Missing second param in convert_shuffle_vector")?;
-            let third = params
-                .next()
-                .ok_or("Missing third param in convert_shuffle_vector")?;
+            let [first, second, third]: [_; 3] = params
+                .try_into()
+                .map_err(|_| "`convert_shuffle_vector` must have exactly 3 parameters")?;
             let mut new_params = vec![first];
 
             // Some don't take a second param, but the expr is still there for some reason


### PR DESCRIPTION
Instead of `it.next().unwrap().parse().unwrap()` chains use slice patterns and a single `expect` call.