### PR TITLE
Update paths to homebrew LLVM for M1 macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For example, the official LLVM packages from [apt.llvm.org](https://apt.llvm.org
     nix-shell
     ```
 
-- **OS X:** XCode command-line tools and recent LLVM (we recommend the Homebrew version) are required.
+- **macOS:** Xcode command-line tools and recent LLVM (we recommend the Homebrew version) are required.
 
     ```sh
     xcode-select --install
@@ -91,11 +91,20 @@ like this, for example:
 LLVM_CONFIG_PATH=llvm-config-14 cargo install c2rust
 ```
 
-On OS X with Homebrew LLVM, you need to point the build system at the LLVM installation as follows:
+On macOS with Homebrew LLVM, you need to point the build system at the LLVM installation. The path for the installation is architecture dependent:
 
-```sh
-LLVM_CONFIG_PATH=/opt/homebrew/opt/llvm/bin/llvm-config cargo install c2rust
-```
+- **Intel Macs:**
+
+    ```sh
+    LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config cargo install c2rust
+    ```
+
+
+- **Arm Macs:**
+
+    ```sh
+    LLVM_CONFIG_PATH=/opt/homebrew/opt/llvm/bin/llvm-config cargo install c2rust
+    ```
 
 On Linux with Linuxbrew LLVM, you need to point the build system at the LLVM installation as follows:
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ LLVM_CONFIG_PATH=llvm-config-14 cargo install c2rust
 On OS X with Homebrew LLVM, you need to point the build system at the LLVM installation as follows:
 
 ```sh
-LLVM_CONFIG_PATH=/usr/local/opt/llvm/bin/llvm-config cargo install c2rust
+LLVM_CONFIG_PATH=/opt/homebrew/opt/llvm/bin/llvm-config cargo install c2rust
 ```
 
 On Linux with Linuxbrew LLVM, you need to point the build system at the LLVM installation as follows:

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -6,24 +6,35 @@ use std::process::{Command, Stdio};
 fn detect_filecheck() -> Option<&'static str> {
     let candidates = [
         "FileCheck",
+        // Intel macOS homebrew location.
         "/usr/local/opt/llvm/bin/FileCheck",
+        // Arm macOS homebrew location.
+        "/opt/homebrew/opt/llvm/bin/FileCheck",
         "FileCheck-14",
         "/usr/local/opt/llvm@14/bin/FileCheck",
+        "/opt/homebrew/opt/llvm@14/bin/FileCheck",
         "FileCheck-13",
         "/usr/local/opt/llvm@13/bin/FileCheck",
+        "/opt/homebrew/opt/llvm@13/bin/FileCheck",
         "FileCheck-12",
         "/usr/local/opt/llvm@12/bin/FileCheck",
+        "/opt/homebrew/opt/llvm@12/bin/FileCheck",
         "FileCheck-11",
         "/usr/local/opt/llvm@11/bin/FileCheck",
+        "/opt/homebrew/opt/llvm@11/bin/FileCheck",
         "FileCheck-10",
         "/usr/local/opt/llvm@10/bin/FileCheck",
+        "/opt/homebrew/opt/llvm@10/bin/FileCheck",
         "FileCheck-9",
         "/usr/local/opt/llvm@9/bin/FileCheck",
+        "/opt/homebrew/opt/llvm@9/bin/FileCheck",
         "FileCheck-8",
         "/usr/local/opt/llvm@8/bin/FileCheck",
+        "/opt/homebrew/opt/llvm@8/bin/FileCheck",
         "FileCheck-7",
         "FileCheck-7.0",
         "/usr/local/opt/llvm@7/bin/FileCheck",
+        "/opt/homebrew/opt/llvm@7/bin/FileCheck",
     ];
 
     for filecheck in candidates {

--- a/c2rust-build-paths/src/lib.rs
+++ b/c2rust-build-paths/src/lib.rs
@@ -98,7 +98,7 @@ pub fn find_llvm_config() -> Option<PathBuf> {
                 "llvm-config-7",
                 "llvm-config-7.0",
                 "llvm-config",
-                // Homebrew install locations on MacOS
+                // Homebrew install locations on Intel macOS
                 "/usr/local/opt/llvm@13/bin/llvm-config",
                 "/usr/local/opt/llvm@12/bin/llvm-config",
                 "/usr/local/opt/llvm@11/bin/llvm-config",
@@ -106,6 +106,14 @@ pub fn find_llvm_config() -> Option<PathBuf> {
                 "/usr/local/opt/llvm@9/bin/llvm-config",
                 "/usr/local/opt/llvm@8/bin/llvm-config",
                 "/usr/local/opt/llvm/bin/llvm-config",
+                // Homebrew install locations on Arm macOS
+                "/opt/homebrew/opt/llvm@13/bin/llvm-config",
+                "/opt/homebrew/opt/llvm@12/bin/llvm-config",
+                "/opt/homebrew/opt/llvm@11/bin/llvm-config",
+                "/opt/homebrew/opt/llvm@10/bin/llvm-config",
+                "/opt/homebrew/opt/llvm@9/bin/llvm-config",
+                "/opt/homebrew/opt/llvm@8/bin/llvm-config",
+                "/opt/homebrew/opt/llvm/bin/llvm-config",
             ]
             .iter()
             .map(Path::new)


### PR DESCRIPTION
`/opt/homebrew/` is used by `hombrew` on Apple Silicon Macs, but `/usr/local/` is still used on Intel Macs, and we want to support both.  This lists both paths in the `README.md`, clarifying which is for Intel vs. Apple Silicon Macs.

These paths are also hardcoded in `c2rust-build-paths/src/lib.rs` and `c2rust-analyze/tests/filecheck.rs`.  The latter is meant to be consolidated under `c2rust-build-paths`, but we'll keep them as is for now.  We need to also update these to include the Apple Silicon `homebrew` paths.

Now, `c2rust` builds fine on Intel Macs (CI) and Apple Silicon Macs (@LegNeato's M1).