### PR TITLE
Inline steps from `run_ci_checks.sh` into `azure-pipelines.yml`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,42 +43,66 @@ jobs:
       export PATH="/home/docker/.cargo/bin:$PATH"
       export RUSTUP_HOME=/home/docker/.rustup
       export CARGO_HOME=$AGENT_TEMPDIRECTORY/.cargo
-      ./scripts/run_ci_checks.sh fmt
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      cargo fmt --check
     displayName: 'cargo fmt --check'
   
   - script: |
       export PATH="/home/docker/.cargo/bin:$PATH"
       export RUSTUP_HOME=/home/docker/.rustup
       export CARGO_HOME=$AGENT_TEMPDIRECTORY/.cargo
-      ./scripts/run_ci_checks.sh check
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      # Differs from `cargo build` since we can use `--all-features` here.
+      # We plan to eventually replace `cargo check` with `cargo clippy`.
+      cargo check --tests --all-features
     displayName: 'cargo check'
 
   - script: |
       export PATH="/home/docker/.cargo/bin:$PATH"
       export RUSTUP_HOME=/home/docker/.rustup
       export CARGO_HOME=$AGENT_TEMPDIRECTORY/.cargo
-      ./scripts/run_ci_checks.sh doc
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      cargo doc --all-features --document-private-items --no-deps
     displayName: 'cargo doc'
 
   - script: |
       export PATH="/home/docker/.cargo/bin:$PATH"
       export RUSTUP_HOME=/home/docker/.rustup
       export CARGO_HOME=$AGENT_TEMPDIRECTORY/.cargo
-      ./scripts/run_ci_checks.sh build
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      # Don't build with `--all-features` as `--all-features` includes `--features llvm-static`,
+      # which we don't want to test here (it doesn't work out of the box on Arch and Fedora;
+      # see https://github.com/immunant/c2rust/issues/500).
+      cargo build --release
     displayName: 'cargo build against host clang/LLVM (fast build)'
 
   - script: |
       export PATH="/home/docker/.cargo/bin:$PATH"
       export RUSTUP_HOME=/home/docker/.rustup
       export CARGO_HOME=$AGENT_TEMPDIRECTORY/.cargo
-      ./scripts/run_ci_checks.sh test
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      cargo test --release --exclude c2rust-analyze --workspace
     displayName: 'cargo test'
   
   - script: |
       export PATH="/home/docker/.cargo/bin:$PATH"
       export RUSTUP_HOME=/home/docker/.rustup
       export CARGO_HOME=$AGENT_TEMPDIRECTORY/.cargo
-      ./scripts/run_ci_checks.sh test-translator
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      # `test_translator.py` compiles translated code,
+      # which has tons of warnings.
+      # `RUSTFLAGS="-D warnings"` would be inherited by that,
+      # causing tons of errors, so unset that.
+      # `test_translator.py` does not rebuild,
+      # so changing `RUSTFLAGS` will not trigger a full rebuild.
+      unset RUSTFLAGS
+      ./scripts/test_translator.py tests/
     displayName: 'Test translator (fast build)'
 
 - job: Darwin
@@ -103,29 +127,53 @@ jobs:
 
   - script: |
       export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
-      ./scripts/run_ci_checks.sh fmt
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      cargo fmt --check
     displayName: 'cargo fmt --check'
   
   - script: |
       export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
-      ./scripts/run_ci_checks.sh check
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      # Differs from `cargo build` since we can use `--all-features` here.
+      # We plan to eventually replace `cargo check` with `cargo clippy`.
+      cargo check --tests --all-features
     displayName: 'cargo check'
 
   - script: |
       export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
-      ./scripts/run_ci_checks.sh doc
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      cargo doc --all-features --document-private-items --no-deps
     displayName: 'cargo doc'
 
   - script: |
       export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
-      ./scripts/run_ci_checks.sh build
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      # Don't build with `--all-features` as `--all-features` includes `--features llvm-static`,
+      # which we don't want to test here (it doesn't work out of the box on Arch and Fedora;
+      # see https://github.com/immunant/c2rust/issues/500).
+      cargo build --release
     displayName: 'cargo build against host clang/LLVM (fast build)'
 
   - script: |
       export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
-      ./scripts/run_ci_checks.sh test
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      cargo test --release --exclude c2rust-analyze --workspace
     displayName: 'cargo test'
 
   - script: |
