### PR TITLE
Fixed `clippy::boxed_local` warnings surfaced by de-genericizing PR

### DIFF
--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -883,22 +883,22 @@ impl Builder {
         Box::new(Expr::Unsafe(unsafe_blk))
     }
 
-    pub fn block_expr(self, blk: Box<Block>) -> Box<Expr> {
+    pub fn block_expr(self, block: Block) -> Box<Expr> {
         Box::new(Expr::Block(ExprBlock {
             attrs: self.attrs,
-            block: *blk,
+            block,
             label: None,
         }))
     }
 
-    pub fn labelled_block_expr<L>(self, blk: Box<Block>, lbl: L) -> Box<Expr>
+    pub fn labelled_block_expr<L>(self, block: Block, lbl: L) -> Box<Expr>
     where
         L: Make<Label>,
     {
         let lbl = lbl.make(&self);
         Box::new(Expr::Block(ExprBlock {
             attrs: self.attrs,
-            block: *blk,
+            block,
             label: Some(lbl),
         }))
     }
@@ -1087,11 +1087,11 @@ impl Builder {
         }))
     }
 
-    pub fn arm(self, pat: Box<Pat>, guard: Option<Box<Expr>>, body: Box<Expr>) -> Arm {
+    pub fn arm(self, pat: Pat, guard: Option<Box<Expr>>, body: Box<Expr>) -> Arm {
         let guard = guard.map(|g| (Token![if](self.span), g));
         Arm {
             attrs: self.attrs,
-            pat: *pat,
+            pat,
             guard,
             body,
             fat_arrow_token: Token![=>](self.span),
@@ -1127,10 +1127,10 @@ impl Builder {
     pub fn ifte_expr(
         self,
         cond: Box<Expr>,
-        then_case: Box<Block>,
-        else_case: Option<Box<Expr>>,
+        then_branch: Block,
+        else_branch: Option<Box<Expr>>,
     ) -> Box<Expr> {
-        let else_case = else_case.map(|e| {
+        let else_branch = else_branch.map(|e| {
             // The else branch in libsyntax must be one of these three cases,
             // otherwise we have to manually add the block around the else expression
             (
@@ -1151,12 +1151,12 @@ impl Builder {
             attrs: self.attrs,
             if_token: Token![if](self.span),
             cond,
-            then_branch: *then_case,
-            else_branch: else_case,
+            then_branch,
+            else_branch,
         }))
     }
 
-    pub fn while_expr<I>(self, cond: Box<Expr>, body: Box<Block>, label: Option<I>) -> Box<Expr>
+    pub fn while_expr<I>(self, cond: Box<Expr>, body: Block, label: Option<I>) -> Box<Expr>
     where
         I: Make<Ident>,
     {
@@ -1172,12 +1172,12 @@ impl Builder {
             attrs: self.attrs,
             while_token: Token![while](self.span),
             cond,
-            body: *body,
+            body,
             label,
         }))
     }
 
-    pub fn loop_expr<I>(self, body: Box<Block>, label: Option<I>) -> Box<Expr>
+    pub fn loop_expr<I>(self, body: Block, label: Option<I>) -> Box<Expr>
     where
         I: Make<Ident>,
     {
@@ -1192,16 +1192,16 @@ impl Builder {
         Box::new(Expr::Loop(ExprLoop {
             attrs: self.attrs,
             loop_token: Token![loop](self.span),
-            body: *body,
+            body,
             label,
         }))
     }
 
     pub fn for_expr<I>(
         self,
-        pat: Box<Pat>,
+        pat: Pat,
         expr: Box<Expr>,
-        body: Box<Block>,
+        body: Block,
         label: Option<I>,
     ) -> Box<Expr>
     where
@@ -1219,35 +1219,35 @@ impl Builder {
             attrs: self.attrs,
             for_token: Token![for](self.span),
             in_token: Token![in](self.span),
-            pat: *pat,
+            pat,
             expr,
-            body: *body,
+            body,
             label,
         }))
     }
 
     // Patterns
 
-    pub fn ident_pat<I>(self, name: I) -> Box<Pat>
+    pub fn ident_pat<I>(self, name: I) -> Pat
     where
         I: Make<Ident>,
     {
         let name = name.make(&self);
-        Box::new(Pat::Ident(PatIdent {
+        Pat::Ident(PatIdent {
             attrs: self.attrs,
             mutability: self.mutbl.to_token(),
             by_ref: None,
             ident: name,
             subpat: None,
-        }))
+        })
     }
 
-    pub fn tuple_pat(self, pats: Vec<Box<Pat>>) -> Box<Pat> {
-        Box::new(Pat::Tuple(PatTuple {
+    pub fn tuple_pat(self, pats: Vec<Pat>) -> Pat {
+        Pat::Tuple(PatTuple {
             attrs: self.attrs,
             paren_token: token::Paren(self.span),
-            elems: punct_box(pats),
-        }))
+            elems: punct(pats),
+        })
     }
 
     pub fn qpath_pat<Pa>(self, qself: Option<QSelf>, path: Pa) -> Box<Pat>
@@ -1262,53 +1262,53 @@ impl Builder {
         }))
     }
 
-    pub fn wild_pat(self) -> Box<Pat> {
-        Box::new(Pat::Wild(PatWild {
+    pub fn wild_pat(self) -> Pat {
+        Pat::Wild(PatWild {
             attrs: self.attrs,
             underscore_token: Token![_](self.span),
-        }))
+        })
     }
 
-    pub fn lit_pat(self, lit: Box<Expr>) -> Box<Pat> {
-        Box::new(Pat::Lit(PatLit {
+    pub fn lit_pat(self, lit: Box<Expr>) -> Pat {
+        Pat::Lit(PatLit {
             attrs: self.attrs,
             expr: lit,
-        }))
+        })
     }
 
-    pub fn mac_pat(self, mac: Macro) -> Box<Pat> {
-        Box::new(Pat::Macro(PatMacro {
+    pub fn mac_pat(self, mac: Macro) -> Pat {
+        Pat::Macro(PatMacro {
             attrs: self.attrs,
             mac,
-        }))
+        })
     }
 
-    pub fn ident_ref_pat<I>(self, name: I) -> Box<Pat>
+    pub fn ident_ref_pat<I>(self, name: I) -> Pat
     where
         I: Make<Ident>,
     {
         let name = name.make(&self);
-        Box::new(Pat::Ident(PatIdent {
+        Pat::Ident(PatIdent {
             attrs: self.attrs,
             by_ref: Some(Token![ref](self.span)),
             mutability: self.mutbl.to_token(),
             ident: name,
             subpat: None,
-        }))
+        })
     }
 
-    pub fn or_pat(self, pats: Vec<Box<Pat>>) -> Box<Pat> {
-        Box::new(Pat::Or(PatOr {
+    pub fn or_pat(self, pats: Vec<Pat>) -> Pat {
+        Pat::Or(PatOr {
             attrs: self.attrs,
             leading_vert: None, // Untested
-            cases: punct_box(pats),
-        }))
+            cases: punct(pats),
+        })
     }
 
     // Types
 
-    pub fn barefn_ty(self, decl: Box<BareFnTyParts>) -> Box<Type> {
-        let (inputs, variadic, output) = *decl;
+    pub fn barefn_ty(self, decl: BareFnTyParts) -> Box<Type> {
+        let (inputs, variadic, output) = decl;
         let abi = self.get_abi_opt();
 
         let barefn = TypeBareFn {
@@ -1490,7 +1490,7 @@ impl Builder {
         }))
     }
 
-    pub fn fn_item<S>(self, sig: S, block: Box<Block>) -> Box<Item>
+    pub fn fn_item<S>(self, sig: S, block: Block) -> Box<Item>
     where
         S: Make<Signature>,
     {
@@ -1499,7 +1499,7 @@ impl Builder {
             attrs: self.attrs,
             vis: self.vis,
             sig,
-            block,
+            block: Box::new(block),
         }))
     }
 
@@ -1947,11 +1947,11 @@ impl Builder {
         }
     }
 
-    pub fn block(self, stmts: Vec<Stmt>) -> Box<Block> {
-        Box::new(Block {
+    pub fn block(self, stmts: Vec<Stmt>) -> Block {
+        Block {
             stmts,
             brace_token: token::Brace(self.span),
-        })
+        }
     }
 
     pub fn label<L>(self, lbl: L) -> Label
@@ -1986,11 +1986,11 @@ impl Builder {
         }
     }
 
-    pub fn arg(self, ty: Box<Type>, pat: Box<Pat>) -> FnArg {
+    pub fn arg(self, ty: Box<Type>, pat: Pat) -> FnArg {
         FnArg::Typed(PatType {
             attrs: Vec::new(),
             ty,
-            pat,
+            pat: Box::new(pat),
             colon_token: Token![:](self.span),
         })
     }
@@ -2160,17 +2160,17 @@ impl Builder {
     }
 
     /// Create a local variable
-    pub fn local(self, pat: Box<Pat>, ty: Option<Box<Type>>, init: Option<Box<Expr>>) -> Local {
+    pub fn local(self, pat: Pat, ty: Option<Box<Type>>, init: Option<Box<Expr>>) -> Local {
         let init = init.map(|x| (Default::default(), x));
         let pat = if let Some(ty) = ty {
             Pat::Type(PatType {
                 attrs: vec![],
-                pat,
+                pat: Box::new(pat),
                 colon_token: Token![:](self.span),
                 ty,
             })
         } else {
-            *pat
+            pat
         };
         Local {
             attrs: self.attrs,
@@ -2226,10 +2226,10 @@ impl Builder {
         self,
         capture: CaptureBy,
         mov: Movability,
-        decl: Box<FnDecl>,
+        decl: FnDecl,
         body: Box<Expr>,
     ) -> Box<Expr> {
-        let (_name, inputs, _variadic, output) = *decl;
+        let (_name, inputs, _variadic, output) = decl;
         let inputs = inputs
             .into_iter()
             .map(|e| match e {

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -318,7 +318,7 @@ pub enum GenTerminator<Lbl> {
     /// Multi-way branch. The patterns are expected to match the type of the expression.
     Switch {
         expr: Box<Expr>,
-        cases: Vec<(Box<Pat>, Lbl)>, // TODO: support ranges of expressions
+        cases: Vec<(Pat, Lbl)>, // TODO: support ranges of expressions
     },
 }
 
@@ -429,7 +429,7 @@ impl GenTerminator<StructureLabel<StmtOrDecl>> {
 /// been seen which translating the body of the switch.
 #[derive(Clone, Debug, Default)]
 pub struct SwitchCases {
-    cases: Vec<(Box<Pat>, Label)>,
+    cases: Vec<(Pat, Label)>,
     default: Option<Label>,
 }
 

--- a/c2rust-transpile/src/cfg/relooper.rs
+++ b/c2rust-transpile/src/cfg/relooper.rs
@@ -567,7 +567,7 @@ fn simplify_structure<Stmt: Clone>(structures: Vec<Structure<Stmt>>) -> Vec<Stru
                 } = terminator
                 {
                     // Here, we group patterns by the label they go to.
-                    type Merged = IndexMap<Label, Vec<Box<Pat>>>;
+                    type Merged = IndexMap<Label, Vec<Pat>>;
                     let mut merged_goto: Merged = IndexMap::new();
                     let mut merged_exit: Merged = IndexMap::new();
 

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -288,7 +288,7 @@ fn structured_cfg_help<S: StructuredStatement<E = Box<Expr>, P = Pat, L = Label,
                             let branched_cases = cases
                                 .iter()
                                 .map(|&(ref pat, ref slbl)| Ok((pat.clone(), branch(slbl)?)))
-                                .collect::<TranslationResult<Vec<(Pat, S)>>>()?;
+                                .collect::<TranslationResult<_>>()?;
 
                             S::mk_match(expr.clone(), branched_cases)
                         }
@@ -299,12 +299,12 @@ fn structured_cfg_help<S: StructuredStatement<E = Box<Expr>, P = Pat, L = Label,
             Multiple { branches, then, .. } => {
                 let cases = branches
                     .iter()
-                    .map(|(lbl, body)| -> TranslationResult<(Label, S)> {
+                    .map(|(lbl, body)| {
                         let stmts =
                             structured_cfg_help(exits.clone(), next, body, used_loop_labels)?;
                         Ok((lbl.clone(), stmts))
                     })
-                    .collect::<TranslationResult<Vec<(Label, S)>>>()?;
+                    .collect::<TranslationResult<_>>()?;
 
                 let then: S = structured_cfg_help(exits.clone(), next, then, used_loop_labels)?;
 

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -248,11 +248,11 @@ impl TypeConverter {
 
         let variadic = is_variadic.then(|| mk().variadic_arg(vec![]));
 
-        let fn_ty = Box::new((
+        let fn_ty = (
             barefn_inputs,
             variadic,
             ReturnType::Type(Default::default(), output),
-        ));
+        );
         Ok(mk().unsafe_().extern_("C").barefn_ty(fn_ty))
     }
 

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -216,7 +216,7 @@ impl<'c> Translation<'c> {
                             iter::repeat(self.implicit_default_expr(ty, ctx.is_static))
                                 .take(n - ids.len()),
                         )
-                        .collect::<TranslationResult<WithStmts<Vec<Box<Expr>>>>>()?
+                        .collect::<TranslationResult<WithStmts<_>>>()?
                         .map(|vals| mk().array_expr(vals)))
                 }
             }

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -369,12 +369,12 @@ fn vec_expr(val: Box<Expr>, count: Box<Expr>) -> Box<Expr> {
     mk().call_expr(from_elem, vec![val, count])
 }
 
-pub fn stmts_block(mut stmts: Vec<Stmt>) -> Box<Block> {
+pub fn stmts_block(mut stmts: Vec<Stmt>) -> Block {
     match stmts.pop() {
         None => {}
         Some(Stmt::Expr(Expr::Block(ExprBlock {
             block, label: None, ..
-        }))) if stmts.is_empty() => return Box::new(block),
+        }))) if stmts.is_empty() => return block,
         Some(mut s) => {
             if let Stmt::Expr(e) = s {
                 s = Stmt::Semi(e, Default::default());
@@ -1532,7 +1532,7 @@ impl<'c> Translation<'c> {
             .pick_name("run_static_initializers");
         let fn_ty = ReturnType::Default;
         let fn_decl = mk().fn_decl(fn_name.clone(), vec![], None, fn_ty.clone());
-        let fn_bare_decl = Box::new((vec![], None, fn_ty));
+        let fn_bare_decl = (vec![], None, fn_ty);
         let fn_block = mk().block(sectioned_static_initializers);
         let fn_item = mk().unsafe_().extern_("C").fn_item(fn_decl, fn_block);
 
@@ -3540,23 +3540,23 @@ impl<'c> Translation<'c> {
 
                 if ctx.is_unused() {
                     let is_unsafe = lhs.is_unsafe() || rhs.is_unsafe();
-                    let then: Box<Block> = mk().block(lhs.into_stmts());
-                    let els: Box<Expr> = mk().block_expr(mk().block(rhs.into_stmts()));
+                    let then = mk().block(lhs.into_stmts());
+                    let else_ = mk().block_expr(mk().block(rhs.into_stmts()));
 
                     let mut res = cond.and_then(|c| -> TranslationResult<_> {
                         Ok(WithStmts::new(
-                            vec![mk().semi_stmt(mk().ifte_expr(c, then, Some(els)))],
+                            vec![mk().semi_stmt(mk().ifte_expr(c, then, Some(else_)))],
                             self.panic_or_err("Conditional expression is not supposed to be used"),
                         ))
                     })?;
                     res.merge_unsafe(is_unsafe);
                     Ok(res)
                 } else {
-                    let then: Box<Block> = lhs.to_block();
-                    let els: Box<Expr> = rhs.to_expr();
+                    let then = lhs.to_block();
+                    let else_ = rhs.to_expr();
 
                     Ok(cond.map(|c| {
-                        let ifte_expr = mk().ifte_expr(c, then, Some(els));
+                        let ifte_expr = mk().ifte_expr(c, then, Some(else_));
 
                         if ctx.ternary_needs_parens {
                             mk().paren_expr(ifte_expr)
@@ -3785,12 +3785,11 @@ impl<'c> Translation<'c> {
                                 Type::Tuple(TypeTuple { elems: ref v, .. }) if v.is_empty() => ReturnType::Default,
                                 _ => ReturnType::Type(Default::default(), ret_ty),
                             };
-                            let bare_ty: (Vec<BareFnArg>, Option<Variadic>, ReturnType) = (
+                            let bare_ty = (
                                 vec![mk().bare_arg(mk().infer_ty(), None::<Box<Ident>>); args.len()],
                                 None,
                                 ret_ty
                             );
-                            let bare_ty = Box::new(bare_ty);
                             mk().barefn_ty(bare_ty)
                         };
                         match fn_ty {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3787,7 +3787,7 @@ impl<'c> Translation<'c> {
                             };
                             let bare_ty = (
                                 vec![mk().bare_arg(mk().infer_ty(), None::<Box<Ident>>); args.len()],
-                                None,
+                                None::<Variadic>,
                                 ret_ty
                             );
                             mk().barefn_ty(bare_ty)

--- a/c2rust-transpile/src/with_stmts.rs
+++ b/c2rust-transpile/src/with_stmts.rs
@@ -119,7 +119,7 @@ impl WithStmts<Box<Expr>> {
     }
 
     /// Package a series of statements and an expression into one block
-    pub fn to_block(mut self) -> Box<Block> {
+    pub fn to_block(mut self) -> Block {
         self.stmts.push(mk().expr_stmt(self.val));
         mk().block(self.stmts)
     }


### PR DESCRIPTION
Fixed the `clippy::boxed_local` warnings surfaced by the de-genericizing in https://github.com/immunant/c2rust/pull/549, as well as the cascading de-`Box`ing.  This gets us back to `clippy` warning-free code.