### PR TITLE
Update `print_bytes` crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "print_bytes"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3057e36886667c470305bb076abc7f2f77a5662cb8de4124a4f5e6206ad2acd7"
+checksum = "22093b2707be2d786d367d44a9072a2271c4e2c7ba80d5a5eaf133c27a1f3c6e"
 dependencies = [
  "windows-sys",
 ]

--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -12,7 +12,7 @@ bitflags = "1.3.2"
 
 [build-dependencies]
 c2rust-build-paths = { path = "../c2rust-build-paths" }
-print_bytes = "0.6"
+print_bytes = "0.7"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/c2rust-analyze/build.rs
+++ b/c2rust-analyze/build.rs
@@ -5,5 +5,5 @@ fn main() {
     sysroot.link_rustc_private();
 
     print!("cargo:rustc-env=C2RUST_TARGET_LIB_DIR=");
-    print_bytes::println_bytes(&sysroot.rustlib());
+    print_bytes::println_lossy(&sysroot.rustlib());
 }

--- a/c2rust-build-paths/Cargo.toml
+++ b/c2rust-build-paths/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-print_bytes = "0.6"
+print_bytes = "0.7"

--- a/c2rust-build-paths/src/lib.rs
+++ b/c2rust-build-paths/src/lib.rs
@@ -6,11 +6,11 @@ use std::{
     str,
 };
 
-use print_bytes::println_bytes;
+use print_bytes::println_lossy;
 
 fn print_cargo_path(name: &str, path: &Path) {
     print!("cargo:{name}");
-    println_bytes(path);
+    println_lossy(path);
 }
 
 pub struct SysRoot {


### PR DESCRIPTION
This PR updates the dependency `print_bytes` to `0.7.0`, which has a breaking change, renaming `println_bytes` to `println_lossy`.  The actual functionality doesn't change, but since the function does sometimes replace non-encodable characters with the Unicode replacement character, lossy is a better name.