### PR TITLE
Polyfill `reallocarray`

### DIFF
--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot.snap
@@ -191,7 +191,9 @@ g {
 	n[17]: addr.load     n[16] => _   @ bb13[2]:  fn exercise_allocator;
 	n[18]: copy          n[1]  => _43 @ bb21[7]:  fn exercise_allocator;
 	n[19]: copy          n[18] => _42 @ bb21[8]:  fn exercise_allocator;
-	n[20]: free          n[19] => _41 @ bb22[2]:  fn exercise_allocator;
+	n[20]: copy          n[1]  => _4  @ bb0[2]:   fn reallocarray;      
+	n[21]: copy          n[20] => _1  @ bb1[3]:   fn reallocarray;      
+	n[22]: free          n[19] => _41 @ bb22[2]:  fn exercise_allocator;
 }
 nodes_that_need_write = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
@@ -813,5 +815,5 @@ g {
 nodes_that_need_write = [71, 70, 69, 62, 61, 60, 59, 58, 57, 50, 49, 48, 41, 40, 39, 29, 28, 27, 23, 22, 21, 11, 10, 9, 2, 1, 0]
 
 num_graphs = 77
-num_nodes = 502
+num_nodes = 504
 


### PR DESCRIPTION
Fixes https://github.com/immunant/c2rust/issues/522.

This polyfills `reallocarray` using `realloc`, as `reallocarray` doesn't exist on macOS.

The polyfilling is done through a `const` function pointer so that the instrumentation does not see the `realloc` and generate an extra `free` and `malloc` event for it (though the instrumentation probably should see it; when this breaks, we'll know instrumentation is smart enough to see through things like a `const` function pointer).

Normally we'd only polyfill it on macOS, but then we'd need a different snapshot file for macOS, as polyfilling results in a couple of extra copies.  Thus, we just polyfill always.