### PR TITLE
Update to `clap` 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ checksum = "c00704156a7de8df8da0911424e30c2049957b0a714542a44e05fe693dd85313"
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encode_unicode"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,15 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,7 +129,7 @@ dependencies = [
  "anyhow",
  "c2rust-build-paths",
  "c2rust-transpile",
- "clap 2.34.0",
+ "clap",
  "env_logger",
  "git-testament",
  "is_executable",
@@ -240,7 +231,7 @@ dependencies = [
  "bincode",
  "c2rust-analysis-rt",
  "c2rust-build-paths",
- "clap 3.2.23",
+ "clap",
  "env_logger",
  "fs-err",
  "fs2",
@@ -259,7 +250,7 @@ dependencies = [
  "bincode",
  "c2rust-analysis-rt",
  "c2rust-build-paths",
- "clap 3.2.23",
+ "clap",
  "color-eyre",
  "env_logger",
  "fs-err",
@@ -338,22 +329,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
- "yaml-rust 0.3.5",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
@@ -364,9 +339,10 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -764,7 +740,7 @@ dependencies = [
  "lazy_static",
  "linked-hash-map",
  "similar",
- "yaml-rust 0.4.5",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -1271,12 +1247,6 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -1344,15 +1314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1495,12 +1456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,12 +1466,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1622,12 +1571,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
-
-[[package]]
-name = "yaml-rust"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 
 [[package]]
 name = "yaml-rust"

--- a/c2rust/Cargo.toml
+++ b/c2rust/Cargo.toml
@@ -18,7 +18,7 @@ azure-devops = { project = "immunant/c2rust", pipeline = "immunant.c2rust", buil
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "3", features = ["yaml", "cargo"] }
+clap = { version = "3.2.22", features = ["yaml", "cargo"] }
 env_logger = "0.10"
 git-testament = "0.2.1"
 is_executable = "1.0"

--- a/c2rust/Cargo.toml
+++ b/c2rust/Cargo.toml
@@ -18,7 +18,7 @@ azure-devops = { project = "immunant/c2rust", pipeline = "immunant.c2rust", buil
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "2.34", features = ["yaml"] }
+clap = { version = "3", features = ["yaml", "cargo"] }
 env_logger = "0.10"
 git-testament = "0.2.1"
 is_executable = "1.0"

--- a/c2rust/src/transpile.yaml
+++ b/c2rust/src/transpile.yaml
@@ -82,7 +82,6 @@ args:
   - COMPILE_COMMANDS:
       help: Input compile_commands.json file
       required: true
-      index: 1
   - invalid-code:
       long: invalid-code
       help: How to handle violated invariants or invalid code


### PR DESCRIPTION
Some comments on the PR:

The `cargo` feature is required in `clap` 3 to use some functions that before in `clap` 2 were enabled by default instead, such as `crate_version` and similar.

`transpile.yaml` has been modified because of an incompatibility with `clap` 3 where the `compile_commands.json` argument wasn't properly setup as it was with `clap` 2.

About `transpile.yaml`, in the near future it must be removed anyway; `clap` 4 has removed the yaml command descriptions, and even in `clap` 3, although it's still supported, it's not advertised.