### PR TITLE
Add `c2rust-instrument --rustflags`

### DIFF
--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -60,18 +60,20 @@ struct Args {
     #[clap(long)]
     set_runtime: bool,
 
-    /// `$RUSTFLAGS`, but as a CLI argument, not an inheritable environment variable.
-    /// These flags are appended (space-separated) to the existing `$RUSTFLAGS`, if it exists.
+    /// Set `$RUSTFLAGS` for the instrumented `cargo`.
     ///
-    /// The reason this exists is twofold:
-    ///
-    /// 1. It would be convenient if `cargo` itself had such a `--rustflags` argument,
-    ///    so at least we can recreate it here ourselves.
-    ///
-    /// 2. If this binary is invoked by something like `cargo run --bin c2rust-instrument`,
-    ///    then it's impossible to set `$RUSTFLAGS` only for the inner `cargo` that you want to add them to
-    ///    without also adding them to the outer `cargo run` `cargo`.
-    ///    `--rustflags` lets you do that easily.
+    /// This allows setting `$RUSTFLAGS` for the inner `cargo` when `c2rust-instrument` is invoked via `cargo run`, for example.
+    /// If `$RUSTFLAGS` is already set, these `--rustflags` are appended with a space.
+    //
+    // The reason this exists is twofold:
+    //
+    // 1. It would be convenient if `cargo` itself had such a `--rustflags` argument,
+    //    so at least we can recreate it here ourselves.
+    //
+    // 2. If this binary is invoked by something like `cargo run --bin c2rust-instrument`,
+    //    then it's impossible to set `$RUSTFLAGS` only for the inner `cargo` that you want to add them to
+    //    without also adding them to the outer `cargo run` `cargo`.
+    //    `--rustflags` lets you do that easily.
     #[clap(long)]
     rustflags: Option<OsString>,
 

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -24,6 +24,7 @@ mod util;
 use crate::callbacks::{MirTransformCallbacks, INSTRUMENTER};
 
 use std::{
+    borrow::Borrow,
     cmp::Ordering,
     env,
     ffi::{OsStr, OsString},
@@ -58,6 +59,10 @@ struct Args {
     /// Add the runtime as an optional dependency to the instrumented crate using `cargo add`.
     #[clap(long)]
     set_runtime: bool,
+
+    /// `$RUSTFLAGS`, but as a CLI argument, not an inheritable environment variable.
+    #[clap(long)]
+    rustflags: Option<OsString>,
 
     /// `cargo` args.
     cargo_args: Vec<OsString>,
@@ -392,12 +397,40 @@ impl Drop for MetadataFile<'_> {
     }
 }
 
+trait OsStringJoin {
+    fn join(&mut self, sep: &OsStr) -> OsString;
+}
+
+impl<I, T> OsStringJoin for I
+where
+    I: Iterator<Item = T>,
+    T: Borrow<OsStr>,
+{
+    fn join(&mut self, sep: &OsStr) -> OsString {
+        match self.next() {
+            None => OsString::new(),
+            Some(first_elt) => {
+                // estimate lower bound of capacity needed
+                let (lower, _) = self.size_hint();
+                let mut result = OsString::with_capacity(sep.len() * lower);
+                result.push(first_elt.borrow());
+                self.for_each(|elt| {
+                    result.push(sep);
+                    result.push(elt.borrow());
+                });
+                result
+            }
+        }
+    }
+}
+
 /// Run as a `cargo` wrapper/plugin, the default invocation.
 fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
     let Args {
         metadata: metadata_path,
         runtime_path,
         set_runtime,
+        rustflags,
         mut cargo_args,
     } = Args::parse();
 
@@ -452,6 +485,11 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
             None => metadata_path,
         };
 
+        let rustflags = [env::var_os("RUSTFLAGS"), rustflags]
+            .into_iter()
+            .flatten()
+            .join(OsStr::new(" "));
+
         // Enable the runtime dependency.
         add_feature(&mut cargo_args, &["c2rust-analysis-rt"]);
 
@@ -459,6 +497,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
             .env(RUSTC_WRAPPER_VAR, rustc_wrapper)
             .env(RUST_SYSROOT_VAR, &sysroot)
             .env("CARGO_TARGET_DIR", &cargo_target_dir)
+            .env("RUSTFLAGS", &rustflags)
             .env(METADATA_VAR, metadata_path);
         Ok(())
     })?;

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -61,6 +61,17 @@ struct Args {
     set_runtime: bool,
 
     /// `$RUSTFLAGS`, but as a CLI argument, not an inheritable environment variable.
+    /// These flags are appended (space-separated) to the existing `$RUSTFLAGS`, if it exists.
+    ///
+    /// The reason this exists is twofold:
+    ///
+    /// 1. It would be convenient if `cargo` itself had such a `--rustflags` argument,
+    ///    so at least we can recreate it here ourselves.
+    ///
+    /// 2. If this binary is invoked by something like `cargo run --bin c2rust-instrument`,
+    ///    then it's impossible to set `$RUSTFLAGS` only for the inner `cargo` that you want to add them to
+    ///    without also adding them to the outer `cargo run` `cargo`.
+    ///    `--rustflags` lets you do that easily.
     #[clap(long)]
     rustflags: Option<OsString>,
 


### PR DESCRIPTION
Add a `--rustflags` argument to `c2rust-instrument`, as it much more easily allows you specify `$RUSTFLAGS` for the instrumentation only (and not all the other `cargo`s).  Otherwise, you have to split up the `cargo` commands and run `c2rust-instrument` directly, which can be a real pain during development.

I'm also not sure why `cargo` doesn't have this, too.

Perhaps this should only apply to `rustc_wrapper`s where we actually do instrumentation.  What do others think?