### PR TITLE
transpile: remove `trait LitStringable`, `impl Make<T> for &T`

### DIFF
--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -166,12 +166,6 @@ impl<T> Make<T> for T {
     }
 }
 
-impl<'a, T: Clone> Make<T> for &'a T {
-    fn make(self, _mk: &Builder) -> T {
-        self.clone()
-    }
-}
-
 impl Make<Ident> for &str {
     fn make(self, mk: &Builder) -> Ident {
         Ident::new(self, mk.span)
@@ -440,25 +434,6 @@ impl Make<Signature> for Box<FnDecl> {
     }
 }
 
-pub trait LitStringable {
-    fn lit_string(self, _: &Builder) -> String;
-}
-
-impl<T> LitStringable for T
-where
-    T: Make<Type>,
-{
-    fn lit_string(self, b: &Builder) -> String {
-        let ty: Type = self.make(b);
-        ty.to_token_stream().to_string()
-    }
-}
-
-impl LitStringable for &str {
-    fn lit_string(self, _: &Builder) -> String {
-        self.to_string()
-    }
-}
 #[derive(Clone, Debug)]
 pub struct Builder {
     // The builder holds a set of "modifiers", such as visibility and mutability.  Functions for
@@ -1248,28 +1223,16 @@ impl Builder {
 
     // Literals
 
-    pub fn int_lit<T>(self, i: u128, ty: T) -> Lit
-    where
-        T: LitStringable,
-    {
-        Lit::Int(LitInt::new(
-            &format!("{}{}", i, ty.lit_string(&self)),
-            self.span,
-        ))
+    pub fn int_lit(self, i: u128, ty: &str) -> Lit {
+        Lit::Int(LitInt::new(&format!("{}{}", i, ty), self.span))
     }
 
     pub fn int_unsuffixed_lit(self, i: u128) -> Lit {
         Lit::Int(LitInt::new(&format!("{}", i), self.span))
     }
 
-    pub fn float_lit<T>(self, s: &str, ty: T) -> Lit
-    where
-        T: LitStringable,
-    {
-        Lit::Float(LitFloat::new(
-            &format!("{}{}", s, ty.lit_string(&self)),
-            self.span,
-        ))
+    pub fn float_lit(self, s: &str, ty: &str) -> Lit {
+        Lit::Float(LitFloat::new(&format!("{}{}", s, ty), self.span))
     }
 
     pub fn float_unsuffixed_lit(self, s: &str) -> Lit {

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -205,18 +205,16 @@ impl<'c> Translation<'c> {
                     self.convert_expr(ctx, lhs)?.and_then(|lhs_val| {
                         self.convert_expr(rhs_ctx, rhs)?.result_map(|rhs_val| {
                             let expr_ids = Some((lhs, rhs));
-                            self.convert_binary_operator(
-                                ConvertBinaryOperatorArgs {
-                                    op,
-                                    ty,
-                                    ctype: type_id.ctype,
-                                    lhs_type: lhs_type_id,
-                                    rhs_type: rhs_type_id,
-                                    lhs: lhs_val,
-                                    rhs: rhs_val,
-                                    lhs_rhs_ids: expr_ids,
-                                },
-                            )
+                            self.convert_binary_operator(ConvertBinaryOperatorArgs {
+                                op,
+                                ty,
+                                ctype: type_id.ctype,
+                                lhs_type: lhs_type_id,
+                                rhs_type: rhs_type_id,
+                                lhs: lhs_val,
+                                rhs: rhs_val,
+                                lhs_rhs_ids: expr_ids,
+                            })
                         })
                     })
                 }
@@ -267,18 +265,16 @@ impl<'c> Translation<'c> {
                 mk().cast_expr(read, lhs_type.clone())
             };
             let ty = self.convert_type(compute_res_ty.ctype)?;
-            let val = self.convert_binary_operator(
-                ConvertBinaryOperatorArgs {
-                    op: bin_op,
-                    ty,
-                    ctype: compute_res_ty.ctype,
-                    lhs_type: compute_lhs_ty,
-                    rhs_type: rhs_ty,
-                    lhs,
-                    rhs,
-                    lhs_rhs_ids: None,
-                },
-            )?;
+            let val = self.convert_binary_operator(ConvertBinaryOperatorArgs {
+                op: bin_op,
+                ty,
+                ctype: compute_res_ty.ctype,
+                lhs_type: compute_lhs_ty,
+                rhs_type: rhs_ty,
+                lhs,
+                rhs,
+                lhs_rhs_ids: None,
+            })?;
 
             let is_enum_result = self.ast_context[self.ast_context.resolve_type_id(lhs_ty.ctype)]
                 .kind
@@ -435,7 +431,9 @@ impl<'c> Translation<'c> {
                     use c_ast::BinOp::*;
                     let assign_stmt = match op {
                         // Regular (possibly volatile) assignment
-                        Assign if !is_volatile => WithStmts::new_val(mk().assign_expr(&write, rhs)),
+                        Assign if !is_volatile => {
+                            WithStmts::new_val(mk().assign_expr(write.clone(), rhs))
+                        }
                         Assign => WithStmts::new_val(self.volatile_write(
                             write,
                             initial_lhs_type_id,
@@ -450,25 +448,23 @@ impl<'c> Translation<'c> {
                                 .expect("Cannot convert non-assignment operator");
 
                             let val = if compute_lhs_type_id.ctype == initial_lhs_type_id.ctype {
-                                self.convert_binary_operator(
-                                    ConvertBinaryOperatorArgs {
-                                        op,
-                                        ty,
-                                        ctype: qtype.ctype,
-                                        lhs_type: initial_lhs_type_id,
-                                        rhs_type: rhs_type_id,
-                                        lhs: read.clone(),
-                                        rhs,
-                                        lhs_rhs_ids: None,
-                                    },
-                                )?
+                                self.convert_binary_operator(ConvertBinaryOperatorArgs {
+                                    op,
+                                    ty,
+                                    ctype: qtype.ctype,
+                                    lhs_type: initial_lhs_type_id,
+                                    rhs_type: rhs_type_id,
+                                    lhs: read.clone(),
+                                    rhs,
+                                    lhs_rhs_ids: None,
+                                })?
                             } else {
                                 let lhs_type = self.convert_type(compute_type.unwrap().ctype)?;
                                 let write_type = self.convert_type(qtype.ctype)?;
                                 let lhs = mk().cast_expr(read.clone(), lhs_type.clone());
                                 let ty = self.convert_type(result_type_id.ctype)?;
-                                let val = self.convert_binary_operator(
-                                    ConvertBinaryOperatorArgs {
+                                let val =
+                                    self.convert_binary_operator(ConvertBinaryOperatorArgs {
                                         op,
                                         ty,
                                         ctype: result_type_id.ctype,
@@ -477,8 +473,7 @@ impl<'c> Translation<'c> {
                                         lhs,
                                         rhs,
                                         lhs_rhs_ids: None,
-                                    },
-                                )?;
+                                    })?;
 
                                 let is_enum_result = self.ast_context
                                     [self.ast_context.resolve_type_id(qtype.ctype)]
@@ -510,12 +505,12 @@ impl<'c> Translation<'c> {
                         AssignAdd if pointer_lhs.is_some() => {
                             let mul = self.compute_size_of_expr(pointer_lhs.unwrap().ctype);
                             let ptr = pointer_offset(write.clone(), rhs, mul, false, false);
-                            WithStmts::new_val(mk().assign_expr(&write, ptr))
+                            WithStmts::new_val(mk().assign_expr(write.clone(), ptr))
                         }
                         AssignSubtract if pointer_lhs.is_some() => {
                             let mul = self.compute_size_of_expr(pointer_lhs.unwrap().ctype);
                             let ptr = pointer_offset(write.clone(), rhs, mul, true, false);
-                            WithStmts::new_val(mk().assign_expr(&write, ptr))
+                            WithStmts::new_val(mk().assign_expr(write.clone(), ptr))
                         }
 
                         _ => {
@@ -530,7 +525,7 @@ impl<'c> Translation<'c> {
                                     op == AssignSubtract,
                                     false,
                                 );
-                                WithStmts::new_val(mk().assign_expr(&write, ptr))
+                                WithStmts::new_val(mk().assign_expr(write.clone(), ptr))
                             } else {
                                 fn eq<Token: Default, F: Fn(Token) -> BinOp>(f: F) -> BinOp {
                                     f(Default::default())
@@ -883,7 +878,7 @@ impl<'c> Translation<'c> {
                 let assign_stmt = if ty.qualifiers.is_volatile {
                     self.volatile_write(write, ty, val)?
                 } else {
-                    mk().assign_expr(&write, val)
+                    mk().assign_expr(write, val)
                 };
 
                 Ok(WithStmts::new(

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -432,7 +432,7 @@ impl<'c> Translation<'c> {
                     let assign_stmt = match op {
                         // Regular (possibly volatile) assignment
                         Assign if !is_volatile => {
-                            WithStmts::new_val(mk().assign_expr(write.clone(), rhs))
+                            WithStmts::new_val(mk().assign_expr(write, rhs))
                         }
                         Assign => WithStmts::new_val(self.volatile_write(
                             write,
@@ -505,12 +505,12 @@ impl<'c> Translation<'c> {
                         AssignAdd if pointer_lhs.is_some() => {
                             let mul = self.compute_size_of_expr(pointer_lhs.unwrap().ctype);
                             let ptr = pointer_offset(write.clone(), rhs, mul, false, false);
-                            WithStmts::new_val(mk().assign_expr(write.clone(), ptr))
+                            WithStmts::new_val(mk().assign_expr(write, ptr))
                         }
                         AssignSubtract if pointer_lhs.is_some() => {
                             let mul = self.compute_size_of_expr(pointer_lhs.unwrap().ctype);
                             let ptr = pointer_offset(write.clone(), rhs, mul, true, false);
-                            WithStmts::new_val(mk().assign_expr(write.clone(), ptr))
+                            WithStmts::new_val(mk().assign_expr(write, ptr))
                         }
 
                         _ => {
@@ -525,7 +525,7 @@ impl<'c> Translation<'c> {
                                     op == AssignSubtract,
                                     false,
                                 );
-                                WithStmts::new_val(mk().assign_expr(write.clone(), ptr))
+                                WithStmts::new_val(mk().assign_expr(write, ptr))
                             } else {
                                 fn eq<Token: Default, F: Fn(Token) -> BinOp>(f: F) -> BinOp {
                                     f(Default::default())


### PR DESCRIPTION
The `LitStringable` `trait` is deprecated and doesn't do anything useful in the current codebase (it is only implemented for `&str`, which is much easier to take directly).

The `impl Make<T> for &T` is redundant and causes issues with type inference. It is also more clear and easier to optimize if the clones are explicit at use site.