### PR TITLE
Specialize builder functions where unambiguous

### DIFF
--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -518,8 +518,7 @@ impl Builder {
         Builder { span, ..self }
     }
 
-    pub fn generic_over<P: Make<GenericParam>>(mut self, param: P) -> Self {
-        let param = param.make(&self);
+    pub fn generic_over(mut self, param: GenericParam) -> Self {
         self.generics.params.push(param);
         self
     }
@@ -577,11 +576,7 @@ impl Builder {
         }
     }
 
-    pub fn prepare_meta<K>(&self, kind: K) -> PreparedMetaItem
-    where
-        K: Make<Meta>,
-    {
-        let kind: Meta = kind.make(self);
+    pub fn prepare_meta(&self, kind: Meta) -> PreparedMetaItem {
         match kind {
             Meta::List(ml) => self.prepare_meta_list(ml),
             Meta::NameValue(mnv) => self.prepare_meta_namevalue(mnv),
@@ -589,13 +584,11 @@ impl Builder {
         }
     }
 
-    pub fn prepare_nested_meta_item<I, K>(&self, path: I, kind: K) -> PreparedMetaItem
+    pub fn prepare_nested_meta_item<I>(&self, path: I, kind: Meta) -> PreparedMetaItem
     where
         I: Make<Path>,
-        K: Make<Meta>,
     {
         let path = path.make(self);
-        let kind = kind.make(self);
         PreparedMetaItem {
             path,
             tokens: kind.to_token_stream(),
@@ -671,11 +664,7 @@ impl Builder {
         }
     }
 
-    pub fn parenthesized_args<Ts>(self, tys: Ts) -> ParenthesizedGenericArguments
-    where
-        Ts: Make<Vec<Box<Type>>>,
-    {
-        let tys = tys.make(&self);
+    pub fn parenthesized_args(self, tys: Vec<Box<Type>>) -> ParenthesizedGenericArguments {
         ParenthesizedGenericArguments {
             paren_token: token::Paren(self.span),
             inputs: punct_box(tys),
@@ -726,13 +715,11 @@ impl Builder {
         path.make(&self)
     }
 
-    pub fn use_tree<Pa, K>(self, prefix: Pa, kind: K) -> UseTree
+    pub fn use_tree<Pa>(self, prefix: Pa, mut tree: UseTree) -> UseTree
     where
         Pa: Make<Path>,
-        K: Make<UseTree>,
     {
         let path: Path = prefix.make(&self);
-        let mut tree = kind.make(&self);
         for seg in path.segments {
             tree = UseTree::Path(UsePath {
                 ident: seg.ident,
@@ -756,11 +743,8 @@ impl Builder {
     // These are sorted in the same order as the corresponding ExprKind variants, with additional
     // variant-specific details following each variant.
 
-    pub fn array_expr<A>(self, args: Vec<A>) -> Box<Expr>
-    where
-        A: Make<Box<Expr>>,
-    {
-        let args = args.into_iter().map(|a| *a.make(&self)).collect();
+    pub fn array_expr(self, args: Vec<Box<Expr>>) -> Box<Expr> {
+        let args = args.into_iter().map(|a| *a).collect();
         Box::new(Expr::Array(ExprArray {
             attrs: self.attrs,
             bracket_token: token::Bracket(self.span),
@@ -768,13 +752,8 @@ impl Builder {
         }))
     }
 
-    pub fn call_expr<F, A>(self, func: F, args: Vec<A>) -> Box<Expr>
-    where
-        F: Make<Box<Expr>>,
-        A: Make<Box<Expr>>,
-    {
-        let func = func.make(&self);
-        let args = args.into_iter().map(|a| *a.make(&self)).collect();
+    pub fn call_expr(self, func: Box<Expr>, args: Vec<Box<Expr>>) -> Box<Expr> {
+        let args = args.into_iter().map(|a| *a).collect();
         Box::new(parenthesize_if_necessary(Expr::Call(ExprCall {
             attrs: self.attrs,
             paren_token: token::Paren(self.span),
@@ -783,13 +762,10 @@ impl Builder {
         })))
     }
 
-    pub fn method_call_expr<E, S, A>(self, expr: E, seg: S, args: Vec<A>) -> Box<Expr>
+    pub fn method_call_expr<S>(self, expr: Box<Expr>, seg: S, args: Vec<Box<Expr>>) -> Box<Expr>
     where
-        E: Make<Box<Expr>>,
         S: Make<PathSegment>,
-        A: Make<Box<Expr>>,
     {
-        let expr = expr.make(&self);
         let seg = seg.make(&self);
 
         let mut arg_vals = Vec::with_capacity(args.len());
@@ -838,11 +814,7 @@ impl Builder {
         )))
     }
 
-    pub fn tuple_expr<E>(self, exprs: Vec<E>) -> Box<Expr>
-    where
-        E: Make<Box<Expr>>,
-    {
-        let exprs: Vec<Box<Expr>> = exprs.into_iter().map(|x| x.make(&self)).collect();
+    pub fn tuple_expr(self, exprs: Vec<Box<Expr>>) -> Box<Expr> {
         Box::new(Expr::Tuple(ExprTuple {
             attrs: self.attrs,
             paren_token: token::Paren(self.span),
@@ -850,16 +822,7 @@ impl Builder {
         }))
     }
 
-    pub fn binary_expr<O, E>(self, op: O, lhs: E, rhs: E) -> Box<Expr>
-    where
-        O: Make<BinOp>,
-        E: Make<Box<Expr>>,
-    {
-        let op = op.make(&self);
-        // FIXME: set span for op
-        let mut lhs = lhs.make(&self);
-        let rhs = rhs.make(&self);
-
+    pub fn binary_expr(self, op: BinOp, mut lhs: Box<Expr>, rhs: Box<Expr>) -> Box<Expr> {
         match op {
             BinOp::Lt(_) | BinOp::Shl(_) if has_rightmost_cast(&*lhs) => lhs = mk().paren_expr(lhs),
             _ => {}
@@ -873,14 +836,12 @@ impl Builder {
         })))
     }
 
-    pub fn unary_expr<O, E>(self, op: O, a: E) -> Box<Expr>
+    pub fn unary_expr<O>(self, op: O, a: Box<Expr>) -> Box<Expr>
     where
         O: Make<UnOp>,
-        E: Make<Box<Expr>>,
     {
         let op = op.make(&self);
         // FIXME: set span for op
-        let a = a.make(&self);
         Box::new(parenthesize_if_necessary(Expr::Unary(ExprUnary {
             attrs: self.attrs,
             op,
@@ -900,14 +861,7 @@ impl Builder {
         }))
     }
 
-    pub fn cast_expr<E, T>(self, e: E, t: T) -> Box<Expr>
-    where
-        E: Make<Box<Expr>>,
-        T: Make<Box<Type>>,
-    {
-        let e = e.make(&self);
-        let t = t.make(&self);
-
+    pub fn cast_expr(self, e: Box<Expr>, t: Box<Type>) -> Box<Expr> {
         Box::new(parenthesize_if_necessary(Expr::Cast(ExprCast {
             attrs: self.attrs,
             as_token: Token![as](self.span),
@@ -916,13 +870,7 @@ impl Builder {
         })))
     }
 
-    pub fn type_expr<E, T>(self, e: E, t: T) -> Box<Expr>
-    where
-        E: Make<Box<Expr>>,
-        T: Make<Box<Type>>,
-    {
-        let e = e.make(&self);
-        let t = t.make(&self);
+    pub fn type_expr(self, e: Box<Expr>, t: Box<Type>) -> Box<Expr> {
         Box::new(Expr::Type(ExprType {
             attrs: self.attrs,
             colon_token: Token![:](self.span),
@@ -931,19 +879,11 @@ impl Builder {
         }))
     }
 
-    pub fn unsafe_block_expr<B>(self, unsafe_blk: B) -> Box<Expr>
-    where
-        B: Make<ExprUnsafe>,
-    {
-        let unsafe_blk = unsafe_blk.make(&self);
+    pub fn unsafe_block_expr(self, unsafe_blk: ExprUnsafe) -> Box<Expr> {
         Box::new(Expr::Unsafe(unsafe_blk))
     }
 
-    pub fn block_expr<B>(self, blk: B) -> Box<Expr>
-    where
-        B: Make<Box<Block>>,
-    {
-        let blk = blk.make(&self);
+    pub fn block_expr(self, blk: Box<Block>) -> Box<Expr> {
         Box::new(Expr::Block(ExprBlock {
             attrs: self.attrs,
             block: *blk,
@@ -951,12 +891,10 @@ impl Builder {
         }))
     }
 
-    pub fn labelled_block_expr<B, L>(self, blk: B, lbl: L) -> Box<Expr>
+    pub fn labelled_block_expr<L>(self, blk: Box<Block>, lbl: L) -> Box<Expr>
     where
-        B: Make<Box<Block>>,
         L: Make<Label>,
     {
-        let blk = blk.make(&self);
         let lbl = lbl.make(&self);
         Box::new(Expr::Block(ExprBlock {
             attrs: self.attrs,
@@ -965,13 +903,7 @@ impl Builder {
         }))
     }
 
-    pub fn assign_expr<E1, E2>(self, lhs: E1, rhs: E2) -> Box<Expr>
-    where
-        E1: Make<Box<Expr>>,
-        E2: Make<Box<Expr>>,
-    {
-        let lhs = lhs.make(&self);
-        let rhs = rhs.make(&self);
+    pub fn assign_expr(self, lhs: Box<Expr>, rhs: Box<Expr>) -> Box<Expr> {
         Box::new(Expr::Assign(ExprAssign {
             attrs: self.attrs,
             eq_token: Token![=](self.span),
@@ -980,16 +912,7 @@ impl Builder {
         }))
     }
 
-    pub fn assign_op_expr<O, E1, E2>(self, op: O, lhs: E1, rhs: E2) -> Box<Expr>
-    where
-        O: Make<BinOp>,
-        E1: Make<Box<Expr>>,
-        E2: Make<Box<Expr>>,
-    {
-        let op = op.make(&self);
-        // FIXME: set span for op
-        let lhs = lhs.make(&self);
-        let rhs = rhs.make(&self);
+    pub fn assign_op_expr(self, op: BinOp, lhs: Box<Expr>, rhs: Box<Expr>) -> Box<Expr> {
         Box::new(Expr::AssignOp(ExprAssignOp {
             attrs: self.attrs,
             op,
@@ -998,13 +921,7 @@ impl Builder {
         }))
     }
 
-    pub fn index_expr<E1, E2>(self, lhs: E1, rhs: E2) -> Box<Expr>
-    where
-        E1: Make<Box<Expr>>,
-        E2: Make<Box<Expr>>,
-    {
-        let lhs = lhs.make(&self);
-        let rhs = rhs.make(&self);
+    pub fn index_expr(self, lhs: Box<Expr>, rhs: Box<Expr>) -> Box<Expr> {
         Box::new(parenthesize_if_necessary(Expr::Index(ExprIndex {
             attrs: self.attrs,
             bracket_token: token::Bracket(self.span),
@@ -1042,13 +959,7 @@ impl Builder {
 
     /// An array literal constructed from one repeated element.
     /// `[expr; n]`
-    pub fn repeat_expr<E, N>(self, expr: E, n: N) -> Box<Expr>
-    where
-        E: Make<Box<Expr>>,
-        N: Make<Box<Expr>>,
-    {
-        let expr = expr.make(&self);
-        let n = n.make(&self);
+    pub fn repeat_expr(self, expr: Box<Expr>, n: Box<Expr>) -> Box<Expr> {
         Box::new(Expr::Repeat(ExprRepeat {
             attrs: self.attrs,
             bracket_token: token::Bracket(self.span),
@@ -1058,11 +969,7 @@ impl Builder {
         }))
     }
 
-    pub fn paren_expr<E>(self, e: E) -> Box<Expr>
-    where
-        E: Make<Box<Expr>>,
-    {
-        let e = e.make(&self);
+    pub fn paren_expr(self, e: Box<Expr>) -> Box<Expr> {
         Box::new(Expr::Paren(ExprParen {
             attrs: self.attrs,
             paren_token: token::Paren(self.span),
@@ -1078,11 +985,7 @@ impl Builder {
         self.path_expr(vec![name])
     }
 
-    pub fn addr_of_expr<E>(self, e: E) -> Box<Expr>
-    where
-        E: Make<Box<Expr>>,
-    {
-        let e = e.make(&self);
+    pub fn addr_of_expr(self, e: Box<Expr>) -> Box<Expr> {
         Box::new(Expr::Reference(ExprReference {
             attrs: self.attrs,
             and_token: Token![&](self.span),
@@ -1092,11 +995,7 @@ impl Builder {
         }))
     }
 
-    pub fn mac_expr<M>(self, mac: M) -> Box<Expr>
-    where
-        M: Make<Macro>,
-    {
-        let mac = mac.make(&self);
+    pub fn mac_expr(self, mac: Macro) -> Box<Expr> {
         Box::new(Expr::Macro(ExprMacro {
             attrs: self.attrs,
             mac,
@@ -1119,18 +1018,16 @@ impl Builder {
     }
 
     // struct_expr, but with optional base expression
-    pub fn struct_expr_base<Pa, E>(
+    pub fn struct_expr_base<Pa>(
         self,
         path: Pa,
         fields: Vec<FieldValue>,
-        base: Option<E>,
+        base: Option<Box<Expr>>,
     ) -> Box<Expr>
     where
         Pa: Make<Path>,
-        E: Make<Box<Expr>>,
     {
         let path = path.make(&self);
-        let base = base.map(|e| e.make(&self));
         Box::new(Expr::Struct(ExprStruct {
             attrs: self.attrs,
             brace_token: token::Brace(self.span),
@@ -1141,12 +1038,10 @@ impl Builder {
         }))
     }
 
-    pub fn field_expr<E, F>(self, val: E, field: F) -> Box<Expr>
+    pub fn field_expr<F>(self, val: Box<Expr>, field: F) -> Box<Expr>
     where
-        E: Make<Box<Expr>>,
         F: Make<Ident>,
     {
-        let val = val.make(&self);
         let field = field.make(&self);
         Box::new(parenthesize_if_necessary(Expr::Field(ExprField {
             attrs: self.attrs,
@@ -1156,12 +1051,7 @@ impl Builder {
         })))
     }
 
-    pub fn anon_field_expr<E>(self, val: E, field: u32) -> Box<Expr>
-    where
-        E: Make<Box<Expr>>,
-    {
-        let val = val.make(&self);
-        let field = field.make(&self);
+    pub fn anon_field_expr(self, val: Box<Expr>, field: u32) -> Box<Expr> {
         Box::new(parenthesize_if_necessary(Expr::Field(ExprField {
             attrs: self.attrs,
             dot_token: Token![.](self.span),
@@ -1173,13 +1063,11 @@ impl Builder {
         })))
     }
 
-    pub fn field<I, E>(self, ident: I, expr: E) -> FieldValue
+    pub fn field<I>(self, ident: I, expr: Box<Expr>) -> FieldValue
     where
         I: Make<Ident>,
-        E: Make<Box<Expr>>,
     {
         let ident = ident.make(&self);
-        let expr = expr.make(&self);
         FieldValue {
             member: Member::Named(ident),
             expr: *expr,
@@ -1188,12 +1076,8 @@ impl Builder {
         }
     }
 
-    pub fn match_expr<E>(self, cond: E, arms: Vec<Arm>) -> Box<Expr>
-    where
-        E: Make<Box<Expr>>,
-    {
-        let cond = cond.make(&self);
-        let arms = arms.into_iter().map(|arm| arm.make(&self)).collect();
+    pub fn match_expr(self, cond: Box<Expr>, arms: Vec<Arm>) -> Box<Expr> {
+        let arms = arms.into_iter().collect();
         Box::new(Expr::Match(ExprMatch {
             attrs: self.attrs,
             match_token: Token![match](self.span),
@@ -1203,17 +1087,11 @@ impl Builder {
         }))
     }
 
-    pub fn arm<Pa, E>(self, pat: Pa, guard: Option<E>, body: E) -> Arm
-    where
-        E: Make<Box<Expr>>,
-        Pa: Make<Box<Pat>>,
-    {
-        let pat = *pat.make(&self);
-        let guard = guard.map(|g| (Token![if](self.span), g.make(&self)));
-        let body = body.make(&self);
+    pub fn arm(self, pat: Box<Pat>, guard: Option<Box<Expr>>, body: Box<Expr>) -> Arm {
+        let guard = guard.map(|g| (Token![if](self.span), g));
         Arm {
             attrs: self.attrs,
-            pat,
+            pat: *pat,
             guard,
             body,
             fat_arrow_token: Token![=>](self.span),
@@ -1246,17 +1124,13 @@ impl Builder {
         })
     }
 
-    pub fn ifte_expr<C, T, E>(self, cond: C, then_case: T, else_case: Option<E>) -> Box<Expr>
-    where
-        C: Make<Box<Expr>>,
-        T: Make<Box<Block>>,
-        E: Make<Box<Expr>>,
-    {
-        let cond = cond.make(&self);
-        let then_case = *then_case.make(&self);
-        let else_case = else_case.map(|x| {
-            let e = x.make(&self);
-
+    pub fn ifte_expr(
+        self,
+        cond: Box<Expr>,
+        then_case: Box<Block>,
+        else_case: Option<Box<Expr>>,
+    ) -> Box<Expr> {
+        let else_case = else_case.map(|e| {
             // The else branch in libsyntax must be one of these three cases,
             // otherwise we have to manually add the block around the else expression
             (
@@ -1277,19 +1151,15 @@ impl Builder {
             attrs: self.attrs,
             if_token: Token![if](self.span),
             cond,
-            then_branch: then_case,
+            then_branch: *then_case,
             else_branch: else_case,
         }))
     }
 
-    pub fn while_expr<C, B, I>(self, cond: C, body: B, label: Option<I>) -> Box<Expr>
+    pub fn while_expr<I>(self, cond: Box<Expr>, body: Box<Block>, label: Option<I>) -> Box<Expr>
     where
-        C: Make<Box<Expr>>,
-        B: Make<Box<Block>>,
         I: Make<Ident>,
     {
-        let cond = cond.make(&self);
-        let body = *body.make(&self);
         let label = label.map(|l| Label {
             name: Lifetime {
                 ident: l.make(&self),
@@ -1302,17 +1172,15 @@ impl Builder {
             attrs: self.attrs,
             while_token: Token![while](self.span),
             cond,
-            body,
+            body: *body,
             label,
         }))
     }
 
-    pub fn loop_expr<B, I>(self, body: B, label: Option<I>) -> Box<Expr>
+    pub fn loop_expr<I>(self, body: Box<Block>, label: Option<I>) -> Box<Expr>
     where
-        B: Make<Box<Block>>,
         I: Make<Ident>,
     {
-        let body = *body.make(&self);
         let label = label.map(|l| Label {
             name: Lifetime {
                 ident: l.make(&self),
@@ -1324,21 +1192,21 @@ impl Builder {
         Box::new(Expr::Loop(ExprLoop {
             attrs: self.attrs,
             loop_token: Token![loop](self.span),
-            body,
+            body: *body,
             label,
         }))
     }
 
-    pub fn for_expr<Pa, E, B, I>(self, pat: Pa, expr: E, body: B, label: Option<I>) -> Box<Expr>
+    pub fn for_expr<I>(
+        self,
+        pat: Box<Pat>,
+        expr: Box<Expr>,
+        body: Box<Block>,
+        label: Option<I>,
+    ) -> Box<Expr>
     where
-        Pa: Make<Box<Pat>>,
-        E: Make<Box<Expr>>,
-        B: Make<Box<Block>>,
         I: Make<Ident>,
     {
-        let pat = *pat.make(&self);
-        let expr = expr.make(&self);
-        let body = *body.make(&self);
         let label = label.map(|l| Label {
             name: Lifetime {
                 ident: l.make(&self),
@@ -1351,9 +1219,9 @@ impl Builder {
             attrs: self.attrs,
             for_token: Token![for](self.span),
             in_token: Token![in](self.span),
-            pat,
+            pat: *pat,
             expr,
-            body,
+            body: *body,
             label,
         }))
     }
@@ -1374,11 +1242,7 @@ impl Builder {
         }))
     }
 
-    pub fn tuple_pat<Pa>(self, pats: Vec<Pa>) -> Box<Pat>
-    where
-        Pa: Make<Box<Pat>>,
-    {
-        let pats: Vec<Box<Pat>> = pats.into_iter().map(|x| x.make(&self)).collect();
+    pub fn tuple_pat(self, pats: Vec<Box<Pat>>) -> Box<Pat> {
         Box::new(Pat::Tuple(PatTuple {
             attrs: self.attrs,
             paren_token: token::Paren(self.span),
@@ -1405,22 +1269,14 @@ impl Builder {
         }))
     }
 
-    pub fn lit_pat<L>(self, lit: L) -> Box<Pat>
-    where
-        L: Make<Box<Expr>>,
-    {
-        let lit = lit.make(&self);
+    pub fn lit_pat(self, lit: Box<Expr>) -> Box<Pat> {
         Box::new(Pat::Lit(PatLit {
             attrs: self.attrs,
             expr: lit,
         }))
     }
 
-    pub fn mac_pat<M>(self, mac: M) -> Box<Pat>
-    where
-        M: Make<Macro>,
-    {
-        let mac = mac.make(&self);
+    pub fn mac_pat(self, mac: Macro) -> Box<Pat> {
         Box::new(Pat::Macro(PatMacro {
             attrs: self.attrs,
             mac,
@@ -1441,11 +1297,7 @@ impl Builder {
         }))
     }
 
-    pub fn or_pat<Pa>(self, pats: Vec<Pa>) -> Box<Pat>
-    where
-        Pa: Make<Box<Pat>>,
-    {
-        let pats: Vec<Box<Pat>> = pats.into_iter().map(|p| p.make(&self)).collect();
+    pub fn or_pat(self, pats: Vec<Box<Pat>>) -> Box<Pat> {
         Box::new(Pat::Or(PatOr {
             attrs: self.attrs,
             leading_vert: None, // Untested
@@ -1455,11 +1307,7 @@ impl Builder {
 
     // Types
 
-    pub fn barefn_ty<T>(self, decl: T) -> Box<Type>
-    where
-        T: Make<Box<BareFnTyParts>>,
-    {
-        let decl = decl.make(&self);
+    pub fn barefn_ty(self, decl: Box<BareFnTyParts>) -> Box<Type> {
         let (inputs, variadic, output) = *decl;
         let abi = self.get_abi_opt();
 
@@ -1477,37 +1325,23 @@ impl Builder {
         Box::new(Type::BareFn(barefn))
     }
 
-    pub fn array_ty<T, E>(self, ty: T, len: E) -> Box<Type>
-    where
-        T: Make<Box<Type>>,
-        E: Make<Box<Expr>>,
-    {
-        let ty = ty.make(&self);
-        let len = *len.make(&self);
+    pub fn array_ty(self, ty: Box<Type>, len: Box<Expr>) -> Box<Type> {
         Box::new(Type::Array(TypeArray {
             bracket_token: token::Bracket(self.span),
             semi_token: Token![;](self.span),
             elem: ty,
-            len,
+            len: *len,
         }))
     }
 
-    pub fn slice_ty<T>(self, ty: T) -> Box<Type>
-    where
-        T: Make<Box<Type>>,
-    {
-        let ty = ty.make(&self);
+    pub fn slice_ty(self, ty: Box<Type>) -> Box<Type> {
         Box::new(Type::Slice(TypeSlice {
             elem: ty,
             bracket_token: token::Bracket(self.span),
         }))
     }
 
-    pub fn ptr_ty<T>(self, ty: T) -> Box<Type>
-    where
-        T: Make<Box<Type>>,
-    {
-        let ty = ty.make(&self);
+    pub fn ptr_ty(self, ty: Box<Type>) -> Box<Type> {
         let const_token = if self.mutbl.to_token().is_none() {
             Some(Token![const](self.span))
         } else {
@@ -1521,11 +1355,7 @@ impl Builder {
         }))
     }
 
-    pub fn ref_ty<T>(self, ty: T) -> Box<Type>
-    where
-        T: Make<Box<Type>>,
-    {
-        let ty = ty.make(&self);
+    pub fn ref_ty(self, ty: Box<Type>) -> Box<Type> {
         Box::new(Type::Reference(TypeReference {
             lifetime: None,
             elem: ty,
@@ -1534,13 +1364,11 @@ impl Builder {
         }))
     }
 
-    pub fn ref_lt_ty<L, T>(self, lt: L, ty: T) -> Box<Type>
+    pub fn ref_lt_ty<L>(self, lt: L, ty: Box<Type>) -> Box<Type>
     where
         L: Make<Lifetime>,
-        T: Make<Box<Type>>,
     {
         let lt = lt.make(&self);
-        let ty = ty.make(&self);
         Box::new(Type::Reference(TypeReference {
             and_token: Token![&](self.span),
             lifetime: Some(lt),
@@ -1555,11 +1383,8 @@ impl Builder {
         }))
     }
 
-    pub fn tuple_ty<T>(self, elem_tys: Vec<T>) -> Box<Type>
-    where
-        T: Make<Box<Type>>,
-    {
-        let elem_tys = punct(elem_tys.into_iter().map(|ty| *ty.make(&self)).collect());
+    pub fn tuple_ty(self, elem_tys: Vec<Box<Type>>) -> Box<Type> {
+        let elem_tys = punct(elem_tys.into_iter().map(|ty| *ty).collect());
         Box::new(Type::Tuple(TypeTuple {
             paren_token: token::Paren(self.span),
             elems: elem_tys,
@@ -1594,11 +1419,7 @@ impl Builder {
         }))
     }
 
-    pub fn mac_ty<M>(self, mac: M) -> Box<Type>
-    where
-        M: Make<Macro>,
-    {
-        let mac = mac.make(&self);
+    pub fn mac_ty(self, mac: Macro) -> Box<Type> {
         Box::new(Type::Macro(TypeMacro { mac }))
     }
 
@@ -1610,57 +1431,33 @@ impl Builder {
 
     // Stmts
 
-    pub fn local_stmt<L>(self, local: L) -> Stmt
-    where
-        L: Make<Box<Local>>,
-    {
-        let local = *local.make(&self);
-        Stmt::Local(local)
+    pub fn local_stmt(self, local: Box<Local>) -> Stmt {
+        Stmt::Local(*local)
     }
 
-    pub fn expr_stmt<E>(self, expr: E) -> Stmt
-    where
-        E: Make<Box<Expr>>,
-    {
-        let expr = *expr.make(&self);
-        Stmt::Expr(expr)
+    pub fn expr_stmt(self, expr: Box<Expr>) -> Stmt {
+        Stmt::Expr(*expr)
     }
 
-    pub fn semi_stmt<E>(self, expr: E) -> Stmt
-    where
-        E: Make<Box<Expr>>,
-    {
-        let expr = *expr.make(&self);
-        Stmt::Semi(expr, Token![;](self.span))
+    pub fn semi_stmt(self, expr: Box<Expr>) -> Stmt {
+        Stmt::Semi(*expr, Token![;](self.span))
     }
 
-    pub fn item_stmt<I>(self, item: I) -> Stmt
-    where
-        I: Make<Box<Item>>,
-    {
-        let item = *item.make(&self);
-        Stmt::Item(item)
+    pub fn item_stmt(self, item: Box<Item>) -> Stmt {
+        Stmt::Item(*item)
     }
 
-    pub fn mac_stmt<M>(self, mac: M) -> Stmt
-    where
-        M: Make<Macro>,
-    {
-        let mac = mac.make(&self);
+    pub fn mac_stmt(self, mac: Macro) -> Stmt {
         self.semi_stmt(mk().mac_expr(mac))
     }
 
     // Items
 
-    pub fn static_item<I, T, E>(self, name: I, ty: T, init: E) -> Box<Item>
+    pub fn static_item<I>(self, name: I, ty: Box<Type>, init: Box<Expr>) -> Box<Item>
     where
         I: Make<Ident>,
-        T: Make<Box<Type>>,
-        E: Make<Box<Expr>>,
     {
         let name = name.make(&self);
-        let ty = ty.make(&self);
-        let init = init.make(&self);
         Box::new(Item::Static(ItemStatic {
             attrs: self.attrs,
             vis: self.vis,
@@ -1675,15 +1472,11 @@ impl Builder {
         }))
     }
 
-    pub fn const_item<I, T, E>(self, name: I, ty: T, init: E) -> Box<Item>
+    pub fn const_item<I>(self, name: I, ty: Box<Type>, init: Box<Expr>) -> Box<Item>
     where
         I: Make<Ident>,
-        T: Make<Box<Type>>,
-        E: Make<Box<Expr>>,
     {
         let name = name.make(&self);
-        let ty = ty.make(&self);
-        let init = init.make(&self);
         Box::new(Item::Const(ItemConst {
             attrs: self.attrs,
             vis: self.vis,
@@ -1697,13 +1490,11 @@ impl Builder {
         }))
     }
 
-    pub fn fn_item<S, B>(self, sig: S, block: B) -> Box<Item>
+    pub fn fn_item<S>(self, sig: S, block: Box<Block>) -> Box<Item>
     where
         S: Make<Signature>,
-        B: Make<Box<Block>>,
     {
         let sig = sig.make(&self);
-        let block = block.make(&self);
         Box::new(Item::Fn(ItemFn {
             attrs: self.attrs,
             vis: self.vis,
@@ -1795,12 +1586,10 @@ impl Builder {
         }))
     }
 
-    pub fn type_item<I, T>(self, name: I, ty: T) -> Box<Item>
+    pub fn type_item<I>(self, name: I, ty: Box<Type>) -> Box<Item>
     where
         I: Make<Ident>,
-        T: Make<Box<Type>>,
     {
-        let ty = ty.make(&self);
         let name = name.make(&self);
         Box::new(Item::Type(ItemType {
             attrs: self.attrs,
@@ -1830,18 +1619,11 @@ impl Builder {
         }))
     }
 
-    pub fn mod_<I>(self, items: Vec<I>) -> Vec<Item>
-    where
-        I: Make<Box<Item>>,
-    {
-        items.into_iter().map(|i| *i.make(&self)).collect()
+    pub fn mod_(self, items: Vec<Box<Item>>) -> Vec<Item> {
+        items.into_iter().map(|i| *i).collect()
     }
 
-    pub fn mac_item<M>(self, mac: M) -> Box<Item>
-    where
-        M: Make<Macro>,
-    {
-        let mac = mac.make(&self);
+    pub fn mac_item(self, mac: Macro) -> Box<Item> {
         Box::new(Item::Macro(ItemMacro {
             attrs: self.attrs,
             semi_token: Some(Token![;](self.span)), // Untested
@@ -1863,25 +1645,20 @@ impl Builder {
         }
     }
 
-    pub fn unit_variant<I, E>(self, name: I, disc: Option<E>) -> Variant
+    pub fn unit_variant<I>(self, name: I, disc: Option<Box<Expr>>) -> Variant
     where
         I: Make<Ident>,
-        E: Make<Box<Expr>>,
     {
         let name = name.make(&self);
         Variant {
             ident: name,
             fields: Fields::Unit,
-            discriminant: disc.map(|e| (Token![=](self.span), *e.make(&self))),
+            discriminant: disc.map(|e| (Token![=](self.span), *e)),
             attrs: self.attrs,
         }
     }
 
-    pub fn impl_item<T>(self, ty: T, items: Vec<ImplItem>) -> Box<Item>
-    where
-        T: Make<Box<Type>>,
-    {
-        let ty = ty.make(&self);
+    pub fn impl_item(self, ty: Box<Type>, items: Vec<ImplItem>) -> Box<Item> {
         Box::new(Item::Impl(ItemImpl {
             attrs: self.attrs,
             unsafety: self.unsafety.to_token(),
@@ -1912,11 +1689,7 @@ impl Builder {
         }))
     }
 
-    pub fn use_item<U>(self, tree: U) -> Box<Item>
-    where
-        U: Make<UseTree>,
-    {
-        let tree = tree.make(&self);
+    pub fn use_item(self, tree: UseTree) -> Box<Item> {
         Box::new(Item::Use(ItemUse {
             attrs: self.attrs,
             vis: self.vis,
@@ -2057,11 +1830,7 @@ impl Builder {
 
     // Impl Items
 
-    pub fn mac_impl_item<M>(self, mac: M) -> ImplItem
-    where
-        M: Make<Macro>,
-    {
-        let mac = mac.make(&self);
+    pub fn mac_impl_item(self, mac: Macro) -> ImplItem {
         ImplItem::Macro(ImplItemMacro {
             attrs: self.attrs,
             semi_token: None,
@@ -2071,11 +1840,7 @@ impl Builder {
 
     // Trait Items
 
-    pub fn mac_trait_item<M>(self, mac: M) -> TraitItem
-    where
-        M: Make<Macro>,
-    {
-        let mac = mac.make(&self);
+    pub fn mac_trait_item(self, mac: Macro) -> TraitItem {
         TraitItem::Macro(TraitItemMacro {
             attrs: self.attrs,
             semi_token: None,
@@ -2086,11 +1851,7 @@ impl Builder {
     // Foreign Items
 
     /// [`ForeignItem`] is large (472 bytes), so [`Box`] it.
-    pub fn fn_foreign_item<D>(self, decl: D) -> Box<ForeignItem>
-    where
-        D: Make<Box<FnDecl>>,
-    {
-        let decl = decl.make(&self);
+    pub fn fn_foreign_item(self, decl: Box<FnDecl>) -> Box<ForeignItem> {
         let sig = Signature {
             constness: None,
             asyncness: None,
@@ -2106,13 +1867,11 @@ impl Builder {
     }
 
     /// [`ForeignItem`] is large (472 bytes), so [`Box`] it.
-    pub fn static_foreign_item<I, T>(self, name: I, ty: T) -> Box<ForeignItem>
+    pub fn static_foreign_item<I>(self, name: I, ty: Box<Type>) -> Box<ForeignItem>
     where
         I: Make<Ident>,
-        T: Make<Box<Type>>,
     {
         let name = name.make(&self);
-        let ty = ty.make(&self);
         Box::new(ForeignItem::Static(ForeignItemStatic {
             attrs: self.attrs,
             vis: self.vis,
@@ -2140,11 +1899,7 @@ impl Builder {
         }))
     }
 
-    pub fn mac_foreign_item<M>(self, mac: M) -> ForeignItem
-    where
-        M: Make<Macro>,
-    {
-        let mac = mac.make(&self);
+    pub fn mac_foreign_item(self, mac: Macro) -> ForeignItem {
         ForeignItem::Macro(ForeignItemMacro {
             attrs: self.attrs,
             mac,
@@ -2154,31 +1909,25 @@ impl Builder {
 
     // struct fields
 
-    pub fn struct_field<I, T>(self, ident: I, ty: T) -> Field
+    pub fn struct_field<I>(self, ident: I, ty: Box<Type>) -> Field
     where
         I: Make<Ident>,
-        T: Make<Box<Type>>,
     {
         let ident = ident.make(&self);
-        let ty = *ty.make(&self);
         Field {
             ident: Some(ident),
             vis: self.vis,
             attrs: self.attrs,
-            ty,
+            ty: *ty,
             colon_token: Some(Token![:](self.span)),
         }
     }
 
-    pub fn enum_field<T>(self, ty: T) -> Field
-    where
-        T: Make<Box<Type>>,
-    {
-        let ty = *ty.make(&self);
+    pub fn enum_field(self, ty: Box<Type>) -> Field {
         Field {
             ident: None,
             vis: self.vis,
-            ty,
+            ty: *ty,
             attrs: self.attrs,
             colon_token: None,
         }
@@ -2186,11 +1935,7 @@ impl Builder {
 
     // Misc nodes
 
-    pub fn unsafe_block<S>(self, stmts: Vec<S>) -> ExprUnsafe
-    where
-        S: Make<Stmt>,
-    {
-        let stmts = stmts.into_iter().map(|s| s.make(&self)).collect();
+    pub fn unsafe_block(self, stmts: Vec<Stmt>) -> ExprUnsafe {
         let blk = Block {
             stmts,
             brace_token: token::Brace(self.span),
@@ -2202,11 +1947,7 @@ impl Builder {
         }
     }
 
-    pub fn block<S>(self, stmts: Vec<S>) -> Box<Block>
-    where
-        S: Make<Stmt>,
-    {
-        let stmts = stmts.into_iter().map(|s| s.make(&self)).collect();
+    pub fn block(self, stmts: Vec<Stmt>) -> Box<Block> {
         Box::new(Block {
             stmts,
             brace_token: token::Brace(self.span),
@@ -2220,13 +1961,11 @@ impl Builder {
         lbl.make(&self)
     }
 
-    pub fn break_expr_value<L, E>(self, label: Option<L>, value: Option<E>) -> Box<Expr>
+    pub fn break_expr_value<L>(self, label: Option<L>, value: Option<Box<Expr>>) -> Box<Expr>
     where
         L: Make<Label>,
-        E: Make<Box<Expr>>,
     {
         let label = label.map(|l| l.make(&self).name);
-        let value = value.map(|v| v.make(&self));
         Box::new(Expr::Break(ExprBreak {
             attrs: self.attrs,
             break_token: Token![break](self.span),
@@ -2235,27 +1974,19 @@ impl Builder {
         }))
     }
 
-    pub fn bare_arg<T, I>(self, ty: T, name: Option<I>) -> BareFnArg
+    pub fn bare_arg<I>(self, ty: Box<Type>, name: Option<I>) -> BareFnArg
     where
-        T: Make<Box<Type>>,
         I: Make<Box<Ident>>,
     {
-        let ty = *ty.make(&self);
         let name = name.map(|n| (*n.make(&self), Token![:](self.span)));
         BareFnArg {
             attrs: Vec::new(),
             name,
-            ty,
+            ty: *ty,
         }
     }
 
-    pub fn arg<T, Pt>(self, ty: T, pat: Pt) -> FnArg
-    where
-        T: Make<Box<Type>>,
-        Pt: Make<Box<Pat>>,
-    {
-        let ty = ty.make(&self);
-        let pat = pat.make(&self);
+    pub fn arg(self, ty: Box<Type>, pat: Box<Pat>) -> FnArg {
         FnArg::Typed(PatType {
             attrs: Vec::new(),
             ty,
@@ -2264,12 +1995,8 @@ impl Builder {
         })
     }
 
-    pub fn self_arg<S>(self, kind: S) -> FnArg
-    where
-        S: Make<SelfKind>,
-    {
-        let eself = kind.make(&self);
-        let (reference, mutability) = match eself {
+    pub fn self_arg(self, kind: SelfKind) -> FnArg {
+        let (reference, mutability) = match kind {
             SelfKind::Value(mutability) => (None, mutability),
             SelfKind::Region(lt, mutability) => {
                 (Some((Token![&](self.span), Some(lt))), mutability)
@@ -2419,12 +2146,10 @@ impl Builder {
         }
     }
 
-    pub fn mac<Pa, Ts>(self, func: Pa, arguments: Ts, delim: MacroDelimiter) -> Macro
+    pub fn mac<Ts>(self, func: Path, arguments: Ts, delim: MacroDelimiter) -> Macro
     where
-        Pa: Make<Path>,
         Ts: Make<TokenStream>,
     {
-        let func: Path = func.make(&self);
         let tokens = arguments.make(&self);
         Macro {
             path: func,
@@ -2435,15 +2160,8 @@ impl Builder {
     }
 
     /// Create a local variable
-    pub fn local<V, T, E>(self, pat: V, ty: Option<T>, init: Option<E>) -> Local
-    where
-        V: Make<Box<Pat>>,
-        T: Make<Box<Type>>,
-        E: Make<Box<Expr>>,
-    {
-        let pat = pat.make(&self);
-        let ty = ty.map(|x| x.make(&self));
-        let init = init.map(|x| (Default::default(), x.make(&self)));
+    pub fn local(self, pat: Box<Pat>, ty: Option<Box<Type>>, init: Option<Box<Expr>>) -> Local {
+        let init = init.map(|x| (Default::default(), x));
         let pat = if let Some(ty) = ty {
             Pat::Type(PatType {
                 attrs: vec![],
@@ -2463,11 +2181,7 @@ impl Builder {
         }
     }
 
-    pub fn return_expr<E>(self, val: Option<E>) -> Box<Expr>
-    where
-        E: Make<Box<Expr>>,
-    {
-        let val = val.map(|x| x.make(&self));
+    pub fn return_expr(self, val: Option<Box<Expr>>) -> Box<Expr> {
         Box::new(Expr::Return(ExprReturn {
             attrs: self.attrs,
             return_token: Token![return](self.span),
@@ -2508,19 +2222,13 @@ impl Builder {
         }))
     }
 
-    pub fn closure_expr<D, E>(
+    pub fn closure_expr(
         self,
         capture: CaptureBy,
         mov: Movability,
-        decl: D,
-        body: E,
-    ) -> Box<Expr>
-    where
-        D: Make<Box<FnDecl>>,
-        E: Make<Box<Expr>>,
-    {
-        let decl = decl.make(&self);
-        let body = body.make(&self);
+        decl: Box<FnDecl>,
+        body: Box<Expr>,
+    ) -> Box<Expr> {
         let (_name, inputs, _variadic, output) = *decl;
         let inputs = inputs
             .into_iter()

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -602,9 +602,8 @@ impl Cfg<Label, StmtOrDecl> {
                             .push(StmtOrDecl::Stmt(mk().semi_stmt(mk().return_expr(ret_expr))));
                     }
                     ImplicitReturnType::Void => {
-                        wip.body.push(StmtOrDecl::Stmt(
-                            mk().semi_stmt(mk().return_expr(None as Option<Box<Expr>>)),
-                        ));
+                        wip.body
+                            .push(StmtOrDecl::Stmt(mk().semi_stmt(mk().return_expr(None))));
                     }
                     ImplicitReturnType::NoImplicitReturnType => {
                         // NOTE: emitting `ret_expr` is not necessarily an error. For instance,
@@ -2028,10 +2027,10 @@ impl CfgBuilder {
                 false,
             ),
 
-            Some(ImplicitReturnType::Void) => (mk().return_expr(None as Option<Box<Expr>>), false),
+            Some(ImplicitReturnType::Void) => (mk().return_expr(None), false),
 
             _ => (
-                mk().break_expr_value(Some(brk_lbl.pretty_print()), None as Option<Box<Expr>>),
+                mk().break_expr_value(Some(brk_lbl.pretty_print()), None),
                 true,
             ),
         };

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -491,7 +491,7 @@ impl StructureState {
                         let (stmts, span) = self.to_stmt(stmts, comment_store);
 
                         let body = mk().block_expr(mk().span(span).block(stmts));
-                        mk().arm(pat, None as Option<Box<Expr>>, body)
+                        mk().arm(pat, None, body)
                     })
                     .collect();
 
@@ -515,11 +515,8 @@ impl StructureState {
                 let mut if_stmt = match (then_stmts.is_empty(), els_stmts.is_empty()) {
                     (true, true) => mk().semi_stmt(cond),
                     (false, true) => {
-                        let if_expr = mk().ifte_expr(
-                            cond,
-                            mk().span(then_span).block(then_stmts),
-                            None as Option<Box<Expr>>,
-                        );
+                        let if_expr =
+                            mk().ifte_expr(cond, mk().span(then_span).block(then_stmts), None);
                         mk().expr_stmt(if_expr)
                     }
                     (true, false) => {
@@ -527,7 +524,7 @@ impl StructureState {
                         let if_expr = mk().ifte_expr(
                             negated_cond,
                             mk().span(els_span).block(els_stmts),
-                            None as Option<Box<Expr>>,
+                            None,
                         );
                         mk().expr_stmt(if_expr)
                     }
@@ -582,7 +579,7 @@ impl StructureState {
                         };
                         let pat = mk().lit_pat(lbl_expr);
                         let body = mk().block_expr(mk().span(stmts_span).block(stmts));
-                        mk().arm(pat, None as Option<Box<Expr>>, body)
+                        mk().arm(pat, None, body)
                     })
                     .collect();
 
@@ -590,7 +587,7 @@ impl StructureState {
 
                 arms.push(mk().arm(
                     mk().wild_pat(),
-                    None as Option<Box<Expr>>,
+                    None,
                     mk().block_expr(mk().span(then_span).block(then)),
                 ));
 

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -311,7 +311,7 @@ impl TypeConverter {
         }
 
         match ctxt.index(ctype).kind {
-            CTypeKind::Void => Ok(mk().tuple_ty(vec![] as Vec<Box<Type>>)),
+            CTypeKind::Void => Ok(mk().tuple_ty(vec![])),
             CTypeKind::Bool => Ok(mk().path_ty(mk().path(vec!["bool"]))),
             CTypeKind::Short => Ok(mk().path_ty(mk().path(vec!["libc", "c_short"]))),
             CTypeKind::Int => Ok(mk().path_ty(mk().path(vec!["libc", "c_int"]))),

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -850,18 +850,14 @@ impl<'c> Translation<'c> {
                     let output_name = self.renamer.borrow_mut().fresh();
                     let output_local = mk().local(
                         mk().ident_pat(&output_name),
-                        None as Option<Box<Type>>,
+                        None,
                         Some(mk().mutbl().addr_of_expr(out_expr)),
                     );
                     stmts.push(mk().local_stmt(Box::new(output_local)));
 
                     // `let mut freshN;`
                     let inner_name = self.renamer.borrow_mut().fresh();
-                    let inner_local = mk().local(
-                        mk().ident_pat(&inner_name),
-                        None as Option<Box<Type>>,
-                        None as Option<Box<Expr>>,
-                    );
+                    let inner_local = mk().local(mk().ident_pat(&inner_name), None, None);
                     stmts.push(mk().local_stmt(Box::new(inner_local)));
 
                     out_expr = mk().ident_expr(&inner_name);
@@ -892,11 +888,7 @@ impl<'c> Translation<'c> {
                     let (output_name, inner_name) = operand_renames.get(tied_operand).unwrap();
 
                     let input_name = self.renamer.borrow_mut().fresh();
-                    let input_local = mk().local(
-                        mk().ident_pat(&input_name),
-                        None as Option<Box<Type>>,
-                        Some(in_expr),
-                    );
+                    let input_local = mk().local(mk().ident_pat(&input_name), None, Some(in_expr));
                     stmts.push(mk().local_stmt(Box::new(input_local)));
 
                     // Replace `in_expr` with

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -1022,7 +1022,7 @@ impl<'c> Translation<'c> {
         });
 
         let mac = mk().mac(
-            vec!["asm"],
+            mk().path(vec!["asm"]),
             tokens.into_iter().collect::<TokenStream>(),
             MacroDelimiter::Paren(Default::default()),
         );

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -276,7 +276,7 @@ impl<'c> Translation<'c> {
                             let res_name = self.renamer.borrow_mut().fresh();
                             let res_let = mk().local_stmt(Box::new(mk().local(
                                 mk().ident_pat(&res_name),
-                                None as Option<Box<Type>>,
+                                None,
                                 Some(call),
                             )));
                             let assignment = mk().semi_stmt(mk().assign_expr(
@@ -410,14 +410,14 @@ impl<'c> Translation<'c> {
             let arg0_name = self.renamer.borrow_mut().fresh();
             let arg0_let = mk().local_stmt(Box::new(mk().local(
                 mk().ident_pat(&arg0_name),
-                None as Option<Box<Type>>,
+                None,
                 Some(dst),
             )));
 
             let arg1_name = self.renamer.borrow_mut().fresh();
             let arg1_let = mk().local_stmt(Box::new(mk().local(
                 mk().ident_pat(&arg1_name),
-                None as Option<Box<Type>>,
+                None,
                 Some(src),
             )));
 

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -599,7 +599,7 @@ impl<'c> Translation<'c> {
             "__builtin_unwind_init" => Ok(WithStmts::new_val(self.panic_or_err("no value"))),
             "__builtin_unreachable" => Ok(WithStmts::new(
                 vec![mk().semi_stmt(mk().mac_expr(mk().mac(
-                    vec!["unreachable"],
+                    mk().path(vec!["unreachable"]),
                     vec![],
                     MacroDelimiter::Paren(Default::default()),
                 )))],

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -70,8 +70,7 @@ impl<'c> Translation<'c> {
                 let val = self.convert_expr(ctx.used(), args[0])?;
 
                 Ok(val.map(|v| {
-                    let val =
-                        mk().method_call_expr(v, "is_sign_negative", vec![] as Vec<Box<Expr>>);
+                    let val = mk().method_call_expr(v, "is_sign_negative", vec![]);
 
                     mk().cast_expr(val, mk().path_ty(vec!["libc", "c_int"]))
                 }))
@@ -84,11 +83,7 @@ impl<'c> Translation<'c> {
                     let zero = mk().lit_expr(mk().int_lit(0, ""));
                     let one = mk().lit_expr(mk().int_lit(1, ""));
                     let cmp = BinOp::Eq(Default::default());
-                    let zeros = mk().method_call_expr(
-                        x.clone(),
-                        "trailing_zeros",
-                        vec![] as Vec<Box<Expr>>,
-                    );
+                    let zeros = mk().method_call_expr(x.clone(), "trailing_zeros", vec![]);
                     let zeros_cast = mk().cast_expr(zeros, mk().path_ty(vec!["i32"]));
                     let zeros_plus1 = mk().binary_expr(add, zeros_cast, one);
                     let block = mk().block(vec![mk().expr_stmt(zero.clone())]);
@@ -100,25 +95,24 @@ impl<'c> Translation<'c> {
             "__builtin_clz" | "__builtin_clzl" | "__builtin_clzll" => {
                 let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|x| {
-                    let zeros = mk().method_call_expr(x, "leading_zeros", vec![] as Vec<Box<Expr>>);
+                    let zeros = mk().method_call_expr(x, "leading_zeros", vec![]);
                     mk().cast_expr(zeros, mk().path_ty(vec!["i32"]))
                 }))
             }
             "__builtin_ctz" | "__builtin_ctzl" | "__builtin_ctzll" => {
                 let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|x| {
-                    let zeros =
-                        mk().method_call_expr(x, "trailing_zeros", vec![] as Vec<Box<Expr>>);
+                    let zeros = mk().method_call_expr(x, "trailing_zeros", vec![]);
                     mk().cast_expr(zeros, mk().path_ty(vec!["i32"]))
                 }))
             }
             "__builtin_bswap16" | "__builtin_bswap32" | "__builtin_bswap64" => {
                 let val = self.convert_expr(ctx.used(), args[0])?;
-                Ok(val.map(|x| mk().method_call_expr(x, "swap_bytes", vec![] as Vec<Box<Expr>>)))
+                Ok(val.map(|x| mk().method_call_expr(x, "swap_bytes", vec![])))
             }
             "__builtin_fabs" | "__builtin_fabsf" | "__builtin_fabsl" => {
                 let val = self.convert_expr(ctx.used(), args[0])?;
-                Ok(val.map(|x| mk().method_call_expr(x, "abs", vec![] as Vec<Box<Expr>>)))
+                Ok(val.map(|x| mk().method_call_expr(x, "abs", vec![])))
             }
             "__builtin_isfinite" | "__builtin_isnan" => {
                 let val = self.convert_expr(ctx.used(), args[0])?;
@@ -129,7 +123,7 @@ impl<'c> Translation<'c> {
                     _ => panic!(),
                 };
                 Ok(val.map(|x| {
-                    let call = mk().method_call_expr(x, seg, vec![] as Vec<Box<Expr>>);
+                    let call = mk().method_call_expr(x, seg, vec![]);
                     mk().cast_expr(call, mk().path_ty(vec!["i32"]))
                 }))
             }
@@ -137,11 +131,7 @@ impl<'c> Translation<'c> {
                 // isinf_sign(x) -> fabs(x) == infinity ? (signbit(x) ? -1 : 1) : 0
                 let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|x| {
-                    let inner_cond = mk().method_call_expr(
-                        x.clone(),
-                        "is_sign_positive",
-                        vec![] as Vec<Box<Expr>>,
-                    );
+                    let inner_cond = mk().method_call_expr(x.clone(), "is_sign_positive", vec![]);
                     let one = mk().lit_expr(mk().int_lit(1, ""));
                     let minus_one = mk().unary_expr(
                         UnOp::Neg(Default::default()),
@@ -150,8 +140,7 @@ impl<'c> Translation<'c> {
                     let one_block = mk().block(vec![mk().expr_stmt(one)]);
                     let inner_ifte = mk().ifte_expr(inner_cond, one_block, Some(minus_one));
                     let zero = mk().lit_expr(mk().int_lit(0, ""));
-                    let outer_cond =
-                        mk().method_call_expr(x, "is_infinite", vec![] as Vec<Box<Expr>>);
+                    let outer_cond = mk().method_call_expr(x, "is_infinite", vec![]);
                     let inner_ifte_block = mk().block(vec![mk().expr_stmt(inner_ifte)]);
                     mk().ifte_expr(outer_cond, inner_ifte_block, Some(zero))
                 }))
@@ -167,7 +156,7 @@ impl<'c> Translation<'c> {
             "__builtin_popcount" | "__builtin_popcountl" | "__builtin_popcountll" => {
                 let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|x| {
-                    let zeros = mk().method_call_expr(x, "count_ones", vec![] as Vec<Box<Expr>>);
+                    let zeros = mk().method_call_expr(x, "count_ones", vec![]);
                     mk().cast_expr(zeros, mk().path_ty(vec!["i32"]))
                 }))
             }
@@ -272,11 +261,8 @@ impl<'c> Translation<'c> {
                             let fn_ctx = self.function_context.borrow();
                             let src = fn_ctx.get_va_list_arg_name();
 
-                            let call_expr = mk().method_call_expr(
-                                mk().ident_expr(src),
-                                "clone",
-                                vec![] as Vec<Box<Expr>>,
-                            );
+                            let call_expr =
+                                mk().method_call_expr(mk().ident_expr(src), "clone", vec![]);
                             let assign_expr = mk().assign_expr(dst.to_expr(), call_expr);
                             let stmt = mk().semi_stmt(assign_expr);
 
@@ -295,8 +281,7 @@ impl<'c> Translation<'c> {
                         let dst = self.convert_expr(ctx.expect_valistimpl().used(), args[0])?;
                         let src = self.convert_expr(ctx.expect_valistimpl().used(), args[1])?;
 
-                        let call_expr =
-                            mk().method_call_expr(src.to_expr(), "clone", vec![] as Vec<Box<Expr>>);
+                        let call_expr = mk().method_call_expr(src.to_expr(), "clone", vec![]);
                         let assign_expr = mk().assign_expr(dst.to_expr(), call_expr);
                         let stmt = mk().semi_stmt(assign_expr);
 
@@ -326,14 +311,10 @@ impl<'c> Translation<'c> {
                     Ok(WithStmts::new(
                         vec![mk().local_stmt(Box::new(mk().local(
                             mk().mutbl().ident_pat(&alloca_name),
-                            None as Option<Box<Type>>,
+                            None,
                             Some(vec_expr(zero_elem, cast_int(count, "usize", false))),
                         )))],
-                        mk().method_call_expr(
-                            mk().ident_expr(&alloca_name),
-                            "as_mut_ptr",
-                            vec![] as Vec<Box<Expr>>,
-                        ),
+                        mk().method_call_expr(mk().ident_expr(&alloca_name), "as_mut_ptr", vec![]),
                     ))
                 })
             }
@@ -540,7 +521,7 @@ impl<'c> Translation<'c> {
                 self.use_feature("core_intrinsics");
 
                 let atomic_func = mk().abs_path_expr(vec!["core", "intrinsics", "atomic_fence"]);
-                let call_expr = mk().call_expr(atomic_func, vec![] as Vec<Box<Expr>>);
+                let call_expr = mk().call_expr(atomic_func, vec![]);
                 self.convert_side_effects_expr(
                     ctx,
                     WithStmts::new_val(call_expr),
@@ -657,7 +638,7 @@ impl<'c> Translation<'c> {
                     mk().ident_pat(&sum_name),
                     mk().ident_pat(over_name.clone()),
                 ]),
-                None as Option<Box<Type>>,
+                None,
                 Some(overflowing),
             )));
 

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -158,7 +158,7 @@ impl<'c> Translation<'c> {
                                         Some(
                                             mk().mac_expr(
                                                 mk().mac(
-                                                    vec!["format"],
+                                                    mk().path(vec!["format"]),
                                                     vec![
                                                         TokenTree::Literal(
                                                             proc_macro2::Literal::string("{}={}"),

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -61,16 +61,11 @@ impl<'c> Translation<'c> {
                             mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_char"])),
                         ]),
                     )])),
-                    Some(
-                        mk().call_expr(
-                            mk().path_expr(vec!["Vec", "new"]),
-                            vec![] as Vec<Box<Expr>>,
-                        ),
-                    ),
+                    Some(mk().call_expr(mk().path_expr(vec!["Vec", "new"]), vec![])),
                 ))));
                 stmts.push(mk().semi_stmt(mk().for_expr(
                     mk().ident_pat("arg"),
-                    mk().call_expr(args_fn, vec![] as Vec<Box<Expr>>),
+                    mk().call_expr(args_fn, vec![]),
                     mk().block(vec![mk().semi_stmt(mk().method_call_expr(
                         mk().path_expr(vec!["args"]),
                         "push",
@@ -85,7 +80,7 @@ impl<'c> Translation<'c> {
                                 vec![mk().lit_expr("Failed to convert argument into CString.")],
                             ),
                             "into_raw",
-                            vec![] as Vec<Box<Expr>>,
+                            vec![],
                         )],
                     ))]),
                     None as Option<Ident>,
@@ -93,10 +88,9 @@ impl<'c> Translation<'c> {
                 stmts.push(mk().semi_stmt(mk().method_call_expr(
                     mk().path_expr(vec!["args"]),
                     "push",
-                    vec![mk().call_expr(
-                        mk().abs_path_expr(vec!["core", "ptr", "null_mut"]),
-                        vec![] as Vec<Box<Expr>>,
-                    )],
+                    vec![
+                        mk().call_expr(mk().abs_path_expr(vec!["core", "ptr", "null_mut"]), vec![]),
+                    ],
                 )));
 
                 let argc_ty: Box<Type> = match self.ast_context.index(parameters[0]).kind {
@@ -135,12 +129,7 @@ impl<'c> Translation<'c> {
                             mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_char"])),
                         ]),
                     )])),
-                    Some(
-                        mk().call_expr(
-                            mk().path_expr(vec!["Vec", "new"]),
-                            vec![] as Vec<Box<Expr>>,
-                        ),
-                    ),
+                    Some(mk().call_expr(mk().path_expr(vec!["Vec", "new"]), vec![])),
                 ))));
                 let var_name_ident = mk().ident("var_name");
                 let var_value_ident = mk().ident("var_value");
@@ -149,70 +138,69 @@ impl<'c> Translation<'c> {
                         mk().ident_pat("var_name"),
                         mk().ident_pat("var_value"),
                     ]),
-                    mk().call_expr(vars_fn, vec![] as Vec<Box<Expr>>),
+                    mk().call_expr(vars_fn, vec![]),
                     mk().block(vec![
-                                mk().local_stmt(Box::new(
-                                    mk().local(
-                                        mk().ident_pat("var"),
-                                        Some(mk().path_ty(vec!["String"])),
-                                        Some(
-                                            mk().mac_expr(
-                                                mk().mac(
-                                                    mk().path(vec!["format"]),
-                                                    vec![
-                                                        TokenTree::Literal(
-                                                            proc_macro2::Literal::string("{}={}"),
-                                                        ),
-                                                        TokenTree::Punct(Punct::new(
-                                                            ',',
-                                                            proc_macro2::Spacing::Alone,
-                                                        )),
-                                                        TokenTree::Ident(var_name_ident),
-                                                        TokenTree::Punct(Punct::new(
-                                                            ',',
-                                                            proc_macro2::Spacing::Alone,
-                                                        )),
-                                                        TokenTree::Ident(var_value_ident),
-                                                    ]
-                                                    .into_iter()
-                                                    .collect::<TokenStream>(),
-                                                    MacroDelimiter::Paren(Default::default()),
+                        mk().local_stmt(Box::new(
+                            mk().local(
+                                mk().ident_pat("var"),
+                                Some(mk().path_ty(vec!["String"])),
+                                Some(
+                                    mk().mac_expr(
+                                        mk().mac(
+                                            mk().path(vec!["format"]),
+                                            vec![
+                                                TokenTree::Literal(
+                                                    proc_macro2::Literal::string("{}={}"),
                                                 ),
-                                            ),
+                                                TokenTree::Punct(Punct::new(
+                                                    ',',
+                                                    proc_macro2::Spacing::Alone,
+                                                )),
+                                                TokenTree::Ident(var_name_ident),
+                                                TokenTree::Punct(Punct::new(
+                                                    ',',
+                                                    proc_macro2::Spacing::Alone,
+                                                )),
+                                                TokenTree::Ident(var_value_ident),
+                                            ]
+                                            .into_iter()
+                                            .collect::<TokenStream>(),
+                                            MacroDelimiter::Paren(Default::default()),
                                         ),
                                     ),
-                                )),
-                                mk().semi_stmt(mk().method_call_expr(
-                                    mk().path_expr(vec!["vars"]),
-                                    "push",
-                                    vec![mk().method_call_expr(
-                                        mk().method_call_expr(
-                                            mk().call_expr(
-                                                mk().abs_path_expr(vec![
-                                                    // TODO(kkysen) change `"std"` to `"alloc"` after `#![feature(alloc_c_string)]` is stabilized in `1.63.0`
-                                                    "std", "ffi", "CString", "new",
-                                                ]),
-                                                vec![mk().path_expr(vec!["var"])],
-                                            ),
-                                            "expect",
-                                            vec![mk().lit_expr(
-                                            "Failed to convert environment variable into CString."
-                                        )],
-                                        ),
-                                        "into_raw",
-                                        vec![] as Vec<Box<Expr>>,
-                                    )],
-                                )),
-                            ]),
+                                ),
+                            ),
+                        )),
+                        mk().semi_stmt(mk().method_call_expr(
+                            mk().path_expr(vec!["vars"]),
+                            "push",
+                            vec![mk().method_call_expr(
+                                mk().method_call_expr(
+                                    mk().call_expr(
+                                        mk().abs_path_expr(vec![
+                                            // TODO(kkysen) change `"std"` to `"alloc"` after `#![feature(alloc_c_string)]` is stabilized in `1.63.0`
+                                            "std", "ffi", "CString", "new",
+                                        ]),
+                                        vec![mk().path_expr(vec!["var"])],
+                                    ),
+                                    "expect",
+                                    vec![mk().lit_expr(
+                                    "Failed to convert environment variable into CString."
+                                )],
+                                ),
+                                "into_raw",
+                                vec![],
+                            )],
+                        )),
+                    ]),
                     None as Option<Ident>,
                 )));
                 stmts.push(mk().semi_stmt(mk().method_call_expr(
                     mk().path_expr(vec!["vars"]),
                     "push",
-                    vec![mk().call_expr(
-                        mk().abs_path_expr(vec!["core", "ptr", "null_mut"]),
-                        vec![] as Vec<Box<Expr>>,
-                    )],
+                    vec![
+                        mk().call_expr(mk().abs_path_expr(vec!["core", "ptr", "null_mut"]), vec![]),
+                    ],
                 )));
 
                 let envp_ty: Box<Type> = match self.ast_context.index(parameters[2]).kind {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -1333,7 +1333,7 @@ impl<'c> Translation<'c> {
             .into_iter()
             .collect::<TokenStream>();
         mk().mac_expr(mk().mac(
-            vec![macro_name],
+            mk().path(vec![macro_name]),
             macro_msg,
             MacroDelimiter::Paren(Default::default()),
         ))
@@ -2728,7 +2728,7 @@ impl<'c> Translation<'c> {
                         let path = vec!["core", "ffi", "VaListImpl"];
                         mk().path_ty(mk().abs_path(path))
                     };
-                    let local_mut = mk().local::<_, _, Box<Expr>>(pat_mut, Some(ty), None);
+                    let local_mut = mk().local(pat_mut, Some(ty), None);
 
                     return Ok(cfg::DeclStmtInfo::new(
                         vec![],                                     // decl
@@ -4071,7 +4071,7 @@ impl<'c> Translation<'c> {
 
         let ts: TokenStream = syn::parse_str(args).ok()?;
         Some(WithStmts::new_val(mk().mac_expr(mk().mac(
-            ident,
+            mk().path(ident),
             ts,
             MacroDelimiter::Paren(Default::default()),
         ))))

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2519,7 +2519,7 @@ impl<'c> Translation<'c> {
             let local = mk().local(
                 mk().mutbl().ident_pat(current_block_ident),
                 Some(current_block_ty),
-                None as Option<Box<Expr>>,
+                None,
             );
             stmts.push(mk().local_stmt(Box::new(local)))
         }
@@ -2570,12 +2570,12 @@ impl<'c> Translation<'c> {
                 Ok(val.map(|e| {
                     if self.ast_context.is_function_pointer(ptr_type) {
                         if negated {
-                            mk().method_call_expr(e, "is_some", vec![] as Vec<Box<Expr>>)
+                            mk().method_call_expr(e, "is_some", vec![])
                         } else {
-                            mk().method_call_expr(e, "is_none", vec![] as Vec<Box<Expr>>)
+                            mk().method_call_expr(e, "is_none", vec![])
                         }
                     } else {
-                        let is_null = mk().method_call_expr(e, "is_null", vec![] as Vec<Box<Expr>>);
+                        let is_null = mk().method_call_expr(e, "is_null", vec![]);
                         if negated {
                             mk().unary_expr(UnOp::Not(Default::default()), is_null)
                         } else {
@@ -3131,7 +3131,7 @@ impl<'c> Translation<'c> {
 
                         let local = mk().local(
                             mk().ident_pat(name),
-                            None as Option<Box<Type>>,
+                            None,
                             Some(mk().cast_expr(expr, mk().path_ty(vec!["usize"]))),
                         );
 
@@ -3180,7 +3180,7 @@ impl<'c> Translation<'c> {
             mk().path_segment("mem"),
             mk().path_segment_with_args(name, params),
         ];
-        let call = mk().call_expr(mk().abs_path_expr(path), vec![] as Vec<Box<Expr>>);
+        let call = mk().call_expr(mk().abs_path_expr(path), vec![]);
 
         Ok(WithStmts::new_val(call))
     }
@@ -3203,7 +3203,7 @@ impl<'c> Translation<'c> {
             path.push(mk().path_segment("mem"));
             path.push(mk().path_segment_with_args("align_of", mk().angle_bracketed_args(tys)));
         }
-        let call = mk().call_expr(mk().abs_path_expr(path), vec![] as Vec<Box<Expr>>);
+        let call = mk().call_expr(mk().abs_path_expr(path), vec![]);
         Ok(WithStmts::new_val(call))
     }
 
@@ -3400,7 +3400,7 @@ impl<'c> Translation<'c> {
                 if let CTypeKind::VariableArray(..) =
                     self.ast_context.resolve_type(qual_ty.ctype).kind
                 {
-                    val = mk().method_call_expr(val, "as_mut_ptr", vec![] as Vec<Box<Expr>>);
+                    val = mk().method_call_expr(val, "as_mut_ptr", vec![]);
                 }
 
                 let mut res = WithStmts::new_val(val);
@@ -3578,7 +3578,7 @@ impl<'c> Translation<'c> {
                             vec![mk().semi_stmt(mk().ifte_expr(
                                 val,
                                 mk().block(rhs.into_stmts()),
-                                None as Option<Box<Expr>>,
+                                None,
                             ))],
                             self.panic_or_err(
                                 "Binary conditional expression is not supposed to be used",
@@ -3886,9 +3886,7 @@ impl<'c> Translation<'c> {
                         // to and will have to be handled elsewhere, IE `bf.set_a(1)`
                         if !ctx.is_bitfield_write {
                             // Cases A and B above
-                            val = val.map(|v| {
-                                mk().method_call_expr(v, field_name, vec![] as Vec<Box<Expr>>)
-                            });
+                            val = val.map(|v| mk().method_call_expr(v, field_name, vec![]));
                         }
                     } else {
                         val = val.map(|v| mk().field_expr(v, field_name));
@@ -4397,9 +4395,7 @@ impl<'c> Translation<'c> {
                                 "as_mut_ptr"
                             };
 
-                            let call = val.map(|x| {
-                                mk().method_call_expr(x, method, vec![] as Vec<Box<Expr>>)
-                            });
+                            let call = val.map(|x| mk().method_call_expr(x, method, vec![]));
 
                             // Static arrays can now use as_ptr. Can also cast that const ptr to a
                             // mutable pointer as we do here:
@@ -4580,8 +4576,8 @@ impl<'c> Translation<'c> {
         if self.ast_context.is_va_list(resolved_ty_id) {
             // generate MaybeUninit::uninit().assume_init()
             let path = vec!["core", "mem", "MaybeUninit", "uninit"];
-            let call = mk().call_expr(mk().abs_path_expr(path), vec![] as Vec<Box<Expr>>);
-            let call = mk().method_call_expr(call, "assume_init", vec![] as Vec<Box<Expr>>);
+            let call = mk().call_expr(mk().abs_path_expr(path), vec![]);
+            let call = mk().method_call_expr(call, "assume_init", vec![]);
             return Ok(WithStmts::new_val(call));
         }
 
@@ -4610,9 +4606,7 @@ impl<'c> Translation<'c> {
                 .map(|elt| mk().repeat_expr(elt, sz)))
         } else if let &CTypeKind::IncompleteArray(_) = resolved_ty {
             // Incomplete arrays are translated to zero length arrays
-            Ok(WithStmts::new_val(
-                mk().array_expr(vec![] as Vec<Box<Expr>>),
-            ))
+            Ok(WithStmts::new_val(mk().array_expr(vec![])))
         } else if let Some(decl_id) = resolved_ty.as_underlying_decl() {
             self.zero_initializer(decl_id, ty_id, is_static)
         } else if let &CTypeKind::VariableArray(elt, _) = resolved_ty {
@@ -4777,12 +4771,12 @@ impl<'c> Translation<'c> {
 
         if self.ast_context.is_function_pointer(ty_id) {
             if target {
-                mk().method_call_expr(val, "is_some", vec![] as Vec<Box<Expr>>)
+                mk().method_call_expr(val, "is_some", vec![])
             } else {
-                mk().method_call_expr(val, "is_none", vec![] as Vec<Box<Expr>>)
+                mk().method_call_expr(val, "is_none", vec![])
             }
         } else if ty.is_pointer() {
-            let mut res = mk().method_call_expr(val, "is_null", vec![] as Vec<Box<Expr>>);
+            let mut res = mk().method_call_expr(val, "is_null", vec![]);
             if target {
                 res = mk().unary_expr(UnOp::Not(Default::default()), res)
             }

--- a/c2rust-transpile/src/translator/named_references.rs
+++ b/c2rust-transpile/src/translator/named_references.rs
@@ -127,7 +127,7 @@ impl<'c> Translation<'c> {
                 // let ref mut p = lhs;
                 let compute_ref = mk().local_stmt(Box::new(mk().local(
                     mk().mutbl().ident_ref_pat(&ptr_name),
-                    None as Option<Box<Type>>,
+                    None,
                     Some(reference),
                 )));
 

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -7,7 +7,7 @@ fn neg_expr(arg: Box<Expr>) -> Box<Expr> {
 }
 
 fn wrapping_neg_expr(arg: Box<Expr>) -> Box<Expr> {
-    mk().method_call_expr(arg, "wrapping_neg", vec![] as Vec<Box<Expr>>)
+    mk().method_call_expr(arg, "wrapping_neg", vec![])
 }
 
 impl From<c_ast::BinOp> for BinOp {
@@ -634,9 +634,9 @@ impl<'c> Translation<'c> {
                         && self.ast_context.is_null_expr(lhs_expr_id);
 
                     if fn_eq_null {
-                        mk().method_call_expr(lhs, "is_none", vec![] as Vec<Box<Expr>>)
+                        mk().method_call_expr(lhs, "is_none", vec![])
                     } else if null_eq_fn {
-                        mk().method_call_expr(rhs, "is_none", vec![] as Vec<Box<Expr>>)
+                        mk().method_call_expr(rhs, "is_none", vec![])
                     } else {
                         mk().binary_expr(BinOp::Eq(Default::default()), lhs, rhs)
                     }
@@ -656,9 +656,9 @@ impl<'c> Translation<'c> {
                         && self.ast_context.is_null_expr(lhs_expr_id);
 
                     if fn_eq_null {
-                        mk().method_call_expr(lhs, "is_some", vec![] as Vec<Box<Expr>>)
+                        mk().method_call_expr(lhs, "is_some", vec![])
                     } else if null_eq_fn {
-                        mk().method_call_expr(rhs, "is_some", vec![] as Vec<Box<Expr>>)
+                        mk().method_call_expr(rhs, "is_some", vec![])
                     } else {
                         mk().binary_expr(BinOp::Ne(Default::default()), lhs, rhs)
                     }
@@ -822,7 +822,7 @@ impl<'c> Translation<'c> {
                 let val_name = self.renamer.borrow_mut().fresh();
                 let save_old_val = mk().local_stmt(Box::new(mk().local(
                     mk().ident_pat(&val_name),
-                    None as Option<Box<Type>>,
+                    None,
                     Some(read.clone()),
                 )));
 

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -572,8 +572,7 @@ impl<'a> Translation<'a> {
             .collect::<WithStmts<Vec<syn::FieldValue>>>()
             .and_then(|fields| {
                 let struct_expr = mk().struct_expr(name.as_str(), fields);
-                let local_variable =
-                    Box::new(mk().local(local_pat, None as Option<Box<Type>>, Some(struct_expr)));
+                let local_variable = Box::new(mk().local(local_pat, None, Some(struct_expr)));
 
                 let mut is_unsafe = false;
                 let mut stmts = vec![mk().local_stmt(local_variable)];
@@ -790,11 +789,7 @@ impl<'a> Translation<'a> {
                     _ if contains_block(&param_expr) => {
                         let name = self.renamer.borrow_mut().pick_name("rhs");
                         let name_ident = mk().mutbl().ident_pat(name.clone());
-                        let temporary_stmt = mk().local(
-                            name_ident,
-                            None as Option<Box<Type>>,
-                            Some(param_expr.clone()),
-                        );
+                        let temporary_stmt = mk().local(name_ident, None, Some(param_expr.clone()));
                         let assignment_expr = mk().method_call_expr(
                             lhs_expr,
                             setter_name,

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -183,7 +183,7 @@ impl<'c> Translation<'c> {
                     mk().ident("arg"),
                     mk().angle_bracketed_args(vec![arg_ty]),
                 );
-                let mut val = mk().method_call_expr(val, path, vec![] as Vec<Box<Expr>>);
+                let mut val = mk().method_call_expr(val, path, vec![]);
                 if let Some(ty) = real_arg_ty {
                     val = mk().cast_expr(val, ty);
                 }


### PR DESCRIPTION
Remove generic parameters which are actually used only with a single concrete type, substituting that
type instead. 

E.g. a function `fn foo<E: Make<Box<Expr>>, T: Make<Box<Type>>(e: E, t: T)` is turned into a function
`fn foo(e: Box<Expr>, t: Box<Type>)`.

This doesn't restrict the usages of the function in any way, since the only type which is `Make<Box<Expr>>`
is `Box<Expr>` itself. These generic parameters are strictly redundant. They produce generic bloat, harm
compile times, complicate the API, and prevent type inference for function arguments (i.e. if `foo(f1(), f2())`
and either `f1` or `f2` is generic in its return type, then type inference will fail).

Using the concrete types is strictly better, and opens the possibility of more ergonomic API with better type
inference.

Also remove the explicit type casts which were required only due to the overly generic API, and can now be safely elided.

This PR was split from #485. As far as I can tell from the discussion in #485, this change is uncontroversial.

This PR builds on the branch of #548 and should be merged after it to avoid merge conflicts.