### PR TITLE
Tolerate RISC-V vector types

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -400,6 +400,9 @@ class TypeEncoder final : public TypeVisitor<TypeEncoder> {
             case BuiltinType::UInt: return TagUInt;
             case BuiltinType::ULong: return TagULong;
             case BuiltinType::ULongLong: return TagULongLong;
+            // Constructed as a consequence of the conversion of
+            // built-in to normal vector types.
+            case BuiltinType::Float16: return TagHalf;
             case BuiltinType::Half: return TagHalf;     
             #if CLANG_VERSION_MAJOR >= 11
             case BuiltinType::BFloat16: return TagBFloat16;

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -323,7 +323,12 @@ class TypeEncoder final : public TypeVisitor<TypeEncoder> {
 
 #if CLANG_VERSION_MAJOR >= 10
         // Handle built-in vector types as if they're normal vector types
-        if (kind >= BuiltinType::SveInt8 && kind <= BuiltinType::SveBool) {
+        if (kind >= BuiltinType::SveInt8 && kind <= BuiltinType::SveBool
+#if CLANG_VERSION_MAJOR >= 13
+            /* RISC-V vector types */
+            || kind >= BuiltinType::RvvInt8mf8 && kind <= BuiltinType::RvvBool64
+#endif // CLANG_VERSION_MAJOR >= 13
+            ) {
 // Declare ElemType and ElemCount as needed by various Clang versions
 #if CLANG_VERSION_MAJOR >= 11
             auto Info = Context->getBuiltinVectorTypeInfo(T);
@@ -338,6 +343,8 @@ class TypeEncoder final : public TypeVisitor<TypeEncoder> {
 #else // CLANG_VERSION_MAJOR >= 11
             auto &Ctx = *Context;
             // Copy-pasted from Type::getSveEltType introduced after Clang 10:
+            // (Not extended for RISCV types
+            // as they are not available in that version anyway).
             auto ElemType = [&] {
                 switch (kind) {
                 default: llvm_unreachable("Unknown builtin SVE type!");


### PR DESCRIPTION
Closes: #692

Note that I have no clue how these vector types would be used -- I don't even have a processor that supports them, but their mere presence in LLVM's builtins caused the above-mentioned issue.

This follows along the paths of existing vector types, reusing the code already established for SVE. As this produces a `Float16` rather than a `Half` builtin down the road, support for that is added by mapping to Half. That seems to be OK because, unlike C's `int` size mess, `half` is commonly understood to mean an IEEE 16-bit float.