### PR TITLE
Add address-taken local support in dynamic analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "env_logger",
  "fs-err",
  "indexed_vec",
+ "indexmap",
  "insta",
  "itertools",
  "linked_hash_set",

--- a/analysis/runtime/src/handlers.rs
+++ b/analysis/runtime/src/handlers.rs
@@ -174,3 +174,17 @@ pub fn ptr_store(mir_loc: MirLocId, ptr: usize) {
         kind: EventKind::StoreAddr(ptr),
     });
 }
+
+pub fn ptr_store_addr_taken(mir_loc: MirLocId, ptr: usize) {
+    RUNTIME.send_event(Event {
+        mir_loc,
+        kind: EventKind::StoreAddrTaken(ptr),
+    });
+}
+
+pub fn mark_begin_body(mir_loc: MirLocId) {
+    RUNTIME.send_event(Event {
+        mir_loc,
+        kind: EventKind::BeginFuncBody,
+    })
+}

--- a/analysis/test/src/main.rs
+++ b/analysis/test/src/main.rs
@@ -1,6 +1,7 @@
 #![feature(extern_types)]
 #![feature(label_break_value)]
 #![feature(rustc_private)]
+#![feature(c_variadic)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/dynamic_instrumentation/src/point/cast.rs
+++ b/dynamic_instrumentation/src/point/cast.rs
@@ -8,10 +8,7 @@ use rustc_middle::{
 };
 use rustc_span::DUMMY_SP;
 
-use crate::{
-    arg::{ArgKind, InstrumentationArg},
-    mir_utils::remove_outer_deref,
-};
+use crate::arg::{ArgKind, InstrumentationArg};
 
 /// Cast an argument from pointer to `usize`, if needed.
 ///
