### PR TITLE
Detect installed targets by existence of `rustc --print target-libdir`, not checking unstable error messages

### DIFF
--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -130,9 +130,10 @@ def get_native_arch() -> str:
     raise KeyError
 
 def rustc_has_target(target: str) -> bool:
-    args = ["--target", target, "/dev/null"]
-    retcode, stdout, stderr = rustc[args].run(retcode=None)
-    return not "target may not be installed" in stderr
+    args = ["--target", target, "--print", "target-libdir"]
+    stdout = rustc[args]()
+    target_libdir = Path(stdout.strip())
+    return target_libdir.exists()
 
 def target_args(target: Optional[str]) -> List[str]:
     if target:


### PR DESCRIPTION
We should detect installed targets by checking for the existence of the directory `$(rustc --print target-libdir)` rather than checking unstable error messages from `rustc /dev/null`.

This still uses `rustc`, so it works whether or not `rustc` is really `rustup` or not and if `rustup` was used for installation.