### PR TITLE
Improve `c2rust-analyze`'s `.gitignore`

### DIFF
--- a/c2rust-analyze/.gitignore
+++ b/c2rust-analyze/.gitignore
@@ -1,3 +1,2 @@
-/target/
 /inspect/
 *.rlib

--- a/c2rust-analyze/.gitignore
+++ b/c2rust-analyze/.gitignore
@@ -1,2 +1,3 @@
 /target/
 /inspect/
+*.rlib


### PR DESCRIPTION
Improve `c2rust-analyze`'s `.gitignore` to:
* ignore `*.rlib`, which are produced by `cargo test`
* don't redundantly ignore `/target/`, as that's already ignored by the root `.gitignore`