### PR TITLE
Warn if any `--binary`s are not transpiled

### DIFF
--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use failure::Error;
+use itertools::Itertools;
 use log::{info, warn};
 use regex::Regex;
 use serde_derive::Serialize;
@@ -110,11 +111,12 @@ impl TranspilerConfig {
         for binary in &self.binaries {
             if !module_names.contains(binary) {
                 ok = false;
-                warn!("binary not used: {binary:?}");
+                warn!("binary not used: {binary}");
             }
         }
         if !ok {
-            info!("candidate modules for binaries are: {module_names:#?}");
+            let module_names = module_names.iter().format(", ");
+            info!("candidate modules for binaries are: {module_names}");
         }
         ok
     }

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use failure::Error;
-use log::warn;
+use log::{info, warn};
 use regex::Regex;
 use serde_derive::Serialize;
 
@@ -114,7 +114,7 @@ impl TranspilerConfig {
             }
         }
         if !ok {
-            warn!("candidate modules for binaries are: {module_names:#?}");
+            info!("candidate modules for binaries are: {module_names:#?}");
         }
         ok
     }


### PR DESCRIPTION
Fixes #611.

Blocked on #615.

For the example given by @64kramsystem in #611,

```sh
gh repo clone Blzut3/CatacombSDL
cd CatacombSDL
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1
c2rust transpile --binary pizzarulez compile_commands.json
```

this is now the output (once https://github.com/immunant/c2rust/pull/421/commits/6a6c0d8bb6a6a6f5bc5ab18233c622102e5f9291 is fixed):

```shell
warning: binary not used: pizzarulez
info: candidate modules for binaries are: pcrlib_a, catasm, catacomb, objects, cpanel, cat_play, pcrlib_c, rleasm
```

@64kramsystem, if you could review this PR, at least the output, that would be great!