### PR TITLE
Initial function call support in static analysis

### DIFF
--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -223,7 +223,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         let rv_lty = self.visit_operand(&args[0]);
                         self.do_assign(pl_lty, rv_lty);
                     }
-                    None => {}
+                    _ => {}
                 }
             }
             // TODO(spernsteiner): handle other `TerminatorKind`s

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -119,6 +119,9 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         self.next_ptr_id.num_pointers()
     }
 
+    /// Update all `PointerId`s in `self`, replacing each `p` with `map[p]`.  Also sets the "next
+    /// `PointerId`" counter to `counter`.  `map` and `counter` are usually computed together via
+    /// `GlobalEquivSet::renumber`.
     pub fn remap_pointers(
         &mut self,
         map: &GlobalPointerTable<PointerId>,
@@ -237,6 +240,9 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
 }
 
 impl<'tcx> AnalysisCtxtData<'tcx> {
+    /// Update all `PointerId`s in `self`, replacing each `p` with `map[p]`.  Also sets the "next
+    /// `PointerId`" counter to `counter`.  `map` and `counter` are usually computed together via
+    /// `LocalEquivSet::renumber`.
     pub fn remap_pointers(
         &mut self,
         lcx: LTyCtxt<'tcx>,
@@ -267,6 +273,8 @@ impl<'tcx> AnalysisCtxtData<'tcx> {
     }
 }
 
+/// For every `PointerId` `p` that appears in `lty`, replace `p` with `map[p]` (except that
+/// `PointerId::NONE` is left unchanged) and return the updated `LTy`.
 fn remap_lty_pointers<'tcx, T>(lcx: LTyCtxt<'tcx>, map: &T, lty: LTy<'tcx>) -> LTy<'tcx>
 where
     T: Index<PointerId, Output = PointerId>,

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -58,6 +58,7 @@ pub use crate::pointer_id::PointerId;
 pub type LTy<'tcx> = LabeledTy<'tcx, PointerId>;
 pub type LTyCtxt<'tcx> = LabeledTyCtxt<'tcx, PointerId>;
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct LFnSig<'tcx> {
     pub inputs: &'tcx [LTy<'tcx>],
     pub output: LTy<'tcx>,

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -261,6 +261,10 @@ impl<'tcx> AnalysisCtxtData<'tcx> {
 
         *next_ptr_id = counter;
     }
+
+    pub fn num_pointers(&self) -> usize {
+        self.next_ptr_id.num_pointers()
+    }
 }
 
 fn remap_lty_pointers<'tcx, T>(lcx: LTyCtxt<'tcx>, map: &T, lty: LTy<'tcx>) -> LTy<'tcx>
@@ -430,6 +434,7 @@ fn label_no_pointers<'tcx>(acx: &AnalysisCtxt<'_, 'tcx>, ty: Ty<'tcx>) -> LTy<'t
     })
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GlobalAssignment {
     pub perms: GlobalPointerTable<PermissionSet>,
     pub flags: GlobalPointerTable<FlagSet>,

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -119,9 +119,9 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         self.next_ptr_id.num_pointers()
     }
 
