### PR TITLE
`.gitignore` the `inspect/` directory produced by `c2rust-analyze`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ tests/**/*.o
 # Outputs of `c2rust refactor -r json,marks`
 rewrites.*.json
 marks.*.json
+
+# Outputs of `c2rust-analyze`
+inspect/


### PR DESCRIPTION
This `.gitignore`s the `inspect/` directory produced by `c2rust-analyze`.