### PR TITLE
c2rust-analyze: refactor: move type_of logic out of borrowck/dataflow

### DIFF
--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -4,8 +4,8 @@ use crate::context::PermissionSet;
 use crate::util::{self, Callee};
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{
-    BinOp, Body, BorrowKind, Local, LocalDecl, Location, Operand, Place, ProjectionElem, Rvalue,
-    Statement, StatementKind, Terminator, TerminatorKind,
+    BinOp, Body, BorrowKind, Local, LocalDecl, Location, Operand, Place, Rvalue, Statement,
+    StatementKind, Terminator, TerminatorKind,
 };
 use rustc_middle::ty::{TyCtxt, TyKind};
 use std::collections::HashMap;
@@ -34,21 +34,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     pub fn visit_place(&mut self, pl: Place<'tcx>) -> LTy<'tcx> {
         let mut lty = self.local_ltys[pl.local.index()];
         for proj in pl.projection {
-            match proj {
-                ProjectionElem::Deref => {
-                    assert_eq!(lty.args.len(), 1);
-                    lty = lty.args[0];
-                }
-
-                ProjectionElem::Field(f, _field_ty) => match lty.ty.kind() {
-                    TyKind::Tuple(..) => {
-                        lty = lty.args[f.as_usize()];
-                    }
-                    _ => todo!("field of {:?}", lty),
-                },
-
-                ref proj => panic!("unsupported projection {:?} in {:?}", proj, pl),
-            }
+            lty = util::lty_project(lty, &proj);
         }
         lty
     }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -3,13 +3,13 @@ use crate::pointer_id::{
     GlobalPointerTable, LocalPointerTable, NextGlobalPointerId, NextLocalPointerId, PointerTable,
     PointerTableMut,
 };
-use crate::util::{describe_rvalue, RvalueDesc};
+use crate::util::{self, describe_rvalue, RvalueDesc};
 use bitflags::bitflags;
 use rustc_hir::def_id::DefId;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{
     Body, CastKind, HasLocalDecls, Local, LocalDecls, Location, Operand, Place, PlaceElem,
-    PlaceRef, ProjectionElem, Rvalue,
+    PlaceRef, Rvalue,
 };
 use rustc_middle::ty::adjustment::PointerCast;
 use rustc_middle::ty::{Ty, TyCtxt, TyKind};
@@ -356,24 +356,8 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         }
     }
 
-    fn project(&self, lty: LTy<'tcx>, proj: &PlaceElem<'tcx>) -> LTy<'tcx> {
-        match *proj {
-            ProjectionElem::Deref => {
-                assert!(matches!(lty.kind(), TyKind::Ref(..) | TyKind::RawPtr(..)));
-                assert_eq!(lty.args.len(), 1);
-                lty.args[0]
-            }
-            ProjectionElem::Field(f, _) => match lty.kind() {
-                TyKind::Tuple(_) => lty.args[f.index()],
-                TyKind::Adt(..) => todo!("type_of Field(Adt)"),
-                _ => panic!("Field projection is unsupported on type {:?}", lty),
-            },
-            ProjectionElem::Index(..) | ProjectionElem::ConstantIndex { .. } => {
-                todo!("type_of Index")
-            }
-            ProjectionElem::Subslice { .. } => todo!("type_of Subslice"),
-            ProjectionElem::Downcast(..) => todo!("type_of Downcast"),
-        }
+    pub fn project(&self, lty: LTy<'tcx>, proj: &PlaceElem<'tcx>) -> LTy<'tcx> {
+        util::lty_project(lty, proj)
     }
 }
 

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -6,7 +6,7 @@ use rustc_middle::mir::{
     BinOp, Body, Location, Mutability, Operand, Place, PlaceRef, ProjectionElem, Rvalue, Statement,
     StatementKind, Terminator, TerminatorKind,
 };
-use rustc_middle::ty::{SubstsRef, TyKind};
+use rustc_middle::ty::SubstsRef;
 
 /// Visitor that walks over the MIR, computing types of rvalues/operands/places and generating
 /// constraints as a side effect.
@@ -43,11 +43,11 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         }
     }
 
-    pub fn visit_place(&mut self, pl: Place<'tcx>, mutbl: Mutability) -> LTy<'tcx> {
+    pub fn visit_place(&mut self, pl: Place<'tcx>, mutbl: Mutability) {
         self.visit_place_ref(pl.as_ref(), mutbl)
     }
 
-    pub fn visit_place_ref(&mut self, pl: PlaceRef<'tcx>, mutbl: Mutability) -> LTy<'tcx> {
+    pub fn visit_place_ref(&mut self, pl: PlaceRef<'tcx>, mutbl: Mutability) {
         let mut lty = self.acx.type_of(pl.local);
         let mut prev_deref_ptr = None;
 
@@ -69,43 +69,59 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         if let Some(ptr) = prev_deref_ptr.take() {
             self.record_access(ptr, mutbl);
         }
-
-        lty
     }
 
-    pub fn visit_rvalue(&mut self, rv: &Rvalue<'tcx>) -> PointerId {
+    pub fn visit_rvalue(&mut self, rv: &Rvalue<'tcx>, _lty: LTy<'tcx>) {
         eprintln!("visit_rvalue({:?}), desc = {:?}", rv, describe_rvalue(rv));
 
-        match describe_rvalue(rv) {
-            Some(RvalueDesc::Project { base, proj: _ }) => {
-                // TODO: mutability should probably depend on mutability of the output ref/ptr
-                let base_ty = self.visit_place_ref(base, Mutability::Not);
-                base_ty.label
-            }
-            Some(RvalueDesc::AddrOfLocal { local, proj: _ }) => self.acx.addr_of_local[local],
-            None => match *rv {
-                Rvalue::Use(ref op) => self.visit_operand(op).label,
-                Rvalue::BinaryOp(BinOp::Offset, _) => todo!("visit_rvalue BinOp::Offset"),
-                Rvalue::BinaryOp(..) => PointerId::NONE,
-                Rvalue::CheckedBinaryOp(BinOp::Offset, _) => todo!("visit_rvalue BinOp::Offset"),
-                Rvalue::CheckedBinaryOp(..) => PointerId::NONE,
-                Rvalue::Cast(_, _, ty) => {
-                    assert!(!matches!(ty.kind(), TyKind::RawPtr(..) | TyKind::Ref(..)));
-                    PointerId::NONE
+        if let Some(desc) = describe_rvalue(rv) {
+            match desc {
+                RvalueDesc::Project { base, proj: _ } => {
+                    // TODO: mutability should probably depend on mutability of the output ref/ptr
+                    self.visit_place_ref(base, Mutability::Not);
                 }
-                Rvalue::UnaryOp(..) => PointerId::NONE,
-                _ => panic!("TODO: handle assignment of {:?}", rv),
-            },
+                RvalueDesc::AddrOfLocal { .. } => {}
+            }
+            return;
+        }
+
+        match *rv {
+            Rvalue::Use(ref op) => self.visit_operand(op),
+            Rvalue::Repeat(..) => todo!("visit_rvalue Repeat"),
+            Rvalue::Ref(..) => {
+                unreachable!("Rvalue::Ref should be handled by describe_rvalue instead")
+            }
+            Rvalue::ThreadLocalRef(..) => todo!("visit_rvalue ThreadLocalRef"),
+            Rvalue::AddressOf(..) => {
+                unreachable!("Rvalue::AddressOf should be handled by describe_rvalue instead")
+            }
+            Rvalue::Cast(_, ref op, _) => self.visit_operand(op),
+            Rvalue::BinaryOp(BinOp::Offset, _) => todo!("visit_rvalue BinOp::Offset"),
+            Rvalue::BinaryOp(_, ref ops) => {
+                self.visit_operand(&ops.0);
+                self.visit_operand(&ops.1);
+            }
+            Rvalue::CheckedBinaryOp(BinOp::Offset, _) => todo!("visit_rvalue BinOp::Offset"),
+            Rvalue::CheckedBinaryOp(_, ref ops) => {
+                self.visit_operand(&ops.0);
+                self.visit_operand(&ops.1);
+            }
+            Rvalue::NullaryOp(..) => {}
+            Rvalue::UnaryOp(_, ref op) => {
+                self.visit_operand(op);
+            }
+
+            _ => panic!("TODO: handle assignment of {:?}", rv),
         }
     }
 
-    pub fn visit_operand(&mut self, op: &Operand<'tcx>) -> LTy<'tcx> {
+    pub fn visit_operand(&mut self, op: &Operand<'tcx>) {
         match *op {
-            Operand::Copy(pl) | Operand::Move(pl) => self.visit_place(pl, Mutability::Not),
-            Operand::Constant(ref c) => {
-                let ty = c.ty();
-                // TODO
-                self.acx.lcx().label(ty, &mut |_| PointerId::NONE)
+            Operand::Copy(pl) | Operand::Move(pl) => {
+                self.visit_place(pl, Mutability::Not);
+            }
+            Operand::Constant(ref _c) => {
+                // TODO: addr of static may show up as `Operand::Constant`
             }
         }
     }
@@ -147,12 +163,13 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         match stmt.kind {
             StatementKind::Assign(ref x) => {
                 let (pl, ref rv) = **x;
-                let pl_lty = self.visit_place(pl, Mutability::Mut);
+                self.visit_place(pl, Mutability::Mut);
+                let pl_lty = self.acx.type_of(pl);
                 let pl_ptr = pl_lty.label;
 
-                // TODO: combine these
-                let rv_ptr = self.visit_rvalue(rv);
                 let rv_lty = self.acx.type_of_rvalue(rv, loc);
+                self.visit_rvalue(rv, rv_lty);
+                let rv_ptr = rv_lty.label;
 
                 self.do_assign(pl_ptr, rv_ptr);
                 self.do_unify_pointees(pl_lty, rv_lty);
@@ -180,9 +197,11 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 match util::ty_callee(tcx, func_ty) {
                     Some(Callee::PtrOffset { .. }) => {
                         // We handle this like a pointer assignment.
-                        let pl_lty = self.visit_place(destination, Mutability::Mut);
+                        self.visit_place(destination, Mutability::Mut);
+                        let pl_lty = self.acx.type_of(destination);
                         assert!(args.len() == 2);
-                        let rv_lty = self.visit_operand(&args[0]);
+                        self.visit_operand(&args[0]);
+                        let rv_lty = self.acx.type_of(&args[0]);
                         self.do_assign(pl_lty.label, rv_lty.label);
                         self.do_unify_pointees(pl_lty, rv_lty);
                         let perms = PermissionSet::OFFSET_ADD | PermissionSet::OFFSET_SUB;
@@ -216,13 +235,15 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
         // Process pseudo-assignments from `args` to the types declared in `sig`.
         for (arg_op, &input_lty) in args.iter().zip(sig.inputs.iter()) {
-            let arg_lty = self.visit_operand(arg_op);
+            self.visit_operand(arg_op);
+            let arg_lty = self.acx.type_of(arg_op);
             self.do_assign(input_lty.label, arg_lty.label);
             self.do_unify_pointees(input_lty, arg_lty);
         }
 
         // Process a pseudo-assignment from the return type declared in `sig` to `dest`.
-        let dest_lty = self.visit_place(dest, Mutability::Mut);
+        self.visit_place(dest, Mutability::Mut);
+        let dest_lty = self.acx.type_of(dest);
         let output_lty = sig.output;
         self.do_assign(dest_lty.label, output_lty.label);
         self.do_unify_pointees(dest_lty, output_lty);

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -1,7 +1,9 @@
+use crate::labeled_ty::LabeledTy;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
-use rustc_middle::mir::{Local, Mutability, Operand, PlaceElem, PlaceRef, Rvalue};
+use rustc_middle::mir::{Local, Mutability, Operand, PlaceElem, PlaceRef, ProjectionElem, Rvalue};
 use rustc_middle::ty::{DefIdTree, SubstsRef, Ty, TyCtxt, TyKind};
+use std::fmt::Debug;
 
 #[derive(Debug)]
 pub enum RvalueDesc<'tcx> {
@@ -105,5 +107,28 @@ pub fn ty_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Callee<'tcx>> 
             def_id: did,
             substs,
         }),
+    }
+}
+
+pub fn lty_project<'tcx, L: Debug>(
+    lty: LabeledTy<'tcx, L>,
+    proj: &PlaceElem<'tcx>,
+) -> LabeledTy<'tcx, L> {
+    match *proj {
+        ProjectionElem::Deref => {
+            assert!(matches!(lty.kind(), TyKind::Ref(..) | TyKind::RawPtr(..)));
+            assert_eq!(lty.args.len(), 1);
+            lty.args[0]
+        }
+        ProjectionElem::Field(f, _) => match lty.kind() {
+            TyKind::Tuple(_) => lty.args[f.index()],
+            TyKind::Adt(..) => todo!("type_of Field(Adt)"),
+            _ => panic!("Field projection is unsupported on type {:?}", lty),
+        },
+        ProjectionElem::Index(..) | ProjectionElem::ConstantIndex { .. } => {
+            todo!("type_of Index")
+        }
+        ProjectionElem::Subslice { .. } => todo!("type_of Subslice"),
+        ProjectionElem::Downcast(..) => todo!("type_of Downcast"),
     }
 }


### PR DESCRIPTION
Previously, when the `dataflow` and `borrowck` modules traversed a node (such as an `Rvalue`), they would generate constraints and also simultaneously compute the type of the node.  The latter part duplicated logic from `AnalysisCtxt::type_of`.  This branch removes the duplication: `dataflow` and `borrowck` traversals now only generate constraints, and they rely on `AnalysisCtxt` methods for computing the types of nodes.  This will be helpful as the `type_of` logic gets more complex (e.g. adding support for struct fields).