### PR TITLE
More improvements for `refactor.dynamicanalysis`

### DIFF
--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -437,7 +437,7 @@ impl<'a, 'tcx: 'a> InstrumentationBuilder<'a, 'tcx, ReadyToInstrument<'tcx>> {
         self
     }
 
-    fn args(mut self, args: impl IntoIterator<Item = impl IntoOperand<'tcx>>) -> Self {
+    fn arg_vars(mut self, args: impl IntoIterator<Item = impl IntoOperand<'tcx>>) -> Self {
         for arg in args {
             self = self.arg_var(arg);
         }
@@ -747,7 +747,7 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for InstrumentationAdder<'a, 'tcx> {
                             .dest(&dest_place)
                             .after_call()
                             .transfer(TransferKind::Ret(self.func_hash()))
-                            .args(args.iter().cloned())
+                            .arg_vars(args.iter().cloned())
                             .add_to(self);
                     } else if is_region_or_unsafe_ptr(
                         dest_place.ty(&self.body.local_decls, self.tcx).ty,

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -10,9 +10,9 @@ use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_middle::mir::visit::{MutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{
-    BasicBlock, BasicBlockData, Body, BorrowKind, CastKind, Constant, Local, LocalDecl,
-    Location, Mutability, Operand, Place, PlaceElem, PlaceRef, ProjectionElem, Rvalue, SourceInfo,
-    Statement, StatementKind, Terminator, TerminatorKind, START_BLOCK,
+    BasicBlock, BasicBlockData, Body, BorrowKind, CastKind, Constant, Local, LocalDecl, Location,
+    Mutability, Operand, Place, PlaceElem, PlaceRef, ProjectionElem, Rvalue, SourceInfo, Statement,
+    StatementKind, Terminator, TerminatorKind, START_BLOCK,
 };
 use rustc_middle::ty::{self, ParamEnv, TyCtxt, TyS};
 use rustc_span::def_id::{DefId, DefPathHash, CRATE_DEF_INDEX};
@@ -452,7 +452,8 @@ impl<'tcx> InstrumentationBuilder<'_, 'tcx> {
 
     /// Add an argument to this [`InstrumentationPoint`] that is the index of the argument.
     fn arg_index_of(self, arg: impl Idx) -> Self {
-        let index: u32 = arg.index().try_into().expect("`rustc_index::vec::newtype_index!` should use `u32` as the underlying index type, so this shouldn't fail unless that changes");
+        let index: u32 = arg.index().try_into()
+            .expect("`rustc_index::vec::newtype_index!` should use `u32` as the underlying index type, so this shouldn't fail unless that changes");
         self.arg_var(index)
     }
 

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -232,11 +232,9 @@ impl<'a, 'tcx: 'a> InstrumentationAdder<'a, 'tcx> {
     fn into_instrumentation_points(mut self) -> Vec<InstrumentationPoint<'tcx>> {
         // Sort by reverse location so that we can split blocks without
         // perturbing future statement indices
-        self.instrumentation_points.sort_unstable_by(|a, b| {
-            (a.loc, a.after_call, a.id)
-                .cmp(&(b.loc, b.after_call, b.id))
-                .reverse()
-        });
+        let key = |p: &InstrumentationPoint| (p.loc, p.after_call, p.id);
+        self.instrumentation_points
+            .sort_unstable_by(|a, b| key(a).cmp(&key(b)).reverse());
         self.instrumentation_points
     }
 

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -402,6 +402,7 @@ impl Source for u32 {
     }
 }
 
+/// Types that can be passed as an argument to instrumentation hook functions.
 trait IntoOperand<'tcx> {
     fn op(self, tcx: TyCtxt<'tcx>) -> Operand<'tcx>;
 }

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -451,6 +451,9 @@ impl<'tcx> InstrumentationBuilder<'_, 'tcx> {
     }
 
     /// Add an argument to this [`InstrumentationPoint`] that is the index of the argument.
+    /// 
+    /// TODO(kkysen, aneksteind) Currently `Idx`/`u32` types are the only types we support passing as arguments as is,
+    /// but we eventually want to be able to pass other serializable types as well.
     fn arg_index_of(self, arg: impl Idx) -> Self {
         let index: u32 = arg.index().try_into()
             .expect("`rustc_index::vec::newtype_index!` should use `u32` as the underlying index type, so this shouldn't fail unless that changes");

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -438,12 +438,6 @@ derive_u32_index!(Local);
 derive_u32_index!(Field);
 
 impl<'a, 'tcx: 'a> InstrumentationBuilder<'a, 'tcx, ReadyToInstrument<'tcx>> {
-    fn arg_addr_of(mut self, arg: impl IntoOperand<'tcx>) -> Self {
-        let op = arg.op(self.tcx);
-        self.state.point.args.push(InstrumentationArg::AddrOf(op));
-        self
-    }
-
     fn arg_var(mut self, arg: impl IntoOperand<'tcx>) -> Self {
         let op = arg.op(self.tcx);
         let op_ty = op.ty(self.body, self.tcx);
@@ -454,14 +448,20 @@ impl<'a, 'tcx: 'a> InstrumentationBuilder<'a, 'tcx, ReadyToInstrument<'tcx>> {
         self
     }
 
-    fn arg_index_of(self, arg: impl U32Index) -> Self {
-        self.arg_var(arg.index())
-    }
-
     fn arg_vars(mut self, args: impl IntoIterator<Item = impl IntoOperand<'tcx>>) -> Self {
         for arg in args {
             self = self.arg_var(arg);
         }
+        self
+    }
+
+    fn arg_index_of(self, arg: impl U32Index) -> Self {
+        self.arg_var(arg.index())
+    }
+    
+    fn arg_addr_of(mut self, arg: impl IntoOperand<'tcx>) -> Self {
+        let op = arg.op(self.tcx);
+        self.state.point.args.push(InstrumentationArg::AddrOf(op));
         self
     }
 

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -474,8 +474,8 @@ impl<'a, 'tcx: 'a> InstrumentationBuilder<'a, 'tcx, ReadyToInstrument<'tcx>> {
         self
     }
 
-    fn source<T: Source>(mut self, s: &T) -> Self {
-        self.state.point.metadata.source = s.source();
+    fn source<S: Source>(mut self, source: &S) -> Self {
+        self.state.point.metadata.source = source.source();
         self
     }
 
@@ -494,8 +494,8 @@ impl<'a, 'tcx: 'a> InstrumentationBuilder<'a, 'tcx, ReadyToInstrument<'tcx>> {
         self
     }
 
-    fn transfer(mut self, t: TransferKind) -> Self {
-        self.state.point.metadata.transfer_kind = t;
+    fn transfer(mut self, transfer_kind: TransferKind) -> Self {
+        self.state.point.metadata.transfer_kind = transfer_kind;
         self
     }
 

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -437,7 +437,7 @@ macro_rules! derive_u32_index {
 derive_u32_index!(Local);
 derive_u32_index!(Field);
 
-impl<'a, 'tcx: 'a> InstrumentationBuilder<'a, 'tcx, ReadyToInstrument<'tcx>> {
+impl<'tcx> InstrumentationBuilder<'_, 'tcx, ReadyToInstrument<'tcx>> {
     /// Add an argument to this [`InstrumentationPoint`].
     fn arg_var(mut self, arg: impl IntoOperand<'tcx>) -> Self {
         let op = arg.op(self.tcx);
@@ -516,7 +516,7 @@ impl<'a, 'tcx: 'a> InstrumentationBuilder<'a, 'tcx, ReadyToInstrument<'tcx>> {
     }
 }
 
-impl<'a, 'tcx: 'a> Visitor<'tcx> for InstrumentationAdder<'a, 'tcx> {
+impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
     fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, location: Location) {
         self.super_place(place, context, location);
 

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -438,6 +438,7 @@ derive_u32_index!(Local);
 derive_u32_index!(Field);
 
 impl<'a, 'tcx: 'a> InstrumentationBuilder<'a, 'tcx, ReadyToInstrument<'tcx>> {
+    /// Add an argument to this [`InstrumentationPoint`].
     fn arg_var(mut self, arg: impl IntoOperand<'tcx>) -> Self {
         let op = arg.op(self.tcx);
         let op_ty = op.ty(self.body, self.tcx);
@@ -448,6 +449,7 @@ impl<'a, 'tcx: 'a> InstrumentationBuilder<'a, 'tcx, ReadyToInstrument<'tcx>> {
         self
     }
 
+    /// Add multiple arguments to this [`InstrumentationPoint`], using `Self::arg_var`.
     fn arg_vars(mut self, args: impl IntoIterator<Item = impl IntoOperand<'tcx>>) -> Self {
         for arg in args {
             self = self.arg_var(arg);
@@ -455,10 +457,12 @@ impl<'a, 'tcx: 'a> InstrumentationBuilder<'a, 'tcx, ReadyToInstrument<'tcx>> {
         self
     }
 
+    /// Add an argument to this [`InstrumentationPoint`] that is the index of the argument.
     fn arg_index_of(self, arg: impl U32Index) -> Self {
         self.arg_var(arg.index())
     }
     
+    /// Add an argument to this [`InstrumentationPoint`] that is the address of the argument.
     fn arg_addr_of(mut self, arg: impl IntoOperand<'tcx>) -> Self {
         let op = arg.op(self.tcx);
         self.state.point.args.push(InstrumentationArg::AddrOf(op));

--- a/dynamic_instrumentation/src/instrument_memory.rs
+++ b/dynamic_instrumentation/src/instrument_memory.rs
@@ -421,14 +421,14 @@ impl<'tcx> IntoOperand<'tcx> for Operand<'tcx> {
 }
 
 impl<'a, 'tcx: 'a> InstrumentationBuilder<'a, 'tcx, ReadyToInstrument<'tcx>> {
-    fn arg_addr_of(mut self, a: impl IntoOperand<'tcx>) -> Self {
-        let op = a.op(self.tcx);
+    fn arg_addr_of(mut self, arg: impl IntoOperand<'tcx>) -> Self {
+        let op = arg.op(self.tcx);
         self.state.point.args.push(InstrumentationArg::AddrOf(op));
         self
     }
 
-    fn arg_var(mut self, a: impl IntoOperand<'tcx>) -> Self {
-        let op = a.op(self.tcx);
+    fn arg_var(mut self, arg: impl IntoOperand<'tcx>) -> Self {
+        let op = arg.op(self.tcx);
         let op_ty = op.ty(self.body, self.tcx);
         self.state
             .point


### PR DESCRIPTION
Further improvements.

The three larger ones are:
* Remove the builder typestate pattern as it's unused as @aneksteind already found a simpler way.
* Add `InstrumentationPointBuilder`, which is the `Default` fields of `InstrumentationPoint`.  `loc: Location` and `func: DefId` are moved to the `InstrumentationBuilder` itself.
* Added `InstrumentationBuilder::arg_index_of` for where we're using the index of a type as the argument, similarly to how we have `InstrumentationBuilder::arg_addr_of`.

After this is merged, https://github.com/immunant/c2rust/pull/552#pullrequestreview-1051374217 should be good to merge to `master`.