### PR TITLE
Move `lighttpd-minimal.rs` in `lighttpd` to its own `lighttpd-minimal` crate

### DIFF
--- a/analysis/tests/lighttpd-minimal/Cargo.toml
+++ b/analysis/tests/lighttpd-minimal/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lighttpd-minimal"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.1.0" }
+
+[features]
+miri = []

--- a/analysis/tests/lighttpd-minimal/src/main.rs
+++ b/analysis/tests/lighttpd-minimal/src/main.rs
@@ -1,4 +1,15 @@
+#![feature(extern_types)]
+#![feature(label_break_value)]
 #![feature(rustc_private)]
+#![feature(c_variadic)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(dead_code)]
+#![allow(mutable_transmutes)]
+#![allow(unused_mut)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
 
 extern crate libc;
 
@@ -65,3 +76,9 @@ pub unsafe extern "C" fn fdevent_unregister(mut ev: *mut fdevents, mut fd: libc:
 unsafe extern "C" fn fdnode_free(mut fdn: *mut fdnode) {}
 
 pub unsafe extern "C" fn lighttpd_test() {}
+
+fn main() {
+    unsafe {
+        lighttpd_test();
+    }
+}


### PR DESCRIPTION
Fixes #752.

This moves `lighttpd-minimal.rs` in `lighttpd` to its own `lighttpd-minimal` crate.

This allows both of them to be `cargo run`ed without having conflicting symbol names (`#[no_mangle]` is usually specified).