### PR TITLE
Add `c2rust-instrument --rustflags`

### DIFF
--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -58,18 +58,20 @@ struct Args {
     #[clap(long)]
     set_runtime: bool,
 
-    /// `$RUSTFLAGS`, but as a CLI argument, not an inheritable environment variable.
-    /// These flags are appended (space-separated) to the existing `$RUSTFLAGS`, if it exists.
+    /// Set `$RUSTFLAGS` for the instrumented `cargo`.
     ///
-    /// The reason this exists is twofold:
-    ///
-    /// 1. It would be convenient if `cargo` itself had such a `--rustflags` argument,
-    ///    so at least we can recreate it here ourselves.
-    ///
-    /// 2. If this binary is invoked by something like `cargo run --bin c2rust-instrument`,
-    ///    then it's impossible to set `$RUSTFLAGS` only for the inner `cargo` that you want to add them to
-    ///    without also adding them to the outer `cargo run` `cargo`.
-    ///    `--rustflags` lets you do that easily.
+    /// This allows setting `$RUSTFLAGS` for the inner `cargo` when `c2rust-instrument` is invoked via `cargo run`, for example.
+    /// If `$RUSTFLAGS` is already set, these `--rustflags` are appended with a space.
+    //
+    // The reason this exists is twofold:
+    //
+    // 1. It would be convenient if `cargo` itself had such a `--rustflags` argument,
+    //    so at least we can recreate it here ourselves.
+    //
+    // 2. If this binary is invoked by something like `cargo run --bin c2rust-instrument`,
+    //    then it's impossible to set `$RUSTFLAGS` only for the inner `cargo` that you want to add them to
+    //    without also adding them to the outer `cargo run` `cargo`.
+    //    `--rustflags` lets you do that easily.
     #[clap(long)]
     rustflags: Option<OsString>,
 

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -59,6 +59,17 @@ struct Args {
     set_runtime: bool,
 
     /// `$RUSTFLAGS`, but as a CLI argument, not an inheritable environment variable.
+    /// These flags are appended (space-separated) to the existing `$RUSTFLAGS`, if it exists.
+    ///
+    /// The reason this exists is twofold:
+    ///
+    /// 1. It would be convenient if `cargo` itself had such a `--rustflags` argument,
+    ///    so at least we can recreate it here ourselves.
+    ///
+    /// 2. If this binary is invoked by something like `cargo run --bin c2rust-instrument`,
+    ///    then it's impossible to set `$RUSTFLAGS` only for the inner `cargo` that you want to add them to
+    ///    without also adding them to the outer `cargo run` `cargo`.
+    ///    `--rustflags` lets you do that easily.
     #[clap(long)]
     rustflags: Option<OsString>,
 


### PR DESCRIPTION
Reopening #629.  It was merged early.  It was done and ready to merge, but I was waiting to merge it directly into `master` once the 2 PRs in front of it merged.

Add a `--rustflags` argument to `c2rust-instrument`, as it much more easily allows you specify `$RUSTFLAGS` for the instrumentation only (and not all the other `cargo`s).  Otherwise, you have to split up the `cargo` commands and run `c2rust-instrument` directly, which can be a real pain during development.

I'm also not sure why `cargo` doesn't have this, too.

Perhaps this should only apply to `rustc_wrapper`s where we actually do instrumentation.  What do others think?