-    /// Update all `PointerId`s in `self`, replacing each `p` with `map[p]`.  Also sets the "next
-    /// `PointerId`" counter to `counter`.  `map` and `counter` are usually computed together via
-    /// `GlobalEquivSet::renumber`.
+    /// Update all [`PointerId`]s in `self`, replacing each `p` with `map[p]`.  Also sets the "next
+    /// [`PointerId`]" counter to `counter`.  `map` and `counter` are usually computed together via
+    /// [`GlobalEquivSet::renumber`][crate::equiv::GlobalEquivSet::renumber].
     pub fn remap_pointers(
         &mut self,
         map: &GlobalPointerTable<PointerId>,
@@ -240,9 +240,9 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
 }
 
 impl<'tcx> AnalysisCtxtData<'tcx> {
-    /// Update all `PointerId`s in `self`, replacing each `p` with `map[p]`.  Also sets the "next
-    /// `PointerId`" counter to `counter`.  `map` and `counter` are usually computed together via
-    /// `LocalEquivSet::renumber`.
+    /// Update all [`PointerId`]s in `self`, replacing each `p` with `map[p]`.  Also sets the "next
+    /// [`PointerId`]" counter to `counter`.  `map` and `counter` are usually computed together via
+    /// [`LocalEquivSet::renumber`][crate::equiv::LocalEquivSet::renumber].
     pub fn remap_pointers(
         &mut self,
         lcx: LTyCtxt<'tcx>,
@@ -273,8 +273,8 @@ impl<'tcx> AnalysisCtxtData<'tcx> {
     }
 }
 
-/// For every `PointerId` `p` that appears in `lty`, replace `p` with `map[p]` (except that
-/// `PointerId::NONE` is left unchanged) and return the updated `LTy`.
+/// For every [`PointerId`] `p` that appears in `lty`, replace `p` with `map[p]` (except that
+/// [`PointerId::NONE`] is left unchanged) and return the updated `LTy`.
 fn remap_lty_pointers<'tcx, T>(lcx: LTyCtxt<'tcx>, map: &T, lty: LTy<'tcx>) -> LTy<'tcx>
 where
     T: Index<PointerId, Output = PointerId>,

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -235,12 +235,13 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         args: &[Operand<'tcx>],
         dest: Place<'tcx>,
     ) {
-        let tcx = self.acx.tcx();
-
         let sig = match self.acx.gacx.fn_sigs.get(&def_id) {
             Some(&x) => x,
             None => todo!("call to unknown function {:?}", def_id),
         };
+        if substs.non_erasable_generics().next().is_some() {
+            todo!("call to generic function {:?} {:?}", def_id, substs);
+        }
 
         // Process pseudo-assignments from `args` to the types declared in `sig`.
         for (arg_op, &input_lty) in args.iter().zip(sig.inputs.iter()) {

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -112,8 +112,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
     pub fn visit_operand(&mut self, op: &Operand<'tcx>) -> LTy<'tcx> {
         match *op {
-            Operand::Copy(pl) => self.visit_place(pl, Mutability::Not),
-            Operand::Move(pl) => self.visit_place(pl, Mutability::Not),
+            Operand::Copy(pl) | Operand::Move(pl) => self.visit_place(pl, Mutability::Not),
             Operand::Constant(ref c) => {
                 let ty = c.ty();
                 // TODO

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -224,10 +224,10 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     ) {
         let sig = match self.acx.gacx.fn_sigs.get(&def_id) {
             Some(&x) => x,
-            None => todo!("call to unknown function {:?}", def_id),
+            None => todo!("call to unknown function {def_id:?}"),
         };
         if substs.non_erasable_generics().next().is_some() {
-            todo!("call to generic function {:?} {:?}", def_id, substs);
+            todo!("call to generic function {def_id:?} {substs:?}");
         }
 
         // Process pseudo-assignments from `args` to the types declared in `sig`.

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -112,12 +112,8 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
     pub fn visit_operand(&mut self, op: &Operand<'tcx>) -> LTy<'tcx> {
         match *op {
-            Operand::Copy(pl) => {
-                self.visit_place(pl, Mutability::Not)
-            }
-            Operand::Move(pl) => {
-                self.visit_place(pl, Mutability::Not)
-            }
+            Operand::Copy(pl) => self.visit_place(pl, Mutability::Not),
+            Operand::Move(pl) => self.visit_place(pl, Mutability::Not),
             Operand::Constant(ref c) => {
                 let ty = c.ty();
                 // TODO

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -55,8 +55,10 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             match proj {
                 ProjectionElem::Deref => {
                     // All derefs except the last are loads, to retrieve the pointer for the next
-                    // deref.  However, if the last deref is `&mut` (and is used mutably), then the
-                    // previous derefs must be `&mut` as well.
+                    // deref.  However, if the overall `Place` is used mutably (as indicated by
+                    // `mutbl`), then the previous derefs must be `&mut` as well.  The last deref
+                    // may not be a memory access at all; for example, `&(*p).x` does not actually
+                    // access the memory at `*p`.
                     if let Some(ptr) = prev_deref_ptr.take() {
                         self.record_access(ptr, mutbl);
                     }

--- a/c2rust-analyze/src/expr_rewrite.rs
+++ b/c2rust-analyze/src/expr_rewrite.rs
@@ -177,6 +177,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                             self.visit_ptr_offset(&args[0], pl_ty);
                             return;
                         }
+                        _ => {}
                     }
                 }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -216,7 +216,7 @@ fn run(tcx: TyCtxt) {
 
     // Follow a postorder traversal, so that callers are visited after their callees.  This means
     // callee signatures will usually be up to date when we visit the call site.
-    let order = walk_callgraph(tcx);
+    let order = body_owners_postorder(tcx);
     eprintln!("callgraph traversal order:");
     for &ldid in &order {
         eprintln!("  {ldid:?}");
@@ -413,7 +413,7 @@ fn describe_span(tcx: TyCtxt, span: Span) -> String {
 
 /// Return all `body_owners`, ordered according to a postorder traversal of the graph of references
 /// between bodies.
-fn walk_callgraph(tcx: TyCtxt) -> Vec<LocalDefId> {
+fn body_owners_postorder(tcx: TyCtxt) -> Vec<LocalDefId> {
     let mut seen = HashSet::new();
     let mut order = Vec::new();
     enum Visit {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -427,8 +427,8 @@ fn body_owners_postorder(tcx: TyCtxt) -> Vec<LocalDefId> {
             continue;
         }
         stack.push(Visit::Pre(root_ldid));
-        while let Some(x) = stack.pop() {
-            match x {
+        while let Some(visit) = stack.pop() {
+            match visit {
                 Visit::Pre(ldid) => {
                     if seen.insert(ldid) {
                         stack.push(Visit::Post(ldid));

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -187,7 +187,7 @@ fn run(tcx: TyCtxt) {
     // Remap pointers based on equivalence classes, so all members of an equivalence class now use
     // the same `PointerId`.
     let (global_counter, global_equiv_map) = global_equiv.renumber();
-    eprintln!("global_equiv_map = {global_equiv_map:?}", );
+    eprintln!("global_equiv_map = {global_equiv_map:?}");
     gacx.remap_pointers(&global_equiv_map, global_counter);
 
     for ldid in tcx.hir().body_owners() {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -204,7 +204,6 @@ fn run(tcx: TyCtxt) {
         info.local_equiv.clear();
     }
 
-
     // Compute permission and flag assignments.
 
     let mut gasn =
@@ -260,7 +259,6 @@ fn run(tcx: TyCtxt) {
         }
     }
     eprintln!("reached fixpoint in {} iterations", loop_count);
-
 
     // Print results for each function.
     for ldid in tcx.hir().body_owners() {
@@ -347,7 +345,7 @@ fn run(tcx: TyCtxt) {
 
 trait AssignPointerIds<'tcx> {
     fn lcx(&self) -> LTyCtxt<'tcx>;
-    
+
     fn new_pointer(&mut self) -> PointerId;
 
     fn assign_pointer_ids(&mut self, ty: Ty<'tcx>) -> LTy<'tcx> {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -431,7 +431,7 @@ fn for_each_callee(tcx: TyCtxt, ldid: LocalDefId, f: impl FnMut(LocalDefId)) {
     }
 
     impl<'tcx, F: FnMut(LocalDefId)> Visitor<'tcx> for CalleeVisitor<'_, 'tcx, F> {
-        fn visit_operand(&mut self, operand: &Operand<'tcx>, location: Location) {
+        fn visit_operand(&mut self, operand: &Operand<'tcx>, _location: Location) {
             let ty = operand.ty(self.mir, self.tcx);
             if let Some(Callee::Other { def_id, .. }) = util::ty_callee(self.tcx, ty) {
                 if let Some(ldid) = def_id.as_local() {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -180,9 +180,13 @@ fn run(tcx: TyCtxt) {
         let info = func_info.get_mut(&ldid).unwrap();
         let (local_counter, local_equiv_map) = info.local_equiv.renumber(&global_equiv_map);
         eprintln!("local_equiv_map = {local_equiv_map:?}");
-        info.acx_data
-            .remap_pointers(gacx.lcx, global_equiv_map.and(&local_equiv_map), local_counter);
-        info.dataflow.remap_pointers(global_equiv_map.and(&local_equiv_map));
+        info.acx_data.remap_pointers(
+            gacx.lcx,
+            global_equiv_map.and(&local_equiv_map),
+            local_counter,
+        );
+        info.dataflow
+            .remap_pointers(global_equiv_map.and(&local_equiv_map));
         info.local_equiv.clear();
     }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -187,7 +187,7 @@ fn run(tcx: TyCtxt) {
     // Remap pointers based on equivalence classes, so all members of an equivalence class now use
     // the same `PointerId`.
     let (global_counter, global_equiv_map) = global_equiv.renumber();
-    eprintln!("global_equiv_map = {:?}", global_equiv_map);
+    eprintln!("global_equiv_map = {global_equiv_map:?}", );
     gacx.remap_pointers(&global_equiv_map, global_counter);
 
     for ldid in tcx.hir().body_owners() {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -179,7 +179,7 @@ fn run(tcx: TyCtxt) {
     for ldid in tcx.hir().body_owners() {
         let info = func_info.get_mut(&ldid).unwrap();
         let (l_counter, l_equiv_map) = info.l_equiv.renumber(&g_equiv_map);
-        eprintln!("l_equiv_map = {:?}", l_equiv_map);
+        eprintln!("l_equiv_map = {l_equiv_map:?}");
         info.acx_data
             .remap_pointers(gacx.lcx, g_equiv_map.and(&l_equiv_map), l_counter);
         info.dataflow.remap_pointers(g_equiv_map.and(&l_equiv_map));
@@ -198,7 +198,7 @@ fn run(tcx: TyCtxt) {
     let order = walk_callgraph(tcx);
     eprintln!("callgraph traversal order:");
     for &ldid in &order {
-        eprintln!("  {:?}", ldid);
+        eprintln!("  {ldid:?}");
     }
     let mut loop_count = 0;
     loop {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -41,9 +41,10 @@ mod pointer_id;
 mod type_desc;
 mod util;
 
-/// A wrapper around `T` that dynamically tracks whether it's initialized or not.  `RefCell`
-/// dynamically tracks borrowing and panics if the rules are violated at run time; `MaybeUnset`
-/// dynamically tracks initialization and similarly panics if the value is accessed while unset.
+/// A wrapper around `T` that dynamically tracks whether it's initialized or not.
+/// [`RefCell`][std::cell::RefCell] dynamically tracks borrowing and panics if the rules are
+/// violated at run time; `MaybeUnset` dynamically tracks initialization and similarly panics if
+/// the value is accessed while unset.
 #[derive(Clone, Copy, Debug)]
 struct MaybeUnset<T>(Option<T>);
 
@@ -104,19 +105,19 @@ fn run(tcx: TyCtxt) {
     /// parts.  The different fields are set, used, and cleared at various points below.
     #[derive(Default)]
     struct FuncInfo<'tcx> {
-        /// Local analysis context data, such as `LTy`s for all MIR locals.  Combine with the
-        /// `GlobalAnalysisCtxt` to get a complete `AnalysisCtxt` for use within this function.
+        /// Local analysis context data, such as [`LTy`]s for all MIR locals.  Combine with the
+        /// [`GlobalAnalysisCtxt`] to get a complete [`AnalysisCtxt`] for use within this function.
         acx_data: MaybeUnset<AnalysisCtxtData<'tcx>>,
         /// Dataflow constraints gathered from the body of this function.  These are used for
         /// propagating `READ`/`WRITE`/`OFFSET_ADD` and similar permissions.
         dataflow: MaybeUnset<DataflowConstraints>,
-        /// Local equivalence-class information.  Combine with the `GlobalEquivSet` to get a
-        /// complete `EquivSet`, which assigns an equivalence class to each `PointerId` that
-        /// appears in the function.  Used for renumbering `PointerId`s.
+        /// Local equivalence-class information.  Combine with the [`GlobalEquivSet`] to get a
+        /// complete [`EquivSet`], which assigns an equivalence class to each [`PointerId`] that
+        /// appears in the function.  Used for renumbering [`PointerId`]s.
         local_equiv: MaybeUnset<LocalEquivSet>,
-        /// Local part of the permission/flag assignment.  Combine with the `GlobalAssignment` to
-        /// get a complete `Assignment` for this function, which maps every `PointerId` in this
-        /// function to a `PermissionSet` and `FlagSet`.
+        /// Local part of the permission/flag assignment.  Combine with the [`GlobalAssignment`] to
+        /// get a complete [`Assignment`] for this function, which maps every [`PointerId`] in this
+        /// function to a [`PermissionSet`] and [`FlagSet`].
         lasn: MaybeUnset<LocalAssignment>,
     }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -321,6 +321,7 @@ fn run(tcx: TyCtxt) {
 
 trait AssignPointerIds<'tcx> {
     fn lcx(&self) -> LTyCtxt<'tcx>;
+    
     fn new_pointer(&mut self) -> PointerId;
 
     fn assign_pointer_ids(&mut self, ty: Ty<'tcx>) -> LTy<'tcx> {

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -98,11 +98,11 @@ impl NextGlobalPointerId {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 struct PointerTableInner<T>(Vec<T>);
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct LocalPointerTable<T>(PointerTableInner<T>);
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GlobalPointerTable<T>(PointerTableInner<T>);
 pub struct PointerTable<'a, T> {
     global: &'a GlobalPointerTable<T>,

--- a/c2rust-analyze/tests/filecheck/call1.rs
+++ b/c2rust-analyze/tests/filecheck/call1.rs
@@ -1,3 +1,23 @@
+// CHECK-LABEL: final labeling for "call1"
+// CHECK-DAG: ([[#@LINE+1]]: x): &mut i32
+pub unsafe fn call1(x: *mut i32) {
+    // CHECK-DAG: ([[#@LINE+1]]: p): &mut i32
+    let p = x;
+    write(p);
+    // CHECK-DAG: ([[#@LINE+1]]: q): &i32
+    let q = x;
+    let y = read(q);
+}
+
+pub unsafe fn call2(x: *mut i32) {
+    // CHECK-DAG: ([[#@LINE+1]]: p): &mut i32
+    let p = x;
+    write(p);
+    // CHECK-DAG: ([[#@LINE+1]]: q): &mut i32
+    let q = x;
+    non_unique(q);
+}
+
 // CHECK-LABEL: final labeling for "write"
 // CHECK-DAG: ([[#@LINE+1]]: x): &mut i32
 unsafe fn write(x: *mut i32) {
@@ -18,24 +38,4 @@ unsafe fn non_unique(x: *mut i32) {
     *x = 2;
     *y = 3;
     *x = 4;
-}
-
-// CHECK-LABEL: final labeling for "call1"
-// CHECK-DAG: ([[#@LINE+1]]: x): &mut i32
-pub unsafe fn call1(x: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: p): &mut i32
-    let p = x;
-    write(p);
-    // CHECK-DAG: ([[#@LINE+1]]: q): &i32
-    let q = x;
-    let y = read(q);
-}
-
-pub unsafe fn call2(x: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: p): &mut i32
-    let p = x;
-    write(p);
-    // CHECK-DAG: ([[#@LINE+1]]: q): &mut i32
-    let q = x;
-    non_unique(q);
 }

--- a/c2rust-analyze/tests/filecheck/call1.rs
+++ b/c2rust-analyze/tests/filecheck/call1.rs
@@ -1,0 +1,41 @@
+// CHECK-LABEL: final labeling for "write"
+// CHECK-DAG: ([[#@LINE+1]]: x): &mut i32
+unsafe fn write(x: *mut i32) {
+    *x = 1;
+}
+
+// CHECK-LABEL: final labeling for "read"
+// CHECK-DAG: ([[#@LINE+1]]: x): &i32
+unsafe fn read(x: *mut i32) -> i32 {
+    *x
+}
+
+// CHECK-LABEL: final labeling for "non_unique"
+// CHECK-DAG: ([[#@LINE+1]]: x): &std::cell::Cell<i32>
+unsafe fn non_unique(x: *mut i32) {
+    let y = x;
+    *y = 1;
+    *x = 2;
+    *y = 3;
+    *x = 4;
+}
+
+// CHECK-LABEL: final labeling for "call1"
+// CHECK-DAG: ([[#@LINE+1]]: x): &mut i32
+pub unsafe fn call1(x: *mut i32) {
+    // CHECK-DAG: ([[#@LINE+1]]: p): &mut i32
+    let p = x;
+    write(p);
+    // CHECK-DAG: ([[#@LINE+1]]: q): &i32
+    let q = x;
+    let y = read(q);
+}
+
+pub unsafe fn call2(x: *mut i32) {
+    // CHECK-DAG: ([[#@LINE+1]]: p): &mut i32
+    let p = x;
+    write(p);
+    // CHECK-DAG: ([[#@LINE+1]]: q): &mut i32
+    let q = x;
+    non_unique(q);
+}

--- a/c2rust-analyze/tests/filecheck/call1.rs
+++ b/c2rust-analyze/tests/filecheck/call1.rs
@@ -1,3 +1,10 @@
+// With a naive iteration order, reaching a fixpoint used to take 3 iterations.  By following a
+// postorder traversal of the callgraph, we reduce that to 2 iterations: the first iteration
+// computes all the right permissions, and the second checks that we've actually reached a
+// fixpoint.
+//
+// CHECK: reached fixpoint in 2 iterations
+
 // CHECK-LABEL: final labeling for "call1"
 // CHECK-DAG: ([[#@LINE+1]]: x): &mut i32
 pub unsafe fn call1(x: *mut i32) {

--- a/c2rust-analyze/tests/filecheck/ptrptr1.rs
+++ b/c2rust-analyze/tests/filecheck/ptrptr1.rs
@@ -2,11 +2,11 @@
 // CHECK-LABEL: final labeling for "ptrptr1_backward"
 // CHECK-DAG: ([[#@LINE+4]]: x): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL:[lg][0-9]+]]#*mut i32[NONE#i32[]]]
 // CHECK-DAG: ([[#@LINE+3]]: y): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
-// CHECK-DAG: ([[#@LINE+2]]: x): &&mut i32
-// CHECK-DAG: ([[#@LINE+1]]: y): &&mut i32
+// CHECK-DAG: ([[#@LINE+2]]: x): &mut &mut i32
+// CHECK-DAG: ([[#@LINE+1]]: y): &mut &mut i32
 pub unsafe fn ptrptr1_backward(cond: bool, x: *mut *mut i32, y: *mut *mut i32) {
     // CHECK-DAG: ([[#@LINE+2]]: z): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
-    // CHECK-DAG: ([[#@LINE+1]]: z): &&mut i32
+    // CHECK-DAG: ([[#@LINE+1]]: z): &mut &mut i32
     let z = if cond {
         x
     } else {
@@ -18,7 +18,7 @@ pub unsafe fn ptrptr1_backward(cond: bool, x: *mut *mut i32, y: *mut *mut i32) {
 // CHECK-LABEL: final labeling for "ptrptr1_bidir"
 // CHECK-DAG: ([[#@LINE+4]]: x): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL:[lg][0-9]+]]#*mut i32[NONE#i32[]]]
 // CHECK-DAG: ([[#@LINE+3]]: y): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
-// CHECK-DAG: ([[#@LINE+2]]: x): &&mut i32
+// CHECK-DAG: ([[#@LINE+2]]: x): &mut &mut i32
 // CHECK-DAG: ([[#@LINE+1]]: y): &&mut i32
 pub unsafe fn ptrptr1_bidir(cond: bool, x: *mut *mut i32, y: *mut *mut i32) {
     // CHECK-DAG: ([[#@LINE+2]]: z): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]


### PR DESCRIPTION
This branch adds basic interprocedural analysis for pointer permissions.  It propagates the "easy"/dataflow permissions, such as `WRITE` and `OFFSET_ADD`, across function calls and returns.  For example, given `fn f(x: *mut i32) { *x = 1; }`, it will correctly infer that a call `f(p)` means that `p` must have `WRITE` permission, even if there is no explicit write in the calling function.

Handling of the `UNIQUE` permission is much more complex and is left for a separate branch.  In short, at each function call, the borrow checker needs to know how the lifetimes of the various pointers in the arguments and return values are related so that it knows how the call affects borrows within the caller.  For example, given `fn g(x: *mut i32) -> *mut i32 { x }`, it needs to know that the returned pointer borrows from the argument so it can properly remove `UNIQUE` for code like `let y = g(x); let z = g(x); *y = 1;`

Support for struct fields is also left for later, though that should be straightforward - pointers in field types simply get global `PointerId`s like function arguments do and participate in the dataflow analysis the same way.