### PR TITLE
label ADT struct fields in static dataflow analysis

### DIFF
--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -34,7 +34,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     pub fn visit_place(&mut self, pl: Place<'tcx>) -> LTy<'tcx> {
         let mut lty = self.local_ltys[pl.local.index()];
         for proj in pl.projection {
-            lty = util::lty_project(lty, &proj);
+            lty = util::lty_project(lty, &proj, |_, _| panic!("Adt not supported"));
         }
         lty
     }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -13,7 +13,6 @@ use rustc_middle::mir::{
 };
 use rustc_middle::ty::adjustment::PointerCast;
 use rustc_middle::ty::{AdtDef, Ty, TyCtxt, TyKind};
-use rustc_target::abi::VariantIdx;
 use std::collections::HashMap;
 use std::ops::Index;
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -72,7 +72,7 @@ pub struct GlobalAnalysisCtxt<'tcx> {
 
     pub fn_sigs: HashMap<DefId, LFnSig<'tcx>>,
 
-    pub field_tys: HashMap<(DefId, Field, VariantIdx), LTy<'tcx>>,
+    pub field_tys: HashMap<DefId, LTy<'tcx>>,
 
     next_ptr_id: NextGlobalPointerId,
 }
@@ -368,7 +368,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
             let res = *self
                 .gacx
                 .field_tys
-                .get(&(adtdef.did(), field, VariantIdx::from_usize(0)))
+                .get(&(adtdef.all_fields().nth(usize::from(field)).unwrap().did))
                 .unwrap_or_else(|| {
                     panic!("Could not find {adtdef:?}.{fielddef_name:?} in field type map")
                 });

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -362,7 +362,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
 
     pub fn project(&self, lty: LTy<'tcx>, proj: &PlaceElem<'tcx>) -> LTy<'tcx> {
         let adt_func = |adtdef: AdtDef, field: Field| {
-            let field_def = adtdef.all_fields().nth(usize::from(field)).unwrap();
+            let field_def = &adtdef.non_enum_variant().fields[field.index()];
             let field_def_name = field_def.name;
             eprintln!("projecting into {adtdef:?}.{field_def_name:}");
             let res = *self.gacx.field_tys.get(&field_def.did).unwrap_or_else(|| {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -4,6 +4,7 @@ use crate::pointer_id::{
     PointerTableMut,
 };
 use crate::util::{self, describe_rvalue, RvalueDesc};
+use crate::AssignPointerIds;
 use bitflags::bitflags;
 use rustc_hir::def_id::DefId;
 use rustc_index::vec::IndexVec;
@@ -12,7 +13,7 @@ use rustc_middle::mir::{
     PlaceRef, Rvalue,
 };
 use rustc_middle::ty::adjustment::PointerCast;
-use rustc_middle::ty::{AdtDef, Ty, TyCtxt, TyKind};
+use rustc_middle::ty::{AdtDef, FieldDef, Ty, TyCtxt, TyKind};
 use std::collections::HashMap;
 use std::ops::Index;
 
@@ -155,6 +156,17 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         }
 
         *next_ptr_id = counter;
+    }
+
+    pub fn label_field(&mut self, field: &FieldDef) {
+        let lty = self.assign_pointer_ids(self.tcx.type_of(field.did));
+        self.field_tys.insert(field.did, lty);
+    }
+
+    pub fn label_struct_fields(&mut self, did: DefId) {
+        for field in self.tcx.adt_def(did).all_fields() {
+            self.label_field(field);
+        }
     }
 }
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -72,7 +72,7 @@ pub struct GlobalAnalysisCtxt<'tcx> {
 
     pub fn_sigs: HashMap<DefId, LFnSig<'tcx>>,
 
-    pub field_tys: HashMap<(AdtDef<'tcx>, Field, VariantIdx), LTy<'tcx>>,
+    pub field_tys: HashMap<(DefId, Field, VariantIdx), LTy<'tcx>>,
 
     next_ptr_id: NextGlobalPointerId,
 }
@@ -368,7 +368,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
             let res = *self
                 .gacx
                 .field_tys
