### PR TITLE
Fix panicking on wrong `c2rust` subcommand

### DIFF
--- a/c2rust/src/main.rs
+++ b/c2rust/src/main.rs
@@ -126,10 +126,7 @@ fn main() -> anyhow::Result<()> {
     let matches = App::new("C2Rust")
         .version(&*render_testament!(TESTAMENT))
         .author(crate_authors!(", "))
-        .settings(&[
-            AppSettings::SubcommandRequiredElseHelp,
-            AppSettings::AllowExternalSubcommands,
-        ])
+        .settings(&[AppSettings::SubcommandRequiredElseHelp])
         .subcommands(sub_commands.keys().map(|name| {
             clap::SubCommand::with_name(name).arg(
                 Arg::with_name("args")


### PR DESCRIPTION
Fixes #721.

Don't need `clap::AppSettings::AllowExternalSubcommands` anymore since we first discover all of them (not just known ones).