### PR TITLE
c2rust-analyze: assign PointerIds to Rvalues

### DIFF
--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -271,7 +271,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
                 assert_eq!(pointee_ty, pointee_lty.ty);
 
                 let args = self.lcx().mk_slice(&[pointee_lty]);
-                return self.lcx().mk(pointee_ty, args, ptr);
+                return self.lcx().mk(ty, args, ptr);
             }
         }
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -79,6 +79,10 @@ pub struct AnalysisCtxt<'a, 'tcx> {
     pub local_decls: &'a LocalDecls<'tcx>,
     pub local_tys: IndexVec<Local, LTy<'tcx>>,
     pub addr_of_local: IndexVec<Local, PointerId>,
+    /// Types for certain [`Rvalue`]s.  Some `Rvalue`s introduce fresh [`PointerId`]s; to keep
+    /// those `PointerId`s consistent, the `Rvalue`'s type must be stored rather than recomputed on
+    /// the fly.
+    pub rvalue_tys: HashMap<Location, LTy<'tcx>>,
 
     next_ptr_id: NextLocalPointerId,
 }
@@ -86,6 +90,7 @@ pub struct AnalysisCtxt<'a, 'tcx> {
 pub struct AnalysisCtxtData<'tcx> {
     local_tys: IndexVec<Local, LTy<'tcx>>,
     addr_of_local: IndexVec<Local, PointerId>,
+    rvalue_tys: HashMap<Location, LTy<'tcx>>,
     next_ptr_id: NextLocalPointerId,
 }
 
@@ -158,6 +163,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
             local_decls: &mir.local_decls,
             local_tys: IndexVec::new(),
             addr_of_local: IndexVec::new(),
+            rvalue_tys: HashMap::new(),
             next_ptr_id: NextLocalPointerId::new(),
         }
     }
@@ -170,6 +176,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         let AnalysisCtxtData {
             local_tys,
             addr_of_local,
+            rvalue_tys,
             next_ptr_id,
         } = data;
         AnalysisCtxt {
@@ -177,6 +184,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
             local_decls: &mir.local_decls,
             local_tys,
             addr_of_local,
+            rvalue_tys,
             next_ptr_id,
         }
     }
@@ -185,6 +193,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         AnalysisCtxtData {
             local_tys: self.local_tys,
             addr_of_local: self.addr_of_local,
+            rvalue_tys: self.rvalue_tys,
             next_ptr_id: self.next_ptr_id,
         }
     }
@@ -218,7 +227,11 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         }
     }
 
-    pub fn type_of_rvalue(&self, rv: &Rvalue<'tcx>, _loc: Location) -> LTy<'tcx> {
+    pub fn type_of_rvalue(&self, rv: &Rvalue<'tcx>, loc: Location) -> LTy<'tcx> {
+        if let Some(&lty) = self.rvalue_tys.get(&loc) {
+            return lty;
+        }
+
         if let Some(desc) = describe_rvalue(rv) {
             let ty = rv.ty(self, self.tcx());
             if matches!(ty.kind(), TyKind::Ref(..) | TyKind::RawPtr(..)) {
@@ -344,6 +357,7 @@ impl<'tcx> AnalysisCtxtData<'tcx> {
         let AnalysisCtxtData {
             ref mut local_tys,
             ref mut addr_of_local,
+            ref mut rvalue_tys,
             ref mut next_ptr_id,
         } = *self;
 
@@ -355,6 +369,10 @@ impl<'tcx> AnalysisCtxtData<'tcx> {
             if !ptr.is_none() {
                 *ptr = map[*ptr];
             }
+        }
+
+        for lty in rvalue_tys.values_mut() {
+            *lty = remap_lty_pointers(lcx, &map, *lty);
         }
 
         *next_ptr_id = counter;

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -3,7 +3,7 @@ use crate::context::{AnalysisCtxt, LTy, PermissionSet, PointerId};
 use crate::util::{self, describe_rvalue, Callee, RvalueDesc};
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir::{
-    BinOp, Body, Mutability, Operand, Place, PlaceRef, ProjectionElem, Rvalue, Statement,
+    BinOp, Body, Location, Mutability, Operand, Place, PlaceRef, ProjectionElem, Rvalue, Statement,
     StatementKind, Terminator, TerminatorKind,
 };
 use rustc_middle::ty::{SubstsRef, TyKind};
@@ -152,7 +152,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         }
     }
 
-    pub fn visit_statement(&mut self, stmt: &Statement<'tcx>) {
+    pub fn visit_statement(&mut self, stmt: &Statement<'tcx>, loc: Location) {
         eprintln!("visit_statement({:?})", stmt);
         // TODO(spernsteiner): other `StatementKind`s will be handled in the future
         #[allow(clippy::single_match)]
@@ -164,7 +164,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
                 // TODO: combine these
                 let rv_ptr = self.visit_rvalue(rv);
-                let rv_lty = self.acx.type_of(rv);
+                let rv_lty = self.acx.type_of_rvalue(rv, loc);
 
                 self.do_assign(pl_ptr, rv_ptr);
                 self.do_unify_pointees(pl_lty, rv_lty);
@@ -252,9 +252,15 @@ pub fn visit<'tcx>(
         equiv_constraints: Vec::new(),
     };
 
-    for bb_data in mir.basic_blocks().iter() {
-        for stmt in bb_data.statements.iter() {
-            tc.visit_statement(stmt);
+    for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
+        for (i, stmt) in bb_data.statements.iter().enumerate() {
+            tc.visit_statement(
+                stmt,
+                Location {
+                    block: bb,
+                    statement_index: i,
+                },
+            );
         }
         tc.visit_terminator(bb_data.terminator());
     }


### PR DESCRIPTION
Some `Rvalue` kinds have types embedded in them, which may include pointer types.  This PR adds infrastructure for assigning `PointerId`s to those types so we can track their permissions if needed.  Currently we only use this for array aggregates, but in the future we'll use the same support to handle pointer casts (e.g. `x as *mut T`, where we need to track permissions on the `*mut T`).