### PR TITLE
Append `Metadata` to metadata file using a file lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "cargo_metadata",
  "clap 3.2.16",
  "fs-err",
+ "fs2",
  "indexmap",
  "itertools",
  "lazy_static",
@@ -622,6 +623,16 @@ name = "fs-err"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd79fa345a495d3ae89fb7165fec01c0e72f41821d642dda363a1e97975652e"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "generic-array"

--- a/dynamic_instrumentation/Cargo.toml
+++ b/dynamic_instrumentation/Cargo.toml
@@ -18,6 +18,7 @@ camino = "1.0"
 # Used for parsing `rust-toolchain.toml`.
 # We don't need to edit at all, but `cargo` uses `toml-edit`, so we want to match it.
 toml_edit = "0.14"
+fs2 = "0.4"
 
 [build-dependencies]
 rustc-private-link = { path = "../rustc-private-link" }

--- a/dynamic_instrumentation/src/instrument.rs
+++ b/dynamic_instrumentation/src/instrument.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use c2rust_analysis_rt::metadata::Metadata;
 use c2rust_analysis_rt::mir_loc::{self, EventMetadata, Func, MirLoc, MirLocId, TransferKind};
 use c2rust_analysis_rt::HOOK_FUNCTIONS;
+use fs2::FileExt;
 use fs_err::OpenOptions;
 use indexmap::IndexSet;
 use log::debug;
@@ -76,7 +77,10 @@ impl Instrumenter {
             .write(true)
             .open(metadata_path)
             .context("Could not open metadata file")?;
-        file.write_all(&bytes)?;
+        file.file().lock_exclusive()?;
+        let e = file.write_all(&bytes);
+        file.file().unlock()?;
+        e?;
         Ok(())
     }
 

--- a/dynamic_instrumentation/src/instrument.rs
+++ b/dynamic_instrumentation/src/instrument.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use c2rust_analysis_rt::metadata::Metadata;
 use c2rust_analysis_rt::mir_loc::{self, EventMetadata, Func, MirLoc, MirLocId, TransferKind};
 use c2rust_analysis_rt::HOOK_FUNCTIONS;
+use fs_err::OpenOptions;
 use indexmap::IndexSet;
 use log::debug;
 use rustc_index::vec::Idx;
@@ -14,6 +15,7 @@ use rustc_middle::ty::{self, TyCtxt, TyS};
 use rustc_span::def_id::{DefId, DefPathHash};
 use rustc_span::DUMMY_SP;
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::Path;
 use std::sync::Mutex;
 
@@ -62,14 +64,19 @@ impl Instrumenter {
     }
 
     /// Finish instrumentation and write out metadata to `metadata_file_path`.
-    pub fn finalize(&self, metadata_file_path: &Path) -> anyhow::Result<()> {
+    pub fn finalize(&self, metadata_path: &Path) -> anyhow::Result<()> {
         let mut locs = self.mir_locs.lock().unwrap();
         let mut functions = self.functions.lock().unwrap();
         let locs = locs.drain(..).collect::<Vec<_>>();
         let functions = functions.drain().collect::<HashMap<_, _>>();
         let metadata = Metadata { locs, functions };
         let bytes = bincode::serialize(&metadata).context("Location serialization failed")?;
-        fs_err::write(metadata_file_path, &bytes).context("Could not open metadata file")?;
+        let mut file = OpenOptions::new()
+            .append(true)
+            .write(true)
+            .open(metadata_path)
+            .context("Could not open metadata file")?;
+        file.write_all(&bytes)?;
         Ok(())
     }
 

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -31,6 +31,7 @@ use std::{
     process::{self, Command, ExitStatus},
 };
 
+use fs_err::OpenOptions;
 use rustc_driver::{RunCompiler, TimePassesCallbacks};
 use rustc_session::config::CrateType;
 
@@ -310,6 +311,13 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
         // it usually isn't that slow.
         cmd.args(&["clean", "--package", root_package.name.as_str()]);
     })?;
+
+    // Create and truncate the metadata file for the [`rustc_wrapper`]s to append to.
+    OpenOptions::new()
+        .create(true)
+        .write(true) // need write for truncate
+        .truncate(true)
+        .open(&metadata)?;
 
     cargo.run(|cmd| {
         // Enable the runtime dependency.


### PR DESCRIPTION
Fixes #586.

This uses [`fs2`](https://docs.rs/fs2) file locking to append serialized `Metadata`s to the metadata file without race conditions.  Thanks for the suggestion, @ahomescu!

I'm unsure how to test for any race conditions, though.