### PR TITLE
Extract `find_llvm_config` so it's reusable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ name = "c2rust-ast-exporter"
 version = "0.16.0"
 dependencies = [
  "bindgen",
+ "c2rust-build-paths",
  "clang-sys",
  "cmake",
  "env_logger",

--- a/c2rust-ast-exporter/Cargo.toml
+++ b/c2rust-ast-exporter/Cargo.toml
@@ -26,6 +26,7 @@ clang-sys = "1.3"
 # Fixed by https://github.com/rust-lang/cmake-rs/pull/146 on 5/12/2022; waiting for next release.
 cmake = "=0.1.45"
 env_logger = "0.9"
+c2rust-build-paths = { path = "../c2rust-build-paths" }
 
 [features]
 default = []

--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -1,8 +1,9 @@
+use c2rust_build_paths::find_llvm_config;
 use cmake::Config;
 use std::env;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-use std::process::{self, Command, Stdio};
+use std::process::{self, Command};
 
 // Use `cargo build -vv` to get detailed output on this script's progress.
 
@@ -211,60 +212,6 @@ struct LLVMInfo {
 
 impl LLVMInfo {
     fn new() -> Self {
-        fn find_llvm_config() -> Option<String> {
-            // Explicitly provided path in LLVM_CONFIG_PATH
-            env::var("LLVM_CONFIG_PATH")
-                .ok()
-                .or_else(|| {
-                    // Relative to LLVM_LIB_DIR
-                    env::var("LLVM_LIB_DIR").ok().map(|d| {
-                        String::from(
-                            Path::new(&d)
-                                .join("../bin/llvm-config")
-                                .canonicalize()
-                                .unwrap()
-                                .to_string_lossy(),
-                        )
-                    })
-                })
-                .or_else(|| {
-                    // In PATH
-                    [
-                        "llvm-config-14",
-                        "llvm-config-13",
-                        "llvm-config-12",
-                        "llvm-config-11",
-                        "llvm-config-10",
-                        "llvm-config-9",
-                        "llvm-config-8",
-                        "llvm-config-7",
-                        "llvm-config-7.0",
-                        "llvm-config",
-                        // Homebrew install locations on MacOS
-                        "/usr/local/opt/llvm@13/bin/llvm-config",
-                        "/usr/local/opt/llvm@12/bin/llvm-config",
-                        "/usr/local/opt/llvm@11/bin/llvm-config",
-                        "/usr/local/opt/llvm@10/bin/llvm-config",
-                        "/usr/local/opt/llvm@9/bin/llvm-config",
-                        "/usr/local/opt/llvm@8/bin/llvm-config",
-                        "/usr/local/opt/llvm/bin/llvm-config",
-                    ]
-                    .iter()
-                    .find_map(|c| {
-                        if Command::new(c)
-                            .stdout(Stdio::null())
-                            .stderr(Stdio::null())
-                            .spawn()
-                            .is_ok()
-                        {
-                            Some(String::from(*c))
-                        } else {
-                            None
-                        }
-                    })
-                })
-        }
-
         /// Invoke given `command`, if any, with the specified arguments.
         fn invoke_command<I, S>(command: Option<&String>, args: I) -> Option<String>
         where

--- a/c2rust-build-paths/src/lib.rs
+++ b/c2rust-build-paths/src/lib.rs
@@ -2,7 +2,7 @@ use std::{
     env,
     ffi::OsStr,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
     str,
 };
 
@@ -70,4 +70,58 @@ impl SysRoot {
         print_cargo_path("rustc-link-search=native=", &lib);
         print_cargo_path("rustc-link-arg=-Wl,-rpath,", &lib);
     }
+}
+
+pub fn find_llvm_config() -> Option<String> {
+    // Explicitly provided path in LLVM_CONFIG_PATH
+    env::var("LLVM_CONFIG_PATH")
+        .ok()
+        .or_else(|| {
+            // Relative to LLVM_LIB_DIR
+            env::var("LLVM_LIB_DIR").ok().map(|d| {
+                String::from(
+                    Path::new(&d)
+                        .join("../bin/llvm-config")
+                        .canonicalize()
+                        .unwrap()
+                        .to_string_lossy(),
+                )
+            })
+        })
+        .or_else(|| {
+            // In PATH
+            [
+                "llvm-config-14",
+                "llvm-config-13",
+                "llvm-config-12",
+                "llvm-config-11",
+                "llvm-config-10",
+                "llvm-config-9",
+                "llvm-config-8",
+                "llvm-config-7",
+                "llvm-config-7.0",
+                "llvm-config",
+                // Homebrew install locations on MacOS
+                "/usr/local/opt/llvm@13/bin/llvm-config",
+                "/usr/local/opt/llvm@12/bin/llvm-config",
+                "/usr/local/opt/llvm@11/bin/llvm-config",
+                "/usr/local/opt/llvm@10/bin/llvm-config",
+                "/usr/local/opt/llvm@9/bin/llvm-config",
+                "/usr/local/opt/llvm@8/bin/llvm-config",
+                "/usr/local/opt/llvm/bin/llvm-config",
+            ]
+            .iter()
+            .find_map(|c| {
+                if Command::new(c)
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .is_ok()
+                {
+                    Some(String::from(*c))
+                } else {
+                    None
+                }
+            })
+        })
 }


### PR DESCRIPTION
Extract `find_llvm_config` from `c2rust-ast-exporter/build.rs` to `build-utils` so that it can be reused elsewhere (like `FileCheck` resolving in `c2rust-analyze`'s tests).

I accidentally messed up the branches in #618 (I messed things up, then fixed it, but pushed them in the wrong order, so GitHub thought I merged the PR with 0 commits).  This is the same as #618.