### PR TITLE
call `debug_mir` once

### DIFF
--- a/dynamic_instrumentation/src/instrument.rs
+++ b/dynamic_instrumentation/src/instrument.rs
@@ -142,7 +142,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                         .arg_index_of(field)
                         .source(place)
                         .dest_from(proj_dest)
-                        .debug_mir()
                         .add_to(self);
                 }
             }
@@ -181,7 +180,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
             self.loc(location, location, load_fn)
                 .arg_var(p.local)
                 .source(&remove_outer_deref(*p, ctx))
-                .debug_mir()
                 .add_to(self);
         };
 
@@ -201,7 +199,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                 self.loc(location, location, store_fn)
                     .arg_var(base_dest)
                     .source(&remove_outer_deref(dest, self.tcx()))
-                    .debug_mir()
                     .add_to(self);
 
                 if is_region_or_unsafe_ptr(value_ty) {
@@ -209,7 +206,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                         .arg_var(dest)
                         .source(value)
                         .dest(&dest)
-                        .debug_mir()
                         .add_to(self);
                 }
             }
@@ -220,7 +216,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                     self.loc(location, location, ptr_to_int_fn)
                         .arg_var(p.local)
                         .source(p)
-                        .debug_mir()
                         .add_to(self);
                 }
             }
@@ -235,7 +230,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                     .arg_var(dest)
                     .source(&source)
                     .dest(&dest)
-                    .debug_mir()
                     .add_to(self);
             }
             Rvalue::AddressOf(_, p) => {
@@ -245,7 +239,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                     .arg_index_of(p.local)
                     .source(p)
                     .dest(&dest)
-                    .debug_mir()
                     .add_to(self);
             }
             Rvalue::Use(Operand::Copy(p) | Operand::Move(p)) if p.is_indirect() => {
@@ -253,7 +246,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                 self.loc(location, location.successor_within_block(), load_value_fn)
                     .arg_var(dest)
                     .dest(&dest)
-                    .debug_mir()
                     .add_to(self);
             }
             Rvalue::Use(Operand::Copy(p) | Operand::Move(p)) => {
@@ -261,7 +253,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                     .arg_var(dest)
                     .source(p)
                     .dest(&dest)
-                    .debug_mir()
                     .add_to(self);
             }
             Rvalue::Cast(_, op, _) => {
@@ -274,7 +265,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                     .arg_var(dest)
                     .source(op)
                     .dest(&dest)
-                    .debug_mir()
                     .add_to(self);
             }
             Rvalue::Ref(_, bkind, p) if has_outer_deref(p) => {
@@ -286,7 +276,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                         .arg_addr_of(*p)
                         .source(&source)
                         .dest(&dest)
-                        .debug_mir()
                         .add_to(self);
                 } else {
                     // Instrument immutable borrows by tracing the reference itself
@@ -294,7 +283,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                         .arg_var(dest)
                         .source(&source)
                         .dest(&dest)
-                        .debug_mir()
                         .add_to(self);
                 };
             }
@@ -308,7 +296,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                         .arg_index_of(p.local)
                         .source(&source)
                         .dest(&dest)
-                        .debug_mir()
                         .add_to(self);
                 } else {
                     // Instrument immutable borrows by tracing the reference itself
@@ -317,7 +304,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                         .arg_index_of(p.local)
                         .source(&source)
                         .dest(&dest)
-                        .debug_mir()
                         .add_to(self);
                 };
             }
@@ -363,7 +349,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                                     .source(&place)
                                     .dest(&callee_arg)
                                     .transfer(transfer_kind)
-                                    .debug_mir()
                                     .add_to(self);
                             }
                         }
@@ -384,7 +369,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                             .after_call()
                             .transfer(TransferKind::Ret(self.func_hash()))
                             .arg_vars(args.iter().cloned())
-                            .debug_mir()
                             .add_to(self);
                     } else if is_region_or_unsafe_ptr(dest_place.ty(self, self.tcx()).ty) {
                         let instrumentation_location = Location {
@@ -399,7 +383,6 @@ impl<'tcx> Visitor<'tcx> for InstrumentationAdder<'_, 'tcx> {
                                 self.tcx().def_path_hash(def_id).convert(),
                             ))
                             .arg_var(dest_place)
-                            .debug_mir()
                             .add_to(self);
                     }
                 }

--- a/dynamic_instrumentation/src/point/build.rs
+++ b/dynamic_instrumentation/src/point/build.rs
@@ -70,6 +70,7 @@ impl<'a, 'tcx: 'a> InstrumentationAdder<'a, 'tcx> {
             func,
             point: Default::default(),
         }
+        .debug_mir()
     }
 
     pub fn into_instrumentation_points(mut self) -> Vec<InstrumentationPoint<'tcx>> {


### PR DESCRIPTION
`debug_mir` is used everywhere, so call once when constructing the `InstrumentationBuilder`