-      ./scripts/run_ci_checks.sh test-translator
+      export RUSTFLAGS="-D warnings"
+      export RUSTDOCFLAGS="-D warnings"
+      # `test_translator.py` compiles translated code,
+      # which has tons of warnings.
+      # `RUSTFLAGS="-D warnings"` would be inherited by that,
+      # causing tons of errors, so unset that.
+      # `test_translator.py` does not rebuild,
+      # so changing `RUSTFLAGS` will not trigger a full rebuild.
+      unset RUSTFLAGS
+      ./scripts/test_translator.py tests/
     displayName: 'Test translator (fast build)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,9 +149,7 @@ jobs:
       export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
       export RUSTFLAGS="-D warnings"
       export RUSTDOCFLAGS="-D warnings"
-      # Don't build with `--all-features` as `--all-features` includes `--features llvm-static`,
-      # which we don't want to test here (it doesn't work out of the box on Arch and Fedora;
-      # see https://github.com/immunant/c2rust/issues/500).
+      # Don't build with `--all-features` (see analogous step for Linux).
       cargo build --release
     displayName: 'cargo build against host clang/LLVM (fast build)'
 
@@ -163,11 +161,6 @@ jobs:
     displayName: 'cargo test'
 
   - script: |
-      # `test_translator.py` compiles translated code,
-      # which has tons of warnings.
-      # `RUSTFLAGS="-D warnings"` would be inherited by that,
-      # causing tons of errors, so don't set that.
-      # `test_translator.py` does not rebuild,
-      # so changing `RUSTFLAGS` will not trigger a full rebuild.
+      # `RUSTFLAGS` not set (see analogous step for Linux).
       ./scripts/test_translator.py tests/
     displayName: 'Test translator (fast build)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,15 +93,12 @@ jobs:
       export PATH="/home/docker/.cargo/bin:$PATH"
       export RUSTUP_HOME=/home/docker/.rustup
       export CARGO_HOME=$AGENT_TEMPDIRECTORY/.cargo
-      export RUSTFLAGS="-D warnings"
-      export RUSTDOCFLAGS="-D warnings"
       # `test_translator.py` compiles translated code,
       # which has tons of warnings.
       # `RUSTFLAGS="-D warnings"` would be inherited by that,
-      # causing tons of errors, so unset that.
+      # causing tons of errors, so don't set that.
       # `test_translator.py` does not rebuild,
       # so changing `RUSTFLAGS` will not trigger a full rebuild.
-      unset RUSTFLAGS
       ./scripts/test_translator.py tests/
     displayName: 'Test translator (fast build)'
 
@@ -166,14 +163,11 @@ jobs:
     displayName: 'cargo test'
 
   - script: |
-      export RUSTFLAGS="-D warnings"
-      export RUSTDOCFLAGS="-D warnings"
       # `test_translator.py` compiles translated code,
       # which has tons of warnings.
       # `RUSTFLAGS="-D warnings"` would be inherited by that,
-      # causing tons of errors, so unset that.
+      # causing tons of errors, so don't set that.
       # `test_translator.py` does not rebuild,
       # so changing `RUSTFLAGS` will not trigger a full rebuild.
-      unset RUSTFLAGS
       ./scripts/test_translator.py tests/
     displayName: 'Test translator (fast build)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,13 +121,6 @@ jobs:
       source $HOME/.cargo/env
       brew info llvm
     displayName: 'Provision macOS'
-
-  - script: |
-      export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
-      export RUSTFLAGS="-D warnings"
-      export RUSTDOCFLAGS="-D warnings"
-      cargo fmt --check
-    displayName: 'cargo fmt --check'
   
   - script: |
       export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config


### PR DESCRIPTION
This inlines steps from `run_ci_checks.sh` into `azure-pipelines.yml`.

This is a semantic revert of 6593b6c53c6b7c9517aa863f14358a7c65b65c4b.

Previously (in 6593b6c53c6b7c9517aa863f14358a7c65b65c4b), I had deduplicated the code (and documentation) from `run_ci_checks.sh` and `azure-pipelines.yml` (both for the Linux and macOS steps, which were duplicated) so that the CI steps were always in sync.  I had run into a couple of bugs where they were subtly out of sync, so I thought it'd be best to deduplicate them and have the single source of truth in the cross-platform `run_ci_checks.sh`.

However, @thedataking thinks it's more important to keep the code in `azure-pipelines.yml` completely inlined so that it's clear what exactly is being run without needing to consult any other scripts or files, so I'm opening this PR to revert* 6593b6c53c6b7c9517aa863f14358a7c65b65c4b and re-inline all the steps into both the Linux and macOS CI steps.

\* There was another change in 6593b6c53c6b7c9517aa863f14358a7c65b65c4b: putting each step in a separate function and allowing them to be easily called on the command line.  I use this feature often for running CI steps locally, and it is independent from @thedataking's concern about inlining, so I'm leaving it as is instead of doing an automatic `git revert 6593b6c53c6b7c9517aa863f14358a7c65b65c4b`.