### PR TITLE
Remove `camino`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,6 @@ dependencies = [
  "anyhow",
  "c2rust-build-paths",
  "c2rust-transpile",
- "camino",
  "clap 2.34.0",
  "env_logger",
  "git-testament",
@@ -246,7 +245,6 @@ dependencies = [
  "bincode",
  "c2rust-analysis-rt",
  "c2rust-build-paths",
- "camino",
  "clap 3.2.16",
  "env_logger",
  "fs-err",
@@ -309,12 +307,6 @@ dependencies = [
  "strum_macros",
  "syn",
 ]
-
-[[package]]
-name = "camino"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
 
 [[package]]
 name = "cc"

--- a/c2rust/Cargo.toml
+++ b/c2rust/Cargo.toml
@@ -18,7 +18,6 @@ azure-devops = { project = "immunant/c2rust", pipeline = "immunant.c2rust", buil
 
 [dependencies]
 anyhow = "1.0"
-camino = "1.0"
 clap = { version = "2.34", features = ["yaml"] }
 env_logger = "0.9"
 git-testament = "0.2.1"

--- a/c2rust/src/main.rs
+++ b/c2rust/src/main.rs
@@ -1,5 +1,4 @@
 use anyhow::anyhow;
-use camino::Utf8Path;
 use clap::{crate_authors, App, AppSettings, Arg};
 use git_testament::{git_testament, render_testament};
 use is_executable::IsExecutable;
@@ -7,7 +6,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::env;
 use std::ffi::OsStr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process;
 use std::process::Command;
 use std::str;
@@ -29,12 +28,11 @@ impl SubCommand {
     /// They are of the form `c2rust-{name}`.
     pub fn find_all() -> anyhow::Result<Vec<Self>> {
         let c2rust = env::current_exe()?;
-        let c2rust_name: &Utf8Path = c2rust
+        let c2rust_name = c2rust
             .file_name()
-            .map(Path::new)
-            .ok_or_else(|| anyhow!("no file name: {}", c2rust.display()))?
-            .try_into()?;
-        let c2rust_name = c2rust_name.as_str();
+            .ok_or_else(|| anyhow!("no file name for c2rust: {}", c2rust.display()))?
+            .to_str()
+            .ok_or_else(|| anyhow!("c2rust file name is not UTF-8: {}", c2rust.display()))?;
         let dir = c2rust
             .parent()
             .ok_or_else(|| anyhow!("no directory: {}", c2rust.display()))?;

--- a/dynamic_instrumentation/Cargo.toml
+++ b/dynamic_instrumentation/Cargo.toml
@@ -13,7 +13,6 @@ once_cell = "1.13"
 log = "0.4"
 fs-err = "2"
 clap = { version = "3.2", features = ["derive"] }
-camino = "1.0"
 # Used for parsing `rust-toolchain.toml`.
 # We don't need to edit at all, but `cargo` uses `toml-edit`, so we want to match it.
 toml_edit = "0.14"


### PR DESCRIPTION
`camino` is now only used in 2 places and is not very necessary anymore.  This replaces the `&camino::Utf8Path` usages with `&str` and custom error messages, and then removes `camino` as a dependency from the whole workspace.