### PR TITLE
Convert `println!`s in `c2rust-instrument` to `log::trace!`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "camino",
  "cargo_metadata",
  "clap 3.2.16",
+ "env_logger",
  "fs-err",
  "fs2",
  "indexmap",

--- a/dynamic_instrumentation/Cargo.toml
+++ b/dynamic_instrumentation/Cargo.toml
@@ -19,6 +19,7 @@ camino = "1.0"
 # We don't need to edit at all, but `cargo` uses `toml-edit`, so we want to match it.
 toml_edit = "0.14"
 fs2 = "0.4"
+env_logger = "0.9"
 
 [build-dependencies]
 rustc-private-link = { path = "../rustc-private-link" }

--- a/dynamic_instrumentation/src/instrument.rs
+++ b/dynamic_instrumentation/src/instrument.rs
@@ -5,7 +5,7 @@ use c2rust_analysis_rt::HOOK_FUNCTIONS;
 use fs2::FileExt;
 use fs_err::OpenOptions;
 use indexmap::IndexSet;
-use log::debug;
+use log::{debug, info};
 use rustc_index::vec::Idx;
 use rustc_middle::mir::visit::{MutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{
@@ -378,7 +378,7 @@ impl<'tcx> Visitor<'tcx> for CollectInstrumentationPoints<'_, 'tcx> {
                     }
                 }
                 if let (&ty::FnDef(def_id, _), &Some(target)) = (func_kind, target) {
-                    println!("term: {:?}", terminator.kind);
+                    info!("term: {:?}", terminator.kind);
                     let fn_name = self.tcx().item_name(def_id);
                     if HOOK_FUNCTIONS.contains(&fn_name.as_str()) {
                         let func_def_id = self.hooks().find_from_symbol(fn_name);
@@ -486,7 +486,7 @@ pub fn insert_call<'tcx>(
     func: DefId,
     mut args: Vec<InstrumentationArg<'tcx>>,
 ) -> (BasicBlock, Local) {
-    println!("ST: {:?}", statement_index);
+    info!("ST: {:?}", statement_index);
 
     let blocks = body.basic_blocks.as_mut();
     let locals = &mut body.local_decls;

--- a/dynamic_instrumentation/src/instrument.rs
+++ b/dynamic_instrumentation/src/instrument.rs
@@ -5,7 +5,7 @@ use c2rust_analysis_rt::HOOK_FUNCTIONS;
 use fs2::FileExt;
 use fs_err::OpenOptions;
 use indexmap::IndexSet;
-use log::{debug, info};
+use log::{debug, trace};
 use rustc_index::vec::Idx;
 use rustc_middle::mir::visit::{MutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{
@@ -378,7 +378,7 @@ impl<'tcx> Visitor<'tcx> for CollectInstrumentationPoints<'_, 'tcx> {
                     }
                 }
                 if let (&ty::FnDef(def_id, _), &Some(target)) = (func_kind, target) {
-                    info!("term: {:?}", terminator.kind);
+                    trace!("term: {:?}", terminator.kind);
                     let fn_name = self.tcx().item_name(def_id);
                     if HOOK_FUNCTIONS.contains(&fn_name.as_str()) {
                         let func_def_id = self.hooks().find_from_symbol(fn_name);
@@ -486,7 +486,7 @@ pub fn insert_call<'tcx>(
     func: DefId,
     mut args: Vec<InstrumentationArg<'tcx>>,
 ) -> (BasicBlock, Local) {
-    info!("ST: {:?}", statement_index);
+    trace!("ST: {:?}", statement_index);
 
     let blocks = body.basic_blocks.as_mut();
     let locals = &mut body.local_decls;

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -354,6 +354,8 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
 }
 
 fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
     let own_exe = env::current_exe()?;
 
     let wrapping_rustc = env::var_os(RUSTC_WRAPPER_VAR).as_deref() == Some(own_exe.as_os_str());

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -56,8 +56,7 @@ main() {
             --set-runtime \
             --runtime-path "${runtime}" \
             -- run "${profile_args[@]}" \
-            -- "${args[@]}" \
-            1> instrument.out.log
+            -- "${args[@]}"
     )
     (cd pdg
         export RUST_BACKTRACE=full # print sources w/ color-eyre


### PR DESCRIPTION
The `println!`s really clutter up the output, especially for larger crates like `lighttpd`.  This emits them using an actual logger instead so that we can toggle them with just an environment variable.