### PR TITLE
Refactor variadics

### DIFF
--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -107,12 +107,13 @@ impl<'c> Translation<'c> {
         CExprKind::DeclRef(_, decl_id, _) => decl_id }
         match_or! { [self.ast_context[decl_id].kind]
         CDeclKind::Function { ref name, .. } => name }
-        match (name.as_str(), args.as_slice()) {
-            ("__builtin_va_start", &[expr, _]) => self.match_vastart(expr).map(VaPart::Start),
-            ("__builtin_va_copy", &[dst_expr, src_expr]) => self
+        let name = name.strip_prefix("__builtin_va_")?;
+        match (name, args.as_slice()) {
+            ("start", &[expr, _]) => self.match_vastart(expr).map(VaPart::Start),
+            ("copy", &[dst_expr, src_expr]) => self
                 .match_vacopy(dst_expr, src_expr)
                 .map(|(did, sid)| VaPart::Copy(did, sid)),
-            ("__builtin_va_end", &[expr]) => self.match_vaend(expr).map(VaPart::End),
+            ("end", &[expr]) => self.match_vaend(expr).map(VaPart::End),
             _ => None,
         }
     }

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -34,13 +34,13 @@ impl<'c> Translation<'c> {
     }
 
     pub fn match_vastart(&self, expr: CExprId) -> Option<CDeclId> {
-        let ast_context = &self.ast_context;
+        let ast = &self.ast_context;
 
         // `struct`-based `va_list` (e.g. x86_64).
         let match_vastart_struct = || {
-            match_or! { [ast_context[expr].kind]
+            match_or! { [ast[expr].kind]
             CExprKind::ImplicitCast(_, e, _, _, _) => e }
-            match_or! { [ast_context[e].kind]
+            match_or! { [ast[e].kind]
             CExprKind::DeclRef(_, va_id, _) => va_id }
             Some(va_id)
         };
@@ -49,11 +49,11 @@ impl<'c> Translation<'c> {
         //
         // Supporting this pattern is necessary to transpile apache httpd.
         let match_vastart_struct_member = || {
-            match_or! { [ast_context[expr].kind]
+            match_or! { [ast[expr].kind]
             CExprKind::ImplicitCast(_, me, _, _, _) => me }
-            match_or! { [ast_context[me].kind]
+            match_or! { [ast[me].kind]
             CExprKind::Member(_, e, _, _, _) => e }
-            match_or! { [ast_context[e].kind]
+            match_or! { [ast[e].kind]
             CExprKind::DeclRef(_, va_id, _) => va_id }
             Some(va_id)
         };
@@ -63,20 +63,20 @@ impl<'c> Translation<'c> {
         // Supporting this pattern is necessary to transpile
         // [graphviz](https://gitlab.com/graphviz/graphviz/-/blob/5.0.0/lib/sfio/sftable.c#L321).
         let match_vastart_struct_pointer_member = || {
-            match_or! { [ast_context[expr].kind]
+            match_or! { [ast[expr].kind]
             CExprKind::ImplicitCast(_, me, _, _, _) => me }
-            match_or! { [ast_context[me].kind]
+            match_or! { [ast[me].kind]
             CExprKind::Member(_, ie, _, _, _) => ie }
-            match_or! { [ast_context[ie].kind]
+            match_or! { [ast[ie].kind]
             CExprKind::ImplicitCast(_, e, _, _, _) => e }
-            match_or! { [ast_context[e].kind]
+            match_or! { [ast[e].kind]
             CExprKind::DeclRef(_, va_id, _) => va_id }
             Some(va_id)
         };
 
         // `char *` pointer-based `va_list` (e.g. x86).
         let match_vastart_pointer = || {
-            match_or! { [ast_context[expr].kind]
+            match_or! { [ast[expr].kind]
             CExprKind::DeclRef(_, va_id, _) => va_id }
             Some(va_id)
         };

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -108,19 +108,11 @@ impl<'c> Translation<'c> {
         match_or! { [self.ast_context[decl_id].kind]
         CDeclKind::Function { ref name, .. } => name }
         match (name.as_str(), args.as_slice()) {
-            ("__builtin_va_start", &[expr, _]) => {
-                self.match_vastart(expr).map(VaPart::Start)
-            }
-
-            ("__builtin_va_copy", &[dst_expr, src_expr]) => {
-                self.match_vacopy(dst_expr, src_expr)
-                    .map(|(did, sid)| VaPart::Copy(did, sid))
-            }
-
-            ("__builtin_va_end", &[expr]) => {
-                self.match_vaend(expr).map(VaPart::End)
-            }
-
+            ("__builtin_va_start", &[expr, _]) => self.match_vastart(expr).map(VaPart::Start),
+            ("__builtin_va_copy", &[dst_expr, src_expr]) => self
+                .match_vacopy(dst_expr, src_expr)
+                .map(|(did, sid)| VaPart::Copy(did, sid)),
+            ("__builtin_va_end", &[expr]) => self.match_vaend(expr).map(VaPart::End),
             _ => None,
         }
     }

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -25,12 +25,12 @@ macro_rules! match_or {
 impl<'c> Translation<'c> {
     /// Returns true iff `va_start`, `va_end`, or `va_copy` may be called on `decl_id`.
     pub fn is_va_decl(&self, decl_id: CDeclId) -> bool {
-        let fn_ctx = self.function_context.borrow();
-        if let Some(ref decls) = fn_ctx.va_list_decl_ids {
-            decls.contains(&decl_id)
-        } else {
-            false
-        }
+        self.function_context
+            .borrow()
+            .va_list_decl_ids
+            .as_ref()
+            .map(|decls| decls.contains(&decl_id))
+            .unwrap_or_default()
     }
 
     pub fn match_vastart(&self, expr: CExprId) -> Option<CDeclId> {

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -107,7 +107,7 @@ impl<'c> Translation<'c> {
         CExprKind::DeclRef(_, decl_id, _) => decl_id }
         match_or! { [self.ast_context[decl_id].kind]
         CDeclKind::Function { ref name, .. } => name }
-        match name as &str {
+        match name.as_str() {
             "__builtin_va_start" => {
                 if args.len() != 2 {
                     return None;

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -107,18 +107,18 @@ impl<'c> Translation<'c> {
         CExprKind::DeclRef(_, decl_id, _) => decl_id }
         match_or! { [self.ast_context[decl_id].kind]
         CDeclKind::Function { ref name, .. } => name }
-        match name.as_str() {
-            "__builtin_va_start" if args.len() == 2 => {
-                self.match_vastart(args[0]).map(VaPart::Start)
+        match (name.as_str(), args.as_slice()) {
+            ("__builtin_va_start", &[expr, _]) => {
+                self.match_vastart(expr).map(VaPart::Start)
             }
 
-            "__builtin_va_copy" if args.len() == 2 => {
-                self.match_vacopy(args[0], args[1])
+            ("__builtin_va_copy", &[dst_expr, src_expr]) => {
+                self.match_vacopy(dst_expr, src_expr)
                     .map(|(did, sid)| VaPart::Copy(did, sid))
             }
 
-            "__builtin_va_end" if args.len() == 1 => {
-                self.match_vaend(args[0]).map(VaPart::End)
+            ("__builtin_va_end", &[expr]) => {
+                self.match_vaend(expr).map(VaPart::End)
             }
 
             _ => None,

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -23,7 +23,7 @@ macro_rules! match_or {
 }
 
 impl<'c> Translation<'c> {
-    /// Returns true iff `va_start`, `va_end`, or `va_copy` may be called on `decl_id`.
+    /// Returns `true` iff `va_start`, `va_end`, or `va_copy` may be called on `decl_id`.
     pub fn is_va_decl(&self, decl_id: CDeclId) -> bool {
         self.function_context
             .borrow()
@@ -34,7 +34,7 @@ impl<'c> Translation<'c> {
     }
 
     pub fn match_vastart(&self, expr: CExprId) -> Option<CDeclId> {
-        // struct-based va_list (e.g. x86_64)
+        /// `struct`-based `va_list` (e.g. x86_64).
         fn match_vastart_struct(ast_context: &TypedAstContext, expr: CExprId) -> Option<CDeclId> {
             match_or! { [ast_context[expr].kind]
             CExprKind::ImplicitCast(_, e, _, _, _) => e }
@@ -43,8 +43,9 @@ impl<'c> Translation<'c> {
             Some(va_id)
         }
 
-        // struct-based va_list (e.g. x86_64) where va_list is accessed as a struct member
-        // supporting this pattern is necessary to transpile apache httpd
+        /// `struct`-based `va_list` (e.g. x86_64) where `va_list` is accessed as a `struct` member.
+        /// 
+        /// Supporting this pattern is necessary to transpile apache httpd.
         fn match_vastart_struct_member(
             ast_context: &TypedAstContext,
             expr: CExprId,
@@ -58,8 +59,10 @@ impl<'c> Translation<'c> {
             Some(va_id)
         }
 
-        // struct-based va_list (e.g. x86_64) where va_list is accessed as a member of a struct pointer
-        // supporting this pattern is necessary to transpile [graphviz](https://gitlab.com/graphviz/graphviz/-/blob/5.0.0/lib/sfio/sftable.c#L321)
+        /// `struct`-based `va_list` (e.g. x86_64) where `va_list` is accessed as a member of a `struct *` pointer.
+        /// 
+        /// Supporting this pattern is necessary to transpile
+        /// [graphviz](https://gitlab.com/graphviz/graphviz/-/blob/5.0.0/lib/sfio/sftable.c#L321).
         fn match_vastart_struct_pointer_member(
             ast_context: &TypedAstContext,
             expr: CExprId,
@@ -75,7 +78,7 @@ impl<'c> Translation<'c> {
             Some(va_id)
         }
 
-        // char pointer-based va_list (e.g. x86)
+        /// `char *` pointer-based `va_list` (e.g. x86).
         fn match_vastart_pointer(ast_context: &TypedAstContext, expr: CExprId) -> Option<CDeclId> {
             match_or! { [ast_context[expr].kind]
             CExprKind::DeclRef(_, va_id, _) => va_id }

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -108,25 +108,16 @@ impl<'c> Translation<'c> {
         match_or! { [self.ast_context[decl_id].kind]
         CDeclKind::Function { ref name, .. } => name }
         match name.as_str() {
-            "__builtin_va_start" => {
-                if args.len() != 2 {
-                    return None;
-                }
+            "__builtin_va_start" if args.len() == 2 => {
                 self.match_vastart(args[0]).map(VaPart::Start)
             }
 
-            "__builtin_va_copy" => {
-                if args.len() != 2 {
-                    return None;
-                }
+            "__builtin_va_copy" if args.len() == 2 => {
                 self.match_vacopy(args[0], args[1])
                     .map(|(did, sid)| VaPart::Copy(did, sid))
             }
 
-            "__builtin_va_end" => {
-                if args.len() != 1 {
-                    return None;
-                }
+            "__builtin_va_end" if args.len() == 1 => {
                 self.match_vaend(args[0]).map(VaPart::End)
             }
 

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -93,12 +93,9 @@ impl<'c> Translation<'c> {
     }
 
     pub fn match_vacopy(&self, dst_expr: CExprId, src_expr: CExprId) -> Option<(CDeclId, CDeclId)> {
-        let dst_id = self.match_vastart(dst_expr);
-        let src_id = self.match_vastart(src_expr);
-        if let (Some(did), Some(sid)) = (dst_id, src_id) {
-            return Some((did, sid));
-        }
-        None
+        let dst_id = self.match_vastart(dst_expr)?;
+        let src_id = self.match_vastart(src_expr)?;
+        Some((dst_id, src_id))
     }
 
     pub fn match_vapart(&self, expr: CExprId) -> Option<VaPart> {


### PR DESCRIPTION
These are various refactors of the variadics code I made when reviewing #612:

Notably, I felt `match_or!` was quite un-idiomatic as it contained hidden non-local control flow (`return None`) and defined variables in a non-intuitive way.  Thus, I removed these.  Using `?` makes the control flow not any longer but much clearer, and now we have to use actual `let`s, but this improves readability a lot and allows inlay type hints to work, which are very useful.

It might be easier to review by reviewing each commit individually.