-                .get(&(adtdef, field, VariantIdx::from_usize(0)))
+                .get(&(adtdef.did(), field, VariantIdx::from_usize(0)))
                 .unwrap_or_else(|| {
                     panic!("Could not find {adtdef:?}.{fielddef_name:?} in field type map")
                 });

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -362,11 +362,11 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
 
     pub fn project(&self, lty: LTy<'tcx>, proj: &PlaceElem<'tcx>) -> LTy<'tcx> {
         let adt_func = |adtdef: AdtDef, field: Field| {
-            let fielddef = adtdef.all_fields().nth(usize::from(field)).unwrap();
-            let fielddef_name = fielddef.name;
-            eprintln!("projecting into {adtdef:?}.{fielddef_name:}");
-            let res = *self.gacx.field_tys.get(&fielddef.did).unwrap_or_else(|| {
-                panic!("Could not find {adtdef:?}.{fielddef_name:?} in field type map")
+            let field_def = adtdef.all_fields().nth(usize::from(field)).unwrap();
+            let field_def_name = field_def.name;
+            eprintln!("projecting into {adtdef:?}.{field_def_name:}");
+            let res = *self.gacx.field_tys.get(&field_def.did).unwrap_or_else(|| {
+                panic!("Could not find {adtdef:?}.{field_def_name:?} in field type map")
             });
             res
         };

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -377,12 +377,12 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
     }
 
     pub fn project(&self, lty: LTy<'tcx>, proj: &PlaceElem<'tcx>) -> LTy<'tcx> {
-        let adt_func = |adtdef: AdtDef, field: Field| {
-            let field_def = &adtdef.non_enum_variant().fields[field.index()];
+        let adt_func = |adt_def: AdtDef, field: Field| {
+            let field_def = &adt_def.non_enum_variant().fields[field.index()];
             let field_def_name = field_def.name;
-            eprintln!("projecting into {adtdef:?}.{field_def_name:}");
+            eprintln!("projecting into {adt_def:?}.{field_def_name:}");
             let res = *self.gacx.field_tys.get(&field_def.did).unwrap_or_else(|| {
-                panic!("Could not find {adtdef:?}.{field_def_name:?} in field type map")
+                panic!("Could not find {adt_def:?}.{field_def_name:?} in field type map")
             });
             res
         };

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -141,7 +141,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             tcx: _,
             lcx,
             ref mut fn_sigs,
-            field_tys: _,
+            ref mut field_tys,
             ref mut next_ptr_id,
         } = *self;
 
@@ -153,6 +153,10 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
                     .collect::<Vec<_>>(),
             );
             sig.output = remap_lty_pointers(lcx, map, sig.output);
