### PR TITLE
Append to `Metadata` and merge upon deserialization

### DIFF
--- a/analysis/runtime/src/metadata.rs
+++ b/analysis/runtime/src/metadata.rs
@@ -1,9 +1,11 @@
 use std::{
     collections::HashMap,
     fmt::{self, Debug, Formatter},
+    io::Cursor,
+    iter,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::mir_loc::{DefPathHash, Func, MirLoc, MirLocId};
 
@@ -16,6 +18,39 @@ pub struct Metadata {
 impl Metadata {
     pub fn get(&self, index: MirLocId) -> &MirLoc {
         &self.locs[index as usize]
+    }
+
+    pub fn read(bytes: &[u8]) -> bincode::Result<Self> {
+        bincode_deserialize_many(bytes)
+    }
+}
+
+fn bincode_deserialize_many<T, C>(bytes: &[u8]) -> bincode::Result<C>
+where
+    T: DeserializeOwned,
+    C: FromIterator<T>,
+{
+    let len = bytes.len();
+    let mut cursor = Cursor::new(bytes);
+    iter::from_fn(|| {
+        // No good alternatives: <https://github.com/rust-lang/rust/issues/86369>.
+        if cursor.position() == len.try_into().unwrap() {
+            return None;
+        }
+        Some(bincode::deserialize_from(&mut cursor))
+    })
+    .collect::<Result<_, _>>()
+}
+
+impl FromIterator<Metadata> for Metadata {
+    fn from_iter<I: IntoIterator<Item = Metadata>>(iter: I) -> Self {
+        let mut locs = Vec::new();
+        let mut functions = HashMap::new();
+        for metadata in iter {
+            locs.extend(metadata.locs);
+            functions.extend(metadata.functions);
+        }
+        Self { locs, functions }
     }
 }
 

--- a/analysis/runtime/src/runtime/backend.rs
+++ b/analysis/runtime/src/runtime/backend.rs
@@ -103,7 +103,7 @@ impl DetectBackend for DebugBackend {
         // TODO may want to deduplicate this with [`pdg::builder::read_metadata`] in [`Metadata::read`],
         // but that may require adding `color-eyre`/`eyre` as a dependency
         let bytes = fs_err::read(path)?;
-        let metadata = bincode::deserialize(&bytes)?;
+        let metadata = Metadata::read(&bytes)?;
         Ok(Self { metadata })
     }
 }

--- a/dynamic_instrumentation/src/instrument.rs
+++ b/dynamic_instrumentation/src/instrument.rs
@@ -1,7 +1,8 @@
-use anyhow::Context;
+use anyhow::{ensure, Context};
 use c2rust_analysis_rt::metadata::Metadata;
 use c2rust_analysis_rt::mir_loc::{self, EventMetadata, Func, MirLoc, MirLocId, TransferKind};
 use c2rust_analysis_rt::HOOK_FUNCTIONS;
+use fs_err::OpenOptions;
 use indexmap::IndexSet;
 use log::debug;
 use rustc_index::vec::Idx;
@@ -14,6 +15,7 @@ use rustc_middle::ty::{self, TyCtxt, TyS};
 use rustc_span::def_id::{DefId, DefPathHash};
 use rustc_span::DUMMY_SP;
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::Path;
 use std::sync::Mutex;
 
@@ -62,14 +64,20 @@ impl Instrumenter {
     }
 
     /// Finish instrumentation and write out metadata to `metadata_file_path`.
-    pub fn finalize(&self, metadata_file_path: &Path) -> anyhow::Result<()> {
+    pub fn finalize(&self, metadata_path: &Path) -> anyhow::Result<()> {
         let mut locs = self.mir_locs.lock().unwrap();
         let mut functions = self.functions.lock().unwrap();
         let locs = locs.drain(..).collect::<Vec<_>>();
         let functions = functions.drain().collect::<HashMap<_, _>>();
         let metadata = Metadata { locs, functions };
         let bytes = bincode::serialize(&metadata).context("Location serialization failed")?;
-        fs_err::write(metadata_file_path, &bytes).context("Could not open metadata file")?;
+        let mut file = OpenOptions::new()
+            .append(true)
+            .write(true)
+            .open(metadata_path)
+            .context("Could not open metadata file")?;
+        let bytes_written = file.write(&bytes)?;
+        ensure!(bytes_written == bytes.len());
         Ok(())
     }
 

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -31,6 +31,7 @@ use std::{
     process::{self, Command, ExitStatus},
 };
 
+use fs_err::OpenOptions;
 use rustc_driver::{RunCompiler, TimePassesCallbacks};
 use rustc_session::config::CrateType;
 
@@ -310,6 +311,13 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
         // it usually isn't that slow.
         cmd.args(&["clean", "--package", root_package.name.as_str()]);
     })?;
+
+    // Create and truncate the metadata file for the [`rustc_wrapper`]s to append to.
+    OpenOptions::new()
+        .create(true)
+        .write(true) // need write for truncate
+        .truncate(true)
+        .open(&metadata)?;
 
     cargo.run(|cmd| {
         // Enable the runtime dependency.

--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -19,8 +19,7 @@ pub fn read_event_log(path: &Path) -> io::Result<Vec<Event>> {
 
 pub fn read_metadata(path: &Path) -> eyre::Result<Metadata> {
     let bytes = fs_err::read(path)?;
-    let metadata = bincode::deserialize(&bytes)?;
-    Ok(metadata)
+    Ok(Metadata::read(&bytes)?)
 }
 
 pub trait EventKindExt {


### PR DESCRIPTION
Fixes #586.

Atomically append to the `Metadata` file (error if not written all at once) and then merge upon deserialization.

See https://github.com/immunant/c2rust/issues/586#issuecomment-1210068124 for a discussion of solutions, of which this is one.

For each `rustc` wrapper call, we `open` in append mode, serialize to a `Vec<u8>`, and then do a single `write` (not `write_all`).  If the `write` doesn't write all of its data, error, as only single `write`s are atomic*.  This will leave consecutive `Metadata`s in the file, so when reading, we need to keep deserializing `Metadata`s until we reach the end of the file, and then merge the `Metadata`s into one.

\* This should be fine unless there is a signal that interrupts the `write` (or are there other cases the full `write` wouldn't go through?), or if the write is > 2 GB:
from [write(2)](https://man7.org/linux/man-pages/man2/write.2.html):
>  On Linux, `write`() (and similar system calls) will transfer at most 0x7ffff000 (2,147,479,552) bytes, returning the number of bytes actually transferred.  (This is true on both 32-bit and 64-bit systems.)

This was easier to implement than the other option (write to separate files and then read them in, merge, and write the final one), but it may be more brittle if `write`s don't write all at once (`write` is atomic on almost all platforms and filesystems (not old NFS versions)).  It currently works to instrument and run `lighttpd`.