@@ -76,7 +73,6 @@ pub fn cast_ptr_to_usize<'tcx>(
         // create a raw ptr with `addr_of!`.
         InstrumentationArg::AddrOf(arg) => {
             let arg_place = arg.place().expect("Can't get the address of a constant");
-            let arg_place = remove_outer_deref(arg_place, tcx);
 
             let arg_ty = arg_place.ty(locals, tcx).ty;
             let inner_ty = ty::TypeAndMut {

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 bincode = "1.0"
 c2rust-analysis-rt = { path = "../analysis/runtime"}
 indexed_vec = "1.2"
+indexmap = "1.8"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 env_logger = "0.9"

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -325,6 +325,24 @@ impl Graphs {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// The [`Node::dest`] node of [`AddrOfLocal`]is always `Some(local)`
+    /// and is used in determining the sources of subsequent PDG nodes.
+    /// However, for the purposes of static analysis, it's undesired
+    /// and therefore destinations of [`AddrOfLocal`] [`Node`]s are removed.
+    ///
+    /// [`AddrOfLocal`]: NodeKind::AddrOfLocal
+    /// [`Node`]: crate::graph::Node
+    /// [`Node::dest`]: crate::graph::Node::dest
+    pub fn remove_addr_of_local_sources(&mut self) {
+        for graph in &mut self.graphs {
+            for node in &mut graph.nodes {
+                if let NodeKind::AddrOfLocal(..) = node.kind {
+                    node.dest = None;
+                }
+            }
+        }
+    }
 }
 
 impl Display for Graphs {

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -66,6 +66,7 @@ impl Pdg {
         let metadata = read_metadata(metadata_path)?;
         let mut graphs = construct_pdg(&events, &metadata);
         add_info(&mut graphs);
+        graphs.remove_addr_of_local_sources();
         Ok(Self {
             events,
             metadata,

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
@@ -3,37 +3,37 @@ source: pdg/src/main.rs
 expression: pdg
 ---
 g {
-	n[0]: &_1  _    => _11 @ bb3[9]: fn main;   _11 = &_1;
-	n[1]: copy n[0] => _1  @ bb0[0]: fn deref;  _10 = deref(move _11);
+	n[0]: &_1  _    => _   @ bb3[0]:  fn main;   _23 = &raw mut _1;
+	n[1]: copy n[0] => _11 @ bb3[10]: fn main;   _11 = &(*_23);
+	n[2]: copy n[1] => _1  @ bb0[0]:  fn deref;  _10 = deref(move _11);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: copy _    => _10 @ bb3[10]: fn main;  _10 = deref(move _11);
+	n[0]: copy _    => _10 @ bb3[11]: fn main;  _10 = deref(move _11);
 	n[1]: copy n[0] => _9  @ bb4[0]:  fn main;  _9 = &(*_10);
 	n[2]: copy n[1] => _1  @ bb0[0]:  fn iter;  _8 = iter(move _9);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: copy        _    => _14   @ bb6[4]:  fn main;                _14 = null_mut();
-	n[1]: copy        n[0] => _1    @ bb0[0]:  fn once;                _13 = once(move _14);
-	n[2]: int_to_ptr  _    => _17   @ bb4[29]: fn simple;              _17 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
-	n[3]: value.store _    => _20.* @ bb4[7]:  fn invalid;             (*_20) = const 0_usize as *mut pointers::S (PointerFromExposedAddress);
-	n[4]: value.store _    => _17.* @ bb8[4]:  fn fdevent_unregister;  (*_17) = const 0_usize as *mut pointers::fdnode_st (PointerFromExposedAddress);
-	n[5]: int_to_ptr  _    => _2    @ bb0[2]:  fn test_ref_field;      _2 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
-	n[6]: int_to_ptr  _    => _5    @ bb0[8]:  fn test_ref_field;      _5 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[0]: copy        _    => _14    @ bb6[4]:  fn main;                 _14 = null_mut();
+	n[1]: copy        n[0] => _1     @ bb0[0]:  fn once;                 _13 = once(move _14);
+	n[2]: int_to_ptr  _    => _17    @ bb4[29]: fn simple;               _17 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[3]: value.store _    => _20.*  @ bb4[7]:  fn invalid;              (*_20) = const 0_usize as *mut pointers::S (PointerFromExposedAddress);
+	n[4]: value.store _    => _17.*  @ bb8[4]:  fn fdevent_unregister;   (*_17) = const 0_usize as *mut pointers::fdnode_st (PointerFromExposedAddress);
+	n[5]: int_to_ptr  _    => _2     @ bb0[2]:  fn test_ref_field;       _2 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[6]: int_to_ptr  _    => _5     @ bb0[8]:  fn test_ref_field;       _5 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[7]: int_to_ptr  _    => _51    @ bb36[3]: fn main_0;               _51 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[8]: value.store _    => _3.*.2 @ bb0[1]:  fn test_addr_taken_arg;  ((*_3).2: *const pointers::S) = const 0_usize as *const pointers::S (PointerFromExposedAddress);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: &_5  _    => _19 @ bb10[8]: fn main;  _19 = &_5;
-	n[1]: copy n[0] => _1  @ bb0[0]:  fn len;   _18 = len(move _19);
-}
-nodes_that_need_write = []
-
-g {
-	n[0]: &_5 _ => _22 @ bb12[6]: fn main;  _22 = &mut _5;
+	n[0]: &_5  _    => _   @ bb10[0]: fn main;  _24 = &raw mut _5;
+	n[1]: copy n[0] => _19 @ bb10[9]: fn main;  _19 = &(*_24);
+	n[2]: copy n[1] => _1  @ bb0[0]:  fn len;   _18 = len(move _19);
+	n[3]: copy n[0] => _22 @ bb12[6]: fn main;  _22 = &mut (*_24);
 }
 nodes_that_need_write = []
 
@@ -70,38 +70,34 @@ g {
 	n[12]: field.0     n[3]  => _13    @ bb4[18]: fn simple;  _13 = ((*_1).0: i32);
 	n[13]: addr.load   n[12] => _      @ bb4[18]: fn simple;  _13 = ((*_1).0: i32);
 	n[14]: field.1     n[3]  => _14    @ bb4[21]: fn simple;  _14 = &raw const ((*_1).1: u64);
-	n[15]: copy        n[3]  => _15    @ bb4[24]: fn simple;  _15 = &raw const (*_1);
-	n[16]: field.2     n[3]  => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
-	n[17]: addr.store  n[16] => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
-	n[18]: value.store n[15] => _1.*.2 @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
-	n[19]: field.3     n[1]  => _      @ bb4[32]: fn simple;  ((*_6).3: pointers::T) = move _16;
-	n[20]: addr.store  n[19] => _      @ bb4[32]: fn simple;  ((*_6).3: pointers::T) = move _16;
-	n[21]: addr.load   n[1]  => _      @ bb4[35]: fn simple;  _18 = (*_6);
-	n[22]: addr.store  n[3]  => _      @ bb4[39]: fn simple;  (*_1) = move _19;
-	n[23]: copy        n[3]  => _21    @ bb4[43]: fn simple;  _21 = _1;
-	n[24]: copy        n[23] => _2     @ bb0[0]:  fn recur;   _20 = recur(const 3_i32, move _21);
-	n[25]: copy        n[24] => _13    @ bb8[3]:  fn recur;   _13 = _2;
-	n[26]: copy        n[25] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
-	n[27]: copy        n[26] => _13    @ bb8[3]:  fn recur;   _13 = _2;
-	n[28]: copy        n[27] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
-	n[29]: copy        n[28] => _13    @ bb8[3]:  fn recur;   _13 = _2;
-	n[30]: copy        n[29] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
-	n[31]: copy        n[30] => _8     @ bb1[2]:  fn recur;   _8 = _2;
-	n[32]: copy        n[31] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (Misc);
-	n[33]: free        n[32] => _0     @ bb1[5]:  fn recur;   _0 = free(move _7);
-	n[34]: copy        n[30] => _14    @ bb9[4]:  fn recur;   _14 = _2;
-	n[35]: copy        n[30] => _14    @ bb9[4]:  fn recur;   _14 = _2;
-	n[36]: copy        n[30] => _14    @ bb9[4]:  fn recur;   _14 = _2;
+	n[15]: copy        n[14] => _14    @ bb4[21]: fn simple;  _14 = &raw const ((*_1).1: u64);
+	n[16]: copy        n[3]  => _15    @ bb4[24]: fn simple;  _15 = &raw const (*_1);
+	n[17]: field.2     n[3]  => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
+	n[18]: addr.store  n[17] => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
+	n[19]: value.store n[16] => _1.*.2 @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
+	n[20]: field.3     n[1]  => _      @ bb4[32]: fn simple;  ((*_6).3: pointers::T) = move _16;
+	n[21]: addr.store  n[20] => _      @ bb4[32]: fn simple;  ((*_6).3: pointers::T) = move _16;
+	n[22]: addr.load   n[1]  => _      @ bb4[35]: fn simple;  _18 = (*_6);
+	n[23]: addr.store  n[3]  => _      @ bb4[39]: fn simple;  (*_1) = move _19;
+	n[24]: copy        n[3]  => _21    @ bb4[43]: fn simple;  _21 = _1;
+	n[25]: copy        n[24] => _2     @ bb0[0]:  fn recur;   _20 = recur(const 3_i32, move _21);
+	n[26]: copy        n[25] => _13    @ bb8[3]:  fn recur;   _13 = _2;
+	n[27]: copy        n[26] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
+	n[28]: copy        n[27] => _13    @ bb8[3]:  fn recur;   _13 = _2;
+	n[29]: copy        n[28] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
+	n[30]: copy        n[29] => _13    @ bb8[3]:  fn recur;   _13 = _2;
+	n[31]: copy        n[30] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
+	n[32]: copy        n[31] => _8     @ bb1[2]:  fn recur;   _8 = _2;
+	n[33]: copy        n[32] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (Misc);
+	n[34]: free        n[33] => _0     @ bb1[5]:  fn recur;   _0 = free(move _7);
+	n[35]: copy        n[31] => _14    @ bb9[4]:  fn recur;   _14 = _2;
+	n[36]: copy        n[31] => _14    @ bb9[4]:  fn recur;   _14 = _2;
+	n[37]: copy        n[31] => _14    @ bb9[4]:  fn recur;   _14 = _2;
 }
-nodes_that_need_write = [22, 20, 19, 17, 16, 11, 10, 9, 8, 5, 4, 3, 2, 1, 0]
+nodes_that_need_write = [23, 21, 20, 18, 17, 11, 10, 9, 8, 5, 4, 3, 2, 1, 0]
 
 g {
-	n[0]: &_1 _ => _10 @ bb4[5]: fn simple;  _10 = &raw const ((*_1).0: i32);
-}
-nodes_that_need_write = []
-
-g {
-	n[0]: &_1 _ => _14 @ bb4[21]: fn simple;  _14 = &raw const ((*_1).1: u64);
+	n[0]: &_1 _ => _ @ bb4[5]: fn simple;  _10 = &raw const ((*_1).0: i32);
 }
 nodes_that_need_write = []
 
@@ -393,23 +389,23 @@ g {
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
-	n[0]: &_1  _    => _4 @ bb0[8]: fn testing;  _4 = &mut _1;
-	n[1]: copy n[0] => _3 @ bb0[9]: fn testing;  _3 = &raw mut (*_4);
-}
-nodes_that_need_write = []
-
-g {
-	n[0]: &_3        _    => _5 @ bb0[13]: fn testing;  _5 = &mut _3;
-	n[1]: addr.store n[0] => _  @ bb0[18]: fn testing;  (*_5) = move _6;
+	n[0]: &_1         _    => _    @ bb0[2]:  fn testing;  _8 = &raw mut _1;
+	n[1]: addr.store  n[0] => _    @ bb0[1]:  fn testing;  _1 = const 10_i32;
+	n[2]: copy        n[0] => _4   @ bb0[9]:  fn testing;  _4 = &mut (*_8);
+	n[3]: copy        n[2] => _3   @ bb0[10]: fn testing;  _3 = &raw mut (*_4);
+	n[4]: copy        n[0] => _7   @ bb0[18]: fn testing;  _7 = &mut (*_8);
+	n[5]: copy        n[4] => _6   @ bb0[19]: fn testing;  _6 = &raw mut (*_7);
+	n[6]: value.store n[5] => _5.* @ bb0[20]: fn testing;  (*_5) = move _6;
 }
 nodes_that_need_write = [1, 0]
 
 g {
-	n[0]: &_1         _    => _7   @ bb0[16]: fn testing;  _7 = &mut _1;
-	n[1]: copy        n[0] => _6   @ bb0[17]: fn testing;  _6 = &raw mut (*_7);
-	n[2]: value.store n[1] => _5.* @ bb0[18]: fn testing;  (*_5) = move _6;
+	n[0]: &_3        _    => _  @ bb0[11]: fn testing;  _9 = &raw mut _3;
+	n[1]: addr.store n[0] => _  @ bb0[10]: fn testing;  _3 = &raw mut (*_4);
+	n[2]: copy       n[0] => _5 @ bb0[15]: fn testing;  _5 = &mut (*_9);
+	n[3]: addr.store n[2] => _  @ bb0[20]: fn testing;  (*_5) = move _6;
 }
-nodes_that_need_write = []
+nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn simple1;  _2 = malloc(move _3);
@@ -417,8 +413,8 @@ g {
 	n[2]: copy       n[1] => _8  @ bb2[8]:  fn simple1;  _8 = _1;
 	n[3]: copy       n[2] => _7  @ bb2[9]:  fn simple1;  _7 = move _8 as *mut libc::c_void (Misc);
 	n[4]: free       n[3] => _6  @ bb3[2]:  fn simple1;  _6 = realloc(move _7, move _9);
-	n[5]: copy       n[1] => _16 @ bb4[20]: fn simple1;  _16 = _1;
-	n[6]: ptr_to_int n[5] => _   @ bb4[21]: fn simple1;  _15 = move _16 as usize (PointerExposeAddress);
+	n[5]: copy       n[1] => _16 @ bb4[21]: fn simple1;  _16 = _1;
+	n[6]: ptr_to_int n[5] => _   @ bb4[22]: fn simple1;  _15 = move _16 as usize (PointerExposeAddress);
 }
 nodes_that_need_write = []
 
@@ -430,17 +426,19 @@ g {
 	n[4]:  addr.store n[3] => _   @ bb4[8]:  fn simple1;  ((*_11).0: i32) = const 10_i32;
 	n[5]:  copy       n[1] => _12 @ bb4[10]: fn simple1;  _12 = _5;
 	n[6]:  copy       n[2] => _13 @ bb4[13]: fn simple1;  _13 = _11;
-	n[7]:  int_to_ptr _    => _17 @ bb4[27]: fn simple1;  _17 = move _18 as *const libc::c_void (PointerFromExposedAddress);
-	n[8]:  copy       n[1] => _21 @ bb4[33]: fn simple1;  _21 = _5;
-	n[9]:  copy       n[8] => _20 @ bb4[34]: fn simple1;  _20 = move _21 as *mut libc::c_void (Misc);
-	n[10]: free       n[9] => _19 @ bb4[36]: fn simple1;  _19 = free(move _20);
+	n[7]:  int_to_ptr _    => _17 @ bb4[28]: fn simple1;  _17 = move _18 as *const libc::c_void (PointerFromExposedAddress);
+	n[8]:  copy       n[1] => _21 @ bb4[34]: fn simple1;  _21 = _5;
+	n[9]:  copy       n[8] => _20 @ bb4[35]: fn simple1;  _20 = move _21 as *mut libc::c_void (Misc);
+	n[10]: free       n[9] => _19 @ bb4[37]: fn simple1;  _19 = free(move _20);
 }
 nodes_that_need_write = [4, 3, 2, 1, 0]
 
 g {
-	n[0]: &_13 _ => _14 @ bb4[16]: fn simple1;  _14 = &raw const _13;
+	n[0]: &_13       _    => _   @ bb4[14]: fn simple1;  _22 = &raw mut _13;
+	n[1]: addr.store n[0] => _   @ bb4[13]: fn simple1;  _13 = _11;
+	n[2]: copy       n[0] => _14 @ bb4[17]: fn simple1;  _14 = &raw const (*_22);
 }
-nodes_that_need_write = []
+nodes_that_need_write = [1, 0]
 
 g {
 	n[0]:  alloc       _     => _2     @ bb1[2]:  fn lighttpd_test;       _2 = malloc(move _3);
@@ -492,19 +490,21 @@ g {
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
-	n[0]:  &_11      _    => _10 @ bb4[14]: fn lighttpd_test;        _10 = &mut _11;
-	n[1]:  copy      n[0] => _14 @ bb4[17]: fn lighttpd_test;        _14 = &raw mut (*_10);
-	n[2]:  copy      n[1] => _1  @ bb0[0]:  fn connection_accepted;  _13 = connection_accepted(move _14, const 0_i32);
-	n[3]:  field.0   n[2] => _10 @ bb2[10]: fn connection_accepted;  _10 = ((*_1).0: *mut pointers::fdevents);
-	n[4]:  addr.load n[3] => _   @ bb2[10]: fn connection_accepted;  _10 = ((*_1).0: *mut pointers::fdevents);
-	n[5]:  copy      n[3] => _16 @ bb5[4]:  fn lighttpd_test;        _16 = &raw mut (*_10);
-	n[6]:  copy      n[5] => _1  @ bb0[0]:  fn connection_close;     _15 = connection_close(move _16, move _17);
-	n[7]:  field.0   n[6] => _4  @ bb0[2]:  fn connection_close;     _4 = ((*_1).0: *mut pointers::fdevents);
-	n[8]:  addr.load n[7] => _   @ bb0[2]:  fn connection_close;     _4 = ((*_1).0: *mut pointers::fdevents);
-	n[9]:  field.0   n[6] => _7  @ bb1[5]:  fn connection_close;     _7 = ((*_1).0: *mut pointers::fdevents);
-	n[10]: addr.load n[9] => _   @ bb1[5]:  fn connection_close;     _7 = ((*_1).0: *mut pointers::fdevents);
+	n[0]:  &_11       _     => _   @ bb4[12]: fn lighttpd_test;        _24 = &raw mut _11;
+	n[1]:  addr.store n[0]  => _   @ bb4[11]: fn lighttpd_test;        _11 = pointers::server { ev: move _12 };
+	n[2]:  copy       n[0]  => _10 @ bb4[15]: fn lighttpd_test;        _10 = &mut (*_24);
+	n[3]:  copy       n[2]  => _14 @ bb4[18]: fn lighttpd_test;        _14 = &raw mut (*_10);
+	n[4]:  copy       n[3]  => _1  @ bb0[0]:  fn connection_accepted;  _13 = connection_accepted(move _14, const 0_i32);
+	n[5]:  field.0    n[4]  => _10 @ bb2[10]: fn connection_accepted;  _10 = ((*_1).0: *mut pointers::fdevents);
+	n[6]:  addr.load  n[5]  => _   @ bb2[10]: fn connection_accepted;  _10 = ((*_1).0: *mut pointers::fdevents);
+	n[7]:  copy       n[5]  => _16 @ bb5[4]:  fn lighttpd_test;        _16 = &raw mut (*_10);
+	n[8]:  copy       n[7]  => _1  @ bb0[0]:  fn connection_close;     _15 = connection_close(move _16, move _17);
+	n[9]:  field.0    n[8]  => _4  @ bb0[2]:  fn connection_close;     _4 = ((*_1).0: *mut pointers::fdevents);
+	n[10]: addr.load  n[9]  => _   @ bb0[2]:  fn connection_close;     _4 = ((*_1).0: *mut pointers::fdevents);
+	n[11]: field.0    n[8]  => _7  @ bb1[5]:  fn connection_close;     _7 = ((*_1).0: *mut pointers::fdevents);
+	n[12]: addr.load  n[11] => _   @ bb1[5]:  fn connection_close;     _7 = ((*_1).0: *mut pointers::fdevents);
 }
-nodes_that_need_write = []
+nodes_that_need_write = [1, 0]
 
 g {
 	n[0]:  alloc       _     => _5      @ bb1[2]:  fn connection_accepted;  _5 = malloc(move _6);
@@ -521,7 +521,7 @@ g {
 	n[11]: field.1     n[1]  => _       @ bb3[4]:  fn connection_accepted;  ((*_4).1: *mut pointers::fdnode_st) = move _9;
 	n[12]: addr.store  n[11] => _       @ bb3[4]:  fn connection_accepted;  ((*_4).1: *mut pointers::fdnode_st) = move _9;
 	n[13]: copy        n[8]  => _0      @ bb3[6]:  fn connection_accepted;  _0 = _4;
-	n[14]: copy        n[13] => _13     @ bb4[18]: fn lighttpd_test;        _13 = connection_accepted(move _14, const 0_i32);
+	n[14]: copy        n[13] => _13     @ bb4[19]: fn lighttpd_test;        _13 = connection_accepted(move _14, const 0_i32);
 	n[15]: copy        n[14] => _17     @ bb5[6]:  fn lighttpd_test;        _17 = _13;
 	n[16]: copy        n[15] => _2      @ bb0[0]:  fn connection_close;     _15 = connection_close(move _16, move _17);
 	n[17]: field.1     n[16] => _5      @ bb0[4]:  fn connection_close;     _5 = ((*_2).1: *mut pointers::fdnode_st);
@@ -629,34 +629,36 @@ g {
 nodes_that_need_write = []
 
 g {
-	n[0]: &_1  _    => _2 @ bb0[4]:  fn test_shared_ref;  _2 = &_1;
-	n[1]: copy n[0] => _3 @ bb0[7]:  fn test_shared_ref;  _3 = _2;
-	n[2]: copy n[1] => _5 @ bb0[11]: fn test_shared_ref;  _5 = &(*_3);
-	n[3]: copy n[2] => _1 @ bb0[0]:  fn shared_ref_foo;   _4 = shared_ref_foo(move _5);
-	n[4]: copy n[3] => _0 @ bb0[0]:  fn shared_ref_foo;   _0 = _1;
-	n[5]: copy n[4] => _4 @ bb0[12]: fn test_shared_ref;  _4 = shared_ref_foo(move _5);
-	n[6]: copy n[5] => _6 @ bb1[3]:  fn test_shared_ref;  _6 = &raw const (*_4);
-}
-nodes_that_need_write = []
-
-g {
-	n[0]: &_1  _    => _4 @ bb0[8]: fn test_unique_ref;  _4 = &mut _1;
-	n[1]: copy n[0] => _3 @ bb0[9]: fn test_unique_ref;  _3 = &raw mut (*_4);
-}
-nodes_that_need_write = []
-
-g {
-	n[0]: &_3        _    => _5 @ bb0[13]: fn test_unique_ref;  _5 = &mut _3;
-	n[1]: addr.store n[0] => _  @ bb0[18]: fn test_unique_ref;  (*_5) = move _6;
+	n[0]: &_1        _    => _  @ bb0[2]:  fn test_shared_ref;  _7 = &raw mut _1;
+	n[1]: addr.store n[0] => _  @ bb0[1]:  fn test_shared_ref;  _1 = const 2_u8;
+	n[2]: copy       n[0] => _2 @ bb0[5]:  fn test_shared_ref;  _2 = &(*_7);
+	n[3]: copy       n[2] => _3 @ bb0[8]:  fn test_shared_ref;  _3 = _2;
+	n[4]: copy       n[3] => _5 @ bb0[12]: fn test_shared_ref;  _5 = &(*_3);
+	n[5]: copy       n[4] => _1 @ bb0[0]:  fn shared_ref_foo;   _4 = shared_ref_foo(move _5);
+	n[6]: copy       n[5] => _0 @ bb0[0]:  fn shared_ref_foo;   _0 = _1;
+	n[7]: copy       n[6] => _4 @ bb0[13]: fn test_shared_ref;  _4 = shared_ref_foo(move _5);
+	n[8]: copy       n[7] => _6 @ bb1[3]:  fn test_shared_ref;  _6 = &raw const (*_4);
 }
 nodes_that_need_write = [1, 0]
 
 g {
-	n[0]: &_1         _    => _7   @ bb0[16]: fn test_unique_ref;  _7 = &mut _1;
-	n[1]: copy        n[0] => _6   @ bb0[17]: fn test_unique_ref;  _6 = &raw mut (*_7);
-	n[2]: value.store n[1] => _5.* @ bb0[18]: fn test_unique_ref;  (*_5) = move _6;
+	n[0]: &_1         _    => _    @ bb0[2]:  fn test_unique_ref;  _8 = &raw mut _1;
+	n[1]: addr.store  n[0] => _    @ bb0[1]:  fn test_unique_ref;  _1 = const 10_i32;
+	n[2]: copy        n[0] => _4   @ bb0[9]:  fn test_unique_ref;  _4 = &mut (*_8);
+	n[3]: copy        n[2] => _3   @ bb0[10]: fn test_unique_ref;  _3 = &raw mut (*_4);
+	n[4]: copy        n[0] => _7   @ bb0[18]: fn test_unique_ref;  _7 = &mut (*_8);
+	n[5]: copy        n[4] => _6   @ bb0[19]: fn test_unique_ref;  _6 = &raw mut (*_7);
+	n[6]: value.store n[5] => _5.* @ bb0[20]: fn test_unique_ref;  (*_5) = move _6;
 }
-nodes_that_need_write = []
+nodes_that_need_write = [1, 0]
+
+g {
+	n[0]: &_3        _    => _  @ bb0[11]: fn test_unique_ref;  _9 = &raw mut _3;
+	n[1]: addr.store n[0] => _  @ bb0[10]: fn test_unique_ref;  _3 = &raw mut (*_4);
+	n[2]: copy       n[0] => _5 @ bb0[15]: fn test_unique_ref;  _5 = &mut (*_9);
+	n[3]: addr.store n[2] => _  @ bb0[20]: fn test_unique_ref;  (*_5) = move _6;
+}
+nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc _    => _1 @ bb1[2]: fn test_realloc_reassign;  _1 = malloc(move _2);
@@ -789,32 +791,36 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc      _    => _1 @ bb1[2]: fn test_load_value;  _1 = malloc(move _2);
-	n[1]: value.load _    => _6 @ bb2[7]: fn test_load_value;  _6 = (*_4);
-	n[2]: free       n[1] => _5 @ bb2[8]: fn test_load_value;  _5 = free(move _6);
+	n[1]: value.load _    => _6 @ bb2[8]: fn test_load_value;  _6 = (*_4);
+	n[2]: free       n[1] => _5 @ bb2[9]: fn test_load_value;  _5 = free(move _6);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: &_1       _    => _4 @ bb2[3]: fn test_load_value;  _4 = &raw const _1;
-	n[1]: addr.load n[0] => _  @ bb2[7]: fn test_load_value;  _6 = (*_4);
+	n[0]: &_1       _    => _  @ bb2[0]: fn test_load_value;  _7 = &raw mut _1;
+	n[1]: copy      n[0] => _4 @ bb2[4]: fn test_load_value;  _4 = &raw const (*_7);
+	n[2]: addr.load n[1] => _  @ bb2[8]: fn test_load_value;  _6 = (*_4);
 }
 nodes_that_need_write = []
 
 g {
 	n[0]: alloc       _    => _1   @ bb1[2]:  fn test_store_value;  _1 = malloc(move _2);
-	n[1]: copy        n[0] => _4   @ bb2[3]:  fn test_store_value;  _4 = _1;
-	n[2]: copy        n[1] => _6   @ bb2[9]:  fn test_store_value;  _6 = _4;
-	n[3]: value.store n[2] => _5.* @ bb2[10]: fn test_store_value;  (*_5) = move _6;
-	n[4]: copy        n[0] => _8   @ bb2[14]: fn test_store_value;  _8 = _1;
-	n[5]: free        n[4] => _7   @ bb2[15]: fn test_store_value;  _7 = free(move _8);
+	n[1]: value.load  _    => _4   @ bb2[4]:  fn test_store_value;  _4 = (*_9);
+	n[2]: copy        n[1] => _6   @ bb2[10]: fn test_store_value;  _6 = _4;
+	n[3]: value.store n[2] => _5.* @ bb2[11]: fn test_store_value;  (*_5) = move _6;
+	n[4]: value.load  _    => _8   @ bb2[15]: fn test_store_value;  _8 = (*_9);
+	n[5]: free        n[4] => _7   @ bb2[16]: fn test_store_value;  _7 = free(move _8);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: &_1        _    => _5 @ bb2[6]:  fn test_store_value;  _5 = &raw mut _1;
-	n[1]: addr.store n[0] => _  @ bb2[10]: fn test_store_value;  (*_5) = move _6;
+	n[0]: &_1        _    => _  @ bb2[0]:  fn test_store_value;  _9 = &raw mut _1;
+	n[1]: addr.load  n[0] => _  @ bb2[4]:  fn test_store_value;  _4 = (*_9);
+	n[2]: copy       n[0] => _5 @ bb2[7]:  fn test_store_value;  _5 = &raw mut (*_9);
+	n[3]: addr.store n[2] => _  @ bb2[11]: fn test_store_value;  (*_5) = move _6;
+	n[4]: addr.load  n[0] => _  @ bb2[15]: fn test_store_value;  _8 = (*_9);
 }
-nodes_that_need_write = [1, 0]
+nodes_that_need_write = [3, 2, 0]
 
 g {
 	n[0]:  alloc       _    => _2     @ bb1[2]:  fn test_store_value_field;  _2 = malloc(move _3);
@@ -846,112 +852,183 @@ nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc       _    => _1   @ bb1[2]:  fn test_load_value_store_value;  _1 = malloc(move _2);
-	n[1]: value.load  _    => _5   @ bb2[6]:  fn test_load_value_store_value;  _5 = (*_4);
-	n[2]: value.store n[1] => _4.* @ bb2[7]:  fn test_load_value_store_value;  (*_4) = move _5;
-	n[3]: value.load  _    => _7   @ bb2[11]: fn test_load_value_store_value;  _7 = (*_4);
-	n[4]: free        n[3] => _6   @ bb2[12]: fn test_load_value_store_value;  _6 = free(move _7);
+	n[1]: value.load  _    => _5   @ bb2[7]:  fn test_load_value_store_value;  _5 = (*_4);
+	n[2]: value.store n[1] => _4.* @ bb2[8]:  fn test_load_value_store_value;  (*_4) = move _5;
+	n[3]: value.load  _    => _7   @ bb2[12]: fn test_load_value_store_value;  _7 = (*_4);
+	n[4]: free        n[3] => _6   @ bb2[13]: fn test_load_value_store_value;  _6 = free(move _7);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: &_1        _    => _4 @ bb2[3]:  fn test_load_value_store_value;  _4 = &raw mut _1;
-	n[1]: addr.load  n[0] => _  @ bb2[6]:  fn test_load_value_store_value;  _5 = (*_4);
-	n[2]: addr.store n[0] => _  @ bb2[7]:  fn test_load_value_store_value;  (*_4) = move _5;
-	n[3]: addr.load  n[0] => _  @ bb2[11]: fn test_load_value_store_value;  _7 = (*_4);
+	n[0]: &_1        _    => _  @ bb2[0]:  fn test_load_value_store_value;  _8 = &raw mut _1;
+	n[1]: copy       n[0] => _4 @ bb2[4]:  fn test_load_value_store_value;  _4 = &raw mut (*_8);
+	n[2]: addr.load  n[1] => _  @ bb2[7]:  fn test_load_value_store_value;  _5 = (*_4);
+	n[3]: addr.store n[1] => _  @ bb2[8]:  fn test_load_value_store_value;  (*_4) = move _5;
+	n[4]: addr.load  n[1] => _  @ bb2[12]: fn test_load_value_store_value;  _7 = (*_4);
 }
-nodes_that_need_write = [2, 0]
+nodes_that_need_write = [3, 1, 0]
 
 g {
-	n[0]:  &_39       _     => _38 @ bb31[4]:  fn main_0;          _38 = &mut _39;
-	n[1]:  copy       n[0]  => _44 @ bb31[11]: fn main_0;          _44 = &(*_38);
-	n[2]:  copy       n[1]  => _43 @ bb31[12]: fn main_0;          _43 = move _44 as &[i32] (Pointer(Unsize));
-	n[3]:  copy       n[2]  => _1  @ bb0[0]:   fn len;             _42 = len(move _43);
-	n[4]:  copy       n[0]  => _46 @ bb32[5]:  fn main_0;          _46 = &raw mut (*_38);
-	n[5]:  copy       n[4]  => _45 @ bb32[6]:  fn main_0;          _45 = move _46 as *mut i32 (Pointer(ArrayToPointer));
-	n[6]:  copy       n[5]  => _2  @ bb0[0]:   fn insertion_sort;  _40 = insertion_sort(move _41, move _45);
-	n[7]:  copy       n[6]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
-	n[8]:  offset[1]  n[7]  => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
-	n[9]:  addr.load  n[8]  => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
-	n[10]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[11]: offset[0]  n[10] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[12]: addr.load  n[11] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
-	n[13]: copy       n[6]  => _47 @ bb24[7]:  fn insertion_sort;  _47 = _2;
-	n[14]: offset[1]  n[13] => _46 @ bb24[13]: fn insertion_sort;  _46 = offset(move _47, move _48);
-	n[15]: addr.store n[14] => _   @ bb25[2]:  fn insertion_sort;  (*_46) = move _45;
-	n[16]: copy       n[6]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
-	n[17]: offset[2]  n[16] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
-	n[18]: addr.load  n[17] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
-	n[19]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[20]: offset[1]  n[19] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[21]: addr.load  n[20] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
-	n[22]: copy       n[6]  => _31 @ bb13[3]:  fn insertion_sort;  _31 = _2;
-	n[23]: offset[1]  n[22] => _30 @ bb15[5]:  fn insertion_sort;  _30 = offset(move _31, move _32);
-	n[24]: addr.load  n[23] => _   @ bb16[2]:  fn insertion_sort;  _29 = (*_30);
-	n[25]: copy       n[6]  => _38 @ bb16[5]:  fn insertion_sort;  _38 = _2;
-	n[26]: offset[2]  n[25] => _37 @ bb16[11]: fn insertion_sort;  _37 = offset(move _38, move _39);
-	n[27]: addr.store n[26] => _   @ bb17[2]:  fn insertion_sort;  (*_37) = move _29;
-	n[28]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[29]: offset[0]  n[28] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[30]: addr.load  n[29] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
-	n[31]: copy       n[6]  => _47 @ bb24[7]:  fn insertion_sort;  _47 = _2;
-	n[32]: offset[1]  n[31] => _46 @ bb24[13]: fn insertion_sort;  _46 = offset(move _47, move _48);
-	n[33]: addr.store n[32] => _   @ bb25[2]:  fn insertion_sort;  (*_46) = move _45;
-	n[34]: copy       n[6]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
-	n[35]: offset[3]  n[34] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
-	n[36]: addr.load  n[35] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
-	n[37]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[38]: offset[2]  n[37] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[39]: addr.load  n[38] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
-	n[40]: copy       n[6]  => _31 @ bb13[3]:  fn insertion_sort;  _31 = _2;
-	n[41]: offset[2]  n[40] => _30 @ bb15[5]:  fn insertion_sort;  _30 = offset(move _31, move _32);
-	n[42]: addr.load  n[41] => _   @ bb16[2]:  fn insertion_sort;  _29 = (*_30);
-	n[43]: copy       n[6]  => _38 @ bb16[5]:  fn insertion_sort;  _38 = _2;
-	n[44]: offset[3]  n[43] => _37 @ bb16[11]: fn insertion_sort;  _37 = offset(move _38, move _39);
-	n[45]: addr.store n[44] => _   @ bb17[2]:  fn insertion_sort;  (*_37) = move _29;
-	n[46]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[47]: offset[1]  n[46] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[48]: addr.load  n[47] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
-	n[49]: copy       n[6]  => _31 @ bb13[3]:  fn insertion_sort;  _31 = _2;
-	n[50]: offset[1]  n[49] => _30 @ bb15[5]:  fn insertion_sort;  _30 = offset(move _31, move _32);
-	n[51]: addr.load  n[50] => _   @ bb16[2]:  fn insertion_sort;  _29 = (*_30);
-	n[52]: copy       n[6]  => _38 @ bb16[5]:  fn insertion_sort;  _38 = _2;
-	n[53]: offset[2]  n[52] => _37 @ bb16[11]: fn insertion_sort;  _37 = offset(move _38, move _39);
-	n[54]: addr.store n[53] => _   @ bb17[2]:  fn insertion_sort;  (*_37) = move _29;
-	n[55]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[56]: offset[0]  n[55] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[57]: addr.load  n[56] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
-	n[58]: copy       n[6]  => _31 @ bb13[3]:  fn insertion_sort;  _31 = _2;
-	n[59]: offset[0]  n[58] => _30 @ bb15[5]:  fn insertion_sort;  _30 = offset(move _31, move _32);
-	n[60]: addr.load  n[59] => _   @ bb16[2]:  fn insertion_sort;  _29 = (*_30);
-	n[61]: copy       n[6]  => _38 @ bb16[5]:  fn insertion_sort;  _38 = _2;
-	n[62]: offset[1]  n[61] => _37 @ bb16[11]: fn insertion_sort;  _37 = offset(move _38, move _39);
-	n[63]: addr.store n[62] => _   @ bb17[2]:  fn insertion_sort;  (*_37) = move _29;
-	n[64]: copy       n[6]  => _47 @ bb24[7]:  fn insertion_sort;  _47 = _2;
-	n[65]: offset[0]  n[64] => _46 @ bb24[13]: fn insertion_sort;  _46 = offset(move _47, move _48);
-	n[66]: addr.store n[65] => _   @ bb25[2]:  fn insertion_sort;  (*_46) = move _45;
-	n[67]: copy       n[6]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
-	n[68]: offset[4]  n[67] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
-	n[69]: addr.load  n[68] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
-	n[70]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[71]: offset[3]  n[70] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[72]: addr.load  n[71] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
-	n[73]: copy       n[6]  => _47 @ bb24[7]:  fn insertion_sort;  _47 = _2;
-	n[74]: offset[4]  n[73] => _46 @ bb24[13]: fn insertion_sort;  _46 = offset(move _47, move _48);
-	n[75]: addr.store n[74] => _   @ bb25[2]:  fn insertion_sort;  (*_46) = move _45;
+	n[0]:  &_40       _     => _   @ bb32[4]:  fn main_0;          _59 = &raw mut _40;
+	n[1]:  addr.store n[0]  => _   @ bb32[3]:  fn main_0;          _40 = [const 2_i32, const 5_i32, const 3_i32, const 1_i32, const 6_i32];
+	n[2]:  copy       n[0]  => _39 @ bb32[5]:  fn main_0;          _39 = &mut (*_59);
+	n[3]:  copy       n[2]  => _45 @ bb32[12]: fn main_0;          _45 = &(*_39);
+	n[4]:  copy       n[3]  => _44 @ bb32[13]: fn main_0;          _44 = move _45 as &[i32] (Pointer(Unsize));
+	n[5]:  copy       n[4]  => _1  @ bb0[0]:   fn len;             _43 = len(move _44);
+	n[6]:  copy       n[2]  => _47 @ bb33[5]:  fn main_0;          _47 = &raw mut (*_39);
+	n[7]:  copy       n[6]  => _46 @ bb33[6]:  fn main_0;          _46 = move _47 as *mut i32 (Pointer(ArrayToPointer));
+	n[8]:  copy       n[7]  => _2  @ bb0[0]:   fn insertion_sort;  _41 = insertion_sort(move _42, move _46);
+	n[9]:  copy       n[8]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
+	n[10]: offset[1]  n[9]  => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
+	n[11]: addr.load  n[10] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
+	n[12]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[13]: offset[0]  n[12] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[14]: addr.load  n[13] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
+	n[15]: copy       n[8]  => _47 @ bb24[7]:  fn insertion_sort;  _47 = _2;
+	n[16]: offset[1]  n[15] => _46 @ bb24[13]: fn insertion_sort;  _46 = offset(move _47, move _48);
+	n[17]: addr.store n[16] => _   @ bb25[2]:  fn insertion_sort;  (*_46) = move _45;
+	n[18]: copy       n[8]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
+	n[19]: offset[2]  n[18] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
+	n[20]: addr.load  n[19] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
+	n[21]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[22]: offset[1]  n[21] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[23]: addr.load  n[22] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
+	n[24]: copy       n[8]  => _31 @ bb13[3]:  fn insertion_sort;  _31 = _2;
+	n[25]: offset[1]  n[24] => _30 @ bb15[5]:  fn insertion_sort;  _30 = offset(move _31, move _32);
+	n[26]: addr.load  n[25] => _   @ bb16[2]:  fn insertion_sort;  _29 = (*_30);
+	n[27]: copy       n[8]  => _38 @ bb16[5]:  fn insertion_sort;  _38 = _2;
+	n[28]: offset[2]  n[27] => _37 @ bb16[11]: fn insertion_sort;  _37 = offset(move _38, move _39);
+	n[29]: addr.store n[28] => _   @ bb17[2]:  fn insertion_sort;  (*_37) = move _29;
+	n[30]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[31]: offset[0]  n[30] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[32]: addr.load  n[31] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
+	n[33]: copy       n[8]  => _47 @ bb24[7]:  fn insertion_sort;  _47 = _2;
+	n[34]: offset[1]  n[33] => _46 @ bb24[13]: fn insertion_sort;  _46 = offset(move _47, move _48);
+	n[35]: addr.store n[34] => _   @ bb25[2]:  fn insertion_sort;  (*_46) = move _45;
+	n[36]: copy       n[8]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
+	n[37]: offset[3]  n[36] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
+	n[38]: addr.load  n[37] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
+	n[39]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[40]: offset[2]  n[39] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[41]: addr.load  n[40] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
+	n[42]: copy       n[8]  => _31 @ bb13[3]:  fn insertion_sort;  _31 = _2;
+	n[43]: offset[2]  n[42] => _30 @ bb15[5]:  fn insertion_sort;  _30 = offset(move _31, move _32);
+	n[44]: addr.load  n[43] => _   @ bb16[2]:  fn insertion_sort;  _29 = (*_30);
+	n[45]: copy       n[8]  => _38 @ bb16[5]:  fn insertion_sort;  _38 = _2;
+	n[46]: offset[3]  n[45] => _37 @ bb16[11]: fn insertion_sort;  _37 = offset(move _38, move _39);
+	n[47]: addr.store n[46] => _   @ bb17[2]:  fn insertion_sort;  (*_37) = move _29;
+	n[48]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[49]: offset[1]  n[48] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[50]: addr.load  n[49] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
+	n[51]: copy       n[8]  => _31 @ bb13[3]:  fn insertion_sort;  _31 = _2;
+	n[52]: offset[1]  n[51] => _30 @ bb15[5]:  fn insertion_sort;  _30 = offset(move _31, move _32);
+	n[53]: addr.load  n[52] => _   @ bb16[2]:  fn insertion_sort;  _29 = (*_30);
+	n[54]: copy       n[8]  => _38 @ bb16[5]:  fn insertion_sort;  _38 = _2;
+	n[55]: offset[2]  n[54] => _37 @ bb16[11]: fn insertion_sort;  _37 = offset(move _38, move _39);
+	n[56]: addr.store n[55] => _   @ bb17[2]:  fn insertion_sort;  (*_37) = move _29;
+	n[57]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[58]: offset[0]  n[57] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[59]: addr.load  n[58] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
+	n[60]: copy       n[8]  => _31 @ bb13[3]:  fn insertion_sort;  _31 = _2;
+	n[61]: offset[0]  n[60] => _30 @ bb15[5]:  fn insertion_sort;  _30 = offset(move _31, move _32);
+	n[62]: addr.load  n[61] => _   @ bb16[2]:  fn insertion_sort;  _29 = (*_30);
+	n[63]: copy       n[8]  => _38 @ bb16[5]:  fn insertion_sort;  _38 = _2;
+	n[64]: offset[1]  n[63] => _37 @ bb16[11]: fn insertion_sort;  _37 = offset(move _38, move _39);
+	n[65]: addr.store n[64] => _   @ bb17[2]:  fn insertion_sort;  (*_37) = move _29;
+	n[66]: copy       n[8]  => _47 @ bb24[7]:  fn insertion_sort;  _47 = _2;
+	n[67]: offset[0]  n[66] => _46 @ bb24[13]: fn insertion_sort;  _46 = offset(move _47, move _48);
+	n[68]: addr.store n[67] => _   @ bb25[2]:  fn insertion_sort;  (*_46) = move _45;
+	n[69]: copy       n[8]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
+	n[70]: offset[4]  n[69] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
+	n[71]: addr.load  n[70] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
+	n[72]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[73]: offset[3]  n[72] => _21 @ bb11[5]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[74]: addr.load  n[73] => _   @ bb12[2]:  fn insertion_sort;  _20 = (*_21);
+	n[75]: copy       n[8]  => _47 @ bb24[7]:  fn insertion_sort;  _47 = _2;
+	n[76]: offset[4]  n[75] => _46 @ bb24[13]: fn insertion_sort;  _46 = offset(move _47, move _48);
+	n[77]: addr.store n[76] => _   @ bb25[2]:  fn insertion_sort;  (*_46) = move _45;
 }
-nodes_that_need_write = [75, 74, 73, 66, 65, 64, 63, 62, 61, 54, 53, 52, 45, 44, 43, 33, 32, 31, 27, 26, 25, 15, 14, 13, 6, 5, 4, 0]
+nodes_that_need_write = [77, 76, 75, 68, 67, 66, 65, 64, 63, 56, 55, 54, 47, 46, 45, 35, 34, 33, 29, 28, 27, 17, 16, 15, 8, 7, 6, 2, 1, 0]
 
 g {
-	n[0]: &_4        _    => _3 @ bb0[15]: fn test_ref_field;  _3 = &mut _4;
-	n[1]: field.3    n[0] => _  @ bb0[17]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
-	n[2]: field.3    n[1] => _7 @ bb0[17]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
-	n[3]: addr.load  n[2] => _  @ bb0[17]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
-	n[4]: field.3    n[0] => _  @ bb0[18]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
-	n[5]: field.3    n[4] => _  @ bb0[18]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
-	n[6]: addr.store n[5] => _  @ bb0[18]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
+	n[0]: &_4        _    => _  @ bb0[12]: fn test_ref_field;  _8 = &raw mut _4;
+	n[1]: addr.store n[0] => _  @ bb0[11]: fn test_ref_field;  _4 = pointers::S { field: const 0_i32, field2: const 0_u64, field3: move _5, field4: move _6 };
+	n[2]: copy       n[0] => _3 @ bb0[16]: fn test_ref_field;  _3 = &mut (*_8);
+	n[3]: field.3    n[2] => _  @ bb0[18]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
+	n[4]: field.3    n[3] => _7 @ bb0[18]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
+	n[5]: addr.load  n[4] => _  @ bb0[18]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
+	n[6]: field.3    n[2] => _  @ bb0[19]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
+	n[7]: field.3    n[6] => _  @ bb0[19]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
+	n[8]: addr.store n[7] => _  @ bb0[19]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
 }
-nodes_that_need_write = [6, 5, 4, 0]
+nodes_that_need_write = [8, 7, 6, 2, 1, 0]
 
-num_graphs = 64
-num_nodes = 694
+g {
+	n[0]: &_1        _    => _  @ bb0[2]: fn test_addr_taken;  _10 = &raw mut _1;
+	n[1]: addr.store n[0] => _  @ bb0[1]: fn test_addr_taken;  _1 = const 2_i32;
+	n[2]: addr.load  n[0] => _  @ bb0[6]: fn test_addr_taken;  _3 = (*_10);
+	n[3]: copy       n[0] => _5 @ bb1[4]: fn test_addr_taken;  _5 = &raw const (*_10);
+	n[4]: addr.load  n[0] => _  @ bb1[8]: fn test_addr_taken;  _7 = (*_10);
+}
+nodes_that_need_write = [1, 0]
+
+g {
+	n[0]: &_1        _    => _  @ bb0[0]: fn test_addr_taken_arg;  _3 = &raw mut _1;
+	n[1]: field.2    n[0] => _  @ bb0[1]: fn test_addr_taken_arg;  ((*_3).2: *const pointers::S) = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[2]: addr.store n[1] => _  @ bb0[1]: fn test_addr_taken_arg;  ((*_3).2: *const pointers::S) = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[3]: copy       n[0] => _2 @ bb0[3]: fn test_addr_taken_arg;  _2 = &(*_3);
+}
+nodes_that_need_write = [2, 1, 0]
+
+g {
+	n[0]:  &_3        _    => _   @ bb2[2]:  fn test_addr_taken_loop;  _20 = &raw mut _3;
+	n[1]:  addr.store n[0] => _   @ bb2[1]:  fn test_addr_taken_loop;  _3 = const 2_i32;
+	n[2]:  copy       n[0] => _4  @ bb5[0]:  fn test_addr_taken_loop;  _4 = &(*_20);
+	n[3]:  addr.load  n[2] => _   @ bb14[3]: fn test_addr_taken_loop;  _18 = (*_4);
+	n[4]:  copy       n[0] => _20 @ bb2[2]:  fn test_addr_taken_loop;  _20 = &raw mut _3;
+	n[5]:  addr.store n[4] => _   @ bb2[1]:  fn test_addr_taken_loop;  _3 = const 2_i32;
+	n[6]:  copy       n[4] => _4  @ bb5[0]:  fn test_addr_taken_loop;  _4 = &(*_20);
+	n[7]:  addr.load  n[6] => _   @ bb14[3]: fn test_addr_taken_loop;  _18 = (*_4);
+	n[8]:  copy       n[4] => _20 @ bb2[2]:  fn test_addr_taken_loop;  _20 = &raw mut _3;
+	n[9]:  addr.store n[8] => _   @ bb2[1]:  fn test_addr_taken_loop;  _3 = const 2_i32;
+	n[10]: copy       n[8] => _4  @ bb5[0]:  fn test_addr_taken_loop;  _4 = &(*_20);
+}
+nodes_that_need_write = [9, 8, 5, 4, 1, 0]
+
+g {
+	n[0]: &_2        _    => _  @ bb1[1]: fn test_addr_taken_cond;  _6 = &raw mut _2;
+	n[1]: addr.store n[0] => _  @ bb1[0]: fn test_addr_taken_cond;  _2 = const 1_i32;
+	n[2]: copy       n[0] => _4 @ bb4[3]: fn test_addr_taken_cond;  _4 = &(*_6);
+	n[3]: addr.load  n[0] => _  @ bb4[6]: fn test_addr_taken_cond;  _5 = (*_6);
+}
+nodes_that_need_write = [1, 0]
+
+g {
+	n[0]: &_2        _    => _  @ bb3[1]: fn test_addr_taken_cond;  _6 = &raw mut _2;
+	n[1]: addr.store n[0] => _  @ bb3[0]: fn test_addr_taken_cond;  _2 = const 2_i32;
+	n[2]: copy       n[0] => _4 @ bb4[3]: fn test_addr_taken_cond;  _4 = &(*_6);
+	n[3]: addr.load  n[0] => _  @ bb4[6]: fn test_addr_taken_cond;  _5 = (*_6);
+}
+nodes_that_need_write = [1, 0]
+
+g {
+	n[0]: &_2        _    => _  @ bb1[1]: fn test_addr_taken_init_cond;  _8 = &raw mut _2;
+	n[1]: addr.store n[0] => _  @ bb1[0]: fn test_addr_taken_init_cond;  _2 = const 1_i32;
+	n[2]: copy       n[0] => _6 @ bb1[3]: fn test_addr_taken_init_cond;  _6 = &(*_8);
+	n[3]: copy       n[2] => _3 @ bb1[4]: fn test_addr_taken_init_cond;  _3 = move _6;
+	n[4]: copy       n[0] => _8 @ bb4[3]: fn test_addr_taken_init_cond;  _8 = &raw mut _2;
+	n[5]: addr.store n[4] => _  @ bb4[2]: fn test_addr_taken_init_cond;  _2 = const 2_i32;
+	n[6]: addr.load  n[4] => _  @ bb4[5]: fn test_addr_taken_init_cond;  _7 = (*_8);
+}
+nodes_that_need_write = [5, 4, 1, 0]
+
+g {
+	n[0]: &_2        _    => _ @ bb4[3]: fn test_addr_taken_init_cond;  _8 = &raw mut _2;
+	n[1]: addr.store n[0] => _ @ bb4[2]: fn test_addr_taken_init_cond;  _2 = const 2_i32;
+	n[2]: addr.load  n[0] => _ @ bb4[5]: fn test_addr_taken_init_cond;  _7 = (*_8);
+}
+nodes_that_need_write = [1, 0]
+
+num_graphs = 67
+num_nodes = 759
 

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_release.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_release.snap
@@ -3,37 +3,37 @@ source: pdg/src/main.rs
 expression: pdg
 ---
 g {
-	n[0]: &_1  _    => _11 @ bb3[9]: fn main;   _11 = &_1;
-	n[1]: copy n[0] => _1  @ bb0[0]: fn deref;  _10 = deref(move _11);
+	n[0]: &_1  _    => _   @ bb3[0]:  fn main;   _22 = &raw mut _1;
+	n[1]: copy n[0] => _11 @ bb3[10]: fn main;   _11 = &(*_22);
+	n[2]: copy n[1] => _1  @ bb0[0]:  fn deref;  _10 = deref(move _11);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: copy _    => _10 @ bb3[10]: fn main;  _10 = deref(move _11);
+	n[0]: copy _    => _10 @ bb3[11]: fn main;  _10 = deref(move _11);
 	n[1]: copy n[0] => _9  @ bb4[0]:  fn main;  _9 = &(*_10);
 	n[2]: copy n[1] => _1  @ bb0[0]:  fn iter;  _8 = iter(move _9);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: copy        _    => _14   @ bb6[4]:  fn main;                _14 = null_mut();
-	n[1]: copy        n[0] => _1    @ bb0[0]:  fn once;                _13 = once(move _14);
-	n[2]: int_to_ptr  _    => _17   @ bb4[29]: fn simple;              _17 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
-	n[3]: value.store _    => _20.* @ bb4[7]:  fn invalid;             (*_20) = const 0_usize as *mut pointers::S (PointerFromExposedAddress);
-	n[4]: value.store _    => _17.* @ bb8[4]:  fn fdevent_unregister;  (*_17) = const 0_usize as *mut pointers::fdnode_st (PointerFromExposedAddress);
-	n[5]: int_to_ptr  _    => _2    @ bb0[2]:  fn test_ref_field;      _2 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
-	n[6]: int_to_ptr  _    => _5    @ bb0[8]:  fn test_ref_field;      _5 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[0]: copy        _    => _14    @ bb6[4]:  fn main;                 _14 = null_mut();
+	n[1]: copy        n[0] => _1     @ bb0[0]:  fn once;                 _13 = once(move _14);
+	n[2]: int_to_ptr  _    => _17    @ bb4[29]: fn simple;               _17 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[3]: value.store _    => _20.*  @ bb4[7]:  fn invalid;              (*_20) = const 0_usize as *mut pointers::S (PointerFromExposedAddress);
+	n[4]: value.store _    => _17.*  @ bb8[4]:  fn fdevent_unregister;   (*_17) = const 0_usize as *mut pointers::fdnode_st (PointerFromExposedAddress);
+	n[5]: int_to_ptr  _    => _2     @ bb0[2]:  fn test_ref_field;       _2 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[6]: int_to_ptr  _    => _5     @ bb0[8]:  fn test_ref_field;       _5 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[7]: int_to_ptr  _    => _51    @ bb36[3]: fn main_0;               _51 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[8]: value.store _    => _3.*.2 @ bb0[1]:  fn test_addr_taken_arg;  ((*_3).2: *const pointers::S) = const 0_usize as *const pointers::S (PointerFromExposedAddress);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: &_5  _    => _19 @ bb10[8]: fn main;  _19 = &_5;
-	n[1]: copy n[0] => _1  @ bb0[0]:  fn len;   _18 = len(move _19);
-}
-nodes_that_need_write = []
-
-g {
-	n[0]: &_5 _ => _21 @ bb11[7]: fn main;  _21 = &mut _5;
+	n[0]: &_5  _    => _   @ bb10[0]: fn main;  _23 = &raw mut _5;
+	n[1]: copy n[0] => _19 @ bb10[9]: fn main;  _19 = &(*_23);
+	n[2]: copy n[1] => _1  @ bb0[0]:  fn len;   _18 = len(move _19);
+	n[3]: copy n[0] => _21 @ bb11[7]: fn main;  _21 = &mut (*_23);
 }
 nodes_that_need_write = []
 
@@ -70,38 +70,34 @@ g {
 	n[12]: field.0     n[3]  => _13    @ bb4[18]: fn simple;  _13 = ((*_1).0: i32);
 	n[13]: addr.load   n[12] => _      @ bb4[18]: fn simple;  _13 = ((*_1).0: i32);
 	n[14]: field.1     n[3]  => _14    @ bb4[21]: fn simple;  _14 = &raw const ((*_1).1: u64);
-	n[15]: copy        n[3]  => _15    @ bb4[24]: fn simple;  _15 = &raw const (*_1);
-	n[16]: field.2     n[3]  => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
-	n[17]: addr.store  n[16] => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
-	n[18]: value.store n[15] => _1.*.2 @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
-	n[19]: field.3     n[1]  => _      @ bb4[32]: fn simple;  ((*_6).3: pointers::T) = move _16;
-	n[20]: addr.store  n[19] => _      @ bb4[32]: fn simple;  ((*_6).3: pointers::T) = move _16;
-	n[21]: addr.load   n[1]  => _      @ bb4[35]: fn simple;  _18 = (*_6);
-	n[22]: addr.store  n[3]  => _      @ bb4[39]: fn simple;  (*_1) = move _19;
-	n[23]: copy        n[3]  => _21    @ bb4[43]: fn simple;  _21 = _1;
-	n[24]: copy        n[23] => _2     @ bb0[0]:  fn recur;   _20 = recur(const 3_i32, move _21);
-	n[25]: copy        n[24] => _12    @ bb7[9]:  fn recur;   _12 = _2;
-	n[26]: copy        n[25] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _12);
-	n[27]: copy        n[26] => _12    @ bb7[9]:  fn recur;   _12 = _2;
-	n[28]: copy        n[27] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _12);
-	n[29]: copy        n[28] => _12    @ bb7[9]:  fn recur;   _12 = _2;
-	n[30]: copy        n[29] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _12);
-	n[31]: copy        n[30] => _8     @ bb1[2]:  fn recur;   _8 = _2;
-	n[32]: copy        n[31] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (Misc);
-	n[33]: free        n[32] => _0     @ bb1[5]:  fn recur;   _0 = free(move _7);
-	n[34]: copy        n[30] => _13    @ bb8[4]:  fn recur;   _13 = _2;
-	n[35]: copy        n[30] => _13    @ bb8[4]:  fn recur;   _13 = _2;
-	n[36]: copy        n[30] => _13    @ bb8[4]:  fn recur;   _13 = _2;
+	n[15]: copy        n[14] => _14    @ bb4[21]: fn simple;  _14 = &raw const ((*_1).1: u64);
+	n[16]: copy        n[3]  => _15    @ bb4[24]: fn simple;  _15 = &raw const (*_1);
+	n[17]: field.2     n[3]  => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
+	n[18]: addr.store  n[17] => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
+	n[19]: value.store n[16] => _1.*.2 @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _15;
+	n[20]: field.3     n[1]  => _      @ bb4[32]: fn simple;  ((*_6).3: pointers::T) = move _16;
+	n[21]: addr.store  n[20] => _      @ bb4[32]: fn simple;  ((*_6).3: pointers::T) = move _16;
+	n[22]: addr.load   n[1]  => _      @ bb4[35]: fn simple;  _18 = (*_6);
+	n[23]: addr.store  n[3]  => _      @ bb4[39]: fn simple;  (*_1) = move _19;
+	n[24]: copy        n[3]  => _21    @ bb4[43]: fn simple;  _21 = _1;
+	n[25]: copy        n[24] => _2     @ bb0[0]:  fn recur;   _20 = recur(const 3_i32, move _21);
+	n[26]: copy        n[25] => _12    @ bb7[9]:  fn recur;   _12 = _2;
+	n[27]: copy        n[26] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _12);
+	n[28]: copy        n[27] => _12    @ bb7[9]:  fn recur;   _12 = _2;
+	n[29]: copy        n[28] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _12);
+	n[30]: copy        n[29] => _12    @ bb7[9]:  fn recur;   _12 = _2;
+	n[31]: copy        n[30] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _12);
+	n[32]: copy        n[31] => _8     @ bb1[2]:  fn recur;   _8 = _2;
+	n[33]: copy        n[32] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (Misc);
+	n[34]: free        n[33] => _0     @ bb1[5]:  fn recur;   _0 = free(move _7);
+	n[35]: copy        n[31] => _13    @ bb8[4]:  fn recur;   _13 = _2;
+	n[36]: copy        n[31] => _13    @ bb8[4]:  fn recur;   _13 = _2;
+	n[37]: copy        n[31] => _13    @ bb8[4]:  fn recur;   _13 = _2;
 }
-nodes_that_need_write = [22, 20, 19, 17, 16, 11, 10, 9, 8, 5, 4, 3, 2, 1, 0]
+nodes_that_need_write = [23, 21, 20, 18, 17, 11, 10, 9, 8, 5, 4, 3, 2, 1, 0]
 
 g {
-	n[0]: &_1 _ => _10 @ bb4[5]: fn simple;  _10 = &raw const ((*_1).0: i32);
-}
-nodes_that_need_write = []
-
-g {
-	n[0]: &_1 _ => _14 @ bb4[21]: fn simple;  _14 = &raw const ((*_1).1: u64);
+	n[0]: &_1 _ => _ @ bb4[5]: fn simple;  _10 = &raw const ((*_1).0: i32);
 }
 nodes_that_need_write = []
 
@@ -393,23 +389,23 @@ g {
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
-	n[0]: &_1  _    => _4 @ bb0[8]: fn testing;  _4 = &mut _1;
-	n[1]: copy n[0] => _3 @ bb0[9]: fn testing;  _3 = &raw mut (*_4);
-}
-nodes_that_need_write = []
-
-g {
-	n[0]: &_3        _    => _5 @ bb0[13]: fn testing;  _5 = &mut _3;
-	n[1]: addr.store n[0] => _  @ bb0[18]: fn testing;  (*_5) = move _6;
+	n[0]: &_1         _    => _    @ bb0[2]:  fn testing;  _8 = &raw mut _1;
+	n[1]: addr.store  n[0] => _    @ bb0[1]:  fn testing;  _1 = const 10_i32;
+	n[2]: copy        n[0] => _4   @ bb0[9]:  fn testing;  _4 = &mut (*_8);
+	n[3]: copy        n[2] => _3   @ bb0[10]: fn testing;  _3 = &raw mut (*_4);
+	n[4]: copy        n[0] => _7   @ bb0[18]: fn testing;  _7 = &mut (*_8);
+	n[5]: copy        n[4] => _6   @ bb0[19]: fn testing;  _6 = &raw mut (*_7);
+	n[6]: value.store n[5] => _5.* @ bb0[20]: fn testing;  (*_5) = move _6;
 }
 nodes_that_need_write = [1, 0]
 
 g {
-	n[0]: &_1         _    => _7   @ bb0[16]: fn testing;  _7 = &mut _1;
-	n[1]: copy        n[0] => _6   @ bb0[17]: fn testing;  _6 = &raw mut (*_7);
-	n[2]: value.store n[1] => _5.* @ bb0[18]: fn testing;  (*_5) = move _6;
+	n[0]: &_3        _    => _  @ bb0[11]: fn testing;  _9 = &raw mut _3;
+	n[1]: addr.store n[0] => _  @ bb0[10]: fn testing;  _3 = &raw mut (*_4);
+	n[2]: copy       n[0] => _5 @ bb0[15]: fn testing;  _5 = &mut (*_9);
+	n[3]: addr.store n[2] => _  @ bb0[20]: fn testing;  (*_5) = move _6;
 }
-nodes_that_need_write = []
+nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn simple1;  _2 = malloc(move _3);
@@ -417,8 +413,8 @@ g {
 	n[2]: copy       n[1] => _8  @ bb2[8]:  fn simple1;  _8 = _1;
 	n[3]: copy       n[2] => _7  @ bb2[9]:  fn simple1;  _7 = move _8 as *mut libc::c_void (Misc);
 	n[4]: free       n[3] => _6  @ bb3[2]:  fn simple1;  _6 = realloc(move _7, move _9);
-	n[5]: copy       n[1] => _16 @ bb4[20]: fn simple1;  _16 = _1;
-	n[6]: ptr_to_int n[5] => _   @ bb4[21]: fn simple1;  _15 = move _16 as usize (PointerExposeAddress);
+	n[5]: copy       n[1] => _16 @ bb4[21]: fn simple1;  _16 = _1;
+	n[6]: ptr_to_int n[5] => _   @ bb4[22]: fn simple1;  _15 = move _16 as usize (PointerExposeAddress);
 }
 nodes_that_need_write = []
 
@@ -430,17 +426,19 @@ g {
 	n[4]:  addr.store n[3] => _   @ bb4[8]:  fn simple1;  ((*_11).0: i32) = const 10_i32;
 	n[5]:  copy       n[1] => _12 @ bb4[10]: fn simple1;  _12 = _5;
 	n[6]:  copy       n[2] => _13 @ bb4[13]: fn simple1;  _13 = _11;
-	n[7]:  int_to_ptr _    => _17 @ bb4[27]: fn simple1;  _17 = move _18 as *const libc::c_void (PointerFromExposedAddress);
-	n[8]:  copy       n[1] => _21 @ bb4[33]: fn simple1;  _21 = _5;
-	n[9]:  copy       n[8] => _20 @ bb4[34]: fn simple1;  _20 = move _21 as *mut libc::c_void (Misc);
-	n[10]: free       n[9] => _19 @ bb4[36]: fn simple1;  _19 = free(move _20);
+	n[7]:  int_to_ptr _    => _17 @ bb4[28]: fn simple1;  _17 = move _18 as *const libc::c_void (PointerFromExposedAddress);
+	n[8]:  copy       n[1] => _21 @ bb4[34]: fn simple1;  _21 = _5;
+	n[9]:  copy       n[8] => _20 @ bb4[35]: fn simple1;  _20 = move _21 as *mut libc::c_void (Misc);
+	n[10]: free       n[9] => _19 @ bb4[37]: fn simple1;  _19 = free(move _20);
 }
 nodes_that_need_write = [4, 3, 2, 1, 0]
 
 g {
-	n[0]: &_13 _ => _14 @ bb4[16]: fn simple1;  _14 = &raw const _13;
+	n[0]: &_13       _    => _   @ bb4[14]: fn simple1;  _22 = &raw mut _13;
+	n[1]: addr.store n[0] => _   @ bb4[13]: fn simple1;  _13 = _11;
+	n[2]: copy       n[0] => _14 @ bb4[17]: fn simple1;  _14 = &raw const (*_22);
 }
-nodes_that_need_write = []
+nodes_that_need_write = [1, 0]
 
 g {
 	n[0]:  alloc       _     => _2     @ bb1[2]:  fn lighttpd_test;       _2 = malloc(move _3);
@@ -492,19 +490,21 @@ g {
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
-	n[0]:  &_11      _    => _10 @ bb4[14]: fn lighttpd_test;        _10 = &mut _11;
-	n[1]:  copy      n[0] => _14 @ bb4[17]: fn lighttpd_test;        _14 = &raw mut (*_10);
-	n[2]:  copy      n[1] => _1  @ bb0[0]:  fn connection_accepted;  _13 = connection_accepted(move _14, const 0_i32);
-	n[3]:  field.0   n[2] => _10 @ bb2[10]: fn connection_accepted;  _10 = ((*_1).0: *mut pointers::fdevents);
-	n[4]:  addr.load n[3] => _   @ bb2[10]: fn connection_accepted;  _10 = ((*_1).0: *mut pointers::fdevents);
-	n[5]:  copy      n[3] => _16 @ bb5[4]:  fn lighttpd_test;        _16 = &raw mut (*_10);
-	n[6]:  copy      n[5] => _1  @ bb0[0]:  fn connection_close;     _15 = connection_close(move _16, move _17);
-	n[7]:  field.0   n[6] => _4  @ bb0[2]:  fn connection_close;     _4 = ((*_1).0: *mut pointers::fdevents);
-	n[8]:  addr.load n[7] => _   @ bb0[2]:  fn connection_close;     _4 = ((*_1).0: *mut pointers::fdevents);
-	n[9]:  field.0   n[6] => _7  @ bb1[5]:  fn connection_close;     _7 = ((*_1).0: *mut pointers::fdevents);
-	n[10]: addr.load n[9] => _   @ bb1[5]:  fn connection_close;     _7 = ((*_1).0: *mut pointers::fdevents);
+	n[0]:  &_11       _     => _   @ bb4[12]: fn lighttpd_test;        _24 = &raw mut _11;
+	n[1]:  addr.store n[0]  => _   @ bb4[11]: fn lighttpd_test;        _11 = pointers::server { ev: move _12 };
+	n[2]:  copy       n[0]  => _10 @ bb4[15]: fn lighttpd_test;        _10 = &mut (*_24);
+	n[3]:  copy       n[2]  => _14 @ bb4[18]: fn lighttpd_test;        _14 = &raw mut (*_10);
+	n[4]:  copy       n[3]  => _1  @ bb0[0]:  fn connection_accepted;  _13 = connection_accepted(move _14, const 0_i32);
+	n[5]:  field.0    n[4]  => _10 @ bb2[10]: fn connection_accepted;  _10 = ((*_1).0: *mut pointers::fdevents);
+	n[6]:  addr.load  n[5]  => _   @ bb2[10]: fn connection_accepted;  _10 = ((*_1).0: *mut pointers::fdevents);
+	n[7]:  copy       n[5]  => _16 @ bb5[4]:  fn lighttpd_test;        _16 = &raw mut (*_10);
+	n[8]:  copy       n[7]  => _1  @ bb0[0]:  fn connection_close;     _15 = connection_close(move _16, move _17);
+	n[9]:  field.0    n[8]  => _4  @ bb0[2]:  fn connection_close;     _4 = ((*_1).0: *mut pointers::fdevents);
+	n[10]: addr.load  n[9]  => _   @ bb0[2]:  fn connection_close;     _4 = ((*_1).0: *mut pointers::fdevents);
+	n[11]: field.0    n[8]  => _7  @ bb1[5]:  fn connection_close;     _7 = ((*_1).0: *mut pointers::fdevents);
+	n[12]: addr.load  n[11] => _   @ bb1[5]:  fn connection_close;     _7 = ((*_1).0: *mut pointers::fdevents);
 }
-nodes_that_need_write = []
+nodes_that_need_write = [1, 0]
 
 g {
 	n[0]:  alloc       _     => _5      @ bb1[2]:  fn connection_accepted;  _5 = malloc(move _6);
@@ -521,7 +521,7 @@ g {
 	n[11]: field.1     n[1]  => _       @ bb3[4]:  fn connection_accepted;  ((*_4).1: *mut pointers::fdnode_st) = move _9;
 	n[12]: addr.store  n[11] => _       @ bb3[4]:  fn connection_accepted;  ((*_4).1: *mut pointers::fdnode_st) = move _9;
 	n[13]: copy        n[8]  => _0      @ bb3[6]:  fn connection_accepted;  _0 = _4;
-	n[14]: copy        n[13] => _13     @ bb4[18]: fn lighttpd_test;        _13 = connection_accepted(move _14, const 0_i32);
+	n[14]: copy        n[13] => _13     @ bb4[19]: fn lighttpd_test;        _13 = connection_accepted(move _14, const 0_i32);
 	n[15]: copy        n[14] => _17     @ bb5[6]:  fn lighttpd_test;        _17 = _13;
 	n[16]: copy        n[15] => _2      @ bb0[0]:  fn connection_close;     _15 = connection_close(move _16, move _17);
 	n[17]: field.1     n[16] => _5      @ bb0[4]:  fn connection_close;     _5 = ((*_2).1: *mut pointers::fdnode_st);
@@ -629,34 +629,36 @@ g {
 nodes_that_need_write = []
 
 g {
-	n[0]: &_1  _    => _2 @ bb0[4]:  fn test_shared_ref;  _2 = &_1;
-	n[1]: copy n[0] => _3 @ bb0[7]:  fn test_shared_ref;  _3 = _2;
-	n[2]: copy n[1] => _5 @ bb0[11]: fn test_shared_ref;  _5 = &(*_3);
-	n[3]: copy n[2] => _1 @ bb0[0]:  fn shared_ref_foo;   _4 = shared_ref_foo(move _5);
-	n[4]: copy n[3] => _0 @ bb0[0]:  fn shared_ref_foo;   _0 = _1;
-	n[5]: copy n[4] => _4 @ bb0[12]: fn test_shared_ref;  _4 = shared_ref_foo(move _5);
-	n[6]: copy n[5] => _6 @ bb1[3]:  fn test_shared_ref;  _6 = &raw const (*_4);
-}
-nodes_that_need_write = []
-
-g {
-	n[0]: &_1  _    => _4 @ bb0[8]: fn test_unique_ref;  _4 = &mut _1;
-	n[1]: copy n[0] => _3 @ bb0[9]: fn test_unique_ref;  _3 = &raw mut (*_4);
-}
-nodes_that_need_write = []
-
-g {
-	n[0]: &_3        _    => _5 @ bb0[13]: fn test_unique_ref;  _5 = &mut _3;
-	n[1]: addr.store n[0] => _  @ bb0[18]: fn test_unique_ref;  (*_5) = move _6;
+	n[0]: &_1        _    => _  @ bb0[2]:  fn test_shared_ref;  _7 = &raw mut _1;
+	n[1]: addr.store n[0] => _  @ bb0[1]:  fn test_shared_ref;  _1 = const 2_u8;
+	n[2]: copy       n[0] => _2 @ bb0[5]:  fn test_shared_ref;  _2 = &(*_7);
+	n[3]: copy       n[2] => _3 @ bb0[8]:  fn test_shared_ref;  _3 = _2;
+	n[4]: copy       n[3] => _5 @ bb0[12]: fn test_shared_ref;  _5 = &(*_3);
+	n[5]: copy       n[4] => _1 @ bb0[0]:  fn shared_ref_foo;   _4 = shared_ref_foo(move _5);
+	n[6]: copy       n[5] => _0 @ bb0[0]:  fn shared_ref_foo;   _0 = _1;
+	n[7]: copy       n[6] => _4 @ bb0[13]: fn test_shared_ref;  _4 = shared_ref_foo(move _5);
+	n[8]: copy       n[7] => _6 @ bb1[3]:  fn test_shared_ref;  _6 = &raw const (*_4);
 }
 nodes_that_need_write = [1, 0]
 
 g {
-	n[0]: &_1         _    => _7   @ bb0[16]: fn test_unique_ref;  _7 = &mut _1;
-	n[1]: copy        n[0] => _6   @ bb0[17]: fn test_unique_ref;  _6 = &raw mut (*_7);
-	n[2]: value.store n[1] => _5.* @ bb0[18]: fn test_unique_ref;  (*_5) = move _6;
+	n[0]: &_1         _    => _    @ bb0[2]:  fn test_unique_ref;  _8 = &raw mut _1;
+	n[1]: addr.store  n[0] => _    @ bb0[1]:  fn test_unique_ref;  _1 = const 10_i32;
+	n[2]: copy        n[0] => _4   @ bb0[9]:  fn test_unique_ref;  _4 = &mut (*_8);
+	n[3]: copy        n[2] => _3   @ bb0[10]: fn test_unique_ref;  _3 = &raw mut (*_4);
+	n[4]: copy        n[0] => _7   @ bb0[18]: fn test_unique_ref;  _7 = &mut (*_8);
+	n[5]: copy        n[4] => _6   @ bb0[19]: fn test_unique_ref;  _6 = &raw mut (*_7);
+	n[6]: value.store n[5] => _5.* @ bb0[20]: fn test_unique_ref;  (*_5) = move _6;
 }
-nodes_that_need_write = []
+nodes_that_need_write = [1, 0]
+
+g {
+	n[0]: &_3        _    => _  @ bb0[11]: fn test_unique_ref;  _9 = &raw mut _3;
+	n[1]: addr.store n[0] => _  @ bb0[10]: fn test_unique_ref;  _3 = &raw mut (*_4);
+	n[2]: copy       n[0] => _5 @ bb0[15]: fn test_unique_ref;  _5 = &mut (*_9);
+	n[3]: addr.store n[2] => _  @ bb0[20]: fn test_unique_ref;  (*_5) = move _6;
+}
+nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc _    => _1 @ bb1[2]: fn test_realloc_reassign;  _1 = malloc(move _2);
@@ -789,32 +791,36 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc      _    => _1 @ bb1[2]: fn test_load_value;  _1 = malloc(move _2);
-	n[1]: value.load _    => _6 @ bb2[7]: fn test_load_value;  _6 = (*_4);
-	n[2]: free       n[1] => _5 @ bb2[8]: fn test_load_value;  _5 = free(move _6);
+	n[1]: value.load _    => _6 @ bb2[8]: fn test_load_value;  _6 = (*_4);
+	n[2]: free       n[1] => _5 @ bb2[9]: fn test_load_value;  _5 = free(move _6);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: &_1       _    => _4 @ bb2[3]: fn test_load_value;  _4 = &raw const _1;
-	n[1]: addr.load n[0] => _  @ bb2[7]: fn test_load_value;  _6 = (*_4);
+	n[0]: &_1       _    => _  @ bb2[0]: fn test_load_value;  _7 = &raw mut _1;
+	n[1]: copy      n[0] => _4 @ bb2[4]: fn test_load_value;  _4 = &raw const (*_7);
+	n[2]: addr.load n[1] => _  @ bb2[8]: fn test_load_value;  _6 = (*_4);
 }
 nodes_that_need_write = []
 
 g {
 	n[0]: alloc       _    => _1   @ bb1[2]:  fn test_store_value;  _1 = malloc(move _2);
-	n[1]: copy        n[0] => _4   @ bb2[3]:  fn test_store_value;  _4 = _1;
-	n[2]: copy        n[1] => _6   @ bb2[9]:  fn test_store_value;  _6 = _4;
-	n[3]: value.store n[2] => _5.* @ bb2[10]: fn test_store_value;  (*_5) = move _6;
-	n[4]: copy        n[0] => _8   @ bb2[14]: fn test_store_value;  _8 = _1;
-	n[5]: free        n[4] => _7   @ bb2[15]: fn test_store_value;  _7 = free(move _8);
+	n[1]: value.load  _    => _4   @ bb2[4]:  fn test_store_value;  _4 = (*_9);
+	n[2]: copy        n[1] => _6   @ bb2[10]: fn test_store_value;  _6 = _4;
+	n[3]: value.store n[2] => _5.* @ bb2[11]: fn test_store_value;  (*_5) = move _6;
+	n[4]: value.load  _    => _8   @ bb2[15]: fn test_store_value;  _8 = (*_9);
+	n[5]: free        n[4] => _7   @ bb2[16]: fn test_store_value;  _7 = free(move _8);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: &_1        _    => _5 @ bb2[6]:  fn test_store_value;  _5 = &raw mut _1;
-	n[1]: addr.store n[0] => _  @ bb2[10]: fn test_store_value;  (*_5) = move _6;
+	n[0]: &_1        _    => _  @ bb2[0]:  fn test_store_value;  _9 = &raw mut _1;
+	n[1]: addr.load  n[0] => _  @ bb2[4]:  fn test_store_value;  _4 = (*_9);
+	n[2]: copy       n[0] => _5 @ bb2[7]:  fn test_store_value;  _5 = &raw mut (*_9);
+	n[3]: addr.store n[2] => _  @ bb2[11]: fn test_store_value;  (*_5) = move _6;
+	n[4]: addr.load  n[0] => _  @ bb2[15]: fn test_store_value;  _8 = (*_9);
 }
-nodes_that_need_write = [1, 0]
+nodes_that_need_write = [3, 2, 0]
 
 g {
 	n[0]:  alloc       _    => _2     @ bb1[2]:  fn test_store_value_field;  _2 = malloc(move _3);
@@ -846,112 +852,183 @@ nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc       _    => _1   @ bb1[2]:  fn test_load_value_store_value;  _1 = malloc(move _2);
-	n[1]: value.load  _    => _5   @ bb2[6]:  fn test_load_value_store_value;  _5 = (*_4);
-	n[2]: value.store n[1] => _4.* @ bb2[7]:  fn test_load_value_store_value;  (*_4) = move _5;
-	n[3]: value.load  _    => _7   @ bb2[11]: fn test_load_value_store_value;  _7 = (*_4);
-	n[4]: free        n[3] => _6   @ bb2[12]: fn test_load_value_store_value;  _6 = free(move _7);
+	n[1]: value.load  _    => _5   @ bb2[7]:  fn test_load_value_store_value;  _5 = (*_4);
+	n[2]: value.store n[1] => _4.* @ bb2[8]:  fn test_load_value_store_value;  (*_4) = move _5;
+	n[3]: value.load  _    => _7   @ bb2[12]: fn test_load_value_store_value;  _7 = (*_4);
+	n[4]: free        n[3] => _6   @ bb2[13]: fn test_load_value_store_value;  _6 = free(move _7);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: &_1        _    => _4 @ bb2[3]:  fn test_load_value_store_value;  _4 = &raw mut _1;
-	n[1]: addr.load  n[0] => _  @ bb2[6]:  fn test_load_value_store_value;  _5 = (*_4);
-	n[2]: addr.store n[0] => _  @ bb2[7]:  fn test_load_value_store_value;  (*_4) = move _5;
-	n[3]: addr.load  n[0] => _  @ bb2[11]: fn test_load_value_store_value;  _7 = (*_4);
+	n[0]: &_1        _    => _  @ bb2[0]:  fn test_load_value_store_value;  _8 = &raw mut _1;
+	n[1]: copy       n[0] => _4 @ bb2[4]:  fn test_load_value_store_value;  _4 = &raw mut (*_8);
+	n[2]: addr.load  n[1] => _  @ bb2[7]:  fn test_load_value_store_value;  _5 = (*_4);
+	n[3]: addr.store n[1] => _  @ bb2[8]:  fn test_load_value_store_value;  (*_4) = move _5;
+	n[4]: addr.load  n[1] => _  @ bb2[12]: fn test_load_value_store_value;  _7 = (*_4);
 }
-nodes_that_need_write = [2, 0]
+nodes_that_need_write = [3, 1, 0]
 
 g {
-	n[0]:  &_39       _     => _38 @ bb31[4]:  fn main_0;          _38 = &mut _39;
-	n[1]:  copy       n[0]  => _44 @ bb31[11]: fn main_0;          _44 = &(*_38);
-	n[2]:  copy       n[1]  => _43 @ bb31[12]: fn main_0;          _43 = move _44 as &[i32] (Pointer(Unsize));
-	n[3]:  copy       n[2]  => _1  @ bb0[0]:   fn len;             _42 = len(move _43);
-	n[4]:  copy       n[0]  => _46 @ bb32[5]:  fn main_0;          _46 = &raw mut (*_38);
-	n[5]:  copy       n[4]  => _45 @ bb32[6]:  fn main_0;          _45 = move _46 as *mut i32 (Pointer(ArrayToPointer));
-	n[6]:  copy       n[5]  => _2  @ bb0[0]:   fn insertion_sort;  _40 = insertion_sort(move _41, move _45);
-	n[7]:  copy       n[6]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
-	n[8]:  offset[1]  n[7]  => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
-	n[9]:  addr.load  n[8]  => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
-	n[10]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[11]: offset[0]  n[10] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[12]: addr.load  n[11] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
-	n[13]: copy       n[6]  => _44 @ bb21[7]:  fn insertion_sort;  _44 = _2;
-	n[14]: offset[1]  n[13] => _43 @ bb21[13]: fn insertion_sort;  _43 = offset(move _44, move _45);
-	n[15]: addr.store n[14] => _   @ bb22[2]:  fn insertion_sort;  (*_43) = move _42;
-	n[16]: copy       n[6]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
-	n[17]: offset[2]  n[16] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
-	n[18]: addr.load  n[17] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
-	n[19]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[20]: offset[1]  n[19] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[21]: addr.load  n[20] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
-	n[22]: copy       n[6]  => _30 @ bb12[3]:  fn insertion_sort;  _30 = _2;
-	n[23]: offset[1]  n[22] => _29 @ bb12[15]: fn insertion_sort;  _29 = offset(move _30, move _31);
-	n[24]: addr.load  n[23] => _   @ bb14[2]:  fn insertion_sort;  _28 = (*_29);
-	n[25]: copy       n[6]  => _36 @ bb14[5]:  fn insertion_sort;  _36 = _2;
-	n[26]: offset[2]  n[25] => _35 @ bb14[11]: fn insertion_sort;  _35 = offset(move _36, move _37);
-	n[27]: addr.store n[26] => _   @ bb15[2]:  fn insertion_sort;  (*_35) = move _28;
-	n[28]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[29]: offset[0]  n[28] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[30]: addr.load  n[29] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
-	n[31]: copy       n[6]  => _44 @ bb21[7]:  fn insertion_sort;  _44 = _2;
-	n[32]: offset[1]  n[31] => _43 @ bb21[13]: fn insertion_sort;  _43 = offset(move _44, move _45);
-	n[33]: addr.store n[32] => _   @ bb22[2]:  fn insertion_sort;  (*_43) = move _42;
-	n[34]: copy       n[6]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
-	n[35]: offset[3]  n[34] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
-	n[36]: addr.load  n[35] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
-	n[37]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[38]: offset[2]  n[37] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[39]: addr.load  n[38] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
-	n[40]: copy       n[6]  => _30 @ bb12[3]:  fn insertion_sort;  _30 = _2;
-	n[41]: offset[2]  n[40] => _29 @ bb12[15]: fn insertion_sort;  _29 = offset(move _30, move _31);
-	n[42]: addr.load  n[41] => _   @ bb14[2]:  fn insertion_sort;  _28 = (*_29);
-	n[43]: copy       n[6]  => _36 @ bb14[5]:  fn insertion_sort;  _36 = _2;
-	n[44]: offset[3]  n[43] => _35 @ bb14[11]: fn insertion_sort;  _35 = offset(move _36, move _37);
-	n[45]: addr.store n[44] => _   @ bb15[2]:  fn insertion_sort;  (*_35) = move _28;
-	n[46]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[47]: offset[1]  n[46] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[48]: addr.load  n[47] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
-	n[49]: copy       n[6]  => _30 @ bb12[3]:  fn insertion_sort;  _30 = _2;
-	n[50]: offset[1]  n[49] => _29 @ bb12[15]: fn insertion_sort;  _29 = offset(move _30, move _31);
-	n[51]: addr.load  n[50] => _   @ bb14[2]:  fn insertion_sort;  _28 = (*_29);
-	n[52]: copy       n[6]  => _36 @ bb14[5]:  fn insertion_sort;  _36 = _2;
-	n[53]: offset[2]  n[52] => _35 @ bb14[11]: fn insertion_sort;  _35 = offset(move _36, move _37);
-	n[54]: addr.store n[53] => _   @ bb15[2]:  fn insertion_sort;  (*_35) = move _28;
-	n[55]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[56]: offset[0]  n[55] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[57]: addr.load  n[56] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
-	n[58]: copy       n[6]  => _30 @ bb12[3]:  fn insertion_sort;  _30 = _2;
-	n[59]: offset[0]  n[58] => _29 @ bb12[15]: fn insertion_sort;  _29 = offset(move _30, move _31);
-	n[60]: addr.load  n[59] => _   @ bb14[2]:  fn insertion_sort;  _28 = (*_29);
-	n[61]: copy       n[6]  => _36 @ bb14[5]:  fn insertion_sort;  _36 = _2;
-	n[62]: offset[1]  n[61] => _35 @ bb14[11]: fn insertion_sort;  _35 = offset(move _36, move _37);
-	n[63]: addr.store n[62] => _   @ bb15[2]:  fn insertion_sort;  (*_35) = move _28;
-	n[64]: copy       n[6]  => _44 @ bb21[7]:  fn insertion_sort;  _44 = _2;
-	n[65]: offset[0]  n[64] => _43 @ bb21[13]: fn insertion_sort;  _43 = offset(move _44, move _45);
-	n[66]: addr.store n[65] => _   @ bb22[2]:  fn insertion_sort;  (*_43) = move _42;
-	n[67]: copy       n[6]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
-	n[68]: offset[4]  n[67] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
-	n[69]: addr.load  n[68] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
-	n[70]: copy       n[6]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
-	n[71]: offset[3]  n[70] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
-	n[72]: addr.load  n[71] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
-	n[73]: copy       n[6]  => _44 @ bb21[7]:  fn insertion_sort;  _44 = _2;
-	n[74]: offset[4]  n[73] => _43 @ bb21[13]: fn insertion_sort;  _43 = offset(move _44, move _45);
-	n[75]: addr.store n[74] => _   @ bb22[2]:  fn insertion_sort;  (*_43) = move _42;
+	n[0]:  &_40       _     => _   @ bb32[4]:  fn main_0;          _59 = &raw mut _40;
+	n[1]:  addr.store n[0]  => _   @ bb32[3]:  fn main_0;          _40 = [const 2_i32, const 5_i32, const 3_i32, const 1_i32, const 6_i32];
+	n[2]:  copy       n[0]  => _39 @ bb32[5]:  fn main_0;          _39 = &mut (*_59);
+	n[3]:  copy       n[2]  => _45 @ bb32[12]: fn main_0;          _45 = &(*_39);
+	n[4]:  copy       n[3]  => _44 @ bb32[13]: fn main_0;          _44 = move _45 as &[i32] (Pointer(Unsize));
+	n[5]:  copy       n[4]  => _1  @ bb0[0]:   fn len;             _43 = len(move _44);
+	n[6]:  copy       n[2]  => _47 @ bb33[5]:  fn main_0;          _47 = &raw mut (*_39);
+	n[7]:  copy       n[6]  => _46 @ bb33[6]:  fn main_0;          _46 = move _47 as *mut i32 (Pointer(ArrayToPointer));
+	n[8]:  copy       n[7]  => _2  @ bb0[0]:   fn insertion_sort;  _41 = insertion_sort(move _42, move _46);
+	n[9]:  copy       n[8]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
+	n[10]: offset[1]  n[9]  => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
+	n[11]: addr.load  n[10] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
+	n[12]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[13]: offset[0]  n[12] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[14]: addr.load  n[13] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
+	n[15]: copy       n[8]  => _44 @ bb21[7]:  fn insertion_sort;  _44 = _2;
+	n[16]: offset[1]  n[15] => _43 @ bb21[13]: fn insertion_sort;  _43 = offset(move _44, move _45);
+	n[17]: addr.store n[16] => _   @ bb22[2]:  fn insertion_sort;  (*_43) = move _42;
+	n[18]: copy       n[8]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
+	n[19]: offset[2]  n[18] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
+	n[20]: addr.load  n[19] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
+	n[21]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[22]: offset[1]  n[21] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[23]: addr.load  n[22] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
+	n[24]: copy       n[8]  => _30 @ bb12[3]:  fn insertion_sort;  _30 = _2;
+	n[25]: offset[1]  n[24] => _29 @ bb12[15]: fn insertion_sort;  _29 = offset(move _30, move _31);
+	n[26]: addr.load  n[25] => _   @ bb14[2]:  fn insertion_sort;  _28 = (*_29);
+	n[27]: copy       n[8]  => _36 @ bb14[5]:  fn insertion_sort;  _36 = _2;
+	n[28]: offset[2]  n[27] => _35 @ bb14[11]: fn insertion_sort;  _35 = offset(move _36, move _37);
+	n[29]: addr.store n[28] => _   @ bb15[2]:  fn insertion_sort;  (*_35) = move _28;
+	n[30]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[31]: offset[0]  n[30] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[32]: addr.load  n[31] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
+	n[33]: copy       n[8]  => _44 @ bb21[7]:  fn insertion_sort;  _44 = _2;
+	n[34]: offset[1]  n[33] => _43 @ bb21[13]: fn insertion_sort;  _43 = offset(move _44, move _45);
+	n[35]: addr.store n[34] => _   @ bb22[2]:  fn insertion_sort;  (*_43) = move _42;
+	n[36]: copy       n[8]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
+	n[37]: offset[3]  n[36] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
+	n[38]: addr.load  n[37] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
+	n[39]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[40]: offset[2]  n[39] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[41]: addr.load  n[40] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
+	n[42]: copy       n[8]  => _30 @ bb12[3]:  fn insertion_sort;  _30 = _2;
+	n[43]: offset[2]  n[42] => _29 @ bb12[15]: fn insertion_sort;  _29 = offset(move _30, move _31);
+	n[44]: addr.load  n[43] => _   @ bb14[2]:  fn insertion_sort;  _28 = (*_29);
+	n[45]: copy       n[8]  => _36 @ bb14[5]:  fn insertion_sort;  _36 = _2;
+	n[46]: offset[3]  n[45] => _35 @ bb14[11]: fn insertion_sort;  _35 = offset(move _36, move _37);
+	n[47]: addr.store n[46] => _   @ bb15[2]:  fn insertion_sort;  (*_35) = move _28;
+	n[48]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[49]: offset[1]  n[48] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[50]: addr.load  n[49] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
+	n[51]: copy       n[8]  => _30 @ bb12[3]:  fn insertion_sort;  _30 = _2;
+	n[52]: offset[1]  n[51] => _29 @ bb12[15]: fn insertion_sort;  _29 = offset(move _30, move _31);
+	n[53]: addr.load  n[52] => _   @ bb14[2]:  fn insertion_sort;  _28 = (*_29);
+	n[54]: copy       n[8]  => _36 @ bb14[5]:  fn insertion_sort;  _36 = _2;
+	n[55]: offset[2]  n[54] => _35 @ bb14[11]: fn insertion_sort;  _35 = offset(move _36, move _37);
+	n[56]: addr.store n[55] => _   @ bb15[2]:  fn insertion_sort;  (*_35) = move _28;
+	n[57]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[58]: offset[0]  n[57] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[59]: addr.load  n[58] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
+	n[60]: copy       n[8]  => _30 @ bb12[3]:  fn insertion_sort;  _30 = _2;
+	n[61]: offset[0]  n[60] => _29 @ bb12[15]: fn insertion_sort;  _29 = offset(move _30, move _31);
+	n[62]: addr.load  n[61] => _   @ bb14[2]:  fn insertion_sort;  _28 = (*_29);
+	n[63]: copy       n[8]  => _36 @ bb14[5]:  fn insertion_sort;  _36 = _2;
+	n[64]: offset[1]  n[63] => _35 @ bb14[11]: fn insertion_sort;  _35 = offset(move _36, move _37);
+	n[65]: addr.store n[64] => _   @ bb15[2]:  fn insertion_sort;  (*_35) = move _28;
+	n[66]: copy       n[8]  => _44 @ bb21[7]:  fn insertion_sort;  _44 = _2;
+	n[67]: offset[0]  n[66] => _43 @ bb21[13]: fn insertion_sort;  _43 = offset(move _44, move _45);
+	n[68]: addr.store n[67] => _   @ bb22[2]:  fn insertion_sort;  (*_43) = move _42;
+	n[69]: copy       n[8]  => _10 @ bb3[3]:   fn insertion_sort;  _10 = _2;
+	n[70]: offset[4]  n[69] => _9  @ bb3[9]:   fn insertion_sort;  _9 = offset(move _10, move _11);
+	n[71]: addr.load  n[70] => _   @ bb5[2]:   fn insertion_sort;  _8 = (*_9);
+	n[72]: copy       n[8]  => _22 @ bb9[4]:   fn insertion_sort;  _22 = _2;
+	n[73]: offset[3]  n[72] => _21 @ bb9[16]:  fn insertion_sort;  _21 = offset(move _22, move _23);
+	n[74]: addr.load  n[73] => _   @ bb11[2]:  fn insertion_sort;  _20 = (*_21);
+	n[75]: copy       n[8]  => _44 @ bb21[7]:  fn insertion_sort;  _44 = _2;
+	n[76]: offset[4]  n[75] => _43 @ bb21[13]: fn insertion_sort;  _43 = offset(move _44, move _45);
+	n[77]: addr.store n[76] => _   @ bb22[2]:  fn insertion_sort;  (*_43) = move _42;
 }
-nodes_that_need_write = [75, 74, 73, 66, 65, 64, 63, 62, 61, 54, 53, 52, 45, 44, 43, 33, 32, 31, 27, 26, 25, 15, 14, 13, 6, 5, 4, 0]
+nodes_that_need_write = [77, 76, 75, 68, 67, 66, 65, 64, 63, 56, 55, 54, 47, 46, 45, 35, 34, 33, 29, 28, 27, 17, 16, 15, 8, 7, 6, 2, 1, 0]
 
 g {
-	n[0]: &_4        _    => _3 @ bb0[15]: fn test_ref_field;  _3 = &mut _4;
-	n[1]: field.3    n[0] => _  @ bb0[17]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
-	n[2]: field.3    n[1] => _7 @ bb0[17]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
-	n[3]: addr.load  n[2] => _  @ bb0[17]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
-	n[4]: field.3    n[0] => _  @ bb0[18]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
-	n[5]: field.3    n[4] => _  @ bb0[18]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
-	n[6]: addr.store n[5] => _  @ bb0[18]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
+	n[0]: &_4        _    => _  @ bb0[12]: fn test_ref_field;  _8 = &raw mut _4;
+	n[1]: addr.store n[0] => _  @ bb0[11]: fn test_ref_field;  _4 = pointers::S { field: const 0_i32, field2: const 0_u64, field3: move _5, field4: move _6 };
+	n[2]: copy       n[0] => _3 @ bb0[16]: fn test_ref_field;  _3 = &mut (*_8);
+	n[3]: field.3    n[2] => _  @ bb0[18]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
+	n[4]: field.3    n[3] => _7 @ bb0[18]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
+	n[5]: addr.load  n[4] => _  @ bb0[18]: fn test_ref_field;  _7 = (((*_3).3: pointers::T).3: i32);
+	n[6]: field.3    n[2] => _  @ bb0[19]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
+	n[7]: field.3    n[6] => _  @ bb0[19]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
+	n[8]: addr.store n[7] => _  @ bb0[19]: fn test_ref_field;  (((*_3).3: pointers::T).3: i32) = move _7;
 }
-nodes_that_need_write = [6, 5, 4, 0]
+nodes_that_need_write = [8, 7, 6, 2, 1, 0]
 
-num_graphs = 64
-num_nodes = 694
+g {
+	n[0]: &_1        _    => _  @ bb0[2]:  fn test_addr_taken;  _8 = &raw mut _1;
+	n[1]: addr.store n[0] => _  @ bb0[1]:  fn test_addr_taken;  _1 = const 2_i32;
+	n[2]: addr.load  n[0] => _  @ bb0[6]:  fn test_addr_taken;  _3 = (*_8);
+	n[3]: copy       n[0] => _4 @ bb0[11]: fn test_addr_taken;  _4 = &raw const (*_8);
+	n[4]: addr.load  n[0] => _  @ bb0[15]: fn test_addr_taken;  _6 = (*_8);
+}
+nodes_that_need_write = [1, 0]
+
+g {
+	n[0]: &_1        _    => _  @ bb0[0]: fn test_addr_taken_arg;  _3 = &raw mut _1;
+	n[1]: field.2    n[0] => _  @ bb0[1]: fn test_addr_taken_arg;  ((*_3).2: *const pointers::S) = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[2]: addr.store n[1] => _  @ bb0[1]: fn test_addr_taken_arg;  ((*_3).2: *const pointers::S) = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[3]: copy       n[0] => _2 @ bb0[3]: fn test_addr_taken_arg;  _2 = &(*_3);
+}
+nodes_that_need_write = [2, 1, 0]
+
+g {
+	n[0]:  &_3        _    => _   @ bb2[2]:  fn test_addr_taken_loop;  _19 = &raw mut _3;
+	n[1]:  addr.store n[0] => _   @ bb2[1]:  fn test_addr_taken_loop;  _3 = const 2_i32;
+	n[2]:  copy       n[0] => _4  @ bb5[0]:  fn test_addr_taken_loop;  _4 = &(*_19);
+	n[3]:  addr.load  n[2] => _   @ bb14[3]: fn test_addr_taken_loop;  _18 = (*_4);
+	n[4]:  copy       n[0] => _19 @ bb2[2]:  fn test_addr_taken_loop;  _19 = &raw mut _3;
+	n[5]:  addr.store n[4] => _   @ bb2[1]:  fn test_addr_taken_loop;  _3 = const 2_i32;
+	n[6]:  copy       n[4] => _4  @ bb5[0]:  fn test_addr_taken_loop;  _4 = &(*_19);
+	n[7]:  addr.load  n[6] => _   @ bb14[3]: fn test_addr_taken_loop;  _18 = (*_4);
+	n[8]:  copy       n[4] => _19 @ bb2[2]:  fn test_addr_taken_loop;  _19 = &raw mut _3;
+	n[9]:  addr.store n[8] => _   @ bb2[1]:  fn test_addr_taken_loop;  _3 = const 2_i32;
+	n[10]: copy       n[8] => _4  @ bb5[0]:  fn test_addr_taken_loop;  _4 = &(*_19);
+}
+nodes_that_need_write = [9, 8, 5, 4, 1, 0]
+
+g {
+	n[0]: &_2        _    => _  @ bb1[1]: fn test_addr_taken_cond;  _6 = &raw mut _2;
+	n[1]: addr.store n[0] => _  @ bb1[0]: fn test_addr_taken_cond;  _2 = const 1_i32;
+	n[2]: copy       n[0] => _4 @ bb4[3]: fn test_addr_taken_cond;  _4 = &(*_6);
+	n[3]: addr.load  n[0] => _  @ bb4[6]: fn test_addr_taken_cond;  _5 = (*_6);
+}
+nodes_that_need_write = [1, 0]
+
+g {
+	n[0]: &_2        _    => _  @ bb3[1]: fn test_addr_taken_cond;  _6 = &raw mut _2;
+	n[1]: addr.store n[0] => _  @ bb3[0]: fn test_addr_taken_cond;  _2 = const 2_i32;
+	n[2]: copy       n[0] => _4 @ bb4[3]: fn test_addr_taken_cond;  _4 = &(*_6);
+	n[3]: addr.load  n[0] => _  @ bb4[6]: fn test_addr_taken_cond;  _5 = (*_6);
+}
+nodes_that_need_write = [1, 0]
+
+g {
+	n[0]: &_2        _    => _  @ bb1[1]: fn test_addr_taken_init_cond;  _8 = &raw mut _2;
+	n[1]: addr.store n[0] => _  @ bb1[0]: fn test_addr_taken_init_cond;  _2 = const 1_i32;
+	n[2]: copy       n[0] => _6 @ bb1[3]: fn test_addr_taken_init_cond;  _6 = &(*_8);
+	n[3]: copy       n[2] => _3 @ bb1[4]: fn test_addr_taken_init_cond;  _3 = move _6;
+	n[4]: copy       n[0] => _8 @ bb4[3]: fn test_addr_taken_init_cond;  _8 = &raw mut _2;
+	n[5]: addr.store n[4] => _  @ bb4[2]: fn test_addr_taken_init_cond;  _2 = const 2_i32;
+	n[6]: addr.load  n[4] => _  @ bb4[5]: fn test_addr_taken_init_cond;  _7 = (*_8);
+}
+nodes_that_need_write = [5, 4, 1, 0]
+
+g {
+	n[0]: &_2        _    => _ @ bb4[3]: fn test_addr_taken_init_cond;  _8 = &raw mut _2;
+	n[1]: addr.store n[0] => _ @ bb4[2]: fn test_addr_taken_init_cond;  _2 = const 2_i32;
+	n[2]: addr.load  n[0] => _ @ bb4[5]: fn test_addr_taken_init_cond;  _7 = (*_8);
+}
+nodes_that_need_write = [1, 0]
+
+num_graphs = 67
+num_nodes = 759
 


### PR DESCRIPTION
We want to track usage of the memory of address-taken locals in dynamic analysis and in the pointer derivation graph for static analysis. This adds support for that. This also tracks operations on the local's memory even before the local becomes address-taken. Additionally, support for address-taken arguments have been added. Taking references of locals with `&` and `&mut` are also considered taking their address. 

Support for address-taken locals is done in three stages: identifying where address-taken locals get their address taken, a rewriting stage, and post-processing. The first two stages are accomplished in dynamic analysis with the introduction of two new MIR visitors and the last occurs during construction of the pointer derivation graph. 

The first traverses the AST and identifies where locals have their addresses taken and stores that information in a data structure for reference in the next stage. The next stage is another MIR visit that rewrites all address-taken locals in terms of their address. For example, if `_x` is an address-taken local and `_y` stores its address, `_x` is rewritten as `*_y`. These two stages are conducted before instrumentation points are collected in the third and final MIR visitor.

The final stage ensures that all duplicate instances of taking the address of a particular local are treated as copies of its address.

Below are a few examples of what is now supported:

```rust
pub fn test_addr_taken() {
    let x = 2;
    let y = 2 + x;
    let px = std::ptr::addr_of!(x);
    let z = x + y;
}

pub fn test_addr_taken_cond(cond: bool) {
    // let x = if cond { ... } else { ... }; ... &x ...
    let x = if cond { 1 } else { 2 };
    let y = &x;
    let a = x;
}

pub fn test_addr_taken_init_cond(cond: bool) {
    // let mut x; if cond { x = 1; ... &x ... }; x = 2; ... &x ...
    let mut x;
    let mut y;
    if cond {
        x = 1;
        y = &x;
    }
    x = 2;
    let z = x;
}

#[no_mangle]
pub fn test_addr_taken_loop() {
    // loop { let x = ...; ... &x ... }
    let mut count = 0;
    loop {
        let x = 2;
        let z = if count % 2 == 0 { &x } else { &1 };
        if count >= 3 {
            break;
        }
        count += *z;
    }
}

#[no_mangle]
pub fn test_addr_taken_arg(mut t: T) {
    t.field3 = 0 as *const S;
    let z = &t;
}
```