### PR TITLE
Add more comprehensive searching for `FileCheck` using `$(llvm_config --bindir)/FileCheck`

### DIFF
--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -15,5 +15,8 @@ assert_matches = "1.5.0"
 c2rust-build-paths = { path = "../c2rust-build-paths" }
 print_bytes = "0.7"
 
+[dev-dependencies]
+c2rust-build-paths = { path = "../c2rust-build-paths" }
+
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -59,7 +59,6 @@ fn filecheck() {
 
     let filecheck_bin = env::var_os("FILECHECK")
         .map(PathBuf::from)
-        .or_else(|| detect_filecheck().map(|it| it.to_owned()))
         .unwrap_or_else(|| {
             PathBuf::from(
                 invoke_command(find_llvm_config().as_deref(), &["--bindir"])

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -1,7 +1,7 @@
+use c2rust_build_paths::{find_llvm_config, invoke_command};
 use std::env;
 use std::fs;
 use std::os::unix::io::{AsRawFd, FromRawFd};
-use std::path::Path;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
@@ -60,7 +60,14 @@ fn filecheck() {
     let filecheck_bin = env::var_os("FILECHECK")
         .map(PathBuf::from)
         .or_else(|| detect_filecheck().map(|it| it.to_owned()))
-        .unwrap_or_else(|| panic!("FileCheck not found - set FILECHECK=/path/to/FileCheck"));
+        .unwrap_or_else(|| {
+            PathBuf::from(
+                invoke_command(find_llvm_config().as_deref(), &["--bindir"])
+                    .expect("llvm-config not found"),
+            )
+            .join("FileCheck")
+        });
+
     eprintln!("detected FILECHECK={}", filecheck_bin.display());
 
     for entry in fs::read_dir("tests/filecheck").unwrap() {

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -5,53 +5,6 @@ use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-fn detect_filecheck() -> Option<&'static Path> {
-    let candidates = [
-        "FileCheck",
-        // Intel macOS homebrew location.
-        "/usr/local/opt/llvm/bin/FileCheck",
-        // Apple Silicon macOS homebrew location.
-        "/opt/homebrew/opt/llvm/bin/FileCheck",
-        "FileCheck-14",
-        "/usr/local/opt/llvm@14/bin/FileCheck",
-        "/opt/homebrew/opt/llvm@14/bin/FileCheck",
-        "FileCheck-13",
-        "/usr/local/opt/llvm@13/bin/FileCheck",
-        "/opt/homebrew/opt/llvm@13/bin/FileCheck",
-        "FileCheck-12",
-        "/usr/local/opt/llvm@12/bin/FileCheck",
-        "/opt/homebrew/opt/llvm@12/bin/FileCheck",
-        "FileCheck-11",
-        "/usr/local/opt/llvm@11/bin/FileCheck",
-        "/opt/homebrew/opt/llvm@11/bin/FileCheck",
-        "FileCheck-10",
-        "/usr/local/opt/llvm@10/bin/FileCheck",
-        "/opt/homebrew/opt/llvm@10/bin/FileCheck",
-        "FileCheck-9",
-        "/usr/local/opt/llvm@9/bin/FileCheck",
-        "/opt/homebrew/opt/llvm@9/bin/FileCheck",
-        "FileCheck-8",
-        "/usr/local/opt/llvm@8/bin/FileCheck",
-        "/opt/homebrew/opt/llvm@8/bin/FileCheck",
-        "FileCheck-7",
-        "FileCheck-7.0",
-        "/usr/local/opt/llvm@7/bin/FileCheck",
-        "/opt/homebrew/opt/llvm@7/bin/FileCheck",
-    ];
-
-    for filecheck in candidates {
-        let result = Command::new(filecheck)
-            .arg("--version")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
-        if result.is_ok() {
-            return Some(&Path::new(filecheck));
-        }
-    }
-    None
-}
-
 #[test]
 fn filecheck() {
     let lib_dir = env::var("C2RUST_TARGET_LIB_DIR").unwrap();

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -1,4 +1,4 @@
-use c2rust_build_paths::{find_llvm_config, invoke_command};
+use c2rust_build_paths::find_llvm_config;
 use std::env;
 use std::fs;
 use std::os::unix::io::{AsRawFd, FromRawFd};
@@ -13,12 +13,16 @@ fn filecheck() {
     let filecheck_bin = env::var_os("FILECHECK")
         .map(PathBuf::from)
         .unwrap_or_else(|| {
-            PathBuf::from(
-                invoke_command(find_llvm_config().as_deref(), &["--bindir"])
-                    .expect("llvm-config not found"),
-            )
-            .join("FileCheck")
-        });
+            let llvm_config = find_llvm_config().expect("llvm-config not found");
+            let output = Command::new(llvm_config)
+                .args(&["--bindir"])
+                .output()
+                .ok()
+                .filter(|output| output.status.success())
+                .expect("llvm-config error");
+            PathBuf::from(String::from_utf8(output.stdout).unwrap().trim().to_owned())
+        })
+        .join("FileCheck");
 
     eprintln!("detected FILECHECK={}", filecheck_bin.display());
 

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -20,9 +20,9 @@ fn filecheck() {
                 .ok()
                 .filter(|output| output.status.success())
                 .expect("llvm-config error");
-            PathBuf::from(String::from_utf8(output.stdout).unwrap().trim().to_owned())
-        })
-        .join("FileCheck");
+            let bindir = PathBuf::from(String::from_utf8(output.stdout).unwrap().trim().to_owned());
+            bindir.join("FileCheck")
+        });
 
     eprintln!("detected FILECHECK={}", filecheck_bin.display());
 

--- a/c2rust-build-paths/src/lib.rs
+++ b/c2rust-build-paths/src/lib.rs
@@ -128,17 +128,3 @@ pub fn find_llvm_config() -> Option<PathBuf> {
             .next()
         })
 }
-
-pub fn invoke_command<I, S>(command: Option<&Path>, args: I) -> Option<String>
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
-    let command = command?;
-    let output = Command::new(command).args(args).output().ok()?;
-    if output.status.success() {
-        Some(String::from_utf8(output.stdout).unwrap().trim().to_owned())
-    } else {
-        None
-    }
-}

--- a/c2rust-build-paths/src/lib.rs
+++ b/c2rust-build-paths/src/lib.rs
@@ -128,3 +128,17 @@ pub fn find_llvm_config() -> Option<PathBuf> {
             .next()
         })
 }
+
+pub fn invoke_command<I, S>(command: Option<&Path>, args: I) -> Option<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let command = command?;
+    let output = Command::new(command).args(args).output().ok()?;
+    if output.status.success() {
+        Some(String::from_utf8(output.stdout).unwrap().trim().to_owned())
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
- F_ixes part of #593, using `$(llvm-config --bindir)/FileCheck` to use the same resolving logic for `llvm-config` and `FileCheck`.