### PR TITLE
c2rust-analyze: misc features needed for insertion sort driver

### DIFF
--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -4,8 +4,8 @@ use crate::context::PermissionSet;
 use crate::util::{self, Callee};
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{
-    BinOp, Body, BorrowKind, Local, LocalDecl, Location, Operand, Place, Rvalue, Statement,
-    StatementKind, Terminator, TerminatorKind,
+    AggregateKind, BinOp, Body, BorrowKind, Local, LocalDecl, Location, Operand, Place, Rvalue,
+    Statement, StatementKind, Terminator, TerminatorKind,
 };
 use rustc_middle::ty::{TyCtxt, TyKind};
 use std::collections::HashMap;
@@ -156,6 +156,20 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 );
                 Label::default()
             }),
+
+            Rvalue::Aggregate(ref kind, ref _ops) => match **kind {
+                AggregateKind::Array(..) => {
+                    // TODO
+                    let ty = rv.ty(self.local_decls, *self.ltcx);
+                    self.ltcx.label(ty, &mut |_ty| Label::default())
+                }
+                _ => panic!("unsupported rvalue AggregateKind {:?}", kind),
+            },
+
+            Rvalue::Len(..) => {
+                let ty = rv.ty(self.local_decls, *self.ltcx);
+                self.ltcx.label(ty, &mut |_| Label::default())
+            }
 
             ref rv => panic!("unsupported rvalue {:?}", rv),
         }

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -162,8 +162,9 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
             Rvalue::Aggregate(ref kind, ref _ops) => match **kind {
                 AggregateKind::Array(..) => {
-                    // TODO
                     let ty = rv.ty(self.local_decls, *self.ltcx);
+                    // TODO: create fresh origins for all pointers in `ty`, and generate subset
+                    // relations between the regions of the array and the regions of its elements
                     self.ltcx.label(ty, &mut |_ty| Label::default())
                 }
                 _ => panic!("unsupported rvalue AggregateKind {:?}", kind),

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -149,11 +149,14 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 })
             }
 
-            Rvalue::Cast(_, _, ty) => self.ltcx.label(ty, &mut |ty| {
+            Rvalue::Cast(_, _, ty) => self.ltcx.label(ty, &mut |_ty| {
+                // TODO: handle Unsize casts at minimum
+                /*
                 assert!(
                     !matches!(ty.kind(), TyKind::RawPtr(..) | TyKind::Ref(..)),
                     "pointer Cast NYI"
                 );
+                */
                 Label::default()
             }),
 

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -209,7 +209,11 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         let rv_lty = self.visit_operand(&args[0]);
                         self.do_assign(pl_lty, rv_lty);
                     }
-                    _ => {}
+                    Some(Callee::MiscBuiltin) => {}
+                    Some(Callee::Other { .. }) => {
+                        // TODO
+                    }
+                    None => {}
                 }
             }
             // TODO(spernsteiner): handle other `TerminatorKind`s

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -226,6 +226,9 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         let rv_lty = self.visit_operand(&args[0]);
                         self.do_assign(pl_lty, rv_lty);
                     }
+                    Some(Callee::SliceAsPtr { .. }) => {
+                        // TODO: handle this like a cast
+                    }
                     Some(Callee::MiscBuiltin) => {}
                     Some(Callee::Other { .. }) => {
                         // TODO

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -6,7 +6,7 @@ use rustc_middle::mir::{
     AggregateKind, BinOp, Body, Location, Mutability, Operand, Place, PlaceRef, ProjectionElem,
     Rvalue, Statement, StatementKind, Terminator, TerminatorKind,
 };
-use rustc_middle::ty::SubstsRef;
+use rustc_middle::ty::{SubstsRef, TyKind};
 
 /// Visitor that walks over the MIR, computing types of rvalues/operands/places and generating
 /// constraints as a side effect.
@@ -71,7 +71,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         }
     }
 
-    pub fn visit_rvalue(&mut self, rv: &Rvalue<'tcx>, _lty: LTy<'tcx>) {
+    pub fn visit_rvalue(&mut self, rv: &Rvalue<'tcx>, lty: LTy<'tcx>) {
         eprintln!("visit_rvalue({:?}), desc = {:?}", rv, describe_rvalue(rv));
 
         if let Some(desc) = describe_rvalue(rv) {
@@ -120,7 +120,14 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 }
                 match **kind {
                     AggregateKind::Array(..) => {
-                        // TODO: pseudo-assignment from each elem to the overall array type
+                        assert!(matches!(lty.kind(), TyKind::Array(..)));
+                        assert_eq!(lty.args.len(), 1);
+                        let elem_lty = lty.args[0];
+                        // Pseudo-assign from each operand to the element type of the array.
+                        for op in ops {
+                            let op_lty = self.acx.type_of(op);
+                            self.do_assign(elem_lty, op_lty);
+                        }
                     }
                     ref kind => todo!("Rvalue::Aggregate({:?})", kind),
                 }
@@ -142,23 +149,23 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     }
 
     fn do_assign(&mut self, pl_lty: LTy<'tcx>, rv_lty: LTy<'tcx>) {
-        if pl_lty.label == PointerId::NONE && rv_lty.label == PointerId::NONE {
-            return;
+        // If the top-level types are pointers, add a dataflow edge indicating that `rv` flows into
+        // `pl`.
+        if pl_lty.label != PointerId::NONE || rv_lty.label != PointerId::NONE {
+            assert!(pl_lty.label != PointerId::NONE);
+            assert!(rv_lty.label != PointerId::NONE);
+            self.add_edge(rv_lty.label, pl_lty.label);
         }
 
-        // Add a dataflow edge indicating that `rv` flows into `pl`.
-        assert!(pl_lty.label != PointerId::NONE);
-        assert!(rv_lty.label != PointerId::NONE);
-        self.add_edge(rv_lty.label, pl_lty.label);
-
         // Add equivalence constraints for all nested pointers beyond the top level.
-        assert_eq!(pl_lty.args.len(), 1);
-        assert_eq!(rv_lty.args.len(), 1);
+        assert_eq!(pl_lty.ty, rv_lty.ty);
+        for (pl_sub_lty, rv_sub_lty) in pl_lty.iter().zip(rv_lty.iter()) {
+            // Skip the top-level `LTy`s.
+            if pl_sub_lty as *const _ == pl_lty as *const _ {
+                debug_assert_eq!(rv_sub_lty as *const _, rv_lty as *const _);
+                continue;
+            }
 
-        let pl_pointee = pl_lty.args[0];
-        let rv_pointee = rv_lty.args[0];
-        assert_eq!(pl_pointee.ty, rv_pointee.ty);
-        for (pl_sub_lty, rv_sub_lty) in pl_pointee.iter().zip(rv_pointee.iter()) {
             eprintln!("equate {:?} = {:?}", pl_sub_lty, rv_sub_lty);
             if pl_sub_lty.label != PointerId::NONE || rv_sub_lty.label != PointerId::NONE {
                 assert!(pl_sub_lty.label != PointerId::NONE);

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -151,26 +151,31 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     fn do_assign(&mut self, pl_lty: LTy<'tcx>, rv_lty: LTy<'tcx>) {
         // If the top-level types are pointers, add a dataflow edge indicating that `rv` flows into
         // `pl`.
-        if pl_lty.label != PointerId::NONE || rv_lty.label != PointerId::NONE {
-            assert!(pl_lty.label != PointerId::NONE);
-            assert!(rv_lty.label != PointerId::NONE);
-            self.add_edge(rv_lty.label, pl_lty.label);
-        }
+        self.do_assign_pointer_ids(pl_lty.label, rv_lty.label);
 
         // Add equivalence constraints for all nested pointers beyond the top level.
         assert_eq!(pl_lty.ty, rv_lty.ty);
-        for (pl_sub_lty, rv_sub_lty) in pl_lty.iter().zip(rv_lty.iter()) {
-            // Skip the top-level `LTy`s.
-            if pl_sub_lty as *const _ == pl_lty as *const _ {
-                debug_assert_eq!(rv_sub_lty as *const _, rv_lty as *const _);
-                continue;
-            }
+        for (&pl_sub_lty, &rv_sub_lty) in pl_lty.args.iter().zip(rv_lty.args.iter()) {
+            self.do_unify(pl_sub_lty, rv_sub_lty);
+        }
+    }
 
-            eprintln!("equate {:?} = {:?}", pl_sub_lty, rv_sub_lty);
-            if pl_sub_lty.label != PointerId::NONE || rv_sub_lty.label != PointerId::NONE {
-                assert!(pl_sub_lty.label != PointerId::NONE);
-                assert!(rv_sub_lty.label != PointerId::NONE);
-                self.add_equiv(pl_sub_lty.label, rv_sub_lty.label);
+    fn do_assign_pointer_ids(&mut self, pl_ptr: PointerId, rv_ptr: PointerId) {
+        if pl_ptr != PointerId::NONE || rv_ptr != PointerId::NONE {
+            assert!(pl_ptr != PointerId::NONE);
+            assert!(rv_ptr != PointerId::NONE);
+            self.add_edge(rv_ptr, pl_ptr);
+        }
+    }
+
+    fn do_unify(&mut self, lty1: LTy<'tcx>, lty2: LTy<'tcx>) {
+        assert_eq!(lty1.ty, lty2.ty);
+        for (sub_lty1, sub_lty2) in lty1.iter().zip(lty2.iter()) {
+            eprintln!("equate {:?} = {:?}", sub_lty1, sub_lty2);
+            if sub_lty1.label != PointerId::NONE || sub_lty2.label != PointerId::NONE {
+                assert!(sub_lty1.label != PointerId::NONE);
+                assert!(sub_lty2.label != PointerId::NONE);
+                self.add_equiv(sub_lty1.label, sub_lty2.label);
             }
         }
     }
@@ -222,10 +227,37 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         let perms = PermissionSet::OFFSET_ADD | PermissionSet::OFFSET_SUB;
                         self.constraints.add_all_perms(rv_lty.label, perms);
                     }
+
+                    Some(Callee::SliceAsPtr { elem_ty, .. }) => {
+                        // We handle this like an assignment, but with some adjustments due to the
+                        // difference in input and output types.
+                        self.visit_place(destination, Mutability::Mut);
+                        let pl_lty = self.acx.type_of(destination);
+                        assert!(args.len() == 1);
+                        self.visit_operand(&args[0]);
+                        let rv_lty = self.acx.type_of(&args[0]);
+
+                        // Map `rv_lty = &[i32]` to `rv_elem_lty = i32`
+                        let rv_pointee_lty = rv_lty.args[0];
+                        let rv_elem_lty = match *rv_pointee_lty.kind() {
+                            TyKind::Array(..) | TyKind::Slice(..) => rv_pointee_lty.args[0],
+                            TyKind::Str => self.acx.lcx().label(elem_ty, &mut |_| PointerId::NONE),
+                            _ => unreachable!(),
+                        };
+
+                        // Map `pl_lty = *mut i32` to `pl_elem_lty = i32`
+                        let pl_elem_lty = pl_lty.args[0];
+
+                        self.do_unify(pl_elem_lty, rv_elem_lty);
+                        self.do_assign_pointer_ids(pl_lty.label, rv_lty.label);
+                    }
+
                     Some(Callee::MiscBuiltin) => {}
+
                     Some(Callee::Other { def_id, substs }) => {
                         self.visit_call_other(def_id, substs, args, destination);
                     }
+
                     None => {}
                 }
             }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -200,6 +200,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         let perms = PermissionSet::OFFSET_ADD | PermissionSet::OFFSET_SUB;
                         self.constraints.add_all_perms(rv_lty.label, perms);
                     }
+                    Some(Callee::MiscBuiltin) => {}
                     Some(Callee::Other { def_id, substs }) => {
                         self.visit_call_other(def_id, substs, args, destination);
                     }

--- a/c2rust-analyze/src/expr_rewrite.rs
+++ b/c2rust-analyze/src/expr_rewrite.rs
@@ -337,6 +337,8 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             type_desc::perms_to_desc(self.perms[result_ptr], self.flags[result_ptr]);
 
         if op_own == result_own && op_qty == result_qty {
+            // Input and output types will be the same after rewriting, so the `as_ptr` call is not
+            // needed.
             self.emit(RewriteKind::RemoveAsPtr);
         }
     }

--- a/c2rust-analyze/src/expr_rewrite.rs
+++ b/c2rust-analyze/src/expr_rewrite.rs
@@ -39,6 +39,8 @@ pub enum RewriteKind {
     SliceFirst { mutbl: bool },
     /// Replace `ptr` with `&*ptr`, converting `&mut T` to `&T`.
     MutToImm,
+    /// Remove a call to `as_ptr` or `as_mut_ptr`.
+    RemoveAsPtr,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -175,6 +177,10 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                     match callee {
                         Callee::PtrOffset { .. } => {
                             self.visit_ptr_offset(&args[0], pl_ty);
+                            return;
+                        }
+                        Callee::SliceAsPtr { .. } => {
+                            self.visit_slice_as_ptr(&args[0], pl_ty);
                             return;
                         }
                         _ => {}
@@ -318,6 +324,20 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         // If the result is `Single`, also insert an upcast.
         if result_qty == Quantity::Single {
             self.emit(RewriteKind::SliceFirst { mutbl });
+        }
+    }
+
+    fn visit_slice_as_ptr(&mut self, op: &Operand<'tcx>, result_lty: LTy<'tcx>) {
+        let op_lty = self.acx.type_of(op);
+        let op_ptr = op_lty.label;
+        let result_ptr = result_lty.label;
+
+        let (op_own, op_qty) = type_desc::perms_to_desc(self.perms[op_ptr], self.flags[op_ptr]);
+        let (result_own, result_qty) =
+            type_desc::perms_to_desc(self.perms[result_ptr], self.flags[result_ptr]);
+
+        if op_own == result_own && op_qty == result_qty {
+            self.emit(RewriteKind::RemoveAsPtr);
         }
     }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -21,6 +21,7 @@ use crate::context::{
 use crate::dataflow::DataflowConstraints;
 use crate::equiv::{GlobalEquivSet, LocalEquivSet};
 use crate::util::Callee;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::visit::Visitor;
@@ -124,8 +125,16 @@ fn run(tcx: TyCtxt) {
         lasn: MaybeUnset<LocalAssignment>,
     }
 
+    // Follow a postorder traversal, so that callers are visited after their callees.  This means
+    // callee signatures will usually be up to date when we visit the call site.
+    let all_fn_ldids = fn_body_owners_postorder(tcx);
+    eprintln!("callgraph traversal order:");
+    for &ldid in &all_fn_ldids {
+        eprintln!("  {:?}", ldid);
+    }
+
     // Assign global `PointerId`s for all pointers that appear in function signatures.
-    for ldid in tcx.hir().body_owners() {
+    for &ldid in &all_fn_ldids {
         let sig = tcx.fn_sig(ldid.to_def_id());
         let sig = tcx.erase_late_bound_regions(sig);
 
@@ -145,7 +154,7 @@ fn run(tcx: TyCtxt) {
     // that two pointer types must be converted to the same reference type.  Some additional data
     // computed during this the process is kept around for use in later passes.
     let mut global_equiv = GlobalEquivSet::new(gacx.num_pointers());
-    for ldid in tcx.hir().body_owners() {
+    for &ldid in &all_fn_ldids {
         let ldid_const = WithOptConstParam::unknown(ldid);
         let mir = tcx.mir_built(ldid_const);
         let mir = mir.borrow();
@@ -221,7 +230,7 @@ fn run(tcx: TyCtxt) {
     eprintln!("global_equiv_map = {global_equiv_map:?}");
     gacx.remap_pointers(&global_equiv_map, global_counter);
 
-    for ldid in tcx.hir().body_owners() {
+    for &ldid in &all_fn_ldids {
         let info = func_info.get_mut(&ldid).unwrap();
         let (local_counter, local_equiv_map) = info.local_equiv.renumber(&global_equiv_map);
         eprintln!("local_equiv_map = {local_equiv_map:?}");
@@ -245,13 +254,6 @@ fn run(tcx: TyCtxt) {
         info.lasn.set(lasn);
     }
 
-    // Follow a postorder traversal, so that callers are visited after their callees.  This means
-    // callee signatures will usually be up to date when we visit the call site.
-    let order = body_owners_postorder(tcx);
-    eprintln!("callgraph traversal order:");
-    for &ldid in &order {
-        eprintln!("  {ldid:?}");
-    }
     let mut loop_count = 0;
     loop {
         // Loop until the global assignment reaches a fixpoint.  The inner loop also runs until a
@@ -260,7 +262,7 @@ fn run(tcx: TyCtxt) {
         // the outer loop, which runs until the `GlobalAssignment` converges as well.
         loop_count += 1;
         let old_gasn = gasn.clone();
-        for &ldid in &order {
+        for &ldid in &all_fn_ldids {
             let info = func_info.get_mut(&ldid).unwrap();
             let ldid_const = WithOptConstParam::unknown(ldid);
             let name = tcx.item_name(ldid.to_def_id());
@@ -291,9 +293,14 @@ fn run(tcx: TyCtxt) {
     }
     eprintln!("reached fixpoint in {} iterations", loop_count);
 
-    // Print results for each function.
+    // Print results for each function.  We use declaration order (as reported by `body_owners`)
+    // since this makes FileCheck tests easier to write.
     for ldid in tcx.hir().body_owners() {
-        let info = func_info.get_mut(&ldid).unwrap();
+        // Skip any body owners that aren't listed in `func_info`.
+        let info = match func_info.get_mut(&ldid) {
+            Some(x) => x,
+            None => continue,
+        };
         let ldid_const = WithOptConstParam::unknown(ldid);
         let name = tcx.item_name(ldid.to_def_id());
         let mir = tcx.mir_built(ldid_const);
@@ -442,9 +449,9 @@ fn describe_span(tcx: TyCtxt, span: Span) -> String {
     format!("{}: {}{}{}", line, src1, src2, src3)
 }
 
-/// Return all `body_owners`, ordered according to a postorder traversal of the graph of references
-/// between bodies.
-fn body_owners_postorder(tcx: TyCtxt) -> Vec<LocalDefId> {
+/// Return all `LocalDefId`s for all `fn`s that are `body_owners`, ordered according to a postorder
+/// traversal of the graph of references between bodies.
+fn fn_body_owners_postorder(tcx: TyCtxt) -> Vec<LocalDefId> {
     let mut seen = HashSet::new();
     let mut order = Vec::new();
     enum Visit {
@@ -457,6 +464,16 @@ fn body_owners_postorder(tcx: TyCtxt) -> Vec<LocalDefId> {
         if seen.contains(&root_ldid) {
             continue;
         }
+
+        match tcx.def_kind(root_ldid) {
+            DefKind::Fn => {}
+            DefKind::AnonConst => continue,
+            dk => panic!(
+                "unexpected def_kind {:?} for body_owner {:?}",
+                dk, root_ldid
+            ),
+        }
+
         stack.push(Visit::Pre(root_ldid));
         while let Some(visit) = stack.pop() {
             match visit {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -467,7 +467,7 @@ fn fn_body_owners_postorder(tcx: TyCtxt) -> Vec<LocalDefId> {
         }
 
         match tcx.def_kind(root_ldid) {
-            DefKind::Fn => {}
+            DefKind::Fn | DefKind::AssocFn => {}
             DefKind::AnonConst => continue,
             dk => panic!(
                 "unexpected def_kind {:?} for body_owner {:?}",

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -293,10 +293,11 @@ fn run(tcx: TyCtxt) {
     }
     eprintln!("reached fixpoint in {} iterations", loop_count);
 
-    // Print results for each function.  We use declaration order (as reported by `body_owners`)
-    // since this makes FileCheck tests easier to write.
+    // Print results for each function in `all_fn_ldids`, going in declaration order.  Concretely,
+    // we iterate over `body_owners()`, which is a superset of `all_fn_ldids`, and filter based on
+    // membership in `func_info`, which contains an entry for each ID in `all_fn_ldids`.
     for ldid in tcx.hir().body_owners() {
-        // Skip any body owners that aren't listed in `func_info`.
+        // Skip any body owners that aren't present in `func_info`, and also get the info itself.
         let info = match func_info.get_mut(&ldid) {
             Some(x) => x,
             None => continue,

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -311,7 +311,7 @@ fn run(tcx: TyCtxt) {
 
         // Print labeling and rewrites for the current function.
 
-        eprintln!("final labeling for {:?}:", name);
+        eprintln!("\nfinal labeling for {:?}:", name);
         let lcx1 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
         let lcx2 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
         for (local, decl) in mir.local_decls.iter_enumerated() {

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -1,7 +1,7 @@
 use crate::context::{AnalysisCtxt, Assignment, FlagSet, LTy, PermissionSet, PointerId};
 use rustc_hir::def::{DefKind, Res};
 use rustc_middle::ty::subst::GenericArg;
-use rustc_middle::ty::{ReErased, Ty, TyCtxt};
+use rustc_middle::ty::{ReErased, Ty, TyCtxt, TyKind};
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
@@ -100,7 +100,7 @@ pub fn convert_type<'tcx>(
     let perms = asn.perms();
     let flags = asn.flags();
     acx.lcx().rewrite_unlabeled(lty, &mut |ty, args, label| {
-        if label == PointerId::NONE {
+        if label == PointerId::NONE || !matches!(ty.kind(), TyKind::RawPtr(..)) {
             return ty;
         }
         let ptr = label;

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -159,7 +159,9 @@ pub fn lty_project<'tcx, L: Debug>(
             _ => panic!("Field projection is unsupported on type {:?}", lty),
         },
         ProjectionElem::Index(..) | ProjectionElem::ConstantIndex { .. } => {
-            todo!("type_of Index")
+            assert!(matches!(lty.kind(), TyKind::Array(..) | TyKind::Slice(..)));
+            assert_eq!(lty.args.len(), 1);
+            lty.args[0]
         }
         ProjectionElem::Subslice { .. } => todo!("type_of Subslice"),
         ProjectionElem::Downcast(..) => todo!("type_of Downcast"),

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -123,8 +123,8 @@ fn builtin_callee<'tcx>(
             Some(Callee::PtrOffset { pointee_ty, mutbl })
         }
 
-        "abort" => {
-            // std::process::abort
+        "abort" | "exit" => {
+            // `std::process::abort` and `std::process::exit`
             let path = tcx.def_path(did);
             if tcx.crate_name(path.krate).as_str() != "std" {
                 return None;
@@ -135,7 +135,6 @@ fn builtin_callee<'tcx>(
             if path.data[0].to_string() != "process" {
                 return None;
             }
-            debug_assert_eq!(path.data[1].to_string(), "abort");
             Some(Callee::MiscBuiltin)
         }
 

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -2,7 +2,7 @@ use crate::labeled_ty::LabeledTy;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir::{Local, Mutability, Operand, PlaceElem, PlaceRef, ProjectionElem, Rvalue};
-use rustc_middle::ty::{DefIdTree, SubstsRef, Ty, TyCtxt, TyKind};
+use rustc_middle::ty::{DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy};
 use std::fmt::Debug;
 
 #[derive(Debug)]
@@ -74,6 +74,15 @@ pub enum Callee<'tcx> {
         pointee_ty: Ty<'tcx>,
         mutbl: Mutability,
     },
+    /// `<[T]>::as_ptr` and `<[T]>::as_mut_ptr` methods.  Also covers the array and str versions.
+    SliceAsPtr {
+        /// The pointee type.  This is either `TyKind::Slice`, `TyKind::Array`, or `TyKind::Str`.
+        pointee_ty: Ty<'tcx>,
+        /// The slice element type.  For `str`, this is `u8`.
+        elem_ty: Ty<'tcx>,
+        /// Mutability of the output pointer.
+        mutbl: Mutability,
+    },
     /// A built-in or standard library function that requires no special handling.
     MiscBuiltin,
     /// Some other statically-known function, including functions defined in the current crate.
@@ -121,6 +130,34 @@ fn builtin_callee<'tcx>(
                 _ => return None,
             };
             Some(Callee::PtrOffset { pointee_ty, mutbl })
+        }
+
+        name @ "as_ptr" | name @ "as_mut_ptr" => {
+            // The `as_ptr` and `as_mut_ptr` inherent methods of `[T]`, `[T; n]`, and `str`.
+            let parent_did = tcx.parent(did);
+            if tcx.def_kind(parent_did) != DefKind::Impl {
+                return None;
+            }
+            if tcx.impl_trait_ref(parent_did).is_some() {
+                return None;
+            }
+            let parent_impl_ty = tcx.type_of(parent_did);
+            let elem_ty = match *parent_impl_ty.kind() {
+                TyKind::Array(ty, _) => ty,
+                TyKind::Slice(ty) => ty,
+                TyKind::Str => tcx.mk_mach_uint(UintTy::U8),
+                _ => return None,
+            };
+            let mutbl = match name {
+                "as_ptr" => Mutability::Not,
+                "as_mut_ptr" => Mutability::Mut,
+                _ => unreachable!(),
+            };
+            Some(Callee::SliceAsPtr {
+                pointee_ty: parent_impl_ty,
+                elem_ty,
+                mutbl,
+            })
         }
 
         "abort" | "exit" => {

--- a/c2rust-analyze/tests/filecheck/aggregate1.rs
+++ b/c2rust-analyze/tests/filecheck/aggregate1.rs
@@ -1,0 +1,16 @@
+
+// CHECK-LABEL: final labeling for "aggregate1_array"
+// CHECK-DAG: ([[#@LINE+1]]: p): &std::cell::Cell<i32>
+pub unsafe fn aggregate1_array(p: *mut i32) {
+    // CHECK-DAG: ([[#@LINE+1]]: arr): [&std::cell::Cell<i32>; 3]
+    let arr = [p, p, p];
+    *arr[0] = 1;
+}
+
+// CHECK-LABEL: final labeling for "aggregate1_array1"
+// CHECK-DAG: ([[#@LINE+1]]: p): &mut i32
+pub unsafe fn aggregate1_array1(p: *mut i32) {
+    // CHECK-DAG: ([[#@LINE+1]]: arr): [&mut i32; 1]
+    let arr = [p];
+    *arr[0] = 1;
+}

--- a/c2rust-analyze/tests/filecheck/as_ptr.rs
+++ b/c2rust-analyze/tests/filecheck/as_ptr.rs
@@ -1,0 +1,33 @@
+// CHECK-DAG: ([[#@LINE+1]]: x): &[i32]
+pub unsafe fn slice_as_ptr_load(x: &[i32]) -> i32 {
+    // CHECK-DAG: ([[#@LINE+1]]: p): &i32
+    let p = x.as_ptr();
+    *p
+}
+
+// FIXME: currently misinferred as &[[i32; 10]]
+// COM: CHECK-DAG: ([[#@LINE+1]]: x): &[i32]
+pub unsafe fn slice_as_ptr_offset_load(x: &[i32]) -> i32 {
+    // CHECK-DAG: ([[#@LINE+1]]: p): &[i32]
+    let p = x.as_ptr();
+    // CHECK-DAG: ([[#@LINE+1]]: q): &i32
+    let q = p.offset(2);
+    *q
+}
+
+// CHECK-DAG: ([[#@LINE+1]]: x): &[i32; 10]
+pub unsafe fn array_as_ptr_load(x: &[i32; 10]) -> i32 {
+    // CHECK-DAG: ([[#@LINE+1]]: p): &i32
+    let p = x.as_ptr();
+    *p
+}
+
+// FIXME: currently misinferred as &[[i32; 10]]
+// COM: CHECK-DAG: ([[#@LINE+1]]: x): &[i32; 10]
+pub unsafe fn array_as_ptr_offset_load(x: &[i32; 10]) -> i32 {
+    // CHECK-DAG: ([[#@LINE+1]]: p): &[i32]
+    let p = x.as_ptr();
+    // CHECK-DAG: ([[#@LINE+1]]: q): &i32
+    let q = p.offset(2);
+    *q
+}

--- a/c2rust-analyze/tests/filecheck/clone1.rs
+++ b/c2rust-analyze/tests/filecheck/clone1.rs
@@ -1,0 +1,9 @@
+// Just check that the analysis doesn't crash on types deriving `Clone`.  This derive is one of the
+// few sources of `impl`s in translated code.
+
+// CHECK-LABEL: final labeling for "clone"
+#[derive(Clone, Copy)]
+struct Foo {
+    x: i32,
+    y: i32,
+}

--- a/c2rust-analyze/tests/filecheck/extern_fn1.rs
+++ b/c2rust-analyze/tests/filecheck/extern_fn1.rs
@@ -1,0 +1,25 @@
+use std::mem;
+
+extern "C" {
+    fn foo(_: i32) -> i32;
+    fn malloc(_: u64) -> *mut u8;
+    fn free(_: *mut u8);
+}
+
+/*
+// TODO: calls to `malloc`/`free` library functions are not supported
+unsafe fn test_malloc() -> u32 {
+    let p = malloc(4) as *mut u32;
+    (*p) = 1;
+    let x = *p;
+    free(p as *mut u8);
+    x
+}
+*/
+
+// CHECK-LABEL: final labeling for "fn_ptr"
+fn fn_ptr() {
+    // TODO: function pointer types are not fully supported yet
+    //let f: unsafe extern "C" fn(i32) -> i32 = foo;
+    let f = foo;
+}


### PR DESCRIPTION
This branch adds support for various features that were needed for the insertion sort test driver:

* Array aggregate and `Rvalue::Len` expressions
* Array/slice indexing `Place` projections
* Slice `as_ptr` and `as_mut_ptr` methods
* `std::process::exit` and `std::process::abort`

Other misc improvements:

* Only process functions (avoids a crash when encountering `AnonConst` MIR bodies)
* Skip assigning new types for variables that are already safe references (these occur in some transpiled code)
* Add `RewriteKind::RemoveAsPtr` for expressions where an `as_ptr()` method call is no longer needed