+        }
+
+        for labeled_field in field_tys.values_mut() {
+            *labeled_field = remap_lty_pointers(lcx, map, labeled_field);
         }
 
         *next_ptr_id = counter;

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -363,15 +363,12 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
 
     pub fn project(&self, lty: LTy<'tcx>, proj: &PlaceElem<'tcx>) -> LTy<'tcx> {
         let adt_func = |adtdef: AdtDef, field: Field| {
-            let fielddef_name = adtdef.all_fields().collect::<Vec<_>>()[usize::from(field)].name;
+            let fielddef = adtdef.all_fields().nth(usize::from(field)).unwrap();
+            let fielddef_name = fielddef.name;
             eprintln!("projecting into {adtdef:?}.{fielddef_name:}");
-            let res = *self
-                .gacx
-                .field_tys
-                .get(&(adtdef.all_fields().nth(usize::from(field)).unwrap().did))
-                .unwrap_or_else(|| {
-                    panic!("Could not find {adtdef:?}.{fielddef_name:?} in field type map")
-                });
+            let res = *self.gacx.field_tys.get(&fielddef.did).unwrap_or_else(|| {
+                panic!("Could not find {adtdef:?}.{fielddef_name:?} in field type map")
+            });
             res
         };
         util::lty_project(lty, proj, adt_func)

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -157,12 +157,9 @@ fn run(tcx: TyCtxt) {
         if tcx.def_kind(did) != DefKind::Struct {
             continue;
         }
-        let defty = tcx.type_of(did).kind();
-        if let TyKind::Adt(adtdef, _) = defty {
-            for field in adtdef.all_fields() {
-                let lty = gacx.assign_pointer_ids(tcx.type_of(field.did));
-                gacx.field_tys.insert(field.did, lty);
-            }
+        for field in tcx.adt_def(did).all_fields() {
+            let lty = gacx.assign_pointer_ids(tcx.type_of(field.did));
+            gacx.field_tys.insert(field.did, lty);
         }
     }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -157,10 +157,7 @@ fn run(tcx: TyCtxt) {
         if !matches!(tcx.def_kind(did), Struct | Enum | Union) {
             continue;
         }
-        for field in tcx.adt_def(did).all_fields() {
-            let lty = gacx.assign_pointer_ids(tcx.type_of(field.did));
-            gacx.field_tys.insert(field.did, lty);
-        }
+        gacx.label_struct_fields(did);
     }
 
     // Initial pass to assign local `PointerId`s and gather equivalence constraints, which state

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -157,16 +157,9 @@ fn run(tcx: TyCtxt) {
         if let DefKind::Struct = tcx.def_kind(defdid) {
             let defty = tcx.type_of(defdid).kind();
             if let TyKind::Adt(adtdef, _) = defty {
-                for (fid, field) in adtdef.all_fields().enumerate() {
+                for field in adtdef.all_fields() {
                     let lty = gacx.assign_pointer_ids(tcx.type_of(field.did));
-                    gacx.field_tys.insert(
-                        (
-                            adtdef.did(),
-                            Field::from_usize(fid),
-                            VariantIdx::from_usize(0),
-                        ),
-                        lty,
-                    );
+                    gacx.field_tys.insert(field.did, lty);
                 }
             }
         }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -153,7 +153,8 @@ fn run(tcx: TyCtxt) {
     // Label the field types of each struct.
     for ldid in tcx.hir_crate_items(()).definitions() {
         let did = ldid.to_def_id();
-        if tcx.def_kind(did) != DefKind::Struct {
+        use DefKind::*;
+        if !matches!(tcx.def_kind(did), Struct | Enum | Union) {
             continue;
         }
         for field in tcx.adt_def(did).all_fields() {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -160,7 +160,11 @@ fn run(tcx: TyCtxt) {
                 for (fid, field) in adtdef.all_fields().enumerate() {
                     let lty = gacx.assign_pointer_ids(tcx.type_of(field.did));
                     gacx.field_tys.insert(
-                        (*adtdef, Field::from_usize(fid), VariantIdx::from_usize(0)),
+                        (
+                            adtdef.did(),
+                            Field::from_usize(fid),
+                            VariantIdx::from_usize(0),
+                        ),
                         lty,
                     );
                 }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -154,13 +154,14 @@ fn run(tcx: TyCtxt) {
     // Label the field types of each struct.
     for ldid in tcx.hir_crate_items(()).definitions() {
         let did = ldid.to_def_id();
-        if let DefKind::Struct = tcx.def_kind(did) {
-            let defty = tcx.type_of(did).kind();
-            if let TyKind::Adt(adtdef, _) = defty {
-                for field in adtdef.all_fields() {
-                    let lty = gacx.assign_pointer_ids(tcx.type_of(field.did));
-                    gacx.field_tys.insert(field.did, lty);
-                }
+        if tcx.def_kind(did) != DefKind::Struct {
+            continue;
+        }
+        let defty = tcx.type_of(did).kind();
+        if let TyKind::Adt(adtdef, _) = defty {
+            for field in adtdef.all_fields() {
+                let lty = gacx.assign_pointer_ids(tcx.type_of(field.did));
+                gacx.field_tys.insert(field.did, lty);
             }
         }
     }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -26,12 +26,11 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::{
-    AggregateKind, BindingForm, Body, Field, LocalDecl, LocalInfo, LocalKind, Location, Operand,
-    Rvalue, StatementKind,
+    AggregateKind, BindingForm, Body, LocalDecl, LocalInfo, LocalKind, Location, Operand, Rvalue,
+    StatementKind,
 };
 use rustc_middle::ty::{Ty, TyCtxt, TyKind, WithOptConstParam};
 use rustc_span::Span;
-use rustc_target::abi::VariantIdx;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ops::{Deref, DerefMut};

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -152,10 +152,10 @@ fn run(tcx: TyCtxt) {
     }
 
     // Label the field types of each struct.
-    for defldid in tcx.hir_crate_items(()).definitions() {
-        let defdid = defldid.to_def_id();
-        if let DefKind::Struct = tcx.def_kind(defdid) {
-            let defty = tcx.type_of(defdid).kind();
+    for ldid in tcx.hir_crate_items(()).definitions() {
+        let did = ldid.to_def_id();
+        if let DefKind::Struct = tcx.def_kind(did) {
+            let defty = tcx.type_of(did).kind();
             if let TyKind::Adt(adtdef, _) = defty {
                 for field in adtdef.all_fields() {
                     let lty = gacx.assign_pointer_ids(tcx.type_of(field.did));

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -1,8 +1,10 @@
 use crate::labeled_ty::LabeledTy;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
-use rustc_middle::mir::{Local, Mutability, Operand, PlaceElem, PlaceRef, ProjectionElem, Rvalue};
-use rustc_middle::ty::{DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy};
+use rustc_middle::mir::{
+    Field, Local, Mutability, Operand, PlaceElem, PlaceRef, ProjectionElem, Rvalue,
+};
+use rustc_middle::ty::{AdtDef, DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy};
 use std::fmt::Debug;
 
 #[derive(Debug)]
@@ -182,6 +184,7 @@ fn builtin_callee<'tcx>(
 pub fn lty_project<'tcx, L: Debug>(
     lty: LabeledTy<'tcx, L>,
     proj: &PlaceElem<'tcx>,
+    adt_func: impl Fn(AdtDef<'tcx>, Field) -> LabeledTy<'tcx, L>,
 ) -> LabeledTy<'tcx, L> {
     match *proj {
         ProjectionElem::Deref => {
@@ -191,7 +194,7 @@ pub fn lty_project<'tcx, L: Debug>(
         }
         ProjectionElem::Field(f, _) => match lty.kind() {
             TyKind::Tuple(_) => lty.args[f.index()],
-            TyKind::Adt(..) => todo!("type_of Field(Adt)"),
+            TyKind::Adt(def, _) => adt_func(*def, f),
             _ => panic!("Field projection is unsupported on type {:?}", lty),
         },
         ProjectionElem::Index(..) | ProjectionElem::ConstantIndex { .. } => {


### PR DESCRIPTION
Struct fields in `TyKind::Adt` were previously ignored in labeling with `PointerId`s. This PR adds support for that.