### PR TITLE
Add pointer-to-pointer equivalence class analysis

### DIFF
--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -23,7 +23,7 @@ pub type LTy<'tcx> = LabeledTy<'tcx, Label>;
 pub type LTyCtxt<'tcx> = LabeledTyCtxt<'tcx, Label>;
 
 pub fn borrowck_mir<'tcx>(
-    acx: &AnalysisCtxt<'tcx>,
+    acx: &AnalysisCtxt<'_, 'tcx>,
     dataflow: &DataflowConstraints,
     hypothesis: &mut [PermissionSet],
     name: &str,
@@ -102,12 +102,12 @@ pub fn borrowck_mir<'tcx>(
 }
 
 fn run_polonius<'tcx>(
-    acx: &AnalysisCtxt<'tcx>,
+    acx: &AnalysisCtxt<'_, 'tcx>,
     hypothesis: &[PermissionSet],
     name: &str,
     mir: &Body<'tcx>,
 ) -> (AllFacts, AtomMaps<'tcx>, Output) {
-    let tcx = acx.tcx;
+    let tcx = acx.tcx();
     let mut facts = AllFacts::default();
     let mut maps = AtomMaps::default();
 
@@ -202,7 +202,7 @@ fn run_polonius<'tcx>(
     );
 
     // Populate `loan_invalidated_at`
-    def_use::visit_loan_invalidated_at(acx.tcx, &mut facts, &mut maps, &loans, mir);
+    def_use::visit_loan_invalidated_at(acx.tcx(), &mut facts, &mut maps, &loans, mir);
 
     // Populate `var_defined/used/dropped_at` and `path_assigned/accessed_at_base`.
     def_use::visit(&mut facts, &mut maps, mir);

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -3,7 +3,6 @@ use crate::context::{AnalysisCtxt, PermissionSet};
 use crate::dataflow::DataflowConstraints;
 use crate::labeled_ty::{LabeledTy, LabeledTyCtxt};
 use crate::util::{describe_rvalue, RvalueDesc};
-
 use rustc_middle::mir::{Body, BorrowKind, Local, LocalKind, Place, StatementKind, START_BLOCK};
 use rustc_middle::ty::{List, TyKind};
 use std::collections::HashMap;

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -11,8 +11,6 @@ use rustc_middle::mir::{
     Rvalue,
 };
 use rustc_middle::ty::{Ty, TyCtxt, TyKind};
-use std::cell::Cell;
-use std::iter;
 
 bitflags! {
     #[derive(Default)]
@@ -101,7 +99,8 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         AnalysisCtxt::from_data(self, mir, data)
     }
 
-    pub fn new_pointer(&self) -> PointerId {
+    #[allow(dead_code)]
+    pub fn _new_pointer(&self) -> PointerId {
         self.next_ptr_id.next()
     }
 
@@ -111,7 +110,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
 
     pub fn remap_pointers(
         &mut self,
-        map: &GlobalPointerTable<PointerId>,
+        _map: &GlobalPointerTable<PointerId>,
         counter: NextGlobalPointerId,
     ) {
         let GlobalAnalysisCtxt {
@@ -382,8 +381,8 @@ impl<'tcx> TypeOf<'tcx> for Rvalue<'tcx> {
                 let ty = self.ty(acx, acx.tcx());
                 label_no_pointers(acx, ty)
             }
-            Rvalue::Aggregate(ref kind, ref vals) => todo!("type_of Aggregate"),
-            Rvalue::ShallowInitBox(ref op, ty) => todo!("type_of ShallowInitBox"),
+            Rvalue::Aggregate(ref _kind, ref _vals) => todo!("type_of Aggregate"),
+            Rvalue::ShallowInitBox(ref _op, _ty) => todo!("type_of ShallowInitBox"),
         }
     }
 }
@@ -462,7 +461,8 @@ impl Assignment<'_> {
         self.global.flags.and(&self.local.flags)
     }
 
-    pub fn flags_mut(&mut self) -> PointerTableMut<FlagSet> {
+    #[allow(dead_code)]
+    pub fn _flags_mut(&mut self) -> PointerTableMut<FlagSet> {
         self.global.flags.and_mut(&mut self.local.flags)
     }
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -61,9 +61,13 @@ impl PointerId {
 pub type LTy<'tcx> = LabeledTy<'tcx, PointerId>;
 pub type LTyCtxt<'tcx> = LabeledTyCtxt<'tcx, PointerId>;
 
-pub struct AnalysisCtxt<'tcx> {
+pub struct GlobalAnalysisCtxt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub lcx: LTyCtxt<'tcx>,
+}
+
+pub struct AnalysisCtxt<'a, 'tcx> {
+    pub gacx: &'a mut GlobalAnalysisCtxt<'tcx>,
 
     pub local_tys: IndexVec<Local, LTy<'tcx>>,
     pub addr_of_local: IndexVec<Local, PointerId>,
@@ -71,15 +75,35 @@ pub struct AnalysisCtxt<'tcx> {
     next_ptr_id: Cell<u32>,
 }
 
-impl<'tcx> AnalysisCtxt<'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>) -> AnalysisCtxt<'tcx> {
-        AnalysisCtxt {
+impl<'tcx> GlobalAnalysisCtxt<'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>) -> GlobalAnalysisCtxt<'tcx> {
+        GlobalAnalysisCtxt {
             tcx,
             lcx: LabeledTyCtxt::new(tcx),
+        }
+    }
+
+    pub fn enter_function<'a>(&'a mut self) -> AnalysisCtxt<'a, 'tcx> {
+        AnalysisCtxt::new(self)
+    }
+}
+
+impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
+    pub fn new(gacx: &'a mut GlobalAnalysisCtxt<'tcx>) -> AnalysisCtxt<'a, 'tcx> {
+        AnalysisCtxt {
+            gacx,
             local_tys: IndexVec::new(),
             addr_of_local: IndexVec::new(),
             next_ptr_id: Cell::new(0),
         }
+    }
+
+    pub fn tcx(&self) -> TyCtxt<'tcx> {
+        self.gacx.tcx
+    }
+
+    pub fn lcx(&self) -> LTyCtxt<'tcx> {
+        self.gacx.lcx
     }
 
     pub fn new_pointer(&self) -> PointerId {
@@ -107,29 +131,29 @@ impl<'tcx> AnalysisCtxt<'tcx> {
 }
 
 pub trait TypeOf<'tcx> {
-    fn type_of(&self, acx: &AnalysisCtxt<'tcx>) -> LTy<'tcx>;
+    fn type_of(&self, acx: &AnalysisCtxt<'_, 'tcx>) -> LTy<'tcx>;
 }
 
 impl<'tcx, T: TypeOf<'tcx>> TypeOf<'tcx> for &T {
-    fn type_of(&self, acx: &AnalysisCtxt<'tcx>) -> LTy<'tcx> {
+    fn type_of(&self, acx: &AnalysisCtxt<'_, 'tcx>) -> LTy<'tcx> {
         (**self).type_of(acx)
     }
 }
 
 impl<'tcx> TypeOf<'tcx> for Local {
-    fn type_of(&self, acx: &AnalysisCtxt<'tcx>) -> LTy<'tcx> {
+    fn type_of(&self, acx: &AnalysisCtxt<'_, 'tcx>) -> LTy<'tcx> {
         acx.local_tys[*self]
     }
 }
 
 impl<'tcx> TypeOf<'tcx> for Place<'tcx> {
-    fn type_of(&self, acx: &AnalysisCtxt<'tcx>) -> LTy<'tcx> {
+    fn type_of(&self, acx: &AnalysisCtxt<'_, 'tcx>) -> LTy<'tcx> {
         acx.type_of(self.as_ref())
     }
 }
 
 impl<'tcx> TypeOf<'tcx> for PlaceRef<'tcx> {
-    fn type_of(&self, acx: &AnalysisCtxt<'tcx>) -> LTy<'tcx> {
+    fn type_of(&self, acx: &AnalysisCtxt<'_, 'tcx>) -> LTy<'tcx> {
         let mut ty = acx.type_of(self.local);
         for proj in self.projection {
             match *proj {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -87,11 +87,11 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         }
     }
 
-    pub fn enter_function<'a>(&'a mut self, mir: &'a Body<'tcx>) -> AnalysisCtxt<'a, 'tcx> {
+    pub fn function_context<'a>(&'a mut self, mir: &'a Body<'tcx>) -> AnalysisCtxt<'a, 'tcx> {
         AnalysisCtxt::new(self, mir)
     }
 
-    pub fn enter_function_with_data<'a>(
+    pub fn function_context_with_data<'a>(
         &'a mut self,
         mir: &'a Body<'tcx>,
         data: AnalysisCtxtData<'tcx>,
@@ -118,6 +118,8 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             lcx: _,
             ref mut next_ptr_id,
         } = *self;
+
+        // `GlobalAnalysisCtxt` doesn't yet have any fields that need remapping.
 
         *next_ptr_id = counter;
     }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -100,7 +100,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
     }
 
     #[allow(dead_code)]
