### PR TITLE
Run `cargo add` in `c2rust-instrument --set-runtime` to add `c2rust-analysis-rt` automatically

### DIFF
--- a/analysis/test/Cargo.toml
+++ b/analysis/test/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../analysis/runtime", optional = true }
+c2rust-analysis-rt = { path = "../runtime", optional = true, version = "0.1.0" }

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -316,7 +316,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
         // it usually isn't that slow.
         cmd.args(&["clean", "--package", root_package.name.as_str()]);
     })?;
-
+    
     // TODO(kkysen) Once we upgrade to 1.62, we can just use `cargo` and not specify `+stable`.
     // The problem currently is that `+stable` doesn't work on a resolved `$CARGO`,
     // which happens when this runs inside of `cargo test`,

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -51,7 +51,7 @@ struct Args {
     /// Path to the `c2rust-analysis-rt` crate if you want to use a local version of it (vs. the crates.io one).
     /// This is not used unless `--set-runtime` is also passed.
     #[clap(long, value_parser)]
-    runtime: Option<PathBuf>,
+    runtime_path: Option<PathBuf>,
 
     /// Add the runtime as an optional dependency to the instrumented crate using `cargo add`.
     #[clap(long)]
@@ -295,7 +295,7 @@ fn set_rust_toolchain() -> anyhow::Result<()> {
 fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
     let Args {
         metadata,
-        runtime,
+        runtime_path,
         set_runtime,
         mut cargo_args,
     } = Args::parse();
@@ -326,7 +326,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
     if set_runtime {
         cargo.run(|cmd| {
             cmd.args(&["add", "--optional", "c2rust-analysis-rt"]);
-            if let Some(runtime) = runtime {
+            if let Some(runtime) = runtime_path {
                 // Since it's a local path, we don't need the internet,
                 // and running it offline saves a slow index sync.
                 cmd.args(&["--offline", "--path"]).arg(runtime);

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -52,6 +52,10 @@ struct Args {
     #[clap(long, value_parser)]
     runtime: Option<PathBuf>,
 
+    /// Add the runtime as an optional dependency to the instrumented crate using `cargo add`.
+    #[clap(long)]
+    set_runtime: bool,
+
     /// `cargo` args.
     cargo_args: Vec<OsString>,
 }
@@ -291,6 +295,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
     let Args {
         metadata,
         runtime,
+        set_runtime,
         mut cargo_args,
     } = Args::parse();
 
@@ -316,23 +321,17 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
         // it usually isn't that slow.
         cmd.args(&["clean", "--package", root_package.name.as_str()]);
     })?;
-    
-    // TODO(kkysen) Once we upgrade to 1.62, we can just use `cargo` and not specify `+stable`.
-    // The problem currently is that `+stable` doesn't work on a resolved `$CARGO`,
-    // which happens when this runs inside of `cargo test`,
-    // and our current nightly is 1.60, which is before `cargo add` got added
-    // (though it's been in `cargo-edit` for a while).
-    Cargo {
-        path: "cargo".into(),
+
+    if set_runtime {
+        cargo.run(|cmd| {
+            cmd.args(&["add", "--optional", "c2rust-analysis-rt"]);
+            if let Some(runtime) = runtime {
+                // Since it's a local path, we don't need the internet,
+                // and running it offline saves a slow index sync.
+                cmd.args(&["--offline", "--path"]).arg(runtime);
+            }
+        })?;
     }
-    .run(|cmd| {
-        cmd.args(&["+stable", "add", "--optional", "c2rust-analysis-rt"]);
-        if let Some(runtime) = runtime {
-            // Since it's a local path, we don't need the internet,
-            // and running it offline saves a slow index sync.
-            cmd.args(&["--offline", "--path"]).arg(runtime);
-        }
-    })?;
 
     // Create and truncate the metadata file for the [`rustc_wrapper`]s to append to.
     OpenOptions::new()

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -48,7 +48,8 @@ struct Args {
     #[clap(long, value_parser)]
     metadata: PathBuf,
 
-    /// Path to the `c2rust-analysis-rt` crate.
+    /// Path to the `c2rust-analysis-rt` crate if you want to use a local version of it (vs. the crates.io one).
+    /// This is not used unless `--set-runtime` is also passed.
     #[clap(long, value_parser)]
     runtime: Option<PathBuf>,
 

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -53,6 +53,7 @@ main() {
 
         time "${c2rust_instrument}" \
             --metadata "${metadata}" \
+            --set-runtime \
             --runtime-path "${runtime}" \
             -- run "${profile_args[@]}" \
             -- "${args[@]}" \

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -53,7 +53,7 @@ main() {
 
         time "${c2rust_instrument}" \
             --metadata "${metadata}" \
-            --runtime "${runtime}" \
+            --runtime-path "${runtime}" \
             -- run "${profile_args[@]}" \
             -- "${args[@]}" \
             1> instrument.out.log

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -41,6 +41,7 @@ main() {
     local c2rust="${CWD}/${profile_dir}/c2rust"
     local c2rust_instrument="${CWD}/${profile_dir}/${instrument}"
     local metadata="${CWD}/${test_dir}/metadata.bc"
+    local runtime="${CWD}/analysis/runtime"
 
     (cd "${test_dir}"
         unset RUSTFLAGS # transpiled code has tons of warnings; don't allow `-D warnings`
@@ -52,6 +53,7 @@ main() {
 
         time "${c2rust_instrument}" \
             --metadata "${metadata}" \
+            --runtime "${runtime}" \
             -- run "${profile_args[@]}" \
             -- "${args[@]}" \
             1> instrument.out.log


### PR DESCRIPTION
Currently, in #554, the `c2rust-analysis-rt` runtime must be added as an (optional) dependency in the instrumented crate.  This runs `cargo add c2rust-analysis-rt --optional` so that it is automatically added and up-to-date when instrumenting.  This also adds an optional `--runtime ${runtime}` argument to `c2rust-instrument`.  If it is given, then `cargo add c2rust-analysis-rt --optional --path ${runtime} --offline` is run.  Thus, it works well both when `c2rust-analysis-rt` is already on your machine and you're developing locally, as well as a user who would download `c2rust-analysis-rt` from [crates.io](https://crates.io).  Note that `cargo add` is only run when `--set-runtime` is passed, so this is off by default, and must be opted-into.

Another, more complex, option is to copy the `Cargo.toml` to a `Cargo.instrument.toml`, add the `c2rust-analysis-rt` dependency there, and the run with `--manifest-path Cargo.instrument.toml`.  However, that's more complex, and not all `cargo` commands uniformly take a `--manifest-path` argument, and there's no environment variable for that, which would be seamlessly inherited.