### PR TITLE
Add a newtype `struct FuncId(pub DefPathHash)`

### DIFF
--- a/analysis/runtime/src/metadata.rs
+++ b/analysis/runtime/src/metadata.rs
@@ -7,12 +7,12 @@ use std::{
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use crate::mir_loc::{DefPathHash, Func, MirLoc, MirLocId};
+use crate::mir_loc::{Func, FuncId, MirLoc, MirLocId};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Metadata {
     pub locs: Vec<MirLoc>,
-    pub functions: HashMap<DefPathHash, String>,
+    pub functions: HashMap<FuncId, String>,
 }
 
 impl Metadata {
@@ -57,11 +57,7 @@ impl FromIterator<Metadata> for Metadata {
 impl Debug for MirLoc {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let MirLoc {
-            func:
-                Func {
-                    def_path_hash: _,
-                    name: fn_name,
-                },
+            func: Func { name: fn_name, .. },
             basic_block_idx,
             statement_idx,
             metadata: _,

--- a/analysis/runtime/src/mir_loc.rs
+++ b/analysis/runtime/src/mir_loc.rs
@@ -125,15 +125,18 @@ impl From<DefPathHash> for (u64, u64) {
     }
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug)]
+pub struct FuncId(pub DefPathHash);
+
 #[derive(Serialize, Deserialize, Eq, Clone)]
 pub struct Func {
-    pub def_path_hash: DefPathHash,
+    pub id: FuncId,
     pub name: String,
 }
 
 impl Func {
     fn cmp_fields(&self) -> impl Eq + Hash + Ord + '_ {
-        self.def_path_hash
+        self.id
     }
 }
 
@@ -176,8 +179,8 @@ impl Debug for Func {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TransferKind {
     None,
-    Arg(DefPathHash),
-    Ret(DefPathHash),
+    Arg(FuncId),
+    Ret(FuncId),
 }
 
 impl Default for TransferKind {
@@ -192,7 +195,7 @@ pub struct EventMetadata {
     pub source: Option<MirPlace>,
     /// Destination [`Local`] for an [`Event`](crate::events::Event).
     pub destination: Option<MirPlace>,
-    /// Destination func [`DefPathHash`] of [`Event`](crate::events::Event).
+    /// Destination func [`FuncId`] of [`Event`](crate::events::Event).
     pub transfer_kind: TransferKind,
     /// Any string useful for debugging.
     pub debug_info: String,

--- a/dynamic_instrumentation/src/point/apply.rs
+++ b/dynamic_instrumentation/src/point/apply.rs
@@ -62,8 +62,8 @@ impl<'tcx, 'a> InstrumentationApplier<'tcx, 'a> {
         } = point;
         let mut args = args.clone();
 
-        if let TransferKind::Arg(def_path_hash) = metadata.transfer_kind {
-            let callee_id = tcx.def_path_hash_to_def_id(def_path_hash.convert(), &mut || {
+        if let TransferKind::Arg(func_id) = metadata.transfer_kind {
+            let callee_id = tcx.def_path_hash_to_def_id(func_id.0.convert(), &mut || {
                 panic!("cannot find DefId of callee func hash")
             });
             state.add_fn(callee_id, tcx);

--- a/dynamic_instrumentation/src/point/mod.rs
+++ b/dynamic_instrumentation/src/point/mod.rs
@@ -3,7 +3,7 @@ pub mod build;
 mod cast;
 pub mod source;
 
-use c2rust_analysis_rt::mir_loc::{self, EventMetadata};
+use c2rust_analysis_rt::mir_loc::{EventMetadata, FuncId};
 use rustc_middle::{
     mir::{Body, HasLocalDecls, LocalDecls, Location, Place, Rvalue},
     ty::TyCtxt,
@@ -75,9 +75,11 @@ impl<'a, 'tcx: 'a> CollectInstrumentationPoints<'a, 'tcx> {
         self.assignment = old_assignment;
     }
 
-    pub fn func_hash(&self) -> mir_loc::DefPathHash {
-        self.tcx()
-            .def_path_hash(self.body.source.def_id())
-            .convert()
+    pub fn func_id(&self) -> FuncId {
+        FuncId(
+            self.tcx()
+                .def_path_hash(self.body.source.def_id())
+                .convert(),
+        )
     }
 }

--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -135,11 +135,11 @@ pub fn add_node(
         metadata: event_metadata,
     } = metadata.get(event.mir_loc);
 
-    let this_func_hash = func.def_path_hash;
+    let this_id = func.id;
     let (src_fn, dest_fn) = match event_metadata.transfer_kind {
-        TransferKind::None => (this_func_hash, this_func_hash),
-        TransferKind::Arg(p) => (this_func_hash, p),
-        TransferKind::Ret(p) => (p, this_func_hash),
+        TransferKind::None => (this_id, this_id),
+        TransferKind::Arg(id) => (this_id, id),
+        TransferKind::Ret(id) => (id, this_id),
     };
 
     if let TransferKind::Arg(_) = event_metadata.transfer_kind {
@@ -191,7 +191,7 @@ pub fn add_node(
     });
 
     let function = Func {
-        def_path_hash: dest_fn,
+        id: dest_fn,
         name: metadata.functions[&dest_fn].clone(),
     };
 

--- a/pdg/src/graph.rs
+++ b/pdg/src/graph.rs
@@ -1,5 +1,5 @@
-use c2rust_analysis_rt::mir_loc::MirPlace;
 use c2rust_analysis_rt::mir_loc::{self, DefPathHash, Func};
+use c2rust_analysis_rt::mir_loc::{FuncId, MirPlace};
 use rustc_index::newtype_index;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{BasicBlock, Field, Local};
@@ -318,7 +318,7 @@ pub struct Graphs {
     pub graphs: IndexVec<GraphId, Graph>,
 
     /// Lookup table for finding all nodes in all graphs that store to a particular MIR local.
-    pub latest_assignment: HashMap<(mir_loc::DefPathHash, mir_loc::Local), (GraphId, NodeId)>,
+    pub latest_assignment: HashMap<(FuncId, mir_loc::Local), (GraphId, NodeId)>,
 }
 
 impl Graphs {

--- a/pdg/src/info.rs
+++ b/pdg/src/info.rs
@@ -223,13 +223,14 @@ pub fn add_info(pdg: &mut Graphs) {
 mod test {
     use super::*;
     use c2rust_analysis_rt::mir_loc::Func;
+    use c2rust_analysis_rt::mir_loc::FuncId;
     use rustc_middle::mir::Field;
     use rustc_middle::mir::Local;
 
     fn mk_node(g: &mut Graph, kind: NodeKind, source: Option<NodeId>) -> NodeId {
         g.nodes.push(Node {
             function: Func {
-                def_path_hash: (1, 2).into(),
+                id: FuncId((1, 2).into()),
                 name: "fake_function".into(),
             },
             block: 0_u32.into(),


### PR DESCRIPTION
Added a newtype `struct FuncId(pub DefPathHash)` to make a lot of uses much clearer that they're referring to functions only.

This also will help clean up some things in #654, and in general, I think makes a lot of uses of `FuncId`s easier to understand/read.