-    pub fn _new_pointer(&self) -> PointerId {
+    pub fn _new_pointer(&mut self) -> PointerId {
         self.next_ptr_id.next()
     }
 
@@ -172,7 +172,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         self.gacx.lcx
     }
 
-    pub fn new_pointer(&self) -> PointerId {
+    pub fn new_pointer(&mut self) -> PointerId {
         self.next_ptr_id.next()
     }
 

--- a/c2rust-analyze/src/dataflow/mod.rs
+++ b/c2rust-analyze/src/dataflow/mod.rs
@@ -174,7 +174,7 @@ impl DataflowConstraints {
 
     /// Update the pointer permissions in `hypothesis` to satisfy these constraints.
     pub fn propagate_cell(&self, asn: &mut Assignment) {
-        let (perms, mut flags) = asn.all_mut();
+        let (perms, mut flags, _) = asn.all_mut();
         let perms = perms.borrow();
 
         // All pointers that are WRITE and not UNIQUE must have a type like `&Cell<_>`.
@@ -304,6 +304,6 @@ trait PropagateRules<T> {
 pub fn generate_constraints<'tcx>(
     acx: &AnalysisCtxt<'_, 'tcx>,
     mir: &Body<'tcx>,
-) -> DataflowConstraints {
+) -> (DataflowConstraints, Vec<(PointerId, PointerId)>) {
     self::type_check::visit(acx, mir)
 }

--- a/c2rust-analyze/src/dataflow/mod.rs
+++ b/c2rust-analyze/src/dataflow/mod.rs
@@ -243,6 +243,24 @@ impl DataflowConstraints {
     }
 }
 
+impl Constraint {
+    pub fn remap_pointers(&mut self, map: PointerTable<PointerId>) {
+        *self = match *self {
+            Constraint::Subset(a, b) => Constraint::Subset(map[a], map[b]),
+            Constraint::AllPerms(ptr, perms) => Constraint::AllPerms(map[ptr], perms),
+            Constraint::NoPerms(ptr, perms) => Constraint::NoPerms(map[ptr], perms),
+        };
+    }
+}
+
+impl DataflowConstraints {
+    pub fn remap_pointers(&mut self, map: PointerTable<PointerId>) {
+        for c in &mut self.constraints {
+            c.remap_pointers(map.borrow());
+        }
+    }
+}
+
 struct TrackedPointerTable<'a, T> {
     xs: PointerTableMut<'a, T>,
     dirty: OwnedPointerTable<bool>,

--- a/c2rust-analyze/src/dataflow/mod.rs
+++ b/c2rust-analyze/src/dataflow/mod.rs
@@ -174,7 +174,7 @@ impl DataflowConstraints {
 
     /// Update the pointer permissions in `hypothesis` to satisfy these constraints.
     pub fn propagate_cell(&self, asn: &mut Assignment) {
-        let (perms, mut flags, _) = asn.all_mut();
+        let (perms, mut flags) = asn.all_mut();
         let perms = perms.borrow();
 
         // All pointers that are WRITE and not UNIQUE must have a type like `&Cell<_>`.

--- a/c2rust-analyze/src/dataflow/mod.rs
+++ b/c2rust-analyze/src/dataflow/mod.rs
@@ -291,7 +291,7 @@ trait PropagateRules<T> {
 }
 
 pub fn generate_constraints<'tcx>(
-    acx: &AnalysisCtxt<'tcx>,
+    acx: &AnalysisCtxt<'_, 'tcx>,
     mir: &Body<'tcx>,
 ) -> DataflowConstraints {
     self::type_check::visit(acx, mir)

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -11,7 +11,7 @@ use rustc_middle::ty::TyKind;
 /// Visitor that walks over the MIR, computing types of rvalues/operands/places and generating
 /// constraints as a side effect.
 struct TypeChecker<'tcx, 'a> {
-    acx: &'a AnalysisCtxt<'tcx>,
+    acx: &'a AnalysisCtxt<'a, 'tcx>,
     mir: &'a Body<'tcx>,
     constraints: DataflowConstraints,
 }
@@ -123,7 +123,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             Operand::Constant(ref c) => {
                 let ty = c.ty();
                 // TODO
-                self.acx.lcx.label(ty, &mut |_| PointerId::NONE)
+                self.acx.lcx().label(ty, &mut |_| PointerId::NONE)
             }
         }
     }
@@ -158,7 +158,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
     pub fn visit_terminator(&mut self, term: &Terminator<'tcx>) {
         eprintln!("visit_terminator({:?})", term.kind);
-        let tcx = self.acx.tcx;
+        let tcx = self.acx.tcx();
         // TODO(spernsteiner): other `TerminatorKind`s will be handled in the future
         #[allow(clippy::single_match)]
         match term.kind {
@@ -193,7 +193,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     }
 }
 
-pub fn visit<'tcx>(acx: &AnalysisCtxt<'tcx>, mir: &Body<'tcx>) -> DataflowConstraints {
+pub fn visit<'tcx>(acx: &AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>) -> DataflowConstraints {
     let mut tc = TypeChecker {
         acx,
         mir,

--- a/c2rust-analyze/src/equiv.rs
+++ b/c2rust-analyze/src/equiv.rs
@@ -1,7 +1,12 @@
-use crate::pointer_id::{GlobalPointerTable, LocalPointerTable, PointerId, PointerTableMut};
+use crate::pointer_id::{
+    GlobalPointerTable, LocalPointerTable, NextGlobalPointerId, NextLocalPointerId, PointerId,
+    PointerTableMut,
+};
 use std::cell::Cell;
 
+#[derive(Clone, Debug)]
 pub struct GlobalEquivSet(GlobalPointerTable<Cell<PointerId>>);
+#[derive(Clone, Debug)]
 pub struct LocalEquivSet(LocalPointerTable<Cell<PointerId>>);
 pub struct EquivSet<'a>(PointerTableMut<'a, Cell<PointerId>>);
 
@@ -16,6 +21,48 @@ impl GlobalEquivSet {
     pub fn and_mut<'a>(&'a mut self, local: &'a mut LocalEquivSet) -> EquivSet<'a> {
         EquivSet(self.0.and_mut(&mut local.0))
     }
+
+    fn parent(&self, x: PointerId) -> PointerId {
+        self.0[x].get()
+    }
+
+    fn set_parent(&self, x: PointerId, parent: PointerId) {
+        debug_assert!(parent.is_global());
+        self.0[x].set(parent);
+    }
+
+    fn rep(&self, x: PointerId) -> PointerId {
+        let parent = self.parent(x);
+        if parent == x || self.parent(parent) == parent {
+            return parent;
+        }
+
+        let rep = self.rep(parent);
+        self.set_parent(x, rep);
+        rep
+    }
+
+    /// Assign new `PointerId`s for the pointers in this set, with one ID per equivalence class.
+    /// Returns the next-ID counter for the new numbering and a map from old `PointerId`s to new
+    /// ones.
+    pub fn renumber(&self) -> (NextGlobalPointerId, GlobalPointerTable<PointerId>) {
+        let mut counter = NextGlobalPointerId::new();
+        let mut map = GlobalPointerTable::from_raw(vec![PointerId::NONE; self.0.len()]);
+
+        for old_id in self.0.iter().map(|(x, _)| x) {
+            let rep = self.rep(old_id);
+
+            if !map[rep].is_none() {
+                map[old_id] = map[rep];
+            } else {
+                let new_id = counter.next();
+                map[old_id] = new_id;
+                map[rep] = new_id;
+            };
+        }
+
+        (counter, map)
+    }
 }
 
 impl LocalEquivSet {
@@ -24,6 +71,53 @@ impl LocalEquivSet {
             .map(|x| Cell::new(PointerId::local(x)))
             .collect();
         LocalEquivSet(LocalPointerTable::from_raw(raw))
+    }
+
+    fn parent(&self, x: PointerId) -> PointerId {
+        self.0[x].get()
+    }
+
+    fn set_parent(&self, x: PointerId, parent: PointerId) {
+        debug_assert!(!x.is_global());
+        self.0[x].set(parent);
+    }
+
+    fn rep(&self, x: PointerId) -> PointerId {
+        let parent = self.parent(x);
+        if parent == x || parent.is_global() || self.parent(parent) == parent {
+            return parent;
+        }
+
+        let rep = self.rep(parent);
+        self.set_parent(x, rep);
+        rep
+    }
+
+    /// Assign new `PointerId`s for the pointers in this set, with one ID per equivalence class.
+    /// Returns the next-ID counter for the new numbering and a map from old `PointerId`s to new
+    /// ones.
+    pub fn renumber(
+        &self,
+        global_map: &GlobalPointerTable<PointerId>,
+    ) -> (NextLocalPointerId, LocalPointerTable<PointerId>) {
+        let mut counter = NextLocalPointerId::new();
+        let mut map = LocalPointerTable::from_raw(vec![PointerId::NONE; self.0.len()]);
+
+        for old_id in self.0.iter().map(|(x, _)| x) {
+            let rep = self.rep(old_id);
+
+            if rep.is_global() {
+                map[old_id] = global_map[rep];
+            } else if !map[rep].is_none() {
+                map[old_id] = map[rep];
+            } else {
+                let new_id = counter.next();
+                map[old_id] = new_id;
+                map[rep] = new_id;
+            };
+        }
+
+        (counter, map)
     }
 }
 

--- a/c2rust-analyze/src/equiv.rs
+++ b/c2rust-analyze/src/equiv.rs
@@ -46,7 +46,7 @@ impl GlobalEquivSet {
     /// Returns the next-ID counter for the new numbering and a map from old `PointerId`s to new
     /// ones.
     pub fn renumber(&self) -> (NextGlobalPointerId, GlobalPointerTable<PointerId>) {
-        let mut counter = NextGlobalPointerId::new();
+        let counter = NextGlobalPointerId::new();
         let mut map = GlobalPointerTable::from_raw(vec![PointerId::NONE; self.0.len()]);
 
         for old_id in self.0.iter().map(|(x, _)| x) {
@@ -100,7 +100,7 @@ impl LocalEquivSet {
         &self,
         global_map: &GlobalPointerTable<PointerId>,
     ) -> (NextLocalPointerId, LocalPointerTable<PointerId>) {
-        let mut counter = NextLocalPointerId::new();
+        let counter = NextLocalPointerId::new();
         let mut map = LocalPointerTable::from_raw(vec![PointerId::NONE; self.0.len()]);
 
         for old_id in self.0.iter().map(|(x, _)| x) {

--- a/c2rust-analyze/src/equiv.rs
+++ b/c2rust-analyze/src/equiv.rs
@@ -1,0 +1,70 @@
+use crate::pointer_id::{GlobalPointerTable, LocalPointerTable, PointerId, PointerTableMut};
+use std::cell::Cell;
+
+pub struct GlobalEquivSet(GlobalPointerTable<Cell<PointerId>>);
+pub struct LocalEquivSet(LocalPointerTable<Cell<PointerId>>);
+pub struct EquivSet<'a>(PointerTableMut<'a, Cell<PointerId>>);
+
+impl GlobalEquivSet {
+    pub fn new(len: usize) -> GlobalEquivSet {
+        let raw = (0..len as u32)
+            .map(|x| Cell::new(PointerId::global(x)))
+            .collect();
+        GlobalEquivSet(GlobalPointerTable::from_raw(raw))
+    }
+
+    pub fn and_mut<'a>(&'a mut self, local: &'a mut LocalEquivSet) -> EquivSet<'a> {
+        EquivSet(self.0.and_mut(&mut local.0))
+    }
+}
+
+impl LocalEquivSet {
+    pub fn new(len: usize) -> LocalEquivSet {
+        let raw = (0..len as u32)
+            .map(|x| Cell::new(PointerId::local(x)))
+            .collect();
+        LocalEquivSet(LocalPointerTable::from_raw(raw))
+    }
+}
+
+impl<'g> EquivSet<'g> {
+    fn parent(&self, x: PointerId) -> PointerId {
+        self.0[x].get()
+    }
+
+    fn set_parent(&self, x: PointerId, parent: PointerId) {
+        // Local items can point to global ones, but not vice versa.
+        if x.is_global() {
+            debug_assert!(parent.is_global());
+        }
+
+        self.0[x].set(parent);
+    }
+
+    pub fn rep(&self, x: PointerId) -> PointerId {
+        let parent = self.parent(x);
+        if parent == x || self.parent(parent) == parent {
+            return parent;
+        }
+
+        let rep = self.rep(parent);
+        self.set_parent(x, rep);
+        rep
+    }
+
+    pub fn unify(&mut self, x: PointerId, y: PointerId) {
+        let x_rep = self.rep(x);
+        let y_rep = self.rep(y);
+        if x_rep == y_rep {
+            return;
+        }
+
+        if x_rep.is_global() {
+            self.set_parent(y_rep, x_rep);
+            self.set_parent(y, x_rep);
+        } else {
+            self.set_parent(x_rep, y_rep);
+            self.set_parent(x, y_rep);
+        }
+    }
+}

--- a/c2rust-analyze/src/equiv.rs
+++ b/c2rust-analyze/src/equiv.rs
@@ -46,7 +46,7 @@ impl GlobalEquivSet {
     /// Returns the next-ID counter for the new numbering and a map from old `PointerId`s to new
     /// ones.
     pub fn renumber(&self) -> (NextGlobalPointerId, GlobalPointerTable<PointerId>) {
-        let counter = NextGlobalPointerId::new();
+        let mut counter = NextGlobalPointerId::new();
         let mut map = GlobalPointerTable::from_raw(vec![PointerId::NONE; self.0.len()]);
 
         for old_id in self.0.iter().map(|(x, _)| x) {
@@ -100,7 +100,7 @@ impl LocalEquivSet {
         &self,
         global_map: &GlobalPointerTable<PointerId>,
     ) -> (NextLocalPointerId, LocalPointerTable<PointerId>) {
-        let counter = NextLocalPointerId::new();
+        let mut counter = NextLocalPointerId::new();
         let mut map = LocalPointerTable::from_raw(vec![PointerId::NONE; self.0.len()]);
 
         for old_id in self.0.iter().map(|(x, _)| x) {

--- a/c2rust-analyze/src/expr_rewrite.rs
+++ b/c2rust-analyze/src/expr_rewrite.rs
@@ -1,4 +1,5 @@
-use crate::context::{AnalysisCtxt, FlagSet, LTy, PermissionSet, PointerId};
+use crate::context::{AnalysisCtxt, Assignment, FlagSet, LTy, PermissionSet, PointerId};
+use crate::pointer_id::PointerTable;
 use crate::type_desc::{self, Ownership, Quantity};
 use crate::util::{self, Callee};
 use rustc_middle::mir::{
@@ -48,8 +49,8 @@ pub struct ExprRewrite {
 
 struct ExprRewriteVisitor<'a, 'tcx> {
     acx: &'a AnalysisCtxt<'a, 'tcx>,
-    perms: &'a [PermissionSet],
-    flags: &'a [FlagSet],
+    perms: PointerTable<'a, PermissionSet>,
+    flags: PointerTable<'a, FlagSet>,
     rewrites: &'a mut Vec<ExprRewrite>,
     mir: &'a Body<'tcx>,
     loc: ExprLoc,
@@ -58,11 +59,12 @@ struct ExprRewriteVisitor<'a, 'tcx> {
 impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     pub fn new(
         acx: &'a AnalysisCtxt<'a, 'tcx>,
-        perms: &'a [PermissionSet],
-        flags: &'a [FlagSet],
+        asn: &'a Assignment,
         rewrites: &'a mut Vec<ExprRewrite>,
         mir: &'a Body<'tcx>,
     ) -> ExprRewriteVisitor<'a, 'tcx> {
+        let perms = asn.perms();
+        let flags = asn.flags();
         ExprRewriteVisitor {
             acx,
             perms,
@@ -285,10 +287,8 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     fn visit_ptr_offset(&mut self, op: &Operand<'tcx>, result_ty: LTy<'tcx>) {
         // Compute the expected type for the argument, and emit a cast if needed.
         let result_ptr = result_ty.label;
-        let (result_own, result_qty) = type_desc::perms_to_desc(
-            self.perms[result_ptr.index()],
-            self.flags[result_ptr.index()],
-        );
+        let (result_own, result_qty) =
+            type_desc::perms_to_desc(self.perms[result_ptr], self.flags[result_ptr]);
 
         let arg_expect_own = result_own;
         // TODO: infer `arg_expect_qty` based on the type of offset this is (positive / unknown)
@@ -330,10 +330,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     fn emit_ptr_cast(&mut self, ptr: PointerId, expect_ptr: PointerId) {
         assert!(expect_ptr != PointerId::NONE);
 
-        let (own2, qty2) = type_desc::perms_to_desc(
-            self.perms[expect_ptr.index()],
-            self.flags[expect_ptr.index()],
-        );
+        let (own2, qty2) = type_desc::perms_to_desc(self.perms[expect_ptr], self.flags[expect_ptr]);
 
         self.emit_cast(ptr, own2, qty2);
     }
@@ -341,8 +338,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     fn emit_cast(&mut self, ptr: PointerId, expect_own: Ownership, expect_qty: Quantity) {
         assert!(ptr != PointerId::NONE);
 
-        let (own1, qty1) =
-            type_desc::perms_to_desc(self.perms[ptr.index()], self.flags[ptr.index()]);
+        let (own1, qty1) = type_desc::perms_to_desc(self.perms[ptr], self.flags[ptr]);
         let (own2, qty2) = (expect_own, expect_qty);
 
         if (own1, qty1) == (own2, qty2) {
@@ -356,7 +352,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
 
         eprintln!(
             "unsupported cast kind: {:?} {:?} -> {:?}",
-            self.perms[ptr.index()],
+            self.perms[ptr],
             (own1, qty1),
             (own2, qty2)
         );
@@ -365,8 +361,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
 
 pub fn gen_expr_rewrites<'tcx>(
     acx: &AnalysisCtxt<'_, 'tcx>,
-    perms: &[PermissionSet],
-    flags: &[FlagSet],
+    asn: &Assignment,
     mir: &Body<'tcx>,
 ) -> Vec<ExprRewrite> {
     // - walk over statements/terminators
@@ -375,7 +370,7 @@ pub fn gen_expr_rewrites<'tcx>(
 
     let mut out = Vec::new();
 
-    let mut v = ExprRewriteVisitor::new(acx, perms, flags, &mut out, mir);
+    let mut v = ExprRewriteVisitor::new(acx, asn, &mut out, mir);
 
     for (bb_id, bb) in mir.basic_blocks().iter_enumerated() {
         for (i, stmt) in bb.statements.iter().enumerate() {

--- a/c2rust-analyze/src/expr_rewrite.rs
+++ b/c2rust-analyze/src/expr_rewrite.rs
@@ -47,7 +47,7 @@ pub struct ExprRewrite {
 }
 
 struct ExprRewriteVisitor<'a, 'tcx> {
-    acx: &'a AnalysisCtxt<'tcx>,
+    acx: &'a AnalysisCtxt<'a, 'tcx>,
     perms: &'a [PermissionSet],
     flags: &'a [FlagSet],
     rewrites: &'a mut Vec<ExprRewrite>,
@@ -57,7 +57,7 @@ struct ExprRewriteVisitor<'a, 'tcx> {
 
 impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     pub fn new(
-        acx: &'a AnalysisCtxt<'tcx>,
+        acx: &'a AnalysisCtxt<'a, 'tcx>,
         perms: &'a [PermissionSet],
         flags: &'a [FlagSet],
         rewrites: &'a mut Vec<ExprRewrite>,
@@ -141,7 +141,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     }
 
     fn visit_terminator(&mut self, term: &Terminator<'tcx>, loc: Location) {
-        let tcx = self.acx.tcx;
+        let tcx = self.acx.tcx();
         self.loc = ExprLoc {
             stmt: loc,
             span: term.source_info.span,
@@ -364,7 +364,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
 }
 
 pub fn gen_expr_rewrites<'tcx>(
-    acx: &AnalysisCtxt<'tcx>,
+    acx: &AnalysisCtxt<'_, 'tcx>,
     perms: &[PermissionSet],
     flags: &[FlagSet],
     mir: &Body<'tcx>,

--- a/c2rust-analyze/src/labeled_ty.rs
+++ b/c2rust-analyze/src/labeled_ty.rs
@@ -81,7 +81,7 @@ impl<'tcx, L> Iterator for LabeledTyIter<'tcx, L> {
 
     fn next(&mut self) -> Option<LabeledTy<'tcx, L>> {
         if let Some(lty) = self.root.take() {
-            if lty.args.len() > 0 {
+            if !lty.args.is_empty() {
                 self.stack.push(lty.args.iter());
             }
             return Some(lty);
@@ -90,7 +90,7 @@ impl<'tcx, L> Iterator for LabeledTyIter<'tcx, L> {
         loop {
             match self.stack.last_mut()?.next() {
                 Some(lty) => {
-                    if lty.args.len() > 0 {
+                    if !lty.args.is_empty() {
                         self.stack.push(lty.args.iter());
                     }
                     return Some(lty);

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -50,7 +50,7 @@ fn run(tcx: TyCtxt) {
         let mir = tcx.mir_built(ldid_const);
         let mir = mir.borrow();
 
-        let mut acx = gacx.enter_function(&mir);
+        let mut acx = gacx.function_context(&mir);
 
         // Assign PointerIds to local types
         assert!(acx.local_tys.is_empty());
@@ -95,7 +95,7 @@ fn run(tcx: TyCtxt) {
         data.remap_pointers(gacx.lcx, g_equiv_map.and(&l_equiv_map), l_counter);
         dataflow.remap_pointers(g_equiv_map.and(&l_equiv_map));
 
-        let acx = gacx.enter_function_with_data(&mir, data);
+        let acx = gacx.function_context_with_data(&mir, data);
 
         let mut lasn =
             LocalAssignment::new(acx.num_pointers(), PermissionSet::UNIQUE, FlagSet::empty());

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -56,7 +56,7 @@ fn run(tcx: TyCtxt) {
         assert!(acx.local_tys.is_empty());
         acx.local_tys = IndexVec::with_capacity(mir.local_decls.len());
         for (local, decl) in mir.local_decls.iter_enumerated() {
-            let lty = assign_pointer_ids(&acx, decl.ty);
+            let lty = assign_pointer_ids(&mut acx, decl.ty);
             let l = acx.local_tys.push(lty);
             assert_eq!(local, l);
 
@@ -179,7 +179,7 @@ fn run(tcx: TyCtxt) {
     }
 }
 
-fn assign_pointer_ids<'tcx>(acx: &AnalysisCtxt<'_, 'tcx>, ty: Ty<'tcx>) -> LTy<'tcx> {
+fn assign_pointer_ids<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, ty: Ty<'tcx>) -> LTy<'tcx> {
     acx.lcx().label(ty, &mut |ty| match ty.kind() {
         TyKind::Ref(_, _, _) | TyKind::RawPtr(_) => acx.new_pointer(),
         _ => PointerId::NONE,

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -53,7 +53,7 @@ fn run(tcx: TyCtxt) {
         let mut acx = gacx.enter_function(&mir);
 
         // Assign PointerIds to local types
-        assert!(acx.local_tys.len() == 0);
+        assert!(acx.local_tys.is_empty());
         acx.local_tys = IndexVec::with_capacity(mir.local_decls.len());
         for (local, decl) in mir.local_decls.iter_enumerated() {
             let lty = assign_pointer_ids(&acx, decl.ty);
@@ -163,7 +163,7 @@ fn run(tcx: TyCtxt) {
             eprintln!("{:?} ({}): {:?}", local, describe_local(tcx, decl), ty,);
         }
 
-        eprintln!("");
+        eprintln!();
         let rewrites = expr_rewrite::gen_expr_rewrites(&acx, &asn, &mir);
         for rw in &rewrites {
             eprintln!(

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -186,7 +186,7 @@ impl<T> LocalPointerTable<T> {
         self.0 .0.fill(x);
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (PointerId, &'a T)> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = (PointerId, &T)> {
         self.0
              .0
             .iter()
@@ -194,7 +194,7 @@ impl<T> LocalPointerTable<T> {
             .map(|(i, x)| (PointerId::local(i as u32), x))
     }
 
-    pub fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = (PointerId, &'a mut T)> + 'a {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (PointerId, &mut T)> {
         self.0
              .0
             .iter_mut()
@@ -243,7 +243,7 @@ impl<T> GlobalPointerTable<T> {
         self.0 .0.len()
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (PointerId, &'a T)> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = (PointerId, &T)> {
         self.0
              .0
             .iter()
@@ -251,7 +251,7 @@ impl<T> GlobalPointerTable<T> {
             .map(|(i, x)| (PointerId::global(i as u32), x))
     }
 
-    pub fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = (PointerId, &'a mut T)> + 'a {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (PointerId, &mut T)> {
         self.0
              .0
             .iter_mut()
@@ -316,7 +316,7 @@ impl<'a, T> PointerTable<'a, T> {
         self.global.len() + self.local.len()
     }
 
-    pub fn iter<'b>(&'b self) -> impl Iterator<Item = (PointerId, &'b T)> + 'b {
+    pub fn iter(&self) -> impl Iterator<Item = (PointerId, &T)> {
         self.global.iter().chain(self.local.iter())
     }
 }
@@ -353,11 +353,11 @@ impl<'a, T> PointerTableMut<'a, T> {
         self.global.len() + self.local.len()
     }
 
-    pub fn iter<'b>(&'b self) -> impl Iterator<Item = (PointerId, &'b T)> + 'b {
+    pub fn iter(&self) -> impl Iterator<Item = (PointerId, &T)> {
         self.global.iter().chain(self.local.iter())
     }
 
-    pub fn iter_mut<'b>(&'b mut self) -> impl Iterator<Item = (PointerId, &'b mut T)> + 'b {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (PointerId, &mut T)> {
         self.global.iter_mut().chain(self.local.iter_mut())
     }
 
@@ -419,11 +419,11 @@ impl<T> OwnedPointerTable<T> {
         self.global.len() + self.local.len()
     }
 
-    pub fn iter<'b>(&'b self) -> impl Iterator<Item = (PointerId, &'b T)> + 'b {
+    pub fn iter(&self) -> impl Iterator<Item = (PointerId, &T)> {
         self.global.iter().chain(self.local.iter())
     }
 
-    pub fn iter_mut<'b>(&'b mut self) -> impl Iterator<Item = (PointerId, &'b mut T)> + 'b {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (PointerId, &mut T)> {
         self.global.iter_mut().chain(self.local.iter_mut())
     }
 

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::ops::{Index, IndexMut};
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PointerId(u32);
 const GLOBAL_BIT: u32 = 0x8000_0000;
 
@@ -18,6 +18,10 @@ impl PointerId {
 
     pub fn local(x: u32) -> PointerId {
         assert!(x & GLOBAL_BIT == 0);
+        PointerId(x)
+    }
+
+    pub fn from_raw(x: u32) -> PointerId {
         PointerId(x)
     }
 
@@ -48,6 +52,12 @@ impl fmt::Display for PointerId {
             debug_assert!(self.is_global());
             write!(fmt, "g{}", self.index())
         }
+    }
+}
+
+impl fmt::Debug for PointerId {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self)
     }
 }
 

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -61,6 +61,7 @@ impl fmt::Debug for PointerId {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct NextLocalPointerId(Cell<u32>);
 
 impl NextLocalPointerId {
@@ -79,6 +80,7 @@ impl NextLocalPointerId {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct NextGlobalPointerId(Cell<u32>);
 
 impl NextGlobalPointerId {
@@ -97,8 +99,11 @@ impl NextGlobalPointerId {
     }
 }
 
+#[derive(Clone, Debug)]
 struct RawPointerTable<T>(Vec<T>);
+#[derive(Clone, Debug)]
 pub struct LocalPointerTable<T>(RawPointerTable<T>);
+#[derive(Clone, Debug)]
 pub struct GlobalPointerTable<T>(RawPointerTable<T>);
 pub struct PointerTable<'a, T> {
     global: &'a GlobalPointerTable<T>,

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -1,0 +1,438 @@
+use std::cell::Cell;
+use std::convert::TryFrom;
+use std::fmt;
+use std::ops::{Index, IndexMut};
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct PointerId(u32);
+const GLOBAL_BIT: u32 = 0x8000_0000;
+
+impl PointerId {
+    pub const NONE: PointerId = PointerId(u32::MAX);
+
+    pub fn global(x: u32) -> PointerId {
+        assert!(x & GLOBAL_BIT == 0);
+        assert!(x | GLOBAL_BIT != PointerId::NONE.0);
+        PointerId(x | GLOBAL_BIT)
+    }
+
+    pub fn local(x: u32) -> PointerId {
+        assert!(x & GLOBAL_BIT == 0);
+        PointerId(x)
+    }
+
+    pub fn index(self) -> u32 {
+        self.0 & !GLOBAL_BIT
+    }
+
+    pub fn is_none(self) -> bool {
+        self == PointerId::NONE
+    }
+
+    pub fn is_global(self) -> bool {
+        self.0 & GLOBAL_BIT != 0 && !self.is_none()
+    }
+
+    pub fn is_local(self) -> bool {
+        self.0 & GLOBAL_BIT == 0
+    }
+}
+
+impl fmt::Display for PointerId {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        if self.is_none() {
+            write!(fmt, "NONE")
+        } else if self.is_local() {
+            write!(fmt, "l{}", self.index())
+        } else {
+            debug_assert!(self.is_global());
+            write!(fmt, "g{}", self.index())
+        }
+    }
+}
+
+pub struct NextLocalPointerId(Cell<u32>);
+
+impl NextLocalPointerId {
+    pub fn new() -> NextLocalPointerId {
+        NextLocalPointerId(Cell::new(0))
+    }
+
+    pub fn next(&self) -> PointerId {
+        let x = self.0.get();
+        self.0.set(x + 1);
+        PointerId::local(x)
+    }
+
+    pub fn num_pointers(&self) -> usize {
+        self.0.get() as usize
+    }
+}
+
+pub struct NextGlobalPointerId(Cell<u32>);
+
+impl NextGlobalPointerId {
+    pub fn new() -> NextGlobalPointerId {
+        NextGlobalPointerId(Cell::new(0))
+    }
+
+    pub fn next(&self) -> PointerId {
+        let x = self.0.get();
+        self.0.set(x + 1);
+        PointerId::global(x)
+    }
+
+    pub fn num_pointers(&self) -> usize {
+        self.0.get() as usize
+    }
+}
+
+struct RawPointerTable<T>(Vec<T>);
+pub struct LocalPointerTable<T>(RawPointerTable<T>);
+pub struct GlobalPointerTable<T>(RawPointerTable<T>);
+pub struct PointerTable<'a, T> {
+    global: &'a GlobalPointerTable<T>,
+    local: &'a LocalPointerTable<T>,
+}
+pub struct PointerTableMut<'a, T> {
+    global: &'a mut GlobalPointerTable<T>,
+    local: &'a mut LocalPointerTable<T>,
+}
+pub struct OwnedPointerTable<T> {
+    global: GlobalPointerTable<T>,
+    local: LocalPointerTable<T>,
+}
+
+impl<T> RawPointerTable<T> {
+    pub fn empty() -> RawPointerTable<T> {
+        Self::from_raw(Vec::new())
+    }
+
+    pub fn new(len: usize) -> RawPointerTable<T>
+    where
+        T: Default,
+    {
+        let mut v = Vec::new();
+        v.resize_with(len, T::default);
+        Self::from_raw(v)
+    }
+
+    pub fn from_raw(raw: Vec<T>) -> RawPointerTable<T> {
+        RawPointerTable(raw)
+    }
+
+    pub fn into_raw(self) -> Vec<T> {
+        self.0
+    }
+}
+
+impl<T> Index<u32> for RawPointerTable<T> {
+    type Output = T;
+    fn index(&self, index: u32) -> &T {
+        &self.0[index as usize]
+    }
+}
+
+impl<T> IndexMut<u32> for RawPointerTable<T> {
+    fn index_mut(&mut self, index: u32) -> &mut T {
+        &mut self.0[index as usize]
+    }
+}
+
+impl<T> LocalPointerTable<T> {
+    pub fn empty() -> LocalPointerTable<T> {
+        LocalPointerTable(RawPointerTable::empty())
+    }
+
+    pub fn new(len: usize) -> LocalPointerTable<T>
+    where
+        T: Default,
+    {
+        LocalPointerTable(RawPointerTable::new(len))
+    }
+
+    pub fn from_raw(raw: Vec<T>) -> LocalPointerTable<T> {
+        LocalPointerTable(RawPointerTable::from_raw(raw))
+    }
+
+    pub fn into_raw(self) -> Vec<T> {
+        self.0.into_raw()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0 .0.len()
+    }
+
+    pub fn fill(&mut self, x: T)
+    where
+        T: Clone,
+    {
+        self.0 .0.fill(x);
+    }
+
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (PointerId, &'a T)> + 'a {
+        self.0
+             .0
+            .iter()
+            .enumerate()
+            .map(|(i, x)| (PointerId::local(i as u32), x))
+    }
+
+    pub fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = (PointerId, &'a mut T)> + 'a {
+        self.0
+             .0
+            .iter_mut()
+            .enumerate()
+            .map(|(i, x)| (PointerId::local(i as u32), x))
+    }
+}
+
+impl<T> Index<PointerId> for LocalPointerTable<T> {
+    type Output = T;
+    fn index(&self, id: PointerId) -> &T {
+        assert!(id.is_local());
+        &self.0[id.index()]
+    }
+}
+
+impl<T> IndexMut<PointerId> for LocalPointerTable<T> {
+    fn index_mut(&mut self, id: PointerId) -> &mut T {
+        assert!(id.is_local());
+        &mut self.0[id.index()]
+    }
+}
+
+impl<T> GlobalPointerTable<T> {
+    pub fn empty() -> GlobalPointerTable<T> {
+        GlobalPointerTable(RawPointerTable::empty())
+    }
+
+    pub fn new(len: usize) -> GlobalPointerTable<T>
+    where
+        T: Default,
+    {
+        GlobalPointerTable(RawPointerTable::new(len))
+    }
+
+    pub fn from_raw(raw: Vec<T>) -> GlobalPointerTable<T> {
+        GlobalPointerTable(RawPointerTable::from_raw(raw))
+    }
+
+    pub fn into_raw(self) -> Vec<T> {
+        self.0.into_raw()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0 .0.len()
+    }
+
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (PointerId, &'a T)> + 'a {
+        self.0
+             .0
+            .iter()
+            .enumerate()
+            .map(|(i, x)| (PointerId::global(i as u32), x))
+    }
+
+    pub fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = (PointerId, &'a mut T)> + 'a {
+        self.0
+             .0
+            .iter_mut()
+            .enumerate()
+            .map(|(i, x)| (PointerId::global(i as u32), x))
+    }
+
+    pub fn fill(&mut self, x: T)
+    where
+        T: Clone,
+    {
+        self.0 .0.fill(x);
+    }
+
+    pub fn and<'a>(&'a self, local: &'a LocalPointerTable<T>) -> PointerTable<'a, T> {
+        PointerTable {
+            global: self,
+            local,
+        }
+    }
+
+    pub fn and_mut<'a>(
+        &'a mut self,
+        local: &'a mut LocalPointerTable<T>,
+    ) -> PointerTableMut<'a, T> {
+        PointerTableMut {
+            global: self,
+            local,
+        }
+    }
+}
+
+impl<T> Index<PointerId> for GlobalPointerTable<T> {
+    type Output = T;
+    fn index(&self, id: PointerId) -> &T {
+        assert!(id.is_global());
+        &self.0[id.index()]
+    }
+}
+
+impl<T> IndexMut<PointerId> for GlobalPointerTable<T> {
+    fn index_mut(&mut self, id: PointerId) -> &mut T {
+        assert!(id.is_global());
+        &mut self.0[id.index()]
+    }
+}
+
+impl<'a, T> PointerTable<'a, T> {
+    pub fn new(
+        global: &'a GlobalPointerTable<T>,
+        local: &'a LocalPointerTable<T>,
+    ) -> PointerTable<'a, T> {
+        PointerTable { global, local }
+    }
+
+    pub fn borrow(&self) -> PointerTable<T> {
+        PointerTable::new(self.global, self.local)
+    }
+
+    pub fn len(&self) -> usize {
+        self.global.len() + self.local.len()
+    }
+
+    pub fn iter<'b>(&'b self) -> impl Iterator<Item = (PointerId, &'b T)> + 'b {
+        self.global.iter().chain(self.local.iter())
+    }
+}
+
+impl<'a, T> Index<PointerId> for PointerTable<'a, T> {
+    type Output = T;
+    fn index(&self, id: PointerId) -> &T {
+        if id.is_global() {
+            &self.global[id]
+        } else {
+            &self.local[id]
+        }
+    }
+}
+
+impl<'a, T> PointerTableMut<'a, T> {
+    pub fn new(
+        global: &'a mut GlobalPointerTable<T>,
+        local: &'a mut LocalPointerTable<T>,
+    ) -> PointerTableMut<'a, T> {
+        PointerTableMut { global, local }
+    }
+
+    pub fn borrow(&self) -> PointerTable<T> {
+        PointerTable::new(self.global, self.local)
+    }
+
+    pub fn borrow_mut(&mut self) -> PointerTableMut<T> {
+        PointerTableMut::new(self.global, self.local)
+    }
+
+    pub fn len(&self) -> usize {
+        self.global.len() + self.local.len()
+    }
+
+    pub fn iter<'b>(&'b self) -> impl Iterator<Item = (PointerId, &'b T)> + 'b {
+        self.global.iter().chain(self.local.iter())
+    }
+
+    pub fn iter_mut<'b>(&'b mut self) -> impl Iterator<Item = (PointerId, &'b mut T)> + 'b {
+        self.global.iter_mut().chain(self.local.iter_mut())
+    }
+
+    pub fn fill(&mut self, x: T)
+    where
+        T: Clone,
+    {
+        self.global.fill(x.clone());
+        self.local.fill(x);
+    }
+}
+
+impl<'a, T> Index<PointerId> for PointerTableMut<'a, T> {
+    type Output = T;
+    fn index(&self, id: PointerId) -> &T {
+        if id.is_global() {
+            &self.global[id]
+        } else {
+            &self.local[id]
+        }
+    }
+}
+
+impl<'a, T> IndexMut<PointerId> for PointerTableMut<'a, T> {
+    fn index_mut(&mut self, id: PointerId) -> &mut T {
+        if id.is_global() {
+            &mut self.global[id]
+        } else {
+            &mut self.local[id]
+        }
+    }
+}
+
+impl<T> OwnedPointerTable<T> {
+    pub fn new(global: GlobalPointerTable<T>, local: LocalPointerTable<T>) -> OwnedPointerTable<T> {
+        OwnedPointerTable { global, local }
+    }
+
+    pub fn with_len_of<U>(table: &PointerTable<U>) -> OwnedPointerTable<T>
+    where
+        T: Default,
+    {
+        OwnedPointerTable::new(
+            GlobalPointerTable::new(table.global.len()),
+            LocalPointerTable::new(table.local.len()),
+        )
+    }
+
+    pub fn borrow(&self) -> PointerTable<T> {
+        PointerTable::new(&self.global, &self.local)
+    }
+
+    pub fn borrow_mut(&mut self) -> PointerTableMut<T> {
+        PointerTableMut::new(&mut self.global, &mut self.local)
+    }
+
+    pub fn len(&self) -> usize {
+        self.global.len() + self.local.len()
+    }
+
+    pub fn iter<'b>(&'b self) -> impl Iterator<Item = (PointerId, &'b T)> + 'b {
+        self.global.iter().chain(self.local.iter())
+    }
+
+    pub fn iter_mut<'b>(&'b mut self) -> impl Iterator<Item = (PointerId, &'b mut T)> + 'b {
+        self.global.iter_mut().chain(self.local.iter_mut())
+    }
+
+    pub fn fill(&mut self, x: T)
+    where
+        T: Clone,
+    {
+        self.global.fill(x.clone());
+        self.local.fill(x);
+    }
+}
+
+impl<T> Index<PointerId> for OwnedPointerTable<T> {
+    type Output = T;
+    fn index(&self, id: PointerId) -> &T {
+        if id.is_global() {
+            &self.global[id]
+        } else {
+            &self.local[id]
+        }
+    }
+}
+
+impl<T> IndexMut<PointerId> for OwnedPointerTable<T> {
+    fn index_mut(&mut self, id: PointerId) -> &mut T {
+        if id.is_global() {
+            &mut self.global[id]
+        } else {
+            &mut self.local[id]
+        }
+    }
+}

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -1,5 +1,4 @@
 use std::cell::Cell;
-use std::convert::TryFrom;
 use std::fmt;
 use std::ops::{Index, IndexMut};
 
@@ -7,6 +6,7 @@ use std::ops::{Index, IndexMut};
 pub struct PointerId(u32);
 const GLOBAL_BIT: u32 = 0x8000_0000;
 
+#[allow(dead_code)]
 impl PointerId {
     pub const NONE: PointerId = PointerId(u32::MAX);
 
@@ -154,6 +154,7 @@ impl<T> IndexMut<u32> for RawPointerTable<T> {
     }
 }
 
+#[allow(dead_code)]
 impl<T> LocalPointerTable<T> {
     pub fn empty() -> LocalPointerTable<T> {
         LocalPointerTable(RawPointerTable::empty())
@@ -217,6 +218,7 @@ impl<T> IndexMut<PointerId> for LocalPointerTable<T> {
     }
 }
 
+#[allow(dead_code)]
 impl<T> GlobalPointerTable<T> {
     pub fn empty() -> GlobalPointerTable<T> {
         GlobalPointerTable(RawPointerTable::empty())
@@ -297,6 +299,7 @@ impl<T> IndexMut<PointerId> for GlobalPointerTable<T> {
     }
 }
 
+#[allow(dead_code)]
 impl<'a, T> PointerTable<'a, T> {
     pub fn new(
         global: &'a GlobalPointerTable<T>,
@@ -329,6 +332,7 @@ impl<'a, T> Index<PointerId> for PointerTable<'a, T> {
     }
 }
 
+#[allow(dead_code)]
 impl<'a, T> PointerTableMut<'a, T> {
     pub fn new(
         global: &'a mut GlobalPointerTable<T>,
@@ -387,6 +391,7 @@ impl<'a, T> IndexMut<PointerId> for PointerTableMut<'a, T> {
     }
 }
 
+#[allow(dead_code)]
 impl<T> OwnedPointerTable<T> {
     pub fn new(global: GlobalPointerTable<T>, local: LocalPointerTable<T>) -> OwnedPointerTable<T> {
         OwnedPointerTable { global, local }

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -99,11 +99,11 @@ impl NextGlobalPointerId {
 }
 
 #[derive(Clone, Debug)]
-struct RawPointerTable<T>(Vec<T>);
+struct PointerTableInner<T>(Vec<T>);
 #[derive(Clone, Debug)]
-pub struct LocalPointerTable<T>(RawPointerTable<T>);
+pub struct LocalPointerTable<T>(PointerTableInner<T>);
 #[derive(Clone, Debug)]
-pub struct GlobalPointerTable<T>(RawPointerTable<T>);
+pub struct GlobalPointerTable<T>(PointerTableInner<T>);
 pub struct PointerTable<'a, T> {
     global: &'a GlobalPointerTable<T>,
     local: &'a LocalPointerTable<T>,
@@ -117,12 +117,12 @@ pub struct OwnedPointerTable<T> {
     local: LocalPointerTable<T>,
 }
 
-impl<T> RawPointerTable<T> {
-    pub fn empty() -> RawPointerTable<T> {
+impl<T> PointerTableInner<T> {
+    pub fn empty() -> PointerTableInner<T> {
         Self::from_raw(Vec::new())
     }
 
-    pub fn new(len: usize) -> RawPointerTable<T>
+    pub fn new(len: usize) -> PointerTableInner<T>
     where
         T: Default,
     {
@@ -131,8 +131,8 @@ impl<T> RawPointerTable<T> {
         Self::from_raw(v)
     }
 
-    pub fn from_raw(raw: Vec<T>) -> RawPointerTable<T> {
-        RawPointerTable(raw)
+    pub fn from_raw(raw: Vec<T>) -> PointerTableInner<T> {
+        PointerTableInner(raw)
     }
 
     pub fn into_raw(self) -> Vec<T> {
@@ -140,14 +140,14 @@ impl<T> RawPointerTable<T> {
     }
 }
 
-impl<T> Index<u32> for RawPointerTable<T> {
+impl<T> Index<u32> for PointerTableInner<T> {
     type Output = T;
     fn index(&self, index: u32) -> &T {
         &self.0[index as usize]
     }
 }
 
-impl<T> IndexMut<u32> for RawPointerTable<T> {
+impl<T> IndexMut<u32> for PointerTableInner<T> {
     fn index_mut(&mut self, index: u32) -> &mut T {
         &mut self.0[index as usize]
     }
@@ -156,18 +156,18 @@ impl<T> IndexMut<u32> for RawPointerTable<T> {
 #[allow(dead_code)]
 impl<T> LocalPointerTable<T> {
     pub fn empty() -> LocalPointerTable<T> {
-        LocalPointerTable(RawPointerTable::empty())
+        LocalPointerTable(PointerTableInner::empty())
     }
 
     pub fn new(len: usize) -> LocalPointerTable<T>
     where
         T: Default,
     {
-        LocalPointerTable(RawPointerTable::new(len))
+        LocalPointerTable(PointerTableInner::new(len))
     }
 
     pub fn from_raw(raw: Vec<T>) -> LocalPointerTable<T> {
-        LocalPointerTable(RawPointerTable::from_raw(raw))
+        LocalPointerTable(PointerTableInner::from_raw(raw))
     }
 
     pub fn into_raw(self) -> Vec<T> {
@@ -220,18 +220,18 @@ impl<T> IndexMut<PointerId> for LocalPointerTable<T> {
 #[allow(dead_code)]
 impl<T> GlobalPointerTable<T> {
     pub fn empty() -> GlobalPointerTable<T> {
-        GlobalPointerTable(RawPointerTable::empty())
+        GlobalPointerTable(PointerTableInner::empty())
     }
 
     pub fn new(len: usize) -> GlobalPointerTable<T>
     where
         T: Default,
     {
-        GlobalPointerTable(RawPointerTable::new(len))
+        GlobalPointerTable(PointerTableInner::new(len))
     }
 
     pub fn from_raw(raw: Vec<T>) -> GlobalPointerTable<T> {
-        GlobalPointerTable(RawPointerTable::from_raw(raw))
+        GlobalPointerTable(PointerTableInner::from_raw(raw))
     }
 
     pub fn into_raw(self) -> Vec<T> {

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -1,4 +1,3 @@
-use std::cell::Cell;
 use std::fmt;
 use std::ops::{Index, IndexMut};
 
@@ -62,40 +61,40 @@ impl fmt::Debug for PointerId {
 }
 
 #[derive(Clone, Debug)]
-pub struct NextLocalPointerId(Cell<u32>);
+pub struct NextLocalPointerId(u32);
 
 impl NextLocalPointerId {
     pub fn new() -> NextLocalPointerId {
-        NextLocalPointerId(Cell::new(0))
+        NextLocalPointerId(0)
     }
 
-    pub fn next(&self) -> PointerId {
-        let x = self.0.get();
-        self.0.set(x + 1);
+    pub fn next(&mut self) -> PointerId {
+        let x = self.0;
+        self.0 += 1;
         PointerId::local(x)
     }
 
     pub fn num_pointers(&self) -> usize {
-        self.0.get() as usize
+        self.0 as usize
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct NextGlobalPointerId(Cell<u32>);
+pub struct NextGlobalPointerId(u32);
 
 impl NextGlobalPointerId {
     pub fn new() -> NextGlobalPointerId {
-        NextGlobalPointerId(Cell::new(0))
+        NextGlobalPointerId(0)
     }
 
-    pub fn next(&self) -> PointerId {
-        let x = self.0.get();
-        self.0.set(x + 1);
+    pub fn next(&mut self) -> PointerId {
+        let x = self.0;
+        self.0 += 1;
         PointerId::global(x)
     }
 
     pub fn num_pointers(&self) -> usize {
-        self.0.get() as usize
+        self.0 as usize
     }
 }
 

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -92,13 +92,13 @@ fn mk_cell<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Ty<'tcx> {
 }
 
 pub fn convert_type<'tcx>(
-    acx: &AnalysisCtxt<'tcx>,
+    acx: &AnalysisCtxt<'_, 'tcx>,
     lty: LTy<'tcx>,
     perms: &[PermissionSet],
     flags: &[FlagSet],
 ) -> Ty<'tcx> {
-    let tcx = acx.tcx;
-    acx.lcx.rewrite_unlabeled(lty, &mut |ty, args, label| {
+    let tcx = acx.tcx();
+    acx.lcx().rewrite_unlabeled(lty, &mut |ty, args, label| {
         if label == PointerId::NONE {
             return ty;
         }

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -1,4 +1,4 @@
-use crate::context::{AnalysisCtxt, FlagSet, LTy, PermissionSet, PointerId};
+use crate::context::{AnalysisCtxt, Assignment, FlagSet, LTy, PermissionSet, PointerId};
 use rustc_hir::def::{DefKind, Res};
 use rustc_middle::ty::subst::GenericArg;
 use rustc_middle::ty::{ReErased, Ty, TyCtxt};
@@ -94,17 +94,18 @@ fn mk_cell<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Ty<'tcx> {
 pub fn convert_type<'tcx>(
     acx: &AnalysisCtxt<'_, 'tcx>,
     lty: LTy<'tcx>,
-    perms: &[PermissionSet],
-    flags: &[FlagSet],
+    asn: &Assignment,
 ) -> Ty<'tcx> {
     let tcx = acx.tcx();
+    let perms = asn.perms();
+    let flags = asn.flags();
     acx.lcx().rewrite_unlabeled(lty, &mut |ty, args, label| {
         if label == PointerId::NONE {
             return ty;
         }
         let ptr = label;
 
-        let (own, qty) = perms_to_desc(perms[ptr.index()], flags[ptr.index()]);
+        let (own, qty) = perms_to_desc(perms[ptr], flags[ptr]);
 
         assert_eq!(args.len(), 1);
         let mut ty = args[0];

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -4,12 +4,24 @@ use rustc_middle::ty::{DefIdTree, Ty, TyCtxt, TyKind};
 
 #[derive(Debug)]
 pub enum RvalueDesc<'tcx> {
+    /// A pointer projection, such as `&(*x.y).z`.  The rvalue is split into a base pointer
+    /// expression (in this case `x.y`) and a projection (`.z`).  The `&` and `*` are implicit.
     Project {
+        /// The base pointer of the projection.  This is guaranteed to evaluate to a pointer or
+        /// reference type.
+        ///
+        /// This may contain derefs, indicating that the pointer was loaded through another
+        /// pointer.  Only the outermost deref is implicit.  For example, `&(**x).y` has a `base`
+        /// of `*x` and a `proj` of `.y`.
         base: PlaceRef<'tcx>,
+        /// The projection applied to the pointer.  This contains no `Deref` projections.
         proj: &'tcx [PlaceElem<'tcx>],
     },
+    /// The address of a local or one of its fields, such as `&x.y`.  The rvalue is split into a
+    /// base local (in this case `x`) and a projection (`.y`).  The `&` is implicit.
     AddrOfLocal {
         local: Local,
+        /// The projection applied to the local.  This contains no `Deref` projections.
         proj: &'tcx [PlaceElem<'tcx>],
     },
 }

--- a/c2rust-analyze/tests/filecheck/ptrptr1.rs
+++ b/c2rust-analyze/tests/filecheck/ptrptr1.rs
@@ -1,13 +1,33 @@
 
-// CHECK-LABEL: final labeling for "ptrptr1_basic"
-// CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL:[lg][0-9]+]]#*mut i32[NONE#i32[]]]
-// CHECK-DAG: ([[#@LINE+1]]: y): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
-pub unsafe fn ptrptr1_basic(cond: bool, x: *mut *mut i32, y: *mut *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: z): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
+// CHECK-LABEL: final labeling for "ptrptr1_backward"
+// CHECK-DAG: ([[#@LINE+4]]: x): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL:[lg][0-9]+]]#*mut i32[NONE#i32[]]]
+// CHECK-DAG: ([[#@LINE+3]]: y): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
+// CHECK-DAG: ([[#@LINE+2]]: x): &&mut i32
+// CHECK-DAG: ([[#@LINE+1]]: y): &&mut i32
+pub unsafe fn ptrptr1_backward(cond: bool, x: *mut *mut i32, y: *mut *mut i32) {
+    // CHECK-DAG: ([[#@LINE+2]]: z): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
+    // CHECK-DAG: ([[#@LINE+1]]: z): &&mut i32
     let z = if cond {
         x
     } else {
         y
     };
     **z = 1;
+}
+
+// CHECK-LABEL: final labeling for "ptrptr1_bidir"
+// CHECK-DAG: ([[#@LINE+4]]: x): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL:[lg][0-9]+]]#*mut i32[NONE#i32[]]]
+// CHECK-DAG: ([[#@LINE+3]]: y): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
+// CHECK-DAG: ([[#@LINE+2]]: x): &&mut i32
+// CHECK-DAG: ([[#@LINE+1]]: y): &&mut i32
+pub unsafe fn ptrptr1_bidir(cond: bool, x: *mut *mut i32, y: *mut *mut i32) {
+    // CHECK-DAG: ([[#@LINE+2]]: z): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
+    // CHECK-DAG: ([[#@LINE+1]]: z): &&mut i32
+    let z = if cond {
+        x
+    } else {
+        y
+    };
+    // `*x` must be `&mut i32`, so `*z` must be `&mut i32`, so `*y` must be `&mut i32`.
+    **x = 1;
 }

--- a/c2rust-analyze/tests/filecheck/ptrptr1.rs
+++ b/c2rust-analyze/tests/filecheck/ptrptr1.rs
@@ -1,0 +1,13 @@
+
+// CHECK-LABEL: final labeling for "ptrptr1_basic"
+// CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL:[lg][0-9]+]]#*mut i32[NONE#i32[]]]
+// CHECK-DAG: ([[#@LINE+1]]: y): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
+pub unsafe fn ptrptr1_basic(cond: bool, x: *mut *mut i32, y: *mut *mut i32) {
+    // CHECK-DAG: ([[#@LINE+1]]: z): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
+    let z = if cond {
+        x
+    } else {
+        y
+    };
+    **z = 1;
+}


### PR DESCRIPTION
This modifies the static analysis component to compute equivalence classes of pointers that are required to have the same type.  For example, given this code:

```Rust
let x: *mut *mut i32 = ...;
let mut y: *mut *mut i32 = ...;
y = x;
```

The assignment `y = x` requires that the inner pointer types be identical, as there is no safe cast that can turn e.g. `&mut &mut i32` into `&&i32`.  The outer pointer types can still vary (with `y` being a supertype of `x`), so the assignment `x: &mut &mut i32`, `y: &&mut i32` would be valid.

The general strategy is to assign `PointerId`s to all pointer types, compute equivalence classes over `PointerId`s (based on assignments like the one above), and finally reassign `PointerId`s so that pointer types in the same equivalence class use the same `PointerId`.  For example, the above code would first be numbered with unique `PointerId`s like `x: *mut /*1*/ *mut /*2*/ i32`, `y: *mut /*3*/ *mut /*4*/ i32`, then after equivalence classes are computed, it would be renumbered with `x: *mut /*5*/ *mut /*6*/ i32`, `y: *mut /*7*/ *mut /*6*/ i32` - note that both inner pointers now use the same `PointerId`.  The remaining passes can then operate unchanged, assigning permission bits and new types to each `PointerId`, and these results will naturally be shared between all pointer types that use the same `PointerId`.

This branch also splits `PointerId`s into separate local and global namespaces.  The local namespace is for pointer types that are relevant only within a single function body.  The global namespace is for pointer types that may be used in multiple functions, such as struct fields or function argument/return types.  Currently, no global pointers are ever defined, but having this distinction affects the design of the equivalence class data structure.