### PR TITLE
Fix UB in `analysis/test`

### DIFF
--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -417,18 +417,7 @@ pub unsafe extern "C" fn test_realloc_fresh() {
 }
 #[no_mangle]
 pub unsafe extern "C" fn test_load_addr() {
-    let s = malloc(::std::mem::size_of::<S>() as libc::c_ulong) as *mut S;
-    *s = S {
-        field: 0i32,
-        field2: 0u64,
-        field3: 0 as *const S,
-        field4: T {
-            field: 0i32,
-            field2: 0u64,
-            field3: 0 as *const S,
-            field4: 0i32,
-        },
-    };
+    let s = calloc(1, ::std::mem::size_of::<S>() as libc::c_ulong) as *mut S;
     let x = (*s);
     free(s as *mut libc::c_void);
 }

--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -461,7 +461,7 @@ pub unsafe extern "C" fn test_load_self_store_self() {
 #[no_mangle]
 pub unsafe extern "C" fn test_load_self_store_self_inter() {
     let s = calloc(
-        0i32 as libc::c_ulong,
+        1i32 as libc::c_ulong,
         ::std::mem::size_of::<S>() as libc::c_ulong,
     ) as *mut S;
     let y = (*s).field;

--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -452,7 +452,7 @@ pub unsafe extern "C" fn test_load_other_store_self() {
 #[no_mangle]
 pub unsafe extern "C" fn test_load_self_store_self() {
     let s = calloc(
-        0i32 as libc::c_ulong,
+        1i32 as libc::c_ulong,
         ::std::mem::size_of::<S>() as libc::c_ulong,
     ) as *mut S;
     (*s).field4.field4 = (*s).field4.field4;

--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -413,6 +413,17 @@ pub unsafe extern "C" fn test_realloc_fresh() {
 #[no_mangle]
 pub unsafe extern "C" fn test_load_addr() {
     let s = malloc(::std::mem::size_of::<S>() as libc::c_ulong) as *mut S;
+    *s = S {
+        field: 0i32,
+        field2: 0u64,
+        field3: 0 as *const S,
+        field4: T {
+            field: 0i32,
+            field2: 0u64,
+            field3: 0 as *const S,
+            field4: 0i32,
+        },
+    };
     let x = (*s);
     free(s as *mut libc::c_void);
 }

--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -76,6 +76,12 @@ pub unsafe extern "C" fn simple() {
     let k = (*x).field;
     let z = std::ptr::addr_of!((*x).field2);
     (*x).field3 = std::ptr::addr_of!(*x) as *const S;
+    (*y).field4 = T {
+        field: 0i32,
+        field2: 0u64,
+        field3: 0 as *const S,
+        field4: 0i32,
+    };
     let s = *y;
     *x = s;
     recur(3, x);

--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -76,9 +76,9 @@ pub unsafe extern "C" fn simple() {
     let k = (*x).field;
     let z = std::ptr::addr_of!((*x).field2);
     (*x).field3 = std::ptr::addr_of!(*x) as *const S;
-    recur(3, x);
     let s = *y;
     *x = s;
+    recur(3, x);
 }
 #[no_mangle]
 pub unsafe extern "C" fn simple1() {

--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn simple1() {
     let addr_of_copy = std::ptr::addr_of!(x_copy_copy);
     let i_cast = x as usize;
     let x_from_int = i_cast as *const libc::c_void;
-    free(x as *mut libc::c_void);
+    free(z as *mut libc::c_void);
 }
 
 #[derive(Copy, Clone)]

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
@@ -69,24 +69,24 @@ g {
 	n[16]: field.2     n[3]  => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _14;
 	n[17]: addr.store  n[16] => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _14;
 	n[18]: value.store n[15] => _1.*.2 @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _14;
-	n[19]: copy        n[3]  => _16    @ bb4[29]: fn simple;  _16 = _1;
-	n[20]: copy        n[19] => _2     @ bb0[0]:  fn recur;   _15 = recur(const 3_i32, move _16);
-	n[21]: copy        n[20] => _13    @ bb8[3]:  fn recur;   _13 = _2;
-	n[22]: copy        n[21] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
+	n[19]: addr.load   n[1]  => _      @ bb4[28]: fn simple;  _15 = (*_5);
+	n[20]: addr.store  n[3]  => _      @ bb4[32]: fn simple;  (*_1) = move _16;
+	n[21]: copy        n[3]  => _18    @ bb4[36]: fn simple;  _18 = _1;
+	n[22]: copy        n[21] => _2     @ bb0[0]:  fn recur;   _17 = recur(const 3_i32, move _18);
 	n[23]: copy        n[22] => _13    @ bb8[3]:  fn recur;   _13 = _2;
 	n[24]: copy        n[23] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
 	n[25]: copy        n[24] => _13    @ bb8[3]:  fn recur;   _13 = _2;
 	n[26]: copy        n[25] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
-	n[27]: copy        n[26] => _8     @ bb1[2]:  fn recur;   _8 = _2;
-	n[28]: copy        n[27] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (Misc);
-	n[29]: free        n[28] => _0     @ bb1[5]:  fn recur;   _0 = free(move _7);
-	n[30]: copy        n[26] => _14    @ bb9[4]:  fn recur;   _14 = _2;
-	n[31]: copy        n[26] => _14    @ bb9[4]:  fn recur;   _14 = _2;
-	n[32]: copy        n[26] => _14    @ bb9[4]:  fn recur;   _14 = _2;
-	n[33]: addr.load   n[1]  => _      @ bb5[3]:  fn simple;  _17 = (*_5);
-	n[34]: addr.store  n[3]  => _      @ bb5[7]:  fn simple;  (*_1) = move _18;
+	n[27]: copy        n[26] => _13    @ bb8[3]:  fn recur;   _13 = _2;
+	n[28]: copy        n[27] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
+	n[29]: copy        n[28] => _8     @ bb1[2]:  fn recur;   _8 = _2;
+	n[30]: copy        n[29] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (Misc);
+	n[31]: free        n[30] => _0     @ bb1[5]:  fn recur;   _0 = free(move _7);
+	n[32]: copy        n[28] => _14    @ bb9[4]:  fn recur;   _14 = _2;
+	n[33]: copy        n[28] => _14    @ bb9[4]:  fn recur;   _14 = _2;
+	n[34]: copy        n[28] => _14    @ bb9[4]:  fn recur;   _14 = _2;
 }
-nodes_that_need_write = [34, 17, 16, 11, 10, 9, 8, 5, 4, 3, 2, 1, 0]
+nodes_that_need_write = [20, 17, 16, 11, 10, 9, 8, 5, 4, 3, 2, 1, 0]
 
 g {
 	n[0]: &_1 _ => _9 @ bb4[5]: fn simple;  _9 = &raw const ((*_1).0: i32);

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
@@ -21,10 +21,8 @@ g {
 	n[2]: int_to_ptr  _    => _17   @ bb4[29]: fn simple;              _17 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
 	n[3]: value.store _    => _20.* @ bb4[7]:  fn invalid;             (*_20) = const 0_usize as *mut pointers::S (PointerFromExposedAddress);
 	n[4]: value.store _    => _17.* @ bb8[4]:  fn fdevent_unregister;  (*_17) = const 0_usize as *mut pointers::fdnode_st (PointerFromExposedAddress);
-	n[5]: int_to_ptr  _    => _6    @ bb2[6]:  fn test_load_addr;      _6 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
-	n[6]: int_to_ptr  _    => _8    @ bb2[9]:  fn test_load_addr;      _8 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
-	n[7]: int_to_ptr  _    => _2    @ bb0[2]:  fn test_ref_field;      _2 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
-	n[8]: int_to_ptr  _    => _5    @ bb0[8]:  fn test_ref_field;      _5 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[5]: int_to_ptr  _    => _2    @ bb0[2]:  fn test_ref_field;      _2 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[6]: int_to_ptr  _    => _5    @ bb0[8]:  fn test_ref_field;      _5 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
 }
 nodes_that_need_write = []
 
@@ -690,15 +688,14 @@ g {
 nodes_that_need_write = []
 
 g {
-	n[0]: alloc      _    => _2  @ bb1[2]:  fn test_load_addr;  _2 = malloc(move _3);
-	n[1]: copy       n[0] => _1  @ bb2[1]:  fn test_load_addr;  _1 = move _2 as *mut pointers::S (Misc);
-	n[2]: addr.store n[1] => _   @ bb2[15]: fn test_load_addr;  (*_1) = move _5;
-	n[3]: addr.load  n[1] => _   @ bb2[18]: fn test_load_addr;  _9 = (*_1);
-	n[4]: copy       n[1] => _12 @ bb2[23]: fn test_load_addr;  _12 = _1;
-	n[5]: copy       n[4] => _11 @ bb2[24]: fn test_load_addr;  _11 = move _12 as *mut libc::c_void (Misc);
-	n[6]: free       n[5] => _10 @ bb2[26]: fn test_load_addr;  _10 = free(move _11);
+	n[0]: alloc     _    => _2 @ bb1[2]:  fn test_load_addr;  _2 = calloc(const 1_u64, move _3);
+	n[1]: copy      n[0] => _1 @ bb2[1]:  fn test_load_addr;  _1 = move _2 as *mut pointers::S (Misc);
+	n[2]: addr.load n[1] => _  @ bb2[5]:  fn test_load_addr;  _5 = (*_1);
+	n[3]: copy      n[1] => _8 @ bb2[10]: fn test_load_addr;  _8 = _1;
+	n[4]: copy      n[3] => _7 @ bb2[11]: fn test_load_addr;  _7 = move _8 as *mut libc::c_void (Misc);
+	n[5]: free      n[4] => _6 @ bb2[13]: fn test_load_addr;  _6 = free(move _7);
 }
-nodes_that_need_write = [2, 1, 0]
+nodes_that_need_write = []
 
 g {
 	n[0]: alloc _    => _1  @ bb1[2]: fn test_overwrite;  _1 = malloc(move _2);
@@ -956,5 +953,5 @@ g {
 nodes_that_need_write = [6, 5, 4, 0]
 
 num_graphs = 64
-num_nodes = 697
+num_nodes = 694
 

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
@@ -21,8 +21,10 @@ g {
 	n[2]: int_to_ptr  _    => _16   @ bb4[29]: fn simple;              _16 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
 	n[3]: value.store _    => _20.* @ bb4[7]:  fn invalid;             (*_20) = const 0_usize as *mut pointers::S (PointerFromExposedAddress);
 	n[4]: value.store _    => _17.* @ bb8[4]:  fn fdevent_unregister;  (*_17) = const 0_usize as *mut pointers::fdnode_st (PointerFromExposedAddress);
-	n[5]: int_to_ptr  _    => _2    @ bb0[2]:  fn test_ref_field;      _2 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
-	n[6]: int_to_ptr  _    => _5    @ bb0[8]:  fn test_ref_field;      _5 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[5]: int_to_ptr  _    => _6    @ bb2[6]:  fn test_load_addr;      _6 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[6]: int_to_ptr  _    => _8    @ bb2[9]:  fn test_load_addr;      _8 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[7]: int_to_ptr  _    => _2    @ bb0[2]:  fn test_ref_field;      _2 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[8]: int_to_ptr  _    => _5    @ bb0[8]:  fn test_ref_field;      _5 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
 }
 nodes_that_need_write = []
 
@@ -672,14 +674,15 @@ g {
 nodes_that_need_write = []
 
 g {
-	n[0]: alloc     _    => _2 @ bb1[2]:  fn test_load_addr;  _2 = malloc(move _3);
-	n[1]: copy      n[0] => _1 @ bb2[1]:  fn test_load_addr;  _1 = move _2 as *mut pointers::S (Misc);
-	n[2]: addr.load n[1] => _  @ bb2[5]:  fn test_load_addr;  _5 = (*_1);
-	n[3]: copy      n[1] => _8 @ bb2[10]: fn test_load_addr;  _8 = _1;
-	n[4]: copy      n[3] => _7 @ bb2[11]: fn test_load_addr;  _7 = move _8 as *mut libc::c_void (Misc);
-	n[5]: free      n[4] => _6 @ bb2[13]: fn test_load_addr;  _6 = free(move _7);
+	n[0]: alloc      _    => _2  @ bb1[2]:  fn test_load_addr;  _2 = malloc(move _3);
+	n[1]: copy       n[0] => _1  @ bb2[1]:  fn test_load_addr;  _1 = move _2 as *mut pointers::S (Misc);
+	n[2]: addr.store n[1] => _   @ bb2[15]: fn test_load_addr;  (*_1) = move _5;
+	n[3]: addr.load  n[1] => _   @ bb2[18]: fn test_load_addr;  _9 = (*_1);
+	n[4]: copy       n[1] => _12 @ bb2[23]: fn test_load_addr;  _12 = _1;
+	n[5]: copy       n[4] => _11 @ bb2[24]: fn test_load_addr;  _11 = move _12 as *mut libc::c_void (Misc);
+	n[6]: free       n[5] => _10 @ bb2[26]: fn test_load_addr;  _10 = free(move _11);
 }
-nodes_that_need_write = []
+nodes_that_need_write = [2, 1, 0]
 
 g {
 	n[0]: alloc _ => _1 @ bb1[2]: fn test_overwrite;  _1 = malloc(move _2);
@@ -931,5 +934,5 @@ g {
 nodes_that_need_write = [6, 5, 4, 0]
 
 num_graphs = 64
-num_nodes = 672
+num_nodes = 675
 

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
@@ -16,12 +16,13 @@ g {
 nodes_that_need_write = []
 
 g {
-	n[0]: copy        _    => _14   @ bb6[4]: fn main;                _14 = null_mut();
-	n[1]: copy        n[0] => _1    @ bb0[0]: fn once;                _13 = once(move _14);
-	n[2]: value.store _    => _20.* @ bb4[7]: fn invalid;             (*_20) = const 0_usize as *mut pointers::S (PointerFromExposedAddress);
-	n[3]: value.store _    => _17.* @ bb8[4]: fn fdevent_unregister;  (*_17) = const 0_usize as *mut pointers::fdnode_st (PointerFromExposedAddress);
-	n[4]: int_to_ptr  _    => _2    @ bb0[2]: fn test_ref_field;      _2 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
-	n[5]: int_to_ptr  _    => _5    @ bb0[8]: fn test_ref_field;      _5 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[0]: copy        _    => _14   @ bb6[4]:  fn main;                _14 = null_mut();
+	n[1]: copy        n[0] => _1    @ bb0[0]:  fn once;                _13 = once(move _14);
+	n[2]: int_to_ptr  _    => _16   @ bb4[29]: fn simple;              _16 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[3]: value.store _    => _20.* @ bb4[7]:  fn invalid;             (*_20) = const 0_usize as *mut pointers::S (PointerFromExposedAddress);
+	n[4]: value.store _    => _17.* @ bb8[4]:  fn fdevent_unregister;  (*_17) = const 0_usize as *mut pointers::fdnode_st (PointerFromExposedAddress);
+	n[5]: int_to_ptr  _    => _2    @ bb0[2]:  fn test_ref_field;      _2 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
+	n[6]: int_to_ptr  _    => _5    @ bb0[8]:  fn test_ref_field;      _5 = const 0_usize as *const pointers::S (PointerFromExposedAddress);
 }
 nodes_that_need_write = []
 
@@ -69,24 +70,26 @@ g {
 	n[16]: field.2     n[3]  => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _14;
 	n[17]: addr.store  n[16] => _      @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _14;
 	n[18]: value.store n[15] => _1.*.2 @ bb4[25]: fn simple;  ((*_1).2: *const pointers::S) = move _14;
-	n[19]: addr.load   n[1]  => _      @ bb4[28]: fn simple;  _15 = (*_5);
-	n[20]: addr.store  n[3]  => _      @ bb4[32]: fn simple;  (*_1) = move _16;
-	n[21]: copy        n[3]  => _18    @ bb4[36]: fn simple;  _18 = _1;
-	n[22]: copy        n[21] => _2     @ bb0[0]:  fn recur;   _17 = recur(const 3_i32, move _18);
-	n[23]: copy        n[22] => _13    @ bb8[3]:  fn recur;   _13 = _2;
-	n[24]: copy        n[23] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
+	n[19]: field.3     n[1]  => _      @ bb4[32]: fn simple;  ((*_5).3: pointers::T) = move _15;
+	n[20]: addr.store  n[19] => _      @ bb4[32]: fn simple;  ((*_5).3: pointers::T) = move _15;
+	n[21]: addr.load   n[1]  => _      @ bb4[35]: fn simple;  _17 = (*_5);
+	n[22]: addr.store  n[3]  => _      @ bb4[39]: fn simple;  (*_1) = move _18;
+	n[23]: copy        n[3]  => _20    @ bb4[43]: fn simple;  _20 = _1;
+	n[24]: copy        n[23] => _2     @ bb0[0]:  fn recur;   _19 = recur(const 3_i32, move _20);
 	n[25]: copy        n[24] => _13    @ bb8[3]:  fn recur;   _13 = _2;
 	n[26]: copy        n[25] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
 	n[27]: copy        n[26] => _13    @ bb8[3]:  fn recur;   _13 = _2;
 	n[28]: copy        n[27] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
-	n[29]: copy        n[28] => _8     @ bb1[2]:  fn recur;   _8 = _2;
-	n[30]: copy        n[29] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (Misc);
-	n[31]: free        n[30] => _0     @ bb1[5]:  fn recur;   _0 = free(move _7);
-	n[32]: copy        n[28] => _14    @ bb9[4]:  fn recur;   _14 = _2;
-	n[33]: copy        n[28] => _14    @ bb9[4]:  fn recur;   _14 = _2;
-	n[34]: copy        n[28] => _14    @ bb9[4]:  fn recur;   _14 = _2;
+	n[29]: copy        n[28] => _13    @ bb8[3]:  fn recur;   _13 = _2;
+	n[30]: copy        n[29] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
+	n[31]: copy        n[30] => _8     @ bb1[2]:  fn recur;   _8 = _2;
+	n[32]: copy        n[31] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (Misc);
+	n[33]: free        n[32] => _0     @ bb1[5]:  fn recur;   _0 = free(move _7);
+	n[34]: copy        n[30] => _14    @ bb9[4]:  fn recur;   _14 = _2;
+	n[35]: copy        n[30] => _14    @ bb9[4]:  fn recur;   _14 = _2;
+	n[36]: copy        n[30] => _14    @ bb9[4]:  fn recur;   _14 = _2;
 }
-nodes_that_need_write = [20, 17, 16, 11, 10, 9, 8, 5, 4, 3, 2, 1, 0]
+nodes_that_need_write = [22, 20, 19, 17, 16, 11, 10, 9, 8, 5, 4, 3, 2, 1, 0]
 
 g {
 	n[0]: &_1 _ => _9 @ bb4[5]: fn simple;  _9 = &raw const ((*_1).0: i32);
@@ -928,5 +931,5 @@ g {
 nodes_that_need_write = [6, 5, 4, 0]
 
 num_graphs = 64
-num_nodes = 669
+num_nodes = 672
 

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_test_pdg_snapshot_debug.snap
@@ -410,21 +410,21 @@ g {
 	n[4]: free       n[3] => _6  @ bb3[2]:  fn simple1;  _6 = realloc(move _7, move _9);
 	n[5]: copy       n[1] => _16 @ bb4[20]: fn simple1;  _16 = _1;
 	n[6]: ptr_to_int n[5] => _   @ bb4[21]: fn simple1;  _15 = move _16 as usize (PointerExposeAddress);
-	n[7]: copy       n[1] => _21 @ bb4[33]: fn simple1;  _21 = _1;
-	n[8]: copy       n[7] => _20 @ bb4[34]: fn simple1;  _20 = move _21 as *mut libc::c_void (Misc);
-	n[9]: free       n[8] => _19 @ bb4[36]: fn simple1;  _19 = free(move _20);
 }
 nodes_that_need_write = []
 
 g {
-	n[0]: alloc      _    => _6  @ bb3[2]:  fn simple1;  _6 = realloc(move _7, move _9);
-	n[1]: copy       n[0] => _5  @ bb4[2]:  fn simple1;  _5 = move _6 as *mut pointers::S (Misc);
-	n[2]: copy       n[1] => _11 @ bb4[6]:  fn simple1;  _11 = _5;
-	n[3]: field.0    n[2] => _   @ bb4[8]:  fn simple1;  ((*_11).0: i32) = const 10_i32;
-	n[4]: addr.store n[3] => _   @ bb4[8]:  fn simple1;  ((*_11).0: i32) = const 10_i32;
-	n[5]: copy       n[1] => _12 @ bb4[10]: fn simple1;  _12 = _5;
-	n[6]: copy       n[2] => _13 @ bb4[13]: fn simple1;  _13 = _11;
-	n[7]: int_to_ptr _    => _17 @ bb4[27]: fn simple1;  _17 = move _18 as *const libc::c_void (PointerFromExposedAddress);
+	n[0]:  alloc      _    => _6  @ bb3[2]:  fn simple1;  _6 = realloc(move _7, move _9);
+	n[1]:  copy       n[0] => _5  @ bb4[2]:  fn simple1;  _5 = move _6 as *mut pointers::S (Misc);
+	n[2]:  copy       n[1] => _11 @ bb4[6]:  fn simple1;  _11 = _5;
+	n[3]:  field.0    n[2] => _   @ bb4[8]:  fn simple1;  ((*_11).0: i32) = const 10_i32;
+	n[4]:  addr.store n[3] => _   @ bb4[8]:  fn simple1;  ((*_11).0: i32) = const 10_i32;
+	n[5]:  copy       n[1] => _12 @ bb4[10]: fn simple1;  _12 = _5;
+	n[6]:  copy       n[2] => _13 @ bb4[13]: fn simple1;  _13 = _11;
+	n[7]:  int_to_ptr _    => _17 @ bb4[27]: fn simple1;  _17 = move _18 as *const libc::c_void (PointerFromExposedAddress);
+	n[8]:  copy       n[1] => _21 @ bb4[33]: fn simple1;  _21 = _5;
+	n[9]:  copy       n[8] => _20 @ bb4[34]: fn simple1;  _20 = move _21 as *mut libc::c_void (Misc);
+	n[10]: free       n[9] => _19 @ bb4[36]: fn simple1;  _19 = free(move _20);
 }
 nodes_that_need_write = [4, 3, 2, 1, 0]
 


### PR DESCRIPTION
Fixes #680.

See the commits for the individual fixes.  The fixes are:
* 2 use after frees: 429962d193b81ccc638924657bbfea66a9fabea9, 95e483d77d1d293daf1e01760b6bf423b4492041
* 2 uninitialized reads: 50b1bb4c9b0d322a73c75015336a50abd3f5fe4d, f6e5bce29673ff7170a9cec704fcbce925a32f2a
* 2 nullptr derefs: f96bcb23dcd2a5cc42e1d5948399203d10293325, 69de3c3145ec2bb8d1f4dff9e6dc1a3eb94d73e8

Now `cd analysis/test && cargo miri run` reports no UB.  However, `miri` can't run variadic functions like `printf`, so running this requires the monomorphic `printf` shim in #686.