### PR TITLE
Small `clippy` fixes for `c2rust-analyzer`

### DIFF
--- a/c2rust-analyze/src/borrowck/atoms.rs
+++ b/c2rust-analyze/src/borrowck/atoms.rs
@@ -168,7 +168,7 @@ impl<'tcx> AtomMaps<'tcx> {
     ) -> Path {
         let (path, new) = self.path.add_new((local, projection));
         if new {
-            if projection.len() == 0 {
+            if projection.is_empty() {
                 let var = self.variable(local);
                 facts.path_is_var.push((path, var));
             } else {

--- a/c2rust-analyze/src/borrowck/def_use.rs
+++ b/c2rust-analyze/src/borrowck/def_use.rs
@@ -198,11 +198,7 @@ impl<'tcx> LoanInvalidatedAtVisitor<'tcx, '_> {
             context,
             categorize(context)
         );
-        let invalidate = match (borrow_kind, categorize(context)) {
-            (BorrowKind::Shared, Some(DefUse::Use)) => false,
-            (_, None) => false,
-            _ => true,
-        };
+        let invalidate = !matches!((borrow_kind, categorize(context)), (BorrowKind::Shared, Some(DefUse::Use)) | (_, None));
         if !invalidate {
             return;
         }

--- a/c2rust-analyze/src/borrowck/def_use.rs
+++ b/c2rust-analyze/src/borrowck/def_use.rs
@@ -198,7 +198,10 @@ impl<'tcx> LoanInvalidatedAtVisitor<'tcx, '_> {
             context,
             categorize(context)
         );
-        let invalidate = !matches!((borrow_kind, categorize(context)), (BorrowKind::Shared, Some(DefUse::Use)) | (_, None));
+        let invalidate = !matches!(
+            (borrow_kind, categorize(context)),
+            (BorrowKind::Shared, Some(DefUse::Use)) | (_, None)
+        );
         if !invalidate {
             return;
         }

--- a/c2rust-analyze/src/borrowck/def_use.rs
+++ b/c2rust-analyze/src/borrowck/def_use.rs
@@ -262,7 +262,7 @@ impl<'tcx> Visitor<'tcx> for LoanInvalidatedAtVisitor<'tcx, '_> {
             location
         );
 
-        let local_loans = self.loans.get(&local).map_or(&[] as &[_], |x| x);
+        let local_loans = self.loans.get(local).map_or(&[] as &[_], |x| x);
         for &(_path, loan, borrow_kind) in local_loans {
             // All paths rooted in this local overlap the local.
             self.access_loan_at_location(loan, borrow_kind, context, location);

--- a/c2rust-analyze/src/borrowck/def_use.rs
+++ b/c2rust-analyze/src/borrowck/def_use.rs
@@ -198,10 +198,13 @@ impl<'tcx> LoanInvalidatedAtVisitor<'tcx, '_> {
             context,
             categorize(context)
         );
-        let invalidate = !matches!(
-            (borrow_kind, categorize(context)),
-            (BorrowKind::Shared, Some(DefUse::Use)) | (_, None)
-        );
+        // `match` is easier to read.
+        #[allow(clippy::match_like_matches_macro)]
+        let invalidate = match (borrow_kind, categorize(context)) {
+            (BorrowKind::Shared, Some(DefUse::Use)) => false,
+            (_, None) => false,
+            _ => true,
+        };
         if !invalidate {
             return;
         }

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -50,7 +50,7 @@ pub fn borrowck_mir<'tcx>(
         }
 
         let mut changed = false;
-        for (_, loans) in &output.errors {
+        for loans in output.errors.values() {
             for &loan in loans {
                 let issued_point = facts
                     .loan_issued_at

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -3,7 +3,7 @@ use crate::context::{AnalysisCtxt, PermissionSet};
 use crate::dataflow::DataflowConstraints;
 use crate::labeled_ty::{LabeledTy, LabeledTyCtxt};
 use crate::util::{describe_rvalue, RvalueDesc};
-use polonius_engine;
+
 use rustc_middle::mir::{Body, BorrowKind, Local, LocalKind, Place, StatementKind, START_BLOCK};
 use rustc_middle::ty::{List, TyKind};
 use std::collections::HashMap;
@@ -42,7 +42,7 @@ pub fn borrowck_mir<'tcx>(
         );
         i += 1;
 
-        if output.errors.len() == 0 {
+        if output.errors.is_empty() {
             break;
         }
         if i >= 20 {

--- a/c2rust-analyze/src/dataflow/mod.rs
+++ b/c2rust-analyze/src/dataflow/mod.rs
@@ -117,7 +117,7 @@ impl DataflowConstraints {
         let mut i = 0;
         loop {
             if i > xs.len() + self.constraints.len() {
-                return Err(format!("infinite loop in dataflow edges"));
+                return Err("infinite loop in dataflow edges".to_string());
             }
             i += 1;
 

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -138,51 +138,45 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
     pub fn visit_statement(&mut self, stmt: &Statement<'tcx>) {
         eprintln!("visit_statement({:?})", stmt);
-        match stmt.kind {
-            StatementKind::Assign(ref x) => {
-                let (pl, ref rv) = **x;
-                let ctx = PlaceContext::MutatingUse(MutatingUseContext::Store);
-                let pl_lty = self.visit_place(pl, ctx);
-                let pl_ptr = pl_lty.label;
+        if let StatementKind::Assign(ref x) = stmt.kind {
+            let (pl, ref rv) = **x;
+            let ctx = PlaceContext::MutatingUse(MutatingUseContext::Store);
+            let pl_lty = self.visit_place(pl, ctx);
+            let pl_ptr = pl_lty.label;
 
-                let rv_ptr = self.visit_rvalue(rv);
+            let rv_ptr = self.visit_rvalue(rv);
 
-                self.do_assign(pl_ptr, rv_ptr);
-            }
-            _ => {}
+            self.do_assign(pl_ptr, rv_ptr);
         }
     }
 
     pub fn visit_terminator(&mut self, term: &Terminator<'tcx>) {
         eprintln!("visit_terminator({:?})", term.kind);
         let tcx = self.acx.tcx;
-        match term.kind {
-            TerminatorKind::Call {
-                ref func,
-                ref args,
-                destination,
-                ..
-            } => {
-                let func_ty = func.ty(self.mir, tcx);
-                eprintln!("callee = {:?}", util::ty_callee(tcx, func_ty));
-                match util::ty_callee(tcx, func_ty) {
-                    Some(Callee::PtrOffset { .. }) => {
-                        // We handle this like a pointer assignment.
+        if let TerminatorKind::Call {
+                        ref func,
+                        ref args,
+                        destination,
+                        ..
+                    } = term.kind {
+            let func_ty = func.ty(self.mir, tcx);
+            eprintln!("callee = {:?}", util::ty_callee(tcx, func_ty));
+            match util::ty_callee(tcx, func_ty) {
+                Some(Callee::PtrOffset { .. }) => {
+                    // We handle this like a pointer assignment.
 
-                        // `destination` must be `Some` because the function doesn't diverge.
-                        let destination = destination.unwrap();
-                        let ctx = PlaceContext::MutatingUse(MutatingUseContext::Store);
-                        let pl_lty = self.visit_place(destination.0, ctx);
-                        assert!(args.len() == 2);
-                        let rv_lty = self.visit_operand(&args[0]);
-                        self.do_assign(pl_lty.label, rv_lty.label);
-                        let perms = PermissionSet::OFFSET_ADD | PermissionSet::OFFSET_SUB;
-                        self.constraints.add_all_perms(rv_lty.label, perms);
-                    }
-                    None => {}
+                    // `destination` must be `Some` because the function doesn't diverge.
+                    let destination = destination.unwrap();
+                    let ctx = PlaceContext::MutatingUse(MutatingUseContext::Store);
+                    let pl_lty = self.visit_place(destination.0, ctx);
+                    assert!(args.len() == 2);
+                    let rv_lty = self.visit_operand(&args[0]);
+                    self.do_assign(pl_lty.label, rv_lty.label);
+                    let perms = PermissionSet::OFFSET_ADD | PermissionSet::OFFSET_SUB;
+                    self.constraints.add_all_perms(rv_lty.label, perms);
                 }
+                None => {}
             }
-            _ => {}
         }
     }
 }

--- a/c2rust-analyze/src/expr_rewrite.rs
+++ b/c2rust-analyze/src/expr_rewrite.rs
@@ -303,10 +303,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         });
 
         // Emit `OffsetSlice` for the offset itself.
-        let mutbl = match result_own {
-            Ownership::Mut => true,
-            _ => false,
-        };
+        let mutbl = matches!(result_own, Ownership::Mut);
 
         self.emit(RewriteKind::OffsetSlice { mutbl });
 

--- a/c2rust-analyze/src/labeled_ty.rs
+++ b/c2rust-analyze/src/labeled_ty.rs
@@ -195,11 +195,7 @@ impl<'tcx, L: Copy> LabeledTyCtxt<'tcx, L> {
             }
         }
 
-        self.mk(
-            lty.ty,
-            self.subst_slice(lty.args, substs),
-            lty.label,
-        )
+        self.mk(lty.ty, self.subst_slice(lty.args, substs), lty.label)
     }
 
     /// Substitute arguments in multiple labeled types.

--- a/c2rust-analyze/src/labeled_ty.rs
+++ b/c2rust-analyze/src/labeled_ty.rs
@@ -150,7 +150,7 @@ impl<'tcx, L: Copy> LabeledTyCtxt<'tcx, L> {
                     .collect::<Vec<_>>();
                 self.mk(ty, self.mk_slice(&args), label)
             }
-            Tuple(ref elems) => {
+            Tuple(elems) => {
                 let args = elems
                     .types()
                     .map(|ty| self.label(ty, f))
@@ -198,7 +198,7 @@ impl<'tcx, L: Copy> LabeledTyCtxt<'tcx, L> {
         self.mk(
             lty.ty,
             self.subst_slice(lty.args, substs),
-            lty.label.clone(),
+            lty.label,
         )
     }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -39,7 +39,7 @@ fn inspect_mir<'tcx>(tcx: TyCtxt<'tcx>, def: WithOptConstParam<LocalDefId>, mir:
 
     // Label all pointers in local variables.
     // TODO: also label pointers in Rvalue::Cast (and ShallowInitBox?)
-    assert!(acx.local_tys.len() == 0);
+    assert!(acx.local_tys.is_empty());
     acx.local_tys = IndexVec::with_capacity(mir.local_decls.len());
     for (local, decl) in mir.local_decls.iter_enumerated() {
         let lty = assign_pointer_ids(&acx, decl.ty);
@@ -108,7 +108,7 @@ fn inspect_mir<'tcx>(tcx: TyCtxt<'tcx>, def: WithOptConstParam<LocalDefId>, mir:
         eprintln!("{:?} ({}): {:?}", local, describe_local(acx.tcx, decl), ty,);
     }
 
-    eprintln!("");
+    eprintln!();
     let rewrites = expr_rewrite::gen_expr_rewrites(&acx, &hypothesis, &flags, mir);
     for rw in &rewrites {
         eprintln!(
@@ -148,7 +148,7 @@ fn describe_span(tcx: TyCtxt, span: Span) -> String {
     let s = {
         let mut s2 = String::new();
         for word in s.split_ascii_whitespace() {
-            if s2.len() > 0 {
+            if !s2.is_empty() {
                 s2.push(' ');
             }
             s2.push_str(word);

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -44,10 +44,8 @@ pub fn perms_to_desc(perms: PermissionSet, flags: FlagSet) -> (Ownership, Quanti
         Ownership::Imm
     };
 
-    let qty = if perms.contains(PermissionSet::OFFSET_SUB) {
+    let qty = if perms.contains(PermissionSet::OFFSET_SUB) || perms.contains(PermissionSet::OFFSET_ADD) {
         // TODO: should be Quantity::OffsetPtr, but that's not implemented yet
-        Quantity::Slice
-    } else if perms.contains(PermissionSet::OFFSET_ADD) {
         Quantity::Slice
     } else {
         Quantity::Single

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -44,8 +44,12 @@ pub fn perms_to_desc(perms: PermissionSet, flags: FlagSet) -> (Ownership, Quanti
         Ownership::Imm
     };
 
-    let qty = if perms.contains(PermissionSet::OFFSET_SUB) || perms.contains(PermissionSet::OFFSET_ADD) {
-        // TODO: should be Quantity::OffsetPtr, but that's not implemented yet
+    // TODO(spernsteiner): will not remain identical branches
+    #[allow(clippy::if_same_then_else)]
+    let qty = if perms.contains(PermissionSet::OFFSET_SUB) {
+        // TODO(spernsteiner): should be [`Quantity::OffsetPtr`], but that's not implemented yet
+        Quantity::Slice
+    } else if perms.contains(PermissionSet::OFFSET_ADD) {
         Quantity::Slice
     } else {
         Quantity::Single

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -59,7 +59,7 @@ fn filecheck() {
 
         let name = entry.file_name();
         let name = name.to_str().unwrap();
-        if name.starts_with(".") || !name.ends_with(".rs") {
+        if name.starts_with('.') || !name.ends_with(".rs") {
             continue;
         }
 


### PR DESCRIPTION
A bunch of small `clippy` fixes for the `c2rust-analyze` code.  Most were automated (but I still checked them over), and the other 2 were very small.

Keeping things `clippy` warning-free is very helpful as I don't have to wade through them in `rust-analyzer` every time I'm looking for other errors and warnings, and we intend to add `clippy` to CI, too.