### PR TITLE
Avoid rare race condition in `cargo test -p c2rust-pdg` for `cargo add`

### DIFF
--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -329,7 +329,7 @@ mod tests {
                 "--metadata",
             ])
             .arg(&metadata_path)
-            .args(&["--set-runtime", "--runtime-path"])
+            .args(&["--runtime-path"])
             .arg(&runtime_path)
             .args(&["--", "run", "--manifest-path"])
             .arg(&manifest_path)


### PR DESCRIPTION
Turn off `--set-runtime` for `c2rust instrument` in `c2rust-pdg` tests, because they run in parallel and trigger a rare race condition in `cargo add`.

When `--set-runtime` is set, `c2rust instrument` runs `cargo add ...` to add `c2rust-analysis-rt` as a dependency at path `analysis/runtime`.  This is useful to have in general, as it ensures that the relative path to `analysis/runtime` is always up-to-date, but in `analysis/test`, the saved `Cargo.toml` is fine, as that directory isn't moving in CI.  If it does ever move, we just need to update the path manually or run with `--set-runtime` once and commit that change.

The race condition is that `cargo add` itself is not thread-safe.  `cargo add` reads (multiple times I think) and potentially writes to `Cargo.toml`, and if multiple `cargo add`s are run concurrently, it may crash.  Since tests are run concurrently by default, we'll get multiple `cargo add`s for `debug` and `release`.