### PR TITLE
Read and merge multiple `Metadata`

### DIFF
--- a/analysis/runtime/src/metadata.rs
+++ b/analysis/runtime/src/metadata.rs
@@ -1,9 +1,11 @@
 use std::{
     collections::HashMap,
     fmt::{self, Debug, Formatter},
+    io::Cursor,
+    iter,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::mir_loc::{DefPathHash, Func, MirLoc, MirLocId};
 
@@ -16,6 +18,39 @@ pub struct Metadata {
 impl Metadata {
     pub fn get(&self, index: MirLocId) -> &MirLoc {
         &self.locs[index as usize]
+    }
+
+    pub fn read(bytes: &[u8]) -> bincode::Result<Self> {
+        bincode_deserialize_many(bytes)
+    }
+}
+
+fn bincode_deserialize_many<T, C>(bytes: &[u8]) -> bincode::Result<C>
+where
+    T: DeserializeOwned,
+    C: FromIterator<T>,
+{
+    let len = bytes.len();
+    let mut cursor = Cursor::new(bytes);
+    iter::from_fn(|| {
+        // No good alternatives: <https://github.com/rust-lang/rust/issues/86369>.
+        if cursor.position() == len.try_into().unwrap() {
+            return None;
+        }
+        Some(bincode::deserialize_from(&mut cursor))
+    })
+    .collect::<Result<_, _>>()
+}
+
+impl FromIterator<Metadata> for Metadata {
+    fn from_iter<I: IntoIterator<Item = Metadata>>(iter: I) -> Self {
+        let mut locs = Vec::new();
+        let mut functions = HashMap::new();
+        for metadata in iter {
+            locs.extend(metadata.locs);
+            functions.extend(metadata.functions);
+        }
+        Self { locs, functions }
     }
 }
 

--- a/analysis/runtime/src/runtime/backend.rs
+++ b/analysis/runtime/src/runtime/backend.rs
@@ -103,7 +103,7 @@ impl DetectBackend for DebugBackend {
         // TODO may want to deduplicate this with [`pdg::builder::read_metadata`] in [`Metadata::read`],
         // but that may require adding `color-eyre`/`eyre` as a dependency
         let bytes = fs_err::read(path)?;
-        let metadata = bincode::deserialize(&bytes)?;
+        let metadata = Metadata::read(&bytes)?;
         Ok(Self { metadata })
     }
 }

--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -19,8 +19,7 @@ pub fn read_event_log(path: &Path) -> io::Result<Vec<Event>> {
 
 pub fn read_metadata(path: &Path) -> eyre::Result<Metadata> {
     let bytes = fs_err::read(path)?;
-    let metadata = bincode::deserialize(&bytes)?;
-    Ok(metadata)
+    Ok(Metadata::read(&bytes)?)
 }
 
 pub trait EventKindExt {


### PR DESCRIPTION
This allows multiple back-to-back `Metadata` to be read from the metadata file and merged into one.  This is the subset of #602 that would be needed for any of the solutions discussed in #602 and #586.  This PR does not actually change any of the currently broken behavior from #586.