### PR TITLE
Remove `#![feature(rustc_private)]` from `analysis/tests`

### DIFF
--- a/analysis/tests/lighttpd-minimal/src/main.rs
+++ b/analysis/tests/lighttpd-minimal/src/main.rs
@@ -1,6 +1,5 @@
 #![feature(extern_types)]
 #![feature(label_break_value)]
-#![feature(rustc_private)]
 #![feature(c_variadic)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]

--- a/analysis/tests/lighttpd/src/main.rs
+++ b/analysis/tests/lighttpd/src/main.rs
@@ -1,6 +1,5 @@
 #![feature(extern_types)]
 #![feature(label_break_value)]
-#![feature(rustc_private)]
 #![feature(c_variadic)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]

--- a/analysis/tests/misc/src/main.rs
+++ b/analysis/tests/misc/src/main.rs
@@ -1,6 +1,5 @@
 #![feature(extern_types)]
 #![feature(label_break_value)]
-#![feature(rustc_private)]
 #![feature(c_variadic)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]


### PR DESCRIPTION
This removes `#![feature(rustc_private)]` from `analysis/tests` as there's no reason to use rustc internals in test code.  I'm not sure why it was added in the first place in f983821e0fdc9ba80a6a3787680857b2f68a7074, as things build perfectly fine without it, and I'm not sure why we would need rustc internals in the test code.