### PR TITLE
Flush the `Backend` buffer

### DIFF
--- a/analysis/runtime/src/runtime/backend.rs
+++ b/analysis/runtime/src/runtime/backend.rs
@@ -1,7 +1,7 @@
 use enum_dispatch::enum_dispatch;
 use fs_err::{File, OpenOptions};
 use std::fmt::Debug;
-use std::io::{BufWriter, Write};
+use std::io::{stderr, BufWriter, Write};
 use std::sync::mpsc::Receiver;
 
 use bincode;
@@ -59,7 +59,9 @@ impl WriteEvent for DebugBackend {
         eprintln!("{:?}: {:?}", mir_loc, event.kind);
     }
 
-    fn flush(&mut self) {}
+    fn flush(&mut self) {
+        stderr().flush().unwrap();
+    }
 }
 
 pub struct LogBackend {


### PR DESCRIPTION
Fixes #689.

Normally the `BufWriter` in `LogBackend` is `flush`ed in `drop`, but since all of this runs from a static or a background thread, no destructors are run (reliably at least; not sure about the background thread case).  Thus, we need to explicitly `flush` the buffer.  I believe this may be the remaining cause of #613.

This fix adds a `flush` method to `trait WriteEvent`, which is called after all `Event`s have been written so that we never lose any of the `Event`s.  It's implemented by delegating to `Write::flush`, both for `BufWriter` in `LogBackend` and `stderr()` in `DebugBackend` (though that one is usually unbuffered).

I discovered this while implementing #687, as the missing `flush` is reliably detected when running the `Backend` on the main thread.