### PR TITLE
Make `analysis/test` miri-compatible and add a `miri` test for it

### DIFF
--- a/analysis/test/Cargo.toml
+++ b/analysis/test/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 [dependencies]
 libc = "0.2"
 c2rust-analysis-rt = { path = "../runtime", optional = true, version = "0.1.0" }
+
+[features]
+miri = []

--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -21,6 +21,18 @@ extern "C" {
     fn printf(_: *const libc::c_char, _: ...) -> libc::c_int;
 }
 
+/// `miri` does not support calling variadic functions like [`printf`],
+/// but we want to test for UB, leaks, etc. using `cargo miri run`.
+///
+/// Luckily, all [`printf`] calls in this module are monomorphic,
+/// in that they all have the same format string and same call signature,
+/// so we can replace it with a [`printf`] shim that preserves the behavior
+/// only for the exact monomorphic usages in this module.
+///
+/// Note that there is no way to detect `miri` is running,
+/// so we have to put this under a separate `miri` feature
+/// that should be enabled when testing under `miri` with
+/// `cargo miri run --features miri`.
 #[cfg(feature = "miri")]
 fn printf(fmt: *const libc::c_char, i: i32) -> libc::c_int {
     use std::ffi::CStr;

--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -14,7 +14,14 @@ extern "C" {
     fn calloc(_: libc::c_ulong, _: libc::c_ulong) -> *mut libc::c_void;
     fn realloc(_: *mut libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
     fn free(__ptr: *mut libc::c_void);
-    fn printf(_: *const libc::c_char, _: ...) -> libc::c_int;
+}
+
+fn printf(fmt: *const libc::c_char, i: i32) -> libc::c_int {
+    use std::ffi::CStr;
+    assert_eq!(unsafe { CStr::from_ptr(fmt) }, CStr::from_bytes_with_nul(b"%i\n\x00").unwrap());
+    let s = format!("{i}\n");
+    print!("{s}");
+    s.len() as libc::c_int
 }
 
 /// Hidden from instrumentation so that we can polyfill [`reallocarray`] with it.

--- a/analysis/test/src/pointers.rs
+++ b/analysis/test/src/pointers.rs
@@ -16,6 +16,12 @@ extern "C" {
     fn free(__ptr: *mut libc::c_void);
 }
 
+#[cfg(not(feature = "miri"))]
+extern "C" {
+    fn printf(_: *const libc::c_char, _: ...) -> libc::c_int;
+}
+
+#[cfg(feature = "miri")]
 fn printf(fmt: *const libc::c_char, i: i32) -> libc::c_int {
     use std::ffi::CStr;
     assert_eq!(unsafe { CStr::from_ptr(fmt) }, CStr::from_bytes_with_nul(b"%i\n\x00").unwrap());

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -367,6 +367,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn analysis_test_miri() -> eyre::Result<()> {
         init();
         let mut cmd = Command::new("cargo");

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -365,4 +365,16 @@ mod tests {
         insta::assert_display_snapshot!(pdg);
         Ok(())
     }
+
+    #[test]
+    fn analysis_test_miri() -> eyre::Result<()> {
+        init();
+        let mut cmd = Command::new("cargo");
+        cmd.current_dir(repo_dir()?.join("analysis/test"))
+            .args(&["miri", "run", "--features", "miri"])
+            .env("MIRIFLAGS", "");
+        let status = cmd.status()?;
+        ensure!(status.success(), eyre!("{cmd:?} failed: {status}"));
+        Ok(())
+    }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2022-08-08"
-components = ["rustfmt-preview", "rustc-dev", "rust-src"]
+components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]


### PR DESCRIPTION
Fixes #685.

This makes `analysis/test` `miri`-compatible when running with `--features miri`.  This is done by using a monomorphic `printf` shim, since `miri` can't handle variadic functions like `printf`.  Since all uses of `printf` in `analysis/test` are monomorphic (they all have the same format string), we can substitute a `fn printf` that is non-`extern "C"`, non-variadic (and thus `miri`-compatible), and that still has the same behavior for its call sites.

Then we add a test in `c2rust-pdg` that runs `miri` on `analysis/test` to ensure it stays UB-free.

However, we don't yet run this test by default (it's `#[ignore]`d for now) as there are issues with running `miri` in CI (it installs `xargo` every time and I'm getting a permission denied error (not sure from quite what exactly), and it'd be better to install `xargo` upfront, not on every run).  Thus, I'm `#[ignore]`ing it for now in https://github.com/immunant/c2rust/pull/686/commits/4152d34d1f7140f28b346f4be52f0500aa7d7bc4.  We can get it to run in CI correctly later in another PR, but I want to merge this now and avoid over-complicating it here.  The test can still be manually run with `cargo test -p c2rust-pdg -- --ignored analysis_test_miri`.  See #698 for the tracking issue to re-enable this test by default.

The new test passing is blocked on:
* #683 (f ixes #680)
* #684 (f ixes #681)

It would also be nice to f ix #682, but that's not completely necessary for this (though it would create a much less noisy output).