### PR TITLE
Add static analysis support for limited set of previously-unknown functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +175,7 @@ dependencies = [
 name = "c2rust-analyze"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "bitflags",
  "c2rust-build-paths",
  "polonius-engine",

--- a/analysis/tests/lighttpd-minimal/src/main.rs
+++ b/analysis/tests/lighttpd-minimal/src/main.rs
@@ -61,21 +61,58 @@ pub struct fdnode_st {
 
 pub type fdnode = fdnode_st;
 
-unsafe extern "C" fn connection_close(mut srv: *mut server, mut con: *mut connection) {}
+unsafe extern "C" fn fdnode_init() -> *mut libc::c_void /*TODO: handle *mut fdnode */ {
+    let fdn /*TODO: handle : *mut fdnode */ = calloc(
+        1 as libc::c_int as libc::c_ulong,
+        ::std::mem::size_of::<fdnode>() as libc::c_ulong,
+    ) /* TODO: handle cast as *mut fdnode */;
+    if fdn.is_null() {
+        // println!("It's null");
+    }
+
+    return fdn;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn connection_accepted(
+    mut srv: *mut server,
+    mut cnt: libc::c_int,
+) -> *mut libc::c_void /* TODO: handle *mut connection */ {
+    let con = malloc(::std::mem::size_of::<connection>() as libc::c_ulong); // TODO: handle as *mut connection;
+    return con;
+}
+
+unsafe extern "C" fn connection_close(
+    mut srv: *mut server,
+    mut con: *mut libc::c_void, /* TODO: handle *mut connection */
+) {
+    free(con /* TODO: handle cast as *mut libc::c_void */);
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn fdevent_fdnode_event_del(mut ev: *mut fdevents, mut fdn: *mut fdnode) {
-    fdevent_fdnode_event_unsetter(ev, fdn);
+    if !fdn.is_null() {
+        fdevent_fdnode_event_unsetter(ev, fdn);
+    }
 }
 
 unsafe extern "C" fn fdevent_fdnode_event_unsetter(mut ev: *mut fdevents, mut fdn: *mut fdnode) {}
 
 #[no_mangle]
-pub unsafe extern "C" fn fdevent_unregister(mut ev: *mut fdevents, mut fd: libc::c_int) {}
+pub unsafe extern "C" fn fdevent_unregister(mut fds: *mut *mut fdnode, mut fd: libc::c_int) {
+    let mut fdn: *mut fdnode = *(fds).offset(fd as isize);
+}
 
-unsafe extern "C" fn fdnode_free(mut fdn: *mut fdnode) {}
+unsafe extern "C" fn fdnode_free(fdn: *mut libc::c_void) {
+    free(fdn /* TODO: handle cast as *mut libc::c_void */);
+}
 
-pub unsafe extern "C" fn lighttpd_test() {}
+pub unsafe extern "C" fn lighttpd_test() {
+    let fdarr = malloc(::std::mem::size_of::<*mut fdnode>() as libc::c_ulong); // TODO: handle cast as *mut *mut fdnode;
+    let fdes = malloc(::std::mem::size_of::<fdevents>() as libc::c_ulong); // TODO: handle cast as *mut fdevents;
+    free(fdarr /* TODO: handle cast as *mut libc::c_void */);
+    free(fdes /* TODO: handle cast as *mut libc::c_void */);
+}
 
 fn main() {
     unsafe {

--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 polonius-engine = "0.13.0"
 rustc-hash = "1.1.0"
 bitflags = "1.3.2"
+assert_matches = "1.5.0"
 
 [build-dependencies]
 c2rust-build-paths = { path = "../c2rust-build-paths" }

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -175,9 +175,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 self.ltcx.label(ty, &mut |_| Label::default())
             }
 
-            Rvalue::UnaryOp(_, ref op) => {
-                self.visit_operand(op)
-            }
+            Rvalue::UnaryOp(_, ref op) => self.visit_operand(op),
 
             ref rv => panic!("unsupported rvalue {:?}", rv),
         }
@@ -247,18 +245,22 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     Some(Callee::Realloc) => {
                         // We handle this like a pointer assignment.
                         let pl_lty = self.visit_place(destination);
-                        assert!(args.len() == 2);
-                        let rv_lty = self.visit_operand(&args[0]);
+                        let rv_lty = assert_matches!(&args[..], [p, _] => {
+                            self.visit_operand(p)
+                        });
+
                         self.do_assign(pl_lty, rv_lty);
                     }
                     Some(Callee::Free) => {
                         let _pl_lty = self.visit_place(destination);
-                        assert!(args.len() == 1);
-                        let _rv_lty = self.visit_operand(&args[0]);
+                        let _rv_lty = assert_matches!(&args[..], [p] => {
+                            self.visit_operand(p)
+                        });
                     }
                     Some(Callee::IsNull) => {
-                        assert!(args.len() == 1);
-                        let _rv_lty = self.visit_operand(&args[0]);
+                        let _rv_lty = assert_matches!(&args[..], [p] => {
+                            self.visit_operand(p)
+                        });
                     }
                     None => {}
                 }

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -2,6 +2,7 @@ use crate::borrowck::atoms::{AllFacts, AtomMaps, Loan, Origin, Path, Point, SubP
 use crate::borrowck::{LTy, LTyCtxt, Label};
 use crate::context::PermissionSet;
 use crate::util::{self, Callee};
+use assert_matches::assert_matches;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{
     AggregateKind, BinOp, Body, BorrowKind, Local, LocalDecl, Location, Operand, Place, Rvalue,

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -175,6 +175,10 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 self.ltcx.label(ty, &mut |_| Label::default())
             }
 
+            Rvalue::UnaryOp(_, ref op) => {
+                self.visit_operand(op)
+            }
+
             ref rv => panic!("unsupported rvalue {:?}", rv),
         }
     }

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -238,6 +238,28 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     Some(Callee::Other { .. }) => {
                         // TODO
                     }
+                    Some(Callee::Malloc) => {
+                        // TODO
+                    }
+                    Some(Callee::Calloc) => {
+                        // TODO
+                    }
+                    Some(Callee::Realloc) => {
+                        // We handle this like a pointer assignment.
+                        let pl_lty = self.visit_place(destination);
+                        assert!(args.len() == 2);
+                        let rv_lty = self.visit_operand(&args[0]);
+                        self.do_assign(pl_lty, rv_lty);
+                    }
+                    Some(Callee::Free) => {
+                        let _pl_lty = self.visit_place(destination);
+                        assert!(args.len() == 1);
+                        let _rv_lty = self.visit_operand(&args[0]);
+                    }
+                    Some(Callee::IsNull) => {
+                        assert!(args.len() == 1);
+                        let _rv_lty = self.visit_operand(&args[0]);
+                    }
                     None => {}
                 }
             }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -39,6 +39,8 @@ bitflags! {
         const OFFSET_ADD = 0x0010;
         /// This pointer can be offset in the negative direction.
         const OFFSET_SUB = 0x0020;
+        /// This pointer can be freed.
+        const FREE = 0x0030;
     }
 }
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -40,7 +40,7 @@ bitflags! {
         /// This pointer can be offset in the negative direction.
         const OFFSET_SUB = 0x0020;
         /// This pointer can be freed.
-        const FREE = 0x0030;
+        const FREE = 0x0040;
     }
 }
 

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -317,6 +317,10 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         self.visit_place(destination, Mutability::Mut);
                         assert!(args.len() == 1);
                         self.visit_operand(&args[0]);
+
+                        let rv_lty = self.acx.type_of(&args[0]);
+                        let perms = PermissionSet::FREE;
+                        self.constraints.add_all_perms(rv_lty.label, perms);
                     }
 
                     Some(Callee::IsNull) => {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(rustc_private)]
+#[macro_use] extern crate assert_matches;
 extern crate either;
 extern crate rustc_arena;
 extern crate rustc_ast;

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -1,5 +1,4 @@
 #![feature(rustc_private)]
-#[macro_use] extern crate assert_matches;
 extern crate either;
 extern crate rustc_arena;
 extern crate rustc_ast;

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -187,7 +187,20 @@ fn builtin_callee<'tcx>(
             Some(Callee::MiscBuiltin)
         }
 
-        "size_of" => Some(Callee::MiscBuiltin),
+        "size_of" => {
+            // `core::mem::size_of`
+            let path = tcx.def_path(did);
+            if tcx.crate_name(path.krate).as_str() != "core" {
+                return None;
+            }
+            if path.data.len() != 2 {
+                return None;
+            }
+            if path.data[0].to_string() != "mem" {
+                return None;
+            }
+            Some(Callee::MiscBuiltin)
+        },
 
         "malloc" => Some(Callee::Malloc),
 

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -209,7 +209,7 @@ fn builtin_callee<'tcx>(
             None
         }
 
-        "calloc" => {
+        "calloc" | "c2rust_test_typed_calloc" => {
             if matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod) {
                 return Some(Callee::Calloc);
             }

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -203,52 +203,28 @@ fn builtin_callee<'tcx>(
         }
 
         "malloc" | "c2rust_test_typed_malloc" => {
-            if tcx
-                .codegen_fn_attrs(did)
-                .link_name
-                .filter(|s| s.as_str() == "malloc")
-                .is_some()
-                || matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod)
-            {
+            if matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod) {
                 return Some(Callee::Malloc);
             }
             None
         }
 
         "calloc" => {
-            if tcx
-                .codegen_fn_attrs(did)
-                .link_name
-                .filter(|s| s.as_str() == "calloc")
-                .is_some()
-                || matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod)
-            {
+            if matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod) {
                 return Some(Callee::Calloc);
             }
             None
         }
 
         "realloc" | "c2rust_test_typed_realloc" => {
-            if tcx
-                .codegen_fn_attrs(did)
-                .link_name
-                .filter(|s| s.as_str() == "realloc")
-                .is_some()
-                || matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod)
-            {
+            if matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod) {
                 return Some(Callee::Realloc);
             }
             None
         }
 
         "free" | "c2rust_test_typed_free" => {
-            if tcx
-                .codegen_fn_attrs(did)
-                .link_name
-                .filter(|s| s.as_str() == "malloc")
-                .is_some()
-                || matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod)
-            {
+            if matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod) {
                 return Some(Callee::Free);
             }
             None

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -95,7 +95,7 @@ pub enum Callee<'tcx> {
     Free,
     /// libc::realloc
     Realloc,
-    /// std::ptr::is_null
+    /// core::ptr::is_null
     IsNull,
     /// Some other statically-known function, including functions defined in the current crate.
     Other {
@@ -197,7 +197,20 @@ fn builtin_callee<'tcx>(
 
         "free" => Some(Callee::Free),
 
-        "is_null" => Some(Callee::IsNull),
+        "is_null" => {
+            // `core::ptr::is_null`
+            let path = tcx.def_path(did);
+            if tcx.crate_name(path.krate).as_str() != "core" {
+                return None;
+            }
+            if path.data.len() != 4 {
+                return None;
+            }
+            if path.data[0].to_string() != "ptr" {
+                return None;
+            }
+            Some(Callee::IsNull)
+        },
 
         _ => {
             eprintln!("name: {name:?}");

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -200,15 +200,59 @@ fn builtin_callee<'tcx>(
                 return None;
             }
             Some(Callee::MiscBuiltin)
-        },
+        }
 
-        "malloc" => Some(Callee::Malloc),
+        "malloc" | "c2rust_test_typed_malloc" => {
+            if tcx
+                .codegen_fn_attrs(did)
+                .link_name
+                .filter(|s| s.as_str() == "malloc")
+                .is_some()
+                || matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod)
+            {
+                return Some(Callee::Malloc);
+            }
+            None
+        }
 
-        "calloc" => Some(Callee::Calloc),
+        "calloc" => {
+            if tcx
+                .codegen_fn_attrs(did)
+                .link_name
+                .filter(|s| s.as_str() == "calloc")
+                .is_some()
+                || matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod)
+            {
+                return Some(Callee::Calloc);
+            }
+            None
+        }
 
-        "realloc" => Some(Callee::Realloc),
+        "realloc" | "c2rust_test_typed_realloc" => {
+            if tcx
+                .codegen_fn_attrs(did)
+                .link_name
+                .filter(|s| s.as_str() == "realloc")
+                .is_some()
+                || matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod)
+            {
+                return Some(Callee::Realloc);
+            }
+            None
+        }
 
-        "free" => Some(Callee::Free),
+        "free" | "c2rust_test_typed_free" => {
+            if tcx
+                .codegen_fn_attrs(did)
+                .link_name
+                .filter(|s| s.as_str() == "malloc")
+                .is_some()
+                || matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod)
+            {
+                return Some(Callee::Free);
+            }
+            None
+        }
 
         "is_null" => {
             // `core::ptr::is_null`
@@ -223,7 +267,7 @@ fn builtin_callee<'tcx>(
                 return None;
             }
             Some(Callee::IsNull)
-        },
+        }
 
         _ => {
             eprintln!("name: {name:?}");

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -87,6 +87,16 @@ pub enum Callee<'tcx> {
     },
     /// A built-in or standard library function that requires no special handling.
     MiscBuiltin,
+    /// libc::malloc
+    Malloc,
+    /// libc::calloc
+    Calloc,
+    /// libc::free
+    Free,
+    /// libc::realloc
+    Realloc,
+    /// std::ptr::is_null
+    IsNull,
     /// Some other statically-known function, including functions defined in the current crate.
     Other {
         def_id: DefId,
@@ -177,7 +187,22 @@ fn builtin_callee<'tcx>(
             Some(Callee::MiscBuiltin)
         }
 
-        _ => None,
+        "size_of" => Some(Callee::MiscBuiltin),
+
+        "malloc" => Some(Callee::Malloc),
+
+        "calloc" => Some(Callee::Calloc),
+
+        "realloc" => Some(Callee::Realloc),
+
+        "free" => Some(Callee::Free),
+
+        "is_null" => Some(Callee::IsNull),
+
+        _ => {
+            eprintln!("name: {name:?}");
+            None
+        }
     }
 }
 

--- a/c2rust-analyze/tests/filecheck/alloc.rs
+++ b/c2rust-analyze/tests/filecheck/alloc.rs
@@ -1,0 +1,68 @@
+#![feature(extern_types)]
+#![feature(label_break_value)]
+#![feature(rustc_private)]
+#![feature(c_variadic)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+#![allow(mutable_transmutes)]
+#![allow(unused_mut)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+
+extern crate libc;
+
+use libc::*;
+use std::mem;
+pub type size_t = libc::c_ulong;
+
+extern "C" {
+    fn c2rust_test_typed_malloc(_: libc::c_ulong) -> *mut i32;
+    fn c2rust_test_typed_realloc(_: *mut i32, _: libc::c_ulong) -> *mut i32;
+    fn c2rust_test_typed_free(__ptr: *mut i32);
+    fn c2rust_test_typed_calloc(_: libc::c_ulong, _: libc::c_ulong) -> *mut i32;
+}
+
+// CHECK-LABEL: final labeling for "calloc1"
+unsafe extern "C" fn calloc1() -> *mut i32 {
+    // CHECK-DAG: ([[#@LINE+1]]: i): addr_of = UNIQUE
+    let i = c2rust_test_typed_calloc(
+        1 as libc::c_int as libc::c_ulong,
+        ::std::mem::size_of::<i32>() as libc::c_ulong,
+    );
+    if i.is_null() {}
+
+    return i;
+}
+
+// CHECK-LABEL: final labeling for "malloc1"
+pub unsafe extern "C" fn malloc1(mut cnt: libc::c_int) -> *mut i32 {
+    // CHECK-DAG: ([[#@LINE+1]]: i): addr_of = UNIQUE, type = READ
+    let i = c2rust_test_typed_malloc(::std::mem::size_of::<i32>() as libc::c_ulong);
+    let x = *i;
+    return i;
+}
+
+// CHECK-LABEL: final labeling for "free1"
+unsafe extern "C" fn free1(mut i: *mut i32) {
+    // CHECK-DAG: ([[#@LINE+1]]: i): {{.*}}type = UNIQUE | FREE#
+    c2rust_test_typed_free(i);
+}
+
+// CHECK-LABEL: final labeling for "realloc1"
+unsafe extern "C" fn realloc1(mut i: *mut i32, len: libc::c_ulong) {
+    let mut capacity = 1;
+    let mut x = 1;
+    loop {
+        if x == capacity {
+            capacity *= 2;
+            // CHECK-DAG: ([[#@LINE+1]]: i): addr_of = UNIQUE, type = FREE
+            i = c2rust_test_typed_realloc(i, ::std::mem::size_of::<i32>() as libc::c_ulong);
+        }
+        if x == 10 {
+            break;
+        }
+        x += 1;
+    }
+}

--- a/c2rust-analyze/tests/filecheck/alloc.rs
+++ b/c2rust-analyze/tests/filecheck/alloc.rs
@@ -54,12 +54,16 @@ unsafe extern "C" fn free1(mut i: *mut i32) {
 unsafe extern "C" fn realloc1(mut i: *mut i32, len: libc::c_ulong) {
     let mut capacity = 1;
     let mut x = 1;
+    // CHECK-DAG: ([[#@LINE+1]]: mut elem): addr_of = UNIQUE, type = READ | WRITE | OFFSET_ADD | OFFSET_SUB
+    let mut elem = i;
     loop {
         if x == capacity {
             capacity *= 2;
             // CHECK-DAG: ([[#@LINE+1]]: i): addr_of = UNIQUE, type = FREE
             i = c2rust_test_typed_realloc(i, ::std::mem::size_of::<i32>() as libc::c_ulong);
         }
+        *elem = 1;
+        elem = elem.offset(1isize);
         if x == 10 {
             break;
         }


### PR DESCRIPTION
Fixes #734.

Makes static analysis aware of the following: `malloc`, `calloc`, `realloc`, `free` `ptr.is_null`.

Also applies pointer flow rules to those functions.