### PR TITLE
Print the full func name (and path) in the debug MIR

### DIFF
--- a/dynamic_instrumentation/src/point/build.rs
+++ b/dynamic_instrumentation/src/point/build.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use rustc_index::vec::Idx;
 use rustc_middle::{
     mir::{Body, Location, Place, TerminatorKind},
-    ty::{self, TyCtxt},
+    ty::TyCtxt,
 };
 use rustc_span::def_id::DefId;
 
@@ -152,14 +152,8 @@ impl<'tcx> InstrumentationBuilder<'_, 'tcx> {
                 func,
                 ..
             } => {
-                let func_name = if let &ty::FnDef(def_id, _) = func.ty(self.body, self.tcx).kind() {
-                    let name = self.tcx.item_name(def_id);
-                    format!("{name}")
-                } else {
-                    format!("{func:?}")
-                };
                 let args = args.iter().format(", ");
-                format!("{destination:?} = {func_name}({args:?})")
+                format!("{destination:?} = {func:?}({args:?})")
             }
             _ => "".into(),
         }


### PR DESCRIPTION
Print the full func name (and path) in the debug MIR.

The function name itself is not enough for readability.  We can elide well-known items, such as things in the `std` prelude, but that's not what wasn't done, and I'm not sure how difficult it is to do that.

This reverts part of the changes in https://github.com/immunant/c2rust/pull/566/commits/7e3105321218231f871a8110609f922335763f79, which I had missed (https://github.com/immunant/c2rust/pull/566/commits/7e3105321218231f871a8110609f922335763f79#r935146145).

That change changed things like this:

```rust
std::vec::Vec::<*mut i8>::push(move _29, move _30);
```

to this:

```rust
push(move _29, move _30);
```

which is IMO a lot less readable.

What we want is

```rust
Vec::<*mut i8>::push(move _29, move _30);
```

since `Vec` is in the `std` prelude.

Since I'm not sure how easy it is to do that prelude elision (I know `rustc` recently added this), this reverts those changes.