### PR TITLE
Fail on `cargo` compilation failure

### DIFF
--- a/dynamic_instrumentation/src/lib.rs
+++ b/dynamic_instrumentation/src/lib.rs
@@ -142,11 +142,11 @@ pub fn instrument(
     let cwd = env::current_dir().unwrap();
 
     env::set_current_dir(rt_ws.root()).unwrap();
-    let _ = ops::compile_with_exec(&rt_ws, &compile_opts, &exec_dyn);
+    ops::compile_with_exec(&rt_ws, &compile_opts, &exec_dyn)?;
 
     exec.building_rt.store(false, Ordering::Relaxed);
     env::set_current_dir(cwd).unwrap();
-    let _ = ops::compile_with_exec(&ws, &compile_opts, &exec_dyn);
+    ops::compile_with_exec(&ws, &compile_opts, &exec_dyn)?;
 
     INSTRUMENTER.finalize(metadata_file_path)
 }

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -102,10 +102,6 @@ main() {
             2> instrument.err.jsonl; then
                 on-instrument-failure "${metadata}"
             fi
-
-            if ! [[ -x "${binary_path}" ]]; then
-                on-instrument-failure "${metadata}"
-            fi
         fi
         
         export INSTRUMENT_BACKEND=log


### PR DESCRIPTION
Don't ignore compilation errors from `cargo`.  I'm not sure why that was done in the first place.  This made lots of errors silent and hard to debug, as only the JSON `cargo` messages are printed, not the rendered output.

Now that this is done properly, we can remove mitigations like in `pdg.sh` for detecting when `cargo` failed, which were imperfect.