### PR TITLE
Support `va_copy` with a member of a struct pointer

### DIFF
--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -59,6 +59,7 @@ impl<'c> Translation<'c> {
         }
 
         // struct-based va_list (e.g. x86_64) where va_list is accessed as a member of a struct pointer
+        // supporting this pattern is necessary to transpile [graphviz](https://gitlab.com/graphviz/graphviz/-/blob/5.0.0/lib/sfio/sftable.c#L321)
         fn match_vastart_struct_pointer_member(
             ast_context: &TypedAstContext,
             expr: CExprId,

--- a/tests/items/src/test_varargs.rs
+++ b/tests/items/src/test_varargs.rs
@@ -2,7 +2,7 @@
 
 use crate::varargs::{
     rust_call_printf, rust_call_vprintf, rust_my_printf, rust_restart_valist, rust_sample_stddev,
-    rust_simple_vacopy, rust_valist_struct_member,
+    rust_simple_vacopy, rust_valist_struct_member, rust_valist_struct_pointer_member,
 };
 
 use libc::c_char;
@@ -19,6 +19,8 @@ extern "C" {
     fn simple_vacopy(_: *const c_char, ...);
 
     fn valist_struct_member(_: *const c_char, ...);
+
+    fn valist_struct_pointer_member(_: *const c_char, ...);
 
     fn restart_valist(_: *const c_char, ...);
 
@@ -66,6 +68,14 @@ pub fn test_valist_struct_member() {
     unsafe {
         valist_struct_member(fmt_str.as_ptr(), 10, 1.5);
         rust_valist_struct_member(fmt_str.as_ptr(), 10, 1.5);
+    }
+}
+
+pub fn test_valist_struct_pointer_member() {
+    let fmt_str = CString::new("%d, %f\n").unwrap();
+    unsafe {
+        valist_struct_pointer_member(fmt_str.as_ptr(), 10, 1.5);
+        rust_valist_struct_pointer_member(fmt_str.as_ptr(), 10, 1.5);
     }
 }
 

--- a/tests/items/src/varargs.c
+++ b/tests/items/src/varargs.c
@@ -80,6 +80,16 @@ void valist_struct_member(const char *fmt, ...) {
   va_end(thestruct.args);
 }
 
+// pattern first seen in graphviz (sftable.c)
+void valist_struct_pointer_member(const char *fmt, ...) {
+  struct vastruct thestruct;
+  struct vastruct *pointer = &thestruct;
+
+  va_start(pointer->args, fmt);
+  vprintf(fmt, pointer->args);
+  va_end(pointer->args);
+}
+
 // mirrors pattern from json-c's sprintbuf
 void restart_valist(const char *fmt, ...) {
     va_list ap;

--- a/tests/items/src/varargs.c
+++ b/tests/items/src/varargs.c
@@ -73,21 +73,27 @@ struct vastruct {
 
 // pattern first seen in apache (util_script.c)
 void valist_struct_member(const char *fmt, ...) {
-  struct vastruct thestruct;
+  struct vastruct a, b;
 
-  va_start(thestruct.args, fmt);
-  vprintf(fmt, thestruct.args);
-  va_end(thestruct.args);
+  va_start(a.args, fmt);
+  va_copy(b.args, a.args);
+  vprintf(fmt, a.args);
+  vprintf(fmt, b.args);
+  va_end(a.args);
+  va_end(b.args);
 }
 
 // pattern first seen in graphviz (sftable.c)
 void valist_struct_pointer_member(const char *fmt, ...) {
-  struct vastruct thestruct;
-  struct vastruct *pointer = &thestruct;
+  struct vastruct a, b;
+  struct vastruct *p = &a, *q = &b;
 
-  va_start(pointer->args, fmt);
-  vprintf(fmt, pointer->args);
-  va_end(pointer->args);
+  va_start(p->args, fmt);
+  va_copy(q->args, p->args);
+  vprintf(fmt, p->args);
+  vprintf(fmt, q->args);
+  va_end(p->args);
+  va_end(q->args);
 }
 
 // mirrors pattern from json-c's sprintbuf


### PR DESCRIPTION
This PR add support for `va_copy` which argument is a member of a struct point.

Example C code.
```c
#include <stdarg.h>

struct S {
  va_list args;
};

void foo(va_list args) {
  struct S *s;
  va_copy(s->args, args);
}
```

Emitted Rust code.
```rust
#![allow(dead_code, mutable_transmutes, non_camel_case_types, non_snake_case, non_upper_case_globals, unused_assignments, unused_mut)]
#![register_tool(c2rust)]
#![feature(register_tool)]
pub type __builtin_va_list = [__va_list_tag; 1];
#[derive(Copy, Clone)]
#[repr(C)]
pub struct __va_list_tag {
    pub gp_offset: libc::c_uint,
    pub fp_offset: libc::c_uint,
    pub overflow_arg_area: *mut libc::c_void,
    pub reg_save_area: *mut libc::c_void,
}
pub type va_list = __builtin_va_list;
#[derive()]
#[repr(C)]
pub struct S<'a> {
    pub args: ::core::ffi::VaListImpl::<'a>,
}
#[no_mangle]
pub unsafe extern "C" fn foo(mut args: ::core::ffi::VaList) {
    let mut s: *mut S = 0 as *mut S;
    (*s).args = args.clone();
}
```