### PR TITLE
Add a single-threaded instrumentation runtime

### DIFF
--- a/analysis/runtime/src/lib.rs
+++ b/analysis/runtime/src/lib.rs
@@ -2,7 +2,7 @@ pub mod events;
 mod handlers;
 pub mod metadata;
 pub mod mir_loc;
-mod parse;
+pub mod parse;
 pub mod runtime;
 
 pub use handlers::*;

--- a/analysis/runtime/src/runtime/global_runtime.rs
+++ b/analysis/runtime/src/runtime/global_runtime.rs
@@ -5,9 +5,9 @@ use once_cell::sync::OnceCell;
 use crate::events::Event;
 
 use super::{
-    scoped_runtime::ScopedRuntime,
+    scoped_runtime::{ExistingRuntime, ScopedRuntime},
     skip::{skip_event, SkipReason},
-    AnyError,
+    AnyError, Detect,
 };
 
 pub struct GlobalRuntime {
@@ -52,11 +52,11 @@ impl GlobalRuntime {
         }
     }
 
-    /// Try to initialize the [`GlobalRuntime`] with `ScopedRuntime::try_init`.
+    /// Try to initialize the [`GlobalRuntime`] with [`ScopedRuntime::detect`].
     ///
     /// This (or [`GlobalRuntime::init`]), on [`RUNTIME`], should be called at the top of `main`.
     pub fn try_init(&self) -> Result<&ScopedRuntime, AnyError> {
-        self.runtime.get_or_try_init(ScopedRuntime::try_init)
+        self.runtime.get_or_try_init(ScopedRuntime::detect)
     }
 
     /// Same as [`GlobalRuntime::try_init`], if there is an error,

--- a/analysis/runtime/src/runtime/mod.rs
+++ b/analysis/runtime/src/runtime/mod.rs
@@ -12,4 +12,8 @@ use once_cell::sync::Lazy;
 
 type AnyError = Box<dyn Error + Send + Sync + 'static>;
 
+trait Detect: Sized {
+    fn detect() -> Result<Self, AnyError>;
+}
+
 static FINISHED: Lazy<(Mutex<bool>, Condvar)> = Lazy::new(|| (Mutex::new(false), Condvar::new()));

--- a/analysis/runtime/src/runtime/mod.rs
+++ b/analysis/runtime/src/runtime/mod.rs
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;
 
 type AnyError = Box<dyn Error + Send + Sync + 'static>;
 
-trait Detect: Sized {
+pub trait Detect: Sized {
     fn detect() -> Result<Self, AnyError>;
 }
 

--- a/analysis/runtime/src/runtime/scoped_runtime.rs
+++ b/analysis/runtime/src/runtime/scoped_runtime.rs
@@ -13,7 +13,7 @@ use super::{
     AnyError, Detect, FINISHED,
 };
 
-pub(super) trait ExistingRuntime {
+pub trait ExistingRuntime {
     /// Finalize the [`ExistingRuntime`].
     ///
     /// Must be idempotent, i.e. able to be called multiple times.

--- a/analysis/runtime/src/runtime/scoped_runtime.rs
+++ b/analysis/runtime/src/runtime/scoped_runtime.rs
@@ -16,6 +16,8 @@ use super::{
 pub(super) trait ExistingRuntime {
     /// Finalize the [`ExistingRuntime`].
     ///
+    /// Must be idempotent, i.e. able to be called multiple times.
+    ///
     /// Similar to [`Drop::drop`], except it takes `&self`, not `&mut self`,
     /// so it can be run in a [`OnceCell`].
     fn finalize(&self);
@@ -33,12 +35,6 @@ pub struct ScopedRuntime {
 }
 
 impl ExistingRuntime for ScopedRuntime {
-    /// Finalize the [`ScopedRuntime`], shutting it down.
-    ///
-    /// This can be called any number of times; it only finalizes once.
-    ///
-    /// This does the same thing as [`ScopedRuntime::drop`]
-    /// except, of course, it's not a destructor.
     fn finalize(&self) {
         // Only run the finalizer once.
         self.finalized.get_or_init(|| {

--- a/analysis/runtime/src/runtime/scoped_runtime.rs
+++ b/analysis/runtime/src/runtime/scoped_runtime.rs
@@ -8,9 +8,9 @@ use once_cell::sync::OnceCell;
 use crate::events::Event;
 
 use super::{
-    backend::{Backend, DetectBackend},
+    backend::Backend,
     skip::{skip_event, SkipReason},
-    AnyError, FINISHED,
+    AnyError, Detect, FINISHED,
 };
 
 pub struct ScopedRuntime {

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -370,7 +370,7 @@ mod tests {
     #[test]
     fn analysis_test_pdg_snapshot_debug() -> eyre::Result<()> {
         init();
-        let pdg = analysis_test_pdg_snapshot(Profile::Debug, RuntimeKind::BackgroundThread)?;
+        let pdg = analysis_test_pdg_snapshot(Profile::Debug, Default::default())?;
         insta::assert_display_snapshot!(pdg);
         Ok(())
     }

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -332,6 +332,7 @@ mod tests {
             .arg("--")
             .args(args)
             .env("METADATA_FILE", &metadata_path)
+            .env("INSTRUMENT_RUNTIME", "bg")
             .env("INSTRUMENT_BACKEND", "log")
             .env("INSTRUMENT_OUTPUT", &event_log_path)
             .env("INSTRUMENT_OUTPUT_APPEND", "false");

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -203,6 +203,9 @@ mod tests {
         process::Command,
     };
 
+    use c2rust_analysis_rt::runtime::backend::BackendKind;
+    use c2rust_analysis_rt::{parse::AsStr, runtime::scoped_runtime::RuntimeKind};
+
     use color_eyre::eyre::{self, ensure, eyre, Context};
 
     use crate::{Pdg, ToPrint};
@@ -302,6 +305,7 @@ mod tests {
         profile: Profile,
         args: impl IntoIterator<Item = impl AsRef<OsStr>>,
         to_print: &[ToPrint],
+        runtime_kind: RuntimeKind,
     ) -> eyre::Result<impl Display> {
         let runtime_path = repo_dir()?.join("analysis/runtime");
         let manifest_path = test_crate_dir.join("Cargo.toml");
@@ -332,8 +336,8 @@ mod tests {
             .arg("--")
             .args(args)
             .env("METADATA_FILE", &metadata_path)
-            .env("INSTRUMENT_RUNTIME", "bg")
-            .env("INSTRUMENT_BACKEND", "log")
+            .env("INSTRUMENT_RUNTIME", runtime_kind.as_str())
+            .env("INSTRUMENT_BACKEND", BackendKind::Log.as_str())
             .env("INSTRUMENT_OUTPUT", &event_log_path)
             .env("INSTRUMENT_OUTPUT_APPEND", "false");
         let status = cmd.status()?;
@@ -345,7 +349,10 @@ mod tests {
         Ok(repr.to_string())
     }
 
-    fn analysis_test_pdg_snapshot(profile: Profile) -> eyre::Result<impl Display> {
+    fn analysis_test_pdg_snapshot(
+        profile: Profile,
+        runtime_kind: RuntimeKind,
+    ) -> eyre::Result<impl Display> {
         pdg_snapshot(
             repo_dir()?.join("analysis/test").as_path(),
             profile,
@@ -354,6 +361,7 @@ mod tests {
                 use ToPrint::*;
                 &[Graphs, WritePermissions, Counts]
             },
+            runtime_kind,
         )
     }
 
@@ -362,7 +370,7 @@ mod tests {
     #[test]
     fn analysis_test_pdg_snapshot_debug() -> eyre::Result<()> {
         init();
-        let pdg = analysis_test_pdg_snapshot(Profile::Debug)?;
+        let pdg = analysis_test_pdg_snapshot(Profile::Debug, RuntimeKind::BackgroundThread)?;
         insta::assert_display_snapshot!(pdg);
         Ok(())
     }


### PR DESCRIPTION
Fixes #687.

This adds a single (main) thread instrumentation runtime in addition to the existing background thread runtime.

The single-threaded, main thread runtime greatly simplifies the logic, helping to easily and quickly expose bugs, like #613, which I solved in #691 as soon as I added the single-threaded runtime.  This, I think, is the main motivation for adding this, though it may also be faster in certain cases, and would allow instrumented code to run in single-threaded environments in the future.

The runtime, like the backend, is dynamically selected through `$INSTRUMENT_RUNTIME`, which must be either `fg` for the main thread runtime, or `bg` for the background thread runtime.  This is exactly how `$INSTRUMENT_BACKEND` currently works for the backend.