### PR TITLE
handle unary operators in static analysis

### DIFF
--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -105,6 +105,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     assert!(!matches!(ty.kind(), TyKind::RawPtr(..) | TyKind::Ref(..)));
                     PointerId::NONE
                 }
+                Rvalue::UnaryOp(..) => PointerId::NONE,
                 _ => panic!("TODO: handle assignment of {:?}", rv),
             },
         }


### PR DESCRIPTION
both `UnOp::Neg` and `UnOp::Not` are invalid on pointer types