### PR TITLE
Allow remaining warnings in `lighttpd`

### DIFF
--- a/analysis/tests/lighttpd/src/main.rs
+++ b/analysis/tests/lighttpd/src/main.rs
@@ -8,6 +8,8 @@
 #![allow(dead_code)]
 #![allow(mutable_transmutes)]
 #![allow(unused_mut)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
 
 #[path = "lighttpd.rs"]
 pub mod lighttpd;


### PR DESCRIPTION
This adds the necessary `#![allow(unused_*)]`s to `lighttpd` to build without warnings.  Most allows are already there.