### PR TITLE
Fix macOS build crash in #569 by reverting #526

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,6 @@ dependencies = [
  "c2rust-ast-exporter",
  "c2rust-ast-printer",
  "c2rust-bitfields",
- "clap 2.34.0",
  "colored 2.0.0",
  "dtoa",
  "failure",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
+ "clap 3.2.8",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -113,6 +114,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "which",
 ]
 
 [[package]]
@@ -464,6 +466,7 @@ checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
 dependencies = [
  "glob",
  "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1204,6 +1207,16 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+dependencies = [
+ "cfg-if",
+ "winapi",
 ]
 
 [[package]]
@@ -2222,6 +2235,17 @@ dependencies = [
  "same-file",
  "winapi",
  "winapi-util",
+]
+
+[[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ dependencies = [
  "c2rust-ast-exporter",
  "c2rust-ast-printer",
  "c2rust-bitfields",
+ "clap 2.34.0",
  "colored 2.0.0",
  "dtoa",
  "failure",

--- a/c2rust-ast-builder/Cargo.toml
+++ b/c2rust-ast-builder/Cargo.toml
@@ -12,5 +12,5 @@ description = "Rust AST builder support crate for the C2Rust project"
 edition = "2021"
 
 [dependencies]
-proc-macro2 = { version = "1.0", features = ["span-locations"], default-features = false }
-syn = { version = "1.0", features = ["full", "extra-traits", "printing", "clone-impls"], default-features = false }
+proc-macro2 = { version = "1.0", features = ["span-locations"]}
+syn = { version = "1.0", features = ["full", "extra-traits", "printing", "clone-impls"]}

--- a/c2rust-ast-exporter/Cargo.toml
+++ b/c2rust-ast-exporter/Cargo.toml
@@ -20,7 +20,7 @@ serde_bytes = "0.11"
 serde_cbor = "0.11"
 
 [build-dependencies]
-bindgen = { version = "0.60", features = ["logging"], default-features = false }
+bindgen = { version = "0.60", features = ["logging"] }
 clang-sys = "1.3"
 # Pinning until https://github.com/rust-lang/cmake-rs/issues/131 is resolved
 # Fixed by https://github.com/rust-lang/cmake-rs/pull/146 on 5/12/2022; waiting for next release.

--- a/c2rust-ast-printer/Cargo.toml
+++ b/c2rust-ast-printer/Cargo.toml
@@ -9,6 +9,6 @@ description = "Customized version of libsyntax rust pretty-printer"
 
 [dependencies]
 log = "0.4"
-syn = { version = "1.0", features = ["full", "proc-macro", "printing", "clone-impls"], default-features = false }
-proc-macro2 = { version = "1.0", default-features = false }
+syn = { version = "1.0", features = ["full", "proc-macro", "printing", "clone-impls"] }
+proc-macro2 = "1.0"
 prettyplease = "0.1.9"

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -17,7 +17,6 @@ c2rust-ast-builder = { version = "0.16.0", path = "../c2rust-ast-builder" }
 c2rust-ast-exporter = { version = "0.16.0", path = "../c2rust-ast-exporter" }
 c2rust-ast-printer = { version = "0.16.0", path = "../c2rust-ast-printer" }
 c2rust-bitfields = { version = "0.3.0", path = "../c2rust-bitfields" }
-clap = {version = "2.34", features = ["yaml"]}
 colored = "2.0"
 dtoa = "1.0"
 failure = "0.1.5"

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -17,6 +17,7 @@ c2rust-ast-builder = { version = "0.16.0", path = "../c2rust-ast-builder" }
 c2rust-ast-exporter = { version = "0.16.0", path = "../c2rust-ast-exporter" }
 c2rust-ast-printer = { version = "0.16.0", path = "../c2rust-ast-printer" }
 c2rust-bitfields = { version = "0.3.0", path = "../c2rust-bitfields" }
+clap = {version = "2.34", features = ["yaml"]}
 colored = "2.0"
 dtoa = "1.0"
 failure = "0.1.5"
@@ -38,7 +39,7 @@ serde_json = "1.0"
 smallvec = "1.0"
 strum = "0.24"
 strum_macros = "0.24"
-syn = { version = "1.0", features = ["full", "extra-traits", "parsing", "printing"], default-features = false}
+syn = { version = "1.0", features = ["full", "extra-traits", "parsing", "printing"]}
 
 [features]
 # Force static linking of LLVM


### PR DESCRIPTION
Fixes https://github.com/immunant/c2rust/issues/569.

This reverts the `default-features = false` changes from https://github.com/immunant/c2rust/commit/b971ab5d3cadaaa112bb4b51a9e22fa1504352fc (part of https://github.com/immunant/c2rust/pull/526).