### PR TITLE
Forward `--manifest-path` to all `cargo` subcommands in `c2rust-instrument`

### DIFF
--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -450,7 +450,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
             cmd.args(&["add", "--optional", "c2rust-analysis-rt"]);
             if let Some(mut runtime) = runtime_path {
                 if manifest_dir.is_some() {
-                    runtime = runtime.canonicalize()?;
+                    runtime = fs_err::canonicalize(runtime)?;
                 }
                 // Since it's a local path, we don't need the internet,
                 // and running it offline saves a slow index sync.
@@ -473,7 +473,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
 
         // The [`rustc_wrapper`] might run in a different working directory if `--manifest-path` was passed.
         let metadata_path = metadata_file.temp_path();
-        let abs_metadata_path = metadata_path.canonicalize()?;
+        let abs_metadata_path = fs_err::canonicalize(metadata_path)?;
         let metadata_path = match manifest_dir {
             Some(_) => abs_metadata_path.as_path(),
             None => metadata_path,

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -468,7 +468,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
     cargo.run(|cmd| {
         // Enable the runtime dependency.
         let cargo_target_dir = manifest_dir
-            .unwrap_or_else(|| Path::new(""))
+            .unwrap_or_else(|| Path::new("."))
             .join("instrument.target");
 
         // The [`rustc_wrapper`] might run in a different working directory if `--manifest-path` was passed.

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -164,9 +164,9 @@ impl Cargo {
         Command::new(&self.path)
     }
 
-    pub fn run(&self, f: impl FnOnce(&mut Command)) -> anyhow::Result<()> {
+    pub fn run(&self, f: impl FnOnce(&mut Command) -> anyhow::Result<()>) -> anyhow::Result<()> {
         let mut cmd = self.command();
-        f(&mut cmd);
+        f(&mut cmd)?;
         let status = cmd.status()?;
         if !status.success() {
             eprintln!("error ({status}) running: {cmd:?}");
@@ -455,6 +455,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
             if let Some(manifest_path) = manifest_path {
                 cmd.arg("--manifest-path").arg(manifest_path);
             }
+            Ok(())
         })?;
     }
 
@@ -474,6 +475,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
             .env(RUST_SYSROOT_VAR, &sysroot)
             .env("CARGO_TARGET_DIR", &cargo_target_dir)
             .env(METADATA_VAR, &metadata_path);
+        Ok(())
     })?;
 
     metadata_file.close()?;

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -438,6 +438,9 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
 
     let metadata_file = MetadataFile::new(metadata_path)?;
 
+    // The [`rustc_wrapper`] might run in a different working directory if `--manifest-path` was passed.
+    let metadata_path = metadata_path.canonicalize()?;
+
     cargo.run(|cmd| {
         // Enable the runtime dependency.
         add_feature(&mut cargo_args, &["c2rust-analysis-rt"]);

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -426,10 +426,12 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
         mut cargo_args,
     } = Args::parse();
 
+    let args_for_cargo =
+        iter::once(OsStr::new("cargo")).chain(cargo_args.iter().map(OsString::as_os_str));
     let InterceptedCargoArgs {
         manifest_path,
         extra_args: _,
-    } = InterceptedCargoArgs::parse_from(cargo_args.clone());
+    } = InterceptedCargoArgs::parse_from(args_for_cargo);
     let manifest_path = manifest_path.as_deref();
     let manifest_dir = manifest_path.and_then(|path| path.parent());
 

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -448,7 +448,10 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
     if set_runtime {
         cargo.run(|cmd| {
             cmd.args(&["add", "--optional", "c2rust-analysis-rt"]);
-            if let Some(runtime) = runtime_path {
+            if let Some(mut runtime) = runtime_path {
+                if manifest_dir.is_some() {
+                    runtime = runtime.canonicalize()?;
+                }
                 // Since it's a local path, we don't need the internet,
                 // and running it offline saves a slow index sync.
                 cmd.args(&["--offline", "--path"]).arg(runtime);

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -473,7 +473,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
 
         // The [`rustc_wrapper`] might run in a different working directory if `--manifest-path` was passed.
         let metadata_path = metadata_file.temp_path();
-        let metadata_path = if manifest_dir.is_some() {
+        let metadata_path = if !metadata_path.is_absolute() && manifest_dir.is_some() {
             Cow::Owned(fs_err::canonicalize(metadata_path)?)
         } else {
             Cow::Borrowed(metadata_path)

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -466,7 +466,6 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
     let metadata_file = MetadataFile::new(metadata_path)?;
 
     cargo.run(|cmd| {
-        // Enable the runtime dependency.
         let cargo_target_dir = manifest_dir
             .unwrap_or_else(|| Path::new("."))
             .join("instrument.target");
@@ -479,7 +478,9 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
             None => metadata_path,
         };
 
+        // Enable the runtime dependency.
         add_feature(&mut cargo_args, &["c2rust-analysis-rt"]);
+
         cmd.args(cargo_args)
             .env(RUSTC_WRAPPER_VAR, rustc_wrapper)
             .env(RUST_SYSROOT_VAR, &sysroot)

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -36,7 +36,7 @@ use rustc_session::config::CrateType;
 
 use anyhow::{anyhow, ensure, Context};
 use camino::Utf8Path;
-use clap::Parser;
+use clap::{AppSettings, Parser};
 use tempfile::NamedTempFile;
 
 /// Instrument memory accesses for dynamic analysis.
@@ -62,6 +62,7 @@ struct Args {
 
 /// `cargo` args that we intercept.
 #[derive(Debug, Parser)]
+#[clap(setting = AppSettings::IgnoreErrors)]
 struct InterceptedCargoArgs {
     #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -461,14 +461,15 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
 
     let metadata_file = MetadataFile::new(metadata_path)?;
 
-    // The [`rustc_wrapper`] might run in a different working directory if `--manifest-path` was passed.
-    let metadata_path = metadata_file.temp_path().canonicalize()?;
-
     cargo.run(|cmd| {
         // Enable the runtime dependency.
         let cargo_target_dir = manifest_dir
             .unwrap_or_else(|| Path::new(""))
             .join("instrument.target");
+
+        // The [`rustc_wrapper`] might run in a different working directory if `--manifest-path` was passed.
+        let metadata_path = metadata_file.temp_path().canonicalize()?;
+
         add_feature(&mut cargo_args, &["c2rust-analysis-rt"]);
         cmd.args(cargo_args)
             .env(RUSTC_WRAPPER_VAR, rustc_wrapper)

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -65,6 +65,10 @@ struct Args {
 struct InterceptedCargoArgs {
     #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
+
+    /// Need this so `--` is allowed.
+    /// Not actually used.
+    extra_args: Vec<OsString>,
 }
 
 fn exit_with_status(status: ExitStatus) {
@@ -426,6 +430,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
 
     let InterceptedCargoArgs {
         manifest_path,
+        extra_args: _,
     } = InterceptedCargoArgs::parse_from(cargo_args.clone());
     let manifest_path = manifest_path.as_deref();
 

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -35,14 +35,15 @@ main() {
     fi
     local profile_args=(--profile "${profile}")
 
-    local metadata="${CWD}/${test_dir}/metadata.bc"
+    local metadata="${test_dir}/metadata.bc"
+    local event_log="${test_dir}/log.bc"
     local runtime="analysis/runtime"
 
     (
         unset RUSTFLAGS # transpiled code has tons of warnings; don't allow `-D warnings`
         export RUST_BACKTRACE=1
         export INSTRUMENT_BACKEND=log
-        export INSTRUMENT_OUTPUT=log.bc
+        export INSTRUMENT_OUTPUT="${event_log}"
         export INSTRUMENT_OUTPUT_APPEND=false
         export METADATA_FILE="${metadata}"
 
@@ -65,7 +66,7 @@ main() {
             --bin c2rust-pdg \
             "${profile_args[@]}" \
             -- \
-            --event-log "${test_dir}/log.bc" \
+            --event-log "${event_log}" \
             --metadata "${metadata}" \
             --print graphs \
             --print write-permissions \

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -35,15 +35,10 @@ main() {
     fi
     local profile_args=(--profile "${profile}")
 
-    local instrument="c2rust-instrument"
-    cargo build "${profile_args[@]}" --bin "${instrument}"
-
-    local c2rust="${CWD}/${profile_dir}/c2rust"
-    local c2rust_instrument="${CWD}/${profile_dir}/${instrument}"
     local metadata="${CWD}/${test_dir}/metadata.bc"
-    local runtime="${CWD}/analysis/runtime"
+    local runtime="analysis/runtime"
 
-    (cd "${test_dir}"
+    (
         unset RUSTFLAGS # transpiled code has tons of warnings; don't allow `-D warnings`
         export RUST_BACKTRACE=1
         export INSTRUMENT_BACKEND=log
@@ -51,25 +46,31 @@ main() {
         export INSTRUMENT_OUTPUT_APPEND=false
         export METADATA_FILE="${metadata}"
 
-        time "${c2rust_instrument}" \
+        cargo run \
+            --bin c2rust-instrument \
+            "${profile_args[@]}" \
+            -- \
             --metadata "${metadata}" \
             --set-runtime \
             --runtime-path "${runtime}" \
-            -- run "${profile_args[@]}" \
+            -- run \
+            --manifest-path "${test_dir}/Cargo.toml" \
+            "${profile_args[@]}" \
             -- "${args[@]}"
     )
-    (cd pdg
+    (
         export RUST_BACKTRACE=full # print sources w/ color-eyre
         export RUST_LOG=error
         cargo run \
+            --bin c2rust-pdg \
             "${profile_args[@]}" \
             -- \
-            --event-log "../${test_dir}/log.bc" \
+            --event-log "${test_dir}/log.bc" \
             --metadata "${metadata}" \
             --print graphs \
             --print write-permissions \
             --print counts \
-        > "../${test_dir}/pdg.log"
+        > "${test_dir}/pdg.log"
     )
 }
 


### PR DESCRIPTION
Fixes #625.

This uses a separate `clap::Parser` (`cargo` also uses `clap` 3) to parse part of the forwarded `cargo` args (to the primary `cargo` subcommand), in particular, `--manifest-path`, which is the only general `cargo` arg that we need to forward to the only non-primary `cargo` subcommand remaining, `cargo add`.

This also correctly resolves the `$CARGO_TARGET_DIR` and metadata path relative to a `--manifest-path`.

With `--manifest-path` now working, we can do things like this, all in one command, making `pdg.sh` less and less necessary:

```shell
INSTRUMENT_BACKEND=log INSTRUMENT_OUTPUT=log.bc INSTRUMENT_OUTPUT_APPEND=false cargo run --bin c2rust-instrument -- --metadata analysis/test/metadata.bc -- run --manifest-path ../lighttpd/rust/Cargo.toml -- -D -f ~/work/rust/lighttpd-1.4.64/mylighttpd.conf -i 5 1> /dev/null
```

Note that `pdg.sh` has also been updated and simplified with the new improvements using `--manifest-path`.