### PR TITLE
README: Add note about `llvm-dev` requirement in some cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Python 3.6 or later, CMake 3.4.3 or later, and openssl (1.0) are also required. 
     apt install build-essential llvm clang libclang-dev cmake libssl-dev pkg-config python3
     ```
 
+Depending on the LLVM distribution, the `llvm-dev` package may also be required.
+
 - **Arch Linux:**
 
     ```sh

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Python 3.6 or later, CMake 3.4.3 or later, and openssl (1.0) are also required. 
     ```
 
 Depending on the LLVM distribution, the `llvm-dev` package may also be required.
+For example, the official LLVM packages from [apt.llvm.org](https://apt.llvm.org/) require `llvm-dev` to be installed.
 
 - **Arch Linux:**
 


### PR DESCRIPTION
Some LLVM distributions (e.g. LLVM 14 from the official apt.llvm.org repository) include the LLVM CMake configfile in the development package, in which cases the `llvm` package is not enough to install C2Rust.

Test/example:

```sh
wget -qO- https://apt.llvm.org/focal/pool/main/l/llvm-toolchain-14/llvm-14-dev_14.0.6~%2b%2b20220622053131%2bf28c006a5895-1~exp1~20220622173215.157_amd64.deb |
  dpkg-deb --fsys-tarfile /dev/stdin |
  tar tv |
  grep LLVMConfig.cmake
```