### PR TITLE
flow data structure, creation

### DIFF
--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -45,10 +45,7 @@ fn init_flows(n_id: NodeId, n: &Node) -> Flows {
 /// Gathers information from a [`Graph`] (assumed to be acyclic and topologically sorted but not
 /// necessarily connected) for each [`Node`] in it whether there is a path following 'source' edges
 /// from any [`Node`] with a given property to the [`Node`] in question.
-///
-/// [`Node`]: crate::graph::Node
-/// [`Graph`]: graph::graph::Graph
-fn create_flow_info(g: &Graph) -> HashMap<NodeId, Flows> {
+fn set_flow_info(g: &mut Graph) -> HashMap<NodeId, Flows> {
     let mut f = HashMap::from_iter(
         g.nodes
             .iter_enumerated()
@@ -64,20 +61,14 @@ fn create_flow_info(g: &Graph) -> HashMap<NodeId, Flows> {
             parent.neg_offset = parent.neg_offset.or(cur.neg_offset);
         }
     }
-    f
+    node.info = Some(NodeInfo { flows_to: flows.remove(&n_id).unwrap()});
 }
 
 /// Initialize [`Node::info`] for each [`Node`].
 ///
 /// This includes all of the information answering questions of the form "is there a [`Node`] that this is an ancestor of with trait X".
-///
-/// [`Node`]: crate::graph::Node
-/// [`Node::info`]: crate::graph::Node::info
 pub fn add_info(pdg: &mut Graphs) {
     for g in &mut pdg.graphs {
-        let mut flows = create_flow_info(&g);
-        for (n_id,mut node) in g.nodes.iter_enumerated_mut() {
-            node.info = Some(NodeInfo { flows_to: flows.remove(&n_id).unwrap()});
-        }
+        set_flow_info(&mut g);
     }
 }

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -1,7 +1,7 @@
+use crate::graph::{Graph, NodeId, NodeKind};
 use crate::Graphs;
-use crate::graph::{Graph,NodeId,NodeKind};
-use std::fmt::{self, Debug, Display, Formatter};
 use std::collections::HashMap;
+use std::fmt::{self, Debug, Display, Formatter};
 
 /// Information generated from the PDG proper that is queried by static analysis.
 ///
@@ -15,10 +15,10 @@ pub struct NodeInfo {
 }
 
 /// Contains information about what kinds of [`Node`]s a [`Node`] flows to.
-/// Load and store kinds contain both Load/Store-Value and Load/Store-Addr. 
+/// Load and store kinds contain both Load/Store-Value and Load/Store-Addr.
 ///
 /// [`Node`]: crate::graph::Node
-#[derive(Debug, Hash, Clone, Copy,PartialEq,Default)]
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Default)]
 pub struct FlowInfo {
     load: Option<NodeId>,
     store: Option<NodeId>,
@@ -44,14 +44,12 @@ impl Display for NodeInfo {
     }
 }
 
-
-
 /// Gathers information from a [`Graph`] (assumed to be acyclic and topologically sorted but not
 /// necessarily connected) for each [`Node`] in it whether there is a path following 'source' edges
 /// from any [`Node`] with a given property to the [`Node`] in question.
 /// [`Node`]: crate::graph::Node
-fn set_flow_info(g: &mut Graph)  {
-    let mut flow_map : HashMap<NodeId,FlowInfo> = HashMap::from_iter(
+fn set_flow_info(g: &mut Graph) {
+    let mut flow_map: HashMap<NodeId, FlowInfo> = HashMap::from_iter(
         g.nodes
             .iter_enumerated()
             .map(|(idx, node)| (idx, FlowInfo::new(idx, &node.kind))),
@@ -65,7 +63,9 @@ fn set_flow_info(g: &mut Graph)  {
             parent.pos_offset = parent.pos_offset.or(cur_node_flow_info.pos_offset);
             parent.neg_offset = parent.neg_offset.or(cur_node_flow_info.neg_offset);
         }
-        node.info = Some(NodeInfo {flows_to: cur_node_flow_info});
+        node.info = Some(NodeInfo {
+            flows_to: cur_node_flow_info,
+        });
     }
 }
 

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -47,6 +47,7 @@ impl Display for NodeInfo {
 /// Gathers information from a [`Graph`] (assumed to be acyclic and topologically sorted but not
 /// necessarily connected) for each [`Node`] in it whether there is a path following 'source' edges
 /// from any [`Node`] with a given property to the [`Node`] in question.
+///
 /// [`Node`]: crate::graph::Node
 fn set_flow_info(g: &mut Graph) {
     let mut flow_map: HashMap<NodeId, FlowInfo> = HashMap::from_iter(
@@ -74,6 +75,7 @@ fn set_flow_info(g: &mut Graph) {
 /// This includes all of the information answering questions of the form "is there a [`Node`] that this is an ancestor of with trait X".
 ///
 /// [`Node`]: crate::graph::Node
+/// [`Node::info`]: crate::graph::Node::info
 pub fn add_info(pdg: &mut Graphs) {
     for mut g in &mut pdg.graphs {
         set_flow_info(&mut g);

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -16,6 +16,7 @@ pub struct NodeInfo {
 
 /// Contains information about what kinds of [`Node`]s a [`Node`] flows to.
 /// Load and store kinds contain both Load/Store-Value and Load/Store-Addr.
+/// A node A is said to flow into B if it is the transitive 'source' of B.
 ///
 /// [`Node`]: crate::graph::Node
 #[derive(Debug, Hash, Clone, Copy, PartialEq, Default)]

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -14,10 +14,8 @@ pub struct NodeInfo {
     flows_to: Flows,
 }
 
-/// Contains information about what kinds of [`Node`]s the [`Node`] flows to.
-/// Load and store kinds contain both 
-///
-/// [`Node`]: crate::graph::Node.
+/// Contains information about what kinds of [`Node`]s a [`Node`] flows to.
+/// Load and store kinds contain both Load/Store-Value and Load/Store-Addr. 
 #[derive(Debug, Hash, Clone, Copy,PartialEq,Default)]
 pub struct Flows {
     load: Option<NodeId>,
@@ -46,15 +44,15 @@ fn init_flows(n_id: NodeId, n: &Node) -> Flows {
 /// necessarily connected) for each [`Node`] in it whether there is a path following 'source' edges
 /// from any [`Node`] with a given property to the [`Node`] in question.
 fn set_flow_info(g: &mut Graph)  {
-    let mut f : HashMap<NodeId,Flows> = HashMap::from_iter(
+    let mut flow_map : HashMap<NodeId,Flows> = HashMap::from_iter(
         g.nodes
             .iter_enumerated()
             .map(|(idx, node)| (idx, init_flows(idx, node))),
     );
     for (n_id, mut node) in g.nodes.iter_enumerated_mut().rev() {
-        let cur: Flows = f.remove(&n_id).unwrap();
+        let cur: Flows = flow_map.remove(&n_id).unwrap();
         if let Some(p_id) = node.source {
-            let parent = f.get_mut(&p_id).unwrap();
+            let parent = flow_map.get_mut(&p_id).unwrap();
             parent.load = parent.load.or(cur.load);
             parent.store = parent.store.or(cur.store);
             parent.pos_offset = parent.pos_offset.or(cur.pos_offset);

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -78,7 +78,7 @@ fn set_flow_info(g: &mut Graph) {
 /// [`Node`]: crate::graph::Node
 /// [`Node::info`]: crate::graph::Node::info
 pub fn add_info(pdg: &mut Graphs) {
-    for mut g in &mut pdg.graphs {
-        set_flow_info(&mut g);
+    for g in &mut pdg.graphs {
+        set_flow_info(g);
     }
 }

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 /// and eventually will also include its ability to be used as a `&mut`.
 ///
 /// [`Node`]: crate::graph::Node
-#[derive(Hash, Clone, PartialEq, Debug)]
+#[derive(Hash, Clone, PartialEq, Eq, Debug)]
 pub struct NodeInfo {
     flows_to: FlowInfo,
 }
@@ -19,7 +19,7 @@ pub struct NodeInfo {
 /// A node A is said to flow into B if it is the transitive 'source' of B.
 ///
 /// [`Node`]: crate::graph::Node
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq, Default)]
 pub struct FlowInfo {
     load: Option<NodeId>,
     store: Option<NodeId>,

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -1,14 +1,30 @@
 use crate::Graphs;
+use crate::graph::{Graph,NodeId,Node,NodeKind};
 use std::fmt::{self, Debug, Display, Formatter};
+use std::collections::HashMap;
 
 /// Information generated from the PDG proper that is queried by static analysis.
 ///
-/// Eventually this will include information about what kinds of [`Node`]s the [`Node`] flows to,
-/// as well as its ability to be used as a `&mut`.
+/// Includes information about what kinds of [`Node`]s the [`Node`] flows to,
+/// and eventually will also include its ability to be used as a `&mut`.
 ///
 /// [`Node`]: crate::graph::Node
 #[derive(Hash, Clone, PartialEq, Debug)]
-pub struct NodeInfo {}
+pub struct NodeInfo {
+    flows_to: Flows,
+}
+
+/// Contains information about what kinds of [`Node`]s the [`Node`] flows to.
+/// Load and store kinds contain both 
+///
+/// [`Node`]: crate::graph::Node.
+#[derive(Debug, Hash, Clone, Copy,PartialEq,Default)]
+pub struct Flows {
+    load: Option<NodeId>,
+    store: Option<NodeId>,
+    pos_offset: Option<NodeId>,
+    neg_offset: Option<NodeId>,
+}
 
 impl Display for NodeInfo {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -16,10 +32,46 @@ impl Display for NodeInfo {
     }
 }
 
+fn init_flows(n_id: NodeId, n: &Node) -> Flows {
+    Flows {
+        load: matches!(n.kind, NodeKind::LoadAddr | NodeKind::LoadValue).then(|| n_id),
+        store: matches!(n.kind, NodeKind::StoreAddr | NodeKind::StoreValue).then(|| n_id),
+        pos_offset: matches!(n.kind, NodeKind::Offset(x) if x > 0).then(|| n_id),
+        neg_offset: matches!(n.kind, NodeKind::Offset(x) if x < 0).then(|| n_id),
+    }
+}
+
+
+/// Gathers information from a [`Graph`] (assumed to be acyclic and topologically sorted but not
+/// necessarily connected) for each [`Node`] in it whether there is a path following 'source' edges
+/// from any [`Node`] with a given property to the [`Node`] in question.
+///
+/// [`Node`]: crate::graph::Node
+/// [`Graph`]: graph::graph::Graph
+fn create_flow_info(g: &Graph) -> HashMap<NodeId, Flows> {
+    let mut f = HashMap::from_iter(
+        g.nodes
+            .iter_enumerated()
+            .map(|(idx, node)| (idx, init_flows(idx, node))),
+    );
+    for (n_id, node) in g.nodes.iter_enumerated().rev() {
+        let cur: Flows = *(f.get(&n_id).unwrap());
+        if let Some(p_id) = node.source {
+            let parent = f.get_mut(&p_id).unwrap();
+            parent.load = parent.load.or(cur.load);
+            parent.store = parent.store.or(cur.store);
+            parent.pos_offset = parent.pos_offset.or(cur.pos_offset);
+            parent.neg_offset = parent.neg_offset.or(cur.neg_offset);
+        }
+    }
+    f
+}
+
 pub fn add_info(pdg: &mut Graphs) {
     for g in &mut pdg.graphs {
-        for mut node in &mut g.nodes {
-            node.info = Some(NodeInfo {});
+        let mut flows = create_flow_info(&g);
+        for (n_id,mut node) in g.nodes.iter_enumerated_mut() {
+            node.info = Some(NodeInfo { flows_to: flows.remove(&n_id).unwrap()});
         }
     }
 }


### PR DESCRIPTION
The flow data structure is created, and is filled with the correct information for 4 of the 6 flags needed for `c2rust-analyze`:

- `READ`
- `WRITE`
- `OFFSET_ADD`
- `OFFSET_SUB`

The assumption made is that nodes that can alias each other form a tree in which the source fields are the edges.