### PR TITLE
Fix a bunch of comments, mostly in the pdg info tests

### DIFF
--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -220,7 +220,6 @@ mod test {
         pdg.graphs[0_u32.into()].nodes[id].info.as_ref().unwrap()
     }
 
-    #[test]
     /// let mut a = 0;
     /// let b = &mut a;
     /// *b = 0;
@@ -228,6 +227,7 @@ mod test {
     /// *c = 0;
     /// *b = 0;
     /// *c = 0;
+    #[test]
     fn unique_interleave() {
         let mut g = Graph::default();
         // A
@@ -298,13 +298,13 @@ mod test {
         assert!(!info(&pdg, c2).unique);
     }
 
-    #[test]
     /// let mut a = 0;
     /// let b = &mut a;
     /// *b = 0;
     /// let c = &mut *b;
     /// *c = 0;
     /// *b = 0;
+    #[test]
     fn unique_sub_borrow() {
         let mut g = Graph::default();
         // A
@@ -337,7 +337,6 @@ mod test {
         assert!(info(&pdg, c2).unique);
     }
 
-    #[test]
     /// let mut a = 0;
     /// let b = &mut a;
     /// *b = 0;
@@ -345,6 +344,7 @@ mod test {
     /// *c = 0;
     /// *b = 0;
     /// *c = 0;
+    #[test]
     fn unique_sub_borrow_bad() {
         let mut g = Graph::default();
         // A
@@ -381,12 +381,12 @@ mod test {
         assert!(!info(&pdg, c3).unique);
     }
 
-    #[test]
     /// let mut a = Point {x: 0, y: 0};
     /// let b = &mut a.x;
     /// let c = &mut a.y;
     /// *b = 1;
     /// *c = 2;
+    #[test]
     fn okay_use_different_fields() {
         let mut g = Graph::default();
         // A
@@ -418,7 +418,6 @@ mod test {
         assert!(info(&pdg, c2).unique);
     }
 
-    #[test]
     /// let mut a = Point {x: 0, y: 0};
     /// let j = &mut a;
     /// let b = &mut j.x;
@@ -426,6 +425,7 @@ mod test {
     /// *b = 1;
     /// *c = 2;
     /// *(a.y) = 3;
+    #[test]
     fn same_fields_cousins() {
         let mut g = Graph::default();
         // A
@@ -468,12 +468,12 @@ mod test {
         assert!(info(&pdg, d2).unique);
     }
 
-    #[test]
     /// let mut a = Point {x: 0, y: 0};
     /// let b = &mut a;
     /// let c = &mut a.y;
     /// *c = 2;
     /// *b = 1;
+    #[test]
     fn field_vs_raw() {
         let mut g = Graph::default();
         // A
@@ -504,13 +504,13 @@ mod test {
         assert!(!info(&pdg, c2).unique);
     }
 
-    #[test]
     /// let mut a = Point {x: 0, y: 0};
     /// let b = &mut a;
     /// let c = &mut b.y;
     /// let bb = &mut b.y;
     /// *c = 2;
     /// *bb = 1;
+    #[test]
     fn fields_different_levels() {
         let mut g = Graph::default();
         // A
@@ -543,7 +543,6 @@ mod test {
         assert!(!info(&pdg, b2).unique);
     }
 
-    #[test]
     /// let mut a = ColorPoint {x: 0, y: 0, z: Color{ r: 100, g: 100, b: 100}};
     /// let b = &mut a.x;
     /// let c = &mut a.y;
@@ -557,6 +556,7 @@ mod test {
     /// let g = &mut e.g;
     /// *f = 3;
     /// a.z.r = 100;
+    #[test]
     fn lots_of_siblings() {
         let mut g = Graph::default();
 

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -281,11 +281,18 @@ mod test {
         // |    C1
         // |    +-C2
         // B3
+
+        // let mut a = 0;   // A
         let a = mk_addr_of_local(&mut g, 0_u32);
+        // let b = &mut a;  // B1
         let b1 = mk_copy(&mut g, a);
+        // *b = 0;          // B2
         let b2 = mk_store_addr(&mut g, b1);
+        // let c = &mut a;  // C1
         let c1 = mk_copy(&mut g, a);
+        // *c = 0;          // C2
         let c2 = mk_store_addr(&mut g, c1);
+        // *b = 0;          // B3
         let b3 = mk_store_addr(&mut g, b1);
 
         let pdg = build_pdg(g);

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -220,6 +220,7 @@ mod test {
         pdg.graphs[0_u32.into()].nodes[id].info.as_ref().unwrap()
     }
 
+    /// ```rust
     /// let mut a = 0;
     /// let b = &mut a;
     /// *b = 0;
@@ -227,7 +228,9 @@ mod test {
     /// *c = 0;
     /// *b = 0;
     /// *c = 0;
+    /// ```
     ///
+    /// ```text
     /// A
     /// +----.
     /// B1   |
@@ -236,6 +239,7 @@ mod test {
     /// |    +-C2
     /// B3   |
     ///      C3
+    /// ```
     #[test]
     fn unique_interleave() {
         let mut g = Graph::default();
@@ -266,13 +270,16 @@ mod test {
         assert!(!info(&pdg, c3).unique);
     }
 
+    /// ```rust
     /// let mut a = 0;   // A
     /// let b = &mut a;  // B1
     /// *b = 0;          // B2
     /// let c = &mut a;  // C1
     /// *c = 0;          // C2
     /// *b = 0;          // B3
+    /// ```
     ///
+    /// ```text
     /// A
     /// +----.
     /// B1   |
@@ -280,6 +287,7 @@ mod test {
     /// |    C1
     /// |    +-C2
     /// B3
+    /// ```
     #[test]
     fn unique_interleave_onesided() {
         let mut g = Graph::default();
@@ -306,13 +314,16 @@ mod test {
         assert!(!info(&pdg, c2).unique);
     }
 
+    /// ```rust
     /// let mut a = 0;
     /// let b = &mut a;
     /// *b = 0;
     /// let c = &mut *b;
     /// *c = 0;
     /// *b = 0;
+    /// ```
     ///
+    /// ```text
     /// A
     /// |
     /// B1
@@ -320,6 +331,7 @@ mod test {
     /// +----C1
     /// |    +-C2
     /// B3
+    /// ```
     #[test]
     fn unique_sub_borrow() {
         let mut g = Graph::default();
@@ -346,6 +358,7 @@ mod test {
         assert!(info(&pdg, c2).unique);
     }
 
+    /// ```rust
     /// let mut a = 0;
     /// let b = &mut a;
     /// *b = 0;
@@ -353,7 +366,9 @@ mod test {
     /// *c = 0;
     /// *b = 0;
     /// *c = 0;
+    /// ```
     ///
+    /// ```text
     /// A
     /// |
     /// B1
@@ -362,6 +377,7 @@ mod test {
     /// |    +-C2
     /// B3   |
     ///      C3
+    /// ```
     #[test]
     fn unique_sub_borrow_bad() {
         let mut g = Graph::default();
@@ -391,12 +407,15 @@ mod test {
         assert!(!info(&pdg, c3).unique);
     }
 
+    /// ```rust
     /// let mut a = Point {x: 0, y: 0};
     /// let b = &mut a.x;
     /// let c = &mut a.y;
     /// *b = 1;
     /// *c = 2;
+    /// ```
     ///
+    /// ```text
     /// A
     /// |-------
     /// |x     |
@@ -404,6 +423,7 @@ mod test {
     /// |      C1
     /// B2     |
     ///        C2
+    /// ```
     #[test]
     fn okay_use_different_fields() {
         let mut g = Graph::default();
@@ -429,6 +449,7 @@ mod test {
         assert!(info(&pdg, c2).unique);
     }
 
+    /// ```rust
     /// let mut a = Point {x: 0, y: 0};
     /// let j = &mut a;
     /// let b = &mut j.x;
@@ -436,7 +457,9 @@ mod test {
     /// *b = 1;
     /// *c = 2;
     /// *(a.y) = 3;
+    /// ```
     ///
+    /// ```text
     /// A
     /// |-----------
     /// J          |
@@ -448,6 +471,7 @@ mod test {
     /// B2     |   |
     ///        C2  |
     ///            D1
+    /// ```
     #[test]
     fn same_fields_cousins() {
         let mut g = Graph::default();
@@ -480,12 +504,15 @@ mod test {
         assert!(info(&pdg, d2).unique);
     }
 
+    /// ```rust
     /// let mut a = Point {x: 0, y: 0};
     /// let b = &mut a;
     /// let c = &mut a.y;
     /// *c = 2;
     /// *b = 1;
+    /// ```
     ///
+    /// ```text
     /// A
     /// |-------
     /// |      |
@@ -493,6 +520,7 @@ mod test {
     /// |      C1
     /// |      C2
     /// B2
+    /// ```
     #[test]
     fn field_vs_raw() {
         let mut g = Graph::default();
@@ -517,13 +545,16 @@ mod test {
         assert!(!info(&pdg, c2).unique);
     }
 
+    /// ```rust
     /// let mut a = Point {x: 0, y: 0};
     /// let b = &mut a;
     /// let c = &mut b.y;
     /// let bb = &mut b.y;
     /// *c = 2;
     /// *bb = 1;
+    /// ```
     ///
+    /// ```text
     /// A
     /// |-------
     /// |      |
@@ -531,6 +562,7 @@ mod test {
     /// |      C1
     /// |y
     /// B2
+    /// ```
     #[test]
     fn fields_different_levels() {
         let mut g = Graph::default();
@@ -557,6 +589,7 @@ mod test {
         assert!(!info(&pdg, b2).unique);
     }
 
+    /// ```rust
     /// let mut a = ColorPoint {x: 0, y: 0, z: Color{ r: 100, g: 100, b: 100}};
     /// let b = &mut a.x;
     /// let c = &mut a.y;
@@ -570,6 +603,7 @@ mod test {
     /// let g = &mut e.g;
     /// *f = 3;
     /// a.z.r = 100;
+    /// ```
     #[test]
     fn lots_of_siblings() {
         let mut g = Graph::default();

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -408,7 +408,7 @@ mod test {
     }
 
     /// ```rust
-    /// let mut a = Point {x: 0, y: 0};
+    /// let mut a = Point { x: 0, y: 0 };
     /// let b = &mut a.x;
     /// let c = &mut a.y;
     /// *b = 1;
@@ -428,7 +428,7 @@ mod test {
     fn okay_use_different_fields() {
         let mut g = Graph::default();
 
-        // let mut a = Point {x: 0, y: 0};
+        // let mut a = Point { x: 0, y: 0 };
         let a = mk_addr_of_local(&mut g, 0_u32);
         // let b = &mut a.x;
         let b11 = mk_field(&mut g, a, 0_u32);
@@ -450,7 +450,7 @@ mod test {
     }
 
     /// ```rust
-    /// let mut a = Point {x: 0, y: 0};
+    /// let mut a = Point { x: 0, y: 0 };
     /// let j = &mut a;
     /// let b = &mut j.x;
     /// let c = &mut j.x;
@@ -476,7 +476,7 @@ mod test {
     fn same_fields_cousins() {
         let mut g = Graph::default();
 
-        // let mut a = Point {x: 0, y: 0};
+        // let mut a = Point { x: 0, y: 0 };
         let a = mk_addr_of_local(&mut g, 0_u32);
         // let j = &mut a;
         let j = mk_copy(&mut g, a);
@@ -505,7 +505,7 @@ mod test {
     }
 
     /// ```rust
-    /// let mut a = Point {x: 0, y: 0};
+    /// let mut a = Point { x: 0, y: 0 };
     /// let b = &mut a;
     /// let c = &mut a.y;
     /// *c = 2;
@@ -525,7 +525,7 @@ mod test {
     fn field_vs_raw() {
         let mut g = Graph::default();
 
-        // let mut a = Point {x: 0, y: 0};
+        // let mut a = Point { x: 0, y: 0 };
         let a = mk_addr_of_local(&mut g, 0_u32);
         // let b = &mut a;
         let b1 = mk_copy(&mut g, a);
@@ -546,7 +546,7 @@ mod test {
     }
 
     /// ```rust
-    /// let mut a = Point {x: 0, y: 0};
+    /// let mut a = Point { x: 0, y: 0 };
     /// let b = &mut a;
     /// let c = &mut b.y;
     /// let bb = &mut b.y;
@@ -567,7 +567,7 @@ mod test {
     fn fields_different_levels() {
         let mut g = Graph::default();
 
-        // let mut a = Point {x: 0, y: 0};
+        // let mut a = Point { x: 0, y: 0 };
         let a = mk_addr_of_local(&mut g, 0_u32);
         // let b = &mut a;
         let b1 = mk_copy(&mut g, a);
@@ -590,14 +590,14 @@ mod test {
     }
 
     /// ```rust
-    /// let mut a = ColorPoint {x: 0, y: 0, z: Color{ r: 100, g: 100, b: 100}};
+    /// let mut a = ColorPoint { x: 0, y: 0, z: Color { r: 100, g: 100, b: 100 } };
     /// let b = &mut a.x;
     /// let c = &mut a.y;
     /// a.z.r = 200;
     /// *b = 4;
     /// *c = 2;
     /// let d = &mut a;
-    /// *d = ColorPoint {x: 0, y: 0, z: Color {r: 20, g:200, b: 20}};
+    /// *d = ColorPoint { x: 0, y: 0, z: Color { r: 20, g: 200, b: 20 } };
     /// let e = &mut a.z;
     /// let f = &mut e.g;
     /// let g = &mut e.g;
@@ -611,7 +611,7 @@ mod test {
         let (x, y, z) = (0_u32, 1_u32, 2_u32);
         let (red, green, _blue) = (0_u32, 1_u32, 2_u32);
 
-        // let mut a = ColorPoint {x: 0, y: 0, z: Color{ r: 100, g: 100, b: 100}};
+        // let mut a = ColorPoint { x: 0, y: 0, z: Color { r: 100, g: 100, b: 100 } };
         let a = mk_addr_of_local(&mut g, 0_u32);
         // let b = &mut a.x;
         let b1 = mk_field(&mut g, a, x);
@@ -627,7 +627,7 @@ mod test {
         let c2 = mk_store_addr(&mut g, c1);
         // let d = &mut a;
         let d1 = mk_copy(&mut g, a);
-        // *d = ColorPoint {x: 0, y: 0, z: Color {r: 20, g:200, b: 20}};
+        // *d = ColorPoint { x: 0, y: 0, z: Color { r: 20, g: 200, b: 20 } };
         let d2 = mk_store_addr(&mut g, d1);
         // let e = &mut a.z;
         let e = mk_field(&mut g, a, z);

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -227,17 +227,18 @@ mod test {
     /// *c = 0;
     /// *b = 0;
     /// *c = 0;
+    ///
+    /// A
+    /// +----.
+    /// B1   |
+    /// +-B2 |
+    /// |    C1
+    /// |    +-C2
+    /// B3   |
+    ///      C3
     #[test]
     fn unique_interleave() {
         let mut g = Graph::default();
-        // A
-        // +----.
-        // B1   |
-        // +-B2 |
-        // |    C1
-        // |    +-C2
-        // B3   |
-        //      C3
 
         // let mut a = 0;
         let a = mk_addr_of_local(&mut g, 0_u32);
@@ -271,16 +272,17 @@ mod test {
     /// let c = &mut a;  // C1
     /// *c = 0;          // C2
     /// *b = 0;          // B3
+    ///
+    /// A
+    /// +----.
+    /// B1   |
+    /// +-B2 |
+    /// |    C1
+    /// |    +-C2
+    /// B3
     #[test]
     fn unique_interleave_onesided() {
         let mut g = Graph::default();
-        // A
-        // +----.
-        // B1   |
-        // +-B2 |
-        // |    C1
-        // |    +-C2
-        // B3
 
         // let mut a = 0;   // A
         let a = mk_addr_of_local(&mut g, 0_u32);
@@ -310,16 +312,17 @@ mod test {
     /// let c = &mut *b;
     /// *c = 0;
     /// *b = 0;
+    ///
+    /// A
+    /// |
+    /// B1
+    /// +-B2
+    /// +----C1
+    /// |    +-C2
+    /// B3
     #[test]
     fn unique_sub_borrow() {
         let mut g = Graph::default();
-        // A
-        // |
-        // B1
-        // +-B2
-        // +----C1
-        // |    +-C2
-        // B3
 
         // let mut a = 0;
         let a = mk_addr_of_local(&mut g, 0_u32);
@@ -350,17 +353,18 @@ mod test {
     /// *c = 0;
     /// *b = 0;
     /// *c = 0;
+    ///
+    /// A
+    /// |
+    /// B1
+    /// +-B2
+    /// +----C1
+    /// |    +-C2
+    /// B3   |
+    ///      C3
     #[test]
     fn unique_sub_borrow_bad() {
         let mut g = Graph::default();
-        // A
-        // |
-        // B1
-        // +-B2
-        // +----C1
-        // |    +-C2
-        // B3   |
-        //      C3
 
         // let mut a = 0;
         let a = mk_addr_of_local(&mut g, 0_u32);
@@ -392,16 +396,17 @@ mod test {
     /// let c = &mut a.y;
     /// *b = 1;
     /// *c = 2;
+    ///
+    /// A
+    /// |-------
+    /// |x     |
+    /// B1     |y
+    /// |      C1
+    /// B2     |
+    ///        C2
     #[test]
     fn okay_use_different_fields() {
         let mut g = Graph::default();
-        // A
-        // |-------
-        // |x     |
-        // B1     |y
-        // |      C1
-        // B2     |
-        //        C2
 
         // let mut a = Point {x: 0, y: 0};
         let a = mk_addr_of_local(&mut g, 0_u32);
@@ -431,20 +436,21 @@ mod test {
     /// *b = 1;
     /// *c = 2;
     /// *(a.y) = 3;
+    ///
+    /// A
+    /// |-----------
+    /// J          |
+    /// |-------   |
+    /// |x     |   |
+    /// B1     |x  |
+    /// |      C1  |y
+    /// |      |   |
+    /// B2     |   |
+    ///        C2  |
+    ///            D1
     #[test]
     fn same_fields_cousins() {
         let mut g = Graph::default();
-        // A
-        // |-----------
-        // J          |
-        // |-------   |
-        // |x     |   |
-        // B1     |x  |
-        // |      C1  |y
-        // |      |   |
-        // B2     |   |
-        //        C2  |
-        //            D1
 
         // let mut a = Point {x: 0, y: 0};
         let a = mk_addr_of_local(&mut g, 0_u32);
@@ -479,16 +485,17 @@ mod test {
     /// let c = &mut a.y;
     /// *c = 2;
     /// *b = 1;
+    ///
+    /// A
+    /// |-------
+    /// |      |
+    /// B1     |y
+    /// |      C1
+    /// |      C2
+    /// B2
     #[test]
     fn field_vs_raw() {
         let mut g = Graph::default();
-        // A
-        // |-------
-        // |      |
-        // B1     |y
-        // |      C1
-        // |      C2
-        // B2
 
         // let mut a = Point {x: 0, y: 0};
         let a = mk_addr_of_local(&mut g, 0_u32);
@@ -516,16 +523,17 @@ mod test {
     /// let bb = &mut b.y;
     /// *c = 2;
     /// *bb = 1;
+    ///
+    /// A
+    /// |-------
+    /// |      |
+    /// B1     |y
+    /// |      C1
+    /// |y
+    /// B2
     #[test]
     fn fields_different_levels() {
         let mut g = Graph::default();
-        // A
-        // |-------
-        // |      |
-        // B1     |y
-        // |      C1
-        // |y
-        // B2
 
         // let mut a = Point {x: 0, y: 0};
         let a = mk_addr_of_local(&mut g, 0_u32);

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -14,7 +14,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 pub struct NodeInfo {
     flows_to: FlowInfo,
 
-    /// Whether the [`Node`] can be used as a &mut
+    /// Whether the [`Node`] can be used as a `&mut`.
     unique: bool,
 }
 

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -10,8 +10,6 @@ use std::fmt::{self, Debug, Display, Formatter};
 ///
 /// Includes information about what kinds of [`Node`]s the [`Node`] flows to,
 /// as well as its ability to be used as a `&mut`.
-///
-/// [`Node`]: crate::graph::Node
 #[derive(Hash, Clone, PartialEq, Eq, Debug)]
 pub struct NodeInfo {
     flows_to: FlowInfo,

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -265,16 +265,15 @@ mod test {
         assert!(!info(&pdg, c3).unique);
     }
 
+    /// let mut a = 0;   // A
+    /// let b = &mut a;  // B1
+    /// *b = 0;          // B2
+    /// let c = &mut a;  // C1
+    /// *c = 0;          // C2
+    /// *b = 0;          // B3
     #[test]
     fn unique_interleave_onesided() {
         let mut g = Graph::default();
-        // let mut a = 0;   // A
-        // let b = &mut a;  // B1
-        // *b = 0;          // B2
-        // let c = &mut a;  // C1
-        // *c = 0;          // C2
-        // *b = 0;          // B3
-        //
         // A
         // +----.
         // B1   |


### PR DESCRIPTION
Note that the doc tests don't actually run since `c2rust-pdg` only has a binary and not library target (see #665).