### PR TITLE
Disable incremental instrumentation and remove problematic non-primary `cargo` subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,6 @@ dependencies = [
  "c2rust-analysis-rt",
  "c2rust-build-paths",
  "camino",
- "cargo_metadata",
  "clap 3.2.16",
  "env_logger",
  "fs-err",
@@ -313,31 +312,6 @@ name = "camino"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abb7553d5b9b8421c6de7cb02606ff15e0c6eea7d8eadd75ef013fd636bec36"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "cc"
@@ -1109,15 +1083,6 @@ name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
-
-[[package]]
-name = "semver"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "itertools",
  "log",
  "once_cell",
+ "tempfile",
  "toml_edit",
 ]
 
@@ -592,6 +593,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fern"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +757,15 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "similar",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1044,6 +1063,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1087,15 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -1246,6 +1283,20 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/dynamic_instrumentation/Cargo.toml
+++ b/dynamic_instrumentation/Cargo.toml
@@ -19,6 +19,7 @@ camino = "1.0"
 toml_edit = "0.14"
 fs2 = "0.4"
 env_logger = "0.9"
+tempfile = "3.3"
 
 [build-dependencies]
 c2rust-build-paths = { path = "../c2rust-build-paths" }

--- a/dynamic_instrumentation/Cargo.toml
+++ b/dynamic_instrumentation/Cargo.toml
@@ -13,7 +13,6 @@ once_cell = "1.13"
 log = "0.4"
 fs-err = "2"
 clap = { version = "3.2", features = ["derive"] }
-cargo_metadata = "0.15"
 camino = "1.0"
 # Used for parsing `rust-toolchain.toml`.
 # We don't need to edit at all, but `cargo` uses `toml-edit`, so we want to match it.

--- a/dynamic_instrumentation/src/callbacks.rs
+++ b/dynamic_instrumentation/src/callbacks.rs
@@ -22,6 +22,7 @@ pub struct MirTransformCallbacks;
 
 impl rustc_driver::Callbacks for MirTransformCallbacks {
     fn config(&mut self, config: &mut rustc_interface::Config) {
+        config.opts.incremental = None;
         config.override_queries = Some(override_queries);
     }
 

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -321,6 +321,8 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
     // We should keep the old one in that case.
     let mut metadata_file = OpenOptions::new()
         .create(true)
+        .read(true) // For reading new [`Metadata`] at the end.
+        .write(true) // For creation and for writing new [`Metadata`] to the beginning.
         .truncate(false)
         .open(&metadata_path)?;
 

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -40,7 +40,6 @@ use std::io::SeekFrom;
 
 use anyhow::{anyhow, bail, ensure, Context};
 use camino::Utf8Path;
-use cargo_metadata::MetadataCommand;
 use clap::Parser;
 
 /// Instrument memory accesses for dynamic analysis.
@@ -150,12 +149,6 @@ impl Cargo {
             .unwrap_or_else(|| "cargo".into())
             .into();
         Self { path }
-    }
-
-    pub fn metadata(&self) -> MetadataCommand {
-        let mut cmd = MetadataCommand::new();
-        cmd.cargo_path(&self.path);
-        cmd
     }
 
     pub fn command(&self) -> Command {
@@ -310,11 +303,6 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
     let sysroot = resolve_sysroot()?;
 
     let cargo = Cargo::new();
-
-    let cargo_metadata = cargo.metadata().exec()?;
-    let root_package = cargo_metadata
-        .root_package()
-        .ok_or_else(|| anyhow!("no root package found by `cargo`"))?;
 
     if set_runtime {
         cargo.run(|cmd| {

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -294,7 +294,7 @@ fn set_rust_toolchain() -> anyhow::Result<()> {
 /// Run as a `cargo` wrapper/plugin, the default invocation.
 fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
     let Args {
-        metadata,
+        metadata: metadata_path,
         runtime_path,
         set_runtime,
         mut cargo_args,
@@ -339,7 +339,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
         .create(true)
         .write(true) // need write for truncate
         .truncate(true)
-        .open(&metadata)?;
+        .open(&metadata_path)?;
 
     cargo.run(|cmd| {
         // Enable the runtime dependency.
@@ -347,7 +347,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
         cmd.args(cargo_args)
             .env(RUSTC_WRAPPER_VAR, rustc_wrapper)
             .env(RUST_SYSROOT_VAR, &sysroot)
-            .env(METADATA_VAR, &metadata);
+            .env(METADATA_VAR, &metadata_path);
     })?;
 
     Ok(())

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -295,13 +295,13 @@ pub struct MetadataFile {
 }
 
 impl MetadataFile {
-    /// The old, original, intended [`Path`] for the [`Metadata`].
+    /// The old, original, intended, and final [`Path`] for the [`Metadata`].
     ///
     /// This is the location that existing [`Metadata`] may be at,
     /// and where the [`Metadata`] will end after this program exits.
     ///
     /// [`Metadata`]: c2rust_analysis_rt::metadata::Metadata
-    pub fn old_path(&self) -> &Path {
+    pub fn final_path(&self) -> &Path {
         &self.path
     }
 
@@ -310,10 +310,10 @@ impl MetadataFile {
     /// This is the location of the new [`Metadata`] created
     /// during the `cargo` invocation in [`cargo_wrapper`]
     /// and later used (appended to) inside of the [`rustc_wrapper`]s.
-    /// It will later be moved back to [`Self::old_path`] if it is valid (i.e., not empty).
+    /// It will later be moved back to [`Self::final_path`] if it is valid (i.e., not empty).
     ///
     /// [`Metadata`]: c2rust_analysis_rt::metadata::Metadata
-    pub fn new_path(&self) -> &Path {
+    pub fn temp_path(&self) -> &Path {
         self.file.path()
     }
 
@@ -322,7 +322,7 @@ impl MetadataFile {
     ///
     /// This also creates the directory `path` is in if it does not already exist.
     ///
-    /// Also, see [`Self::old_path`] and [`Self::new_path`]
+    /// Also, see [`Self::final_path`] and [`Self::temp_path`]
     /// for an explanation of the locations and uses of the [`Path`]s.
     ///
     /// [`Metadata`]: c2rust_analysis_rt::metadata::Metadata
@@ -444,7 +444,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
         cmd.args(cargo_args)
             .env(RUSTC_WRAPPER_VAR, rustc_wrapper)
             .env(RUST_SYSROOT_VAR, &sysroot)
-            .env(METADATA_VAR, metadata_file.new_path());
+            .env(METADATA_VAR, metadata_file.temp_path());
     })?;
 
     metadata_file.close()?;

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -305,6 +305,9 @@ impl<'a> MetadataFile<'a> {
     /// `cargo` won't recompile, so a new [`MetadataFile`] won't be regenerated.
     /// We should keep the old one in that case.
     pub fn open(path: &'a Path) -> anyhow::Result<Self> {
+        if let Some(dir) = path.parent() {
+            fs_err::create_dir_all(dir)?;
+        }
         let file = OpenOptions::new()
             .create(true)
             .read(true) // For reading new [`Metadata`] at the end.

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -325,8 +325,13 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
 
     // Create a new metadata file for the [`rustc_wrapper`]s to append to.
     // This is a temporary file at first and will be moved into place if it written to.
+    let prefix = {
+        let mut prefix = metadata_file_name.to_owned();
+        prefix.push(".");
+        prefix
+    };
     let metadata_file = tempfile::Builder::new()
-        .prefix(metadata_file_name)
+        .prefix(&prefix)
         .suffix(".new")
         .tempfile_in(metadata_dir)
         .context("create new (temp) metadata file")?;

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -288,6 +288,8 @@ fn set_rust_toolchain() -> anyhow::Result<()> {
 }
 
 /// An open metadata file containing [`Metadata`]s.
+///
+/// [`Metadata`]: c2rust_analysis_rt::metadata::Metadata
 struct MetadataFile<'a> {
     /// The [`Path`] of the [`MetadataFile`].
     path: &'a Path,
@@ -316,6 +318,8 @@ impl<'a> MetadataFile<'a> {
 
     /// Call after the [`MetadataFile`] has been finished being used and potentially appended to.
     /// This will delete any old, out-of-date [`Metadata`]s from the beginning of the [`MetadataFile`] if need be.
+    ///
+    /// [`Metadata`]: c2rust_analysis_rt::metadata::Metadata
     pub fn finish(&mut self) -> anyhow::Result<()> {
         let old_len = self.len;
         if old_len == 0 {


### PR DESCRIPTION
Fixes #624 and f_ixes most of #625.

This disables incremental compilation in the `rustc_wrapper` in `MirTransformCallbacks`, thus disabling incremental instrumentation while still allowing incremental compilation for other `rustc` calls.  Thus, we do not need to `cargo clean --package {root_package}` anymore, fixing #624.

Without `cargo clean --package {root_package}`, `cargo` will not re-run `rustc` if no inputs change, so we also have to account for this case.  We don't have to actually do anything in this case, since nothing has changed, and so we don't need to touch the metadata file at all.  However, we have to avoid truncating the metadata file in this case, as that was the previous behavior.  Since we don't truncate the metadata file at the beginning, we end up with an ever-growing metadata file as subsequent `cargo-instrument`s keep appending new `Metadata`s to the metadata file.  This actually seems to work when they're merged, but is obviously undesirable.  To fix this, we check after if the metadata file has been appended to.  If it previously had `Metadata` and now has more `Metadata`, then we delete the old `Metadata` from the file (in practice, read the new `Metadata`, write it to the beginning, and then truncate the file).

Without having to run `cargo clean --package {root_package}` anymore, we also don't need to run `cargo metadata` either, as we used that to lookup the root package (note that this was incorrect if `c2rust-instrument ... --package {package}` was specified, for example, and we now handle such cases).  Thus, we can also drop the `cargo_metadata` dependency.

The only other `cargo` subcommand we invoke is `cargo add` (and only when `--set-runtime` is explicitly set).  Unlike `cargo clean` and many other `cargo` subcommands, `cargo add`'s arguments are largely orthogonal to other `cargo` args and thus we don't need to forward very many args to it (which is incredibly hard to do correctly).  The only argument that I see that we need to forward is `--manifest-path`, and it should be simple enough to detect that by itself.

Also, this approach is also a bit faster (50-100% faster when there are minimal/no changes), as we don't need a separate `cargo clean` and in the case of no inputs having changed, we don't need to do anything.