### PR TITLE
Kkysen/tests.refs.fields/remove outer deref refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
+name = "apply"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47b57fc4521e3cae26a4d45b5227f8fadee4c345be0fefd8d5d1711afb8aeb9"
+
+[[package]]
 name = "arc-swap"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +290,7 @@ name = "c2rust-dynamic-instrumentation"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "apply",
  "bincode",
  "c2rust-analysis-rt",
  "cargo",

--- a/dynamic_instrumentation/Cargo.toml
+++ b/dynamic_instrumentation/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+apply = "0.3"
 bincode = "1.0.1"
 c2rust-analysis-rt = { path = "../analysis/runtime"}
 cargo = "0.62"

--- a/dynamic_instrumentation/src/instrument.rs
+++ b/dynamic_instrumentation/src/instrument.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use apply::Apply;
 use c2rust_analysis_rt::metadata::Metadata;
 use c2rust_analysis_rt::mir_loc::{self, EventMetadata, Func, MirLoc, MirLocId, TransferKind};
 use c2rust_analysis_rt::HOOK_FUNCTIONS;
@@ -239,13 +240,13 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                     Some(_) => copy_fn,
                     None => addr_local_fn,
                 };
-                let mut b = self
-                    .loc(location.successor_within_block(), func)
-                    .arg_var(dest);
-                if source.is_none() {
-                    b = b.arg_index_of(p.local)
-                }
-                b.source(source.as_ref().unwrap_or(p))
+                self.loc(location.successor_within_block(), func)
+                    .arg_var(dest)
+                    .apply(|b| match source {
+                        Some(_) => b,
+                        None => b.arg_index_of(p.local),
+                    })
+                    .source(source.as_ref().unwrap_or(p))
                     .dest(&dest)
                     .debug_mir(location)
                     .add_to(self);

--- a/dynamic_instrumentation/src/point/mod.rs
+++ b/dynamic_instrumentation/src/point/mod.rs
@@ -12,7 +12,7 @@ use rustc_span::def_id::DefId;
 
 use crate::{arg::InstrumentationArg, hooks::Hooks, util::Convert};
 
-pub use apply::InstrumentationApplier;
+pub use self::apply::InstrumentationApplier;
 pub use cast::cast_ptr_to_usize;
 
 pub struct InstrumentationPoint<'tcx> {


### PR DESCRIPTION
This refactors `mod deref`, implementing most of the functions there in terms of one `try_remove_outer_deref_as_ref` so that we know they're all in sync.  Also, `try_remove_outer_deref` is added so that you don't have to do separate `has_outer_deref` and `remove_outer_deref` calls.

Then I used this to de-duplicate the 1 `has_outer_ref` and 2 `remove_outer_deref` calls in a `RValue::AddressOf` `match` arm by combining those 2 arms and using `try_remove_outer_deref`..

Then I used [`apply`](https://docs.rs/apply) to simplify the conditional builder logic.  It's quite a small but useful dependency for functional, chaining code.