### PR TITLE
 Support struct fields in static analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,7 @@ dependencies = [
  "assert_matches",
  "bitflags",
  "c2rust-build-paths",
+ "indexmap",
  "polonius-engine",
  "print_bytes",
  "rustc-hash",
@@ -738,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",

--- a/analysis/tests/lighttpd-minimal/src/main.rs
+++ b/analysis/tests/lighttpd-minimal/src/main.rs
@@ -23,12 +23,19 @@ extern "C" {
 pub struct connection {
     pub fd: libc::c_int,
     pub fdn: *mut fdnode,
+    pub next: *mut connection,
+    pub prev: *mut connection,
 }
 
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct server {
     pub ev: *mut fdevents,
+    pub cur_fds: libc::c_int,
+    pub con_opened: libc::c_int,
+    pub conns: *mut connection,
+    pub conns_pool: *mut connection,
+    pub lim_conns: uint32_t,
 }
 
 pub struct fdevents {
@@ -51,34 +58,91 @@ pub struct fdnode_st {
     pub fd: libc::c_int,
     pub events: libc::c_int,
     pub fde_ndx: libc::c_int,
+    pub ctx: *mut libc::c_void,
 }
 
 pub type fdnode = fdnode_st;
-
-unsafe extern "C" fn fdnode_init() -> *mut libc::c_void /*TODO: handle *mut fdnode */ {
-    let fdn /*TODO: handle : *mut fdnode */ = calloc(
-        1 as libc::c_int as libc::c_ulong,
-        ::std::mem::size_of::<fdnode>() as libc::c_ulong,
-    ) /* TODO: handle cast as *mut fdnode */;
-    if fdn.is_null() {
-        // println!("It's null");
-    }
-    return fdn;
-}
 
 #[no_mangle]
 pub unsafe extern "C" fn connection_accepted(
     mut srv: *mut server,
     mut cnt: libc::c_int,
     fdn: *mut fdnode,     // TODO: remove when casts from c_void are handled
-    con: *mut connection, // TODO: remove when casts from c_void are handled
+    mut con: *mut connection, // TODO: remove when casts from c_void are handled
 ) -> *mut connection {
     // let con = malloc(::std::mem::size_of::<connection>() as libc::c_ulong); // TODO: handle as *mut connection;
+    (*srv).cur_fds += 1;
+    (*srv).con_opened += 1;
+    con = connections_get_new_connection(srv, con);
     (*con).fd = cnt;
-    (*con).fdn = fdn;
-    let x = &*(*(*(*srv).ev).fdarray).offset(0);
-    (*(*(*(*srv).ev).fdarray).offset(0)).fd = 0;
+    (*con)
+        .fdn = fdevent_register(
+        (*srv).ev,
+        (*con).fd,
+        // Some(
+        //     connection_handle_fdevent
+        //         as unsafe extern "C" fn(*mut libc::c_void, libc::c_int) -> handler_t,
+        // ),
+        // con as *mut libc::c_void,
+        fdn
+    );
     return con;
+}
+
+unsafe extern "C" fn connections_get_new_connection(
+    mut srv: *mut server,
+    mut con: *mut connection,
+) -> *mut connection {
+    // let mut con: *mut connection = 0 as *mut connection;
+    // (*srv).lim_conns = ((*srv).lim_conns).wrapping_sub(1);
+    if !((*srv).conns_pool).is_null() {
+        con = (*srv).conns_pool;
+        (*srv).conns_pool = (*con).next;
+    } else {
+        // con = connection_init(srv);
+        // connection_reset(con);
+    }
+    (*con).next = (*srv).conns;
+    if !((*con).next).is_null() {
+        (*(*con).next).prev = con;
+    }
+    (*srv).conns = con;
+    return (*srv).conns;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn fdevent_register(
+    mut ev: *mut fdevents,
+    mut fd: libc::c_int,
+    // mut handler: fdevent_handler,
+    // mut ctx: *mut libc::c_void,
+    fdn: *mut fdnode
+) -> *mut fdnode {
+    let ref mut fresh0 = *((*ev).fdarray).offset(fd as isize);
+    *fresh0 = fdnode_init(fdn);
+    let mut fdn: *mut fdnode = *fresh0;
+    // (*fdn).handler = handler;
+    (*fdn).fd = fd;
+    // (*fdn).ctx = ctx;
+    (*fdn).events = 0 as libc::c_int;
+    (*fdn).fde_ndx = -(1 as libc::c_int);
+    return fdn;
+}
+
+unsafe extern "C" fn fdnode_init(fdn: *mut fdnode) -> *mut fdnode {
+    // let fdn: *mut fdnode = calloc(
+    //     1 as libc::c_int as libc::c_ulong,
+    //     ::std::mem::size_of::<fdnode>() as libc::c_ulong,
+    // ) as *mut fdnode;
+    if fdn.is_null() {
+        // ck_assert_failed(
+        //     b"src/fdevent_fdnode.c\0" as *const u8 as *const libc::c_char,
+        //     17 as libc::c_int as libc::c_uint,
+        //     b"((void*)0) != fdn\0" as *const u8 as *const libc::c_char,
+        // );
+    }
+
+    fdn
 }
 
 unsafe extern "C" fn connection_close(

--- a/analysis/tests/lighttpd-minimal/src/main.rs
+++ b/analysis/tests/lighttpd-minimal/src/main.rs
@@ -63,7 +63,6 @@ unsafe extern "C" fn fdnode_init() -> *mut libc::c_void /*TODO: handle *mut fdno
     if fdn.is_null() {
         // println!("It's null");
     }
-
     return fdn;
 }
 
@@ -71,8 +70,14 @@ unsafe extern "C" fn fdnode_init() -> *mut libc::c_void /*TODO: handle *mut fdno
 pub unsafe extern "C" fn connection_accepted(
     mut srv: *mut server,
     mut cnt: libc::c_int,
-) -> *mut libc::c_void /* TODO: handle *mut connection */ {
-    let con = malloc(::std::mem::size_of::<connection>() as libc::c_ulong); // TODO: handle as *mut connection;
+    fdn: *mut fdnode,     // TODO: remove when casts from c_void are handled
+    con: *mut connection, // TODO: remove when casts from c_void are handled
+) -> *mut connection {
+    // let con = malloc(::std::mem::size_of::<connection>() as libc::c_ulong); // TODO: handle as *mut connection;
+    (*con).fd = cnt;
+    (*con).fdn = fdn;
+    let x = &*(*(*(*srv).ev).fdarray).offset(0);
+    (*(*(*(*srv).ev).fdarray).offset(0)).fd = 0;
     return con;
 }
 
@@ -90,11 +95,23 @@ pub unsafe extern "C" fn fdevent_fdnode_event_del(mut ev: *mut fdevents, mut fdn
     }
 }
 
-unsafe extern "C" fn fdevent_fdnode_event_unsetter(mut ev: *mut fdevents, mut fdn: *mut fdnode) {}
+unsafe extern "C" fn fdevent_fdnode_event_unsetter(mut ev: *mut fdevents, mut fdn: *mut fdnode) {
+    if -(1 as libc::c_int) == (*fdn).fde_ndx {
+        return;
+    }
+    (*fdn).fde_ndx = -(1 as libc::c_int);
+    (*fdn).events = 0 as libc::c_int;
+}
 
 #[no_mangle]
-pub unsafe extern "C" fn fdevent_unregister(mut fds: *mut *mut fdnode, mut fd: libc::c_int) {
-    let mut fdn: *mut fdnode = *(fds).offset(fd as isize);
+pub unsafe extern "C" fn fdevent_unregister(mut ev: *mut fdevents, mut fd: libc::c_int) {
+    let mut fdn: *mut fdnode = *((*ev).fdarray).offset(fd as isize);
+    if fdn as uintptr_t & 0x3 as libc::c_int as usize != 0 as uintptr_t {
+        return;
+    }
+    let ref mut fresh1 = *((*ev).fdarray).offset(fd as isize);
+    // *fresh1 = 0 as *mut fdnode;
+    // fdnode_free(fdn);
 }
 
 unsafe extern "C" fn fdnode_free(fdn: *mut libc::c_void) {

--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -10,6 +10,7 @@ polonius-engine = "0.13.0"
 rustc-hash = "1.1.0"
 bitflags = "1.3.2"
 assert_matches = "1.5.0"
+indexmap = "1.9.2"
 
 [build-dependencies]
 c2rust-build-paths = { path = "../c2rust-build-paths" }

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -44,8 +44,7 @@ pub struct FieldMetadata<'tcx> {
     pub lifetime_params: LabeledTy<'tcx, &'tcx [OriginArg<'tcx>]>,
 }
 
-/// Metadata describing the lifetime parameters and fields
-/// of a struct.
+/// Metadata describing the lifetime parameters and fields of a `struct`.
 #[derive(Clone, PartialEq, Eq)]
 pub struct AdtMetadata<'tcx> {
     /// The lifetime parameters of a structure, including

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -301,7 +301,7 @@ fn run_polonius<'tcx>(
 
     let mut loans = HashMap::new();
     // Populate `loan_issued_at` and `loans`.
-    type_check::visit(
+    type_check::visit_body(
         tcx,
         ltcx,
         &mut facts,

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -78,7 +78,7 @@ pub enum OriginParam {
 #[derive(Hash, PartialEq, Eq, Clone, Copy)]
 pub enum OriginArg<'tcx> {
     /// An existing [`Region`], i.e. `'a` in `&'a foo`.
-    /// Can be [RegionKind::ReEarlyBound](`rustc_type_ir::RegionKind::ReEarlyBound`) 
+    /// Can be [RegionKind::ReEarlyBound](`rustc_type_ir::RegionKind::ReEarlyBound`)
     /// or [RegionKind::ReStatic](`rustc_type_ir::RegionKind::ReStatic`)
     Actual(Region<'tcx>),
     /// A hypothesized region derived from a pointer type

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -82,7 +82,8 @@ pub enum OriginParam {
 #[derive(Hash, PartialEq, Eq, Clone, Copy)]
 pub enum OriginArg<'tcx> {
     /// An existing [`Region`], i.e. `'a` in `&'a foo`.
-    /// Can be [RegionKind::ReEarlyBound](`rustc_type_ir::RegionKind`) or [RegionKind::ReStatic](`rustc_type_ir::RegionKind`)
+    /// Can be [RegionKind::ReEarlyBound](`rustc_type_ir::RegionKind::ReEarlyBound`) 
+    /// or [RegionKind::ReStatic](`rustc_type_ir::RegionKind::ReStatic`)
     Actual(Region<'tcx>),
     /// A hypothesized region derived from a pointer type
     /// e.g. `'h0` derived from the pointer in `*mut foo`

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -86,7 +86,7 @@ pub enum OriginArg<'tcx> {
     Hypothetical(i64),
 }
 
-impl<'tcx> std::fmt::Debug for OriginArg<'tcx> {
+impl<'tcx> Debug for OriginArg<'tcx> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
             OriginArg::Actual(r) => write!(f, "{:}", r),

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -36,16 +36,13 @@ pub type LTyCtxt<'tcx> = LabeledTyCtxt<'tcx, Label<'tcx>>;
 /// of a struct field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldMetadata<'tcx> {
-    /// The lifetime of the field, e.g. `*mut &'a mut foo_type`
-    /// would have an index set of {'h0, 'a}
-    pub lifetime: IndexSet<OriginArg<'tcx>>,
     /// The lifetime parameters of a field, e.g. if a struct
     /// `foo<'a, 'b>` is a field of `bar<'c, 'd>` as field: `foo<'c, 'd>`,
-    /// the lifetime params would be a set {'c, 'd}
+    /// the lifetime params would be a set {'c, 'd}. For a reference such
+    /// as &'r foo<'c, 'd>, the lifetime params in the label would be
+    /// {'r}, and {'c, 'd} would be the label of the sole argument
+    /// of the labeled reference type
     pub lifetime_params: LabeledTy<'tcx, &'tcx [OriginArg<'tcx>]>,
-    /// The type of the field when fully dereferenced, e.g.
-    /// `&mut &mut foo_type` would have a type of `foo_type`
-    pub fully_derefed_ty: Option<Ty<'tcx>>,
 }
 
 /// Metadata describing the lifetime parameters and fields

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -45,21 +45,12 @@ pub struct FieldMetadata<'tcx> {
 }
 
 /// Metadata describing the lifetime parameters and fields of a `struct`.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct AdtMetadata<'tcx> {
     /// The lifetime parameters of a structure, including
     /// hypothetical lifetimes derived from pointer fields.
     pub lifetime_params: IndexSet<OriginParam>,
     pub field_info: IndexMap<DefId, FieldMetadata<'tcx>>,
-}
-
-impl Default for AdtMetadata<'_> {
-    fn default() -> Self {
-        Self {
-            lifetime_params: IndexSet::new(),
-            field_info: IndexMap::new(),
-        }
-    }
 }
 
 /// An origin parameter of a type to resolve in a MIR body

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -32,7 +32,8 @@ pub struct Label<'tcx> {
 pub type LTy<'tcx> = LabeledTy<'tcx, Label<'tcx>>;
 pub type LTyCtxt<'tcx> = LabeledTyCtxt<'tcx, Label<'tcx>>;
 
-/// Metadata describing lifetimes and lifetime parameters of a `struct` field.
+/// Metadata describing lifetimes and lifetime parameters of a
+/// [TyKind::Adt](`rustc_type_ir::TyKind::Adt`) field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldMetadata<'tcx> {
     /// The lifetime parameters of a field, e.g. if a struct
@@ -44,7 +45,8 @@ pub struct FieldMetadata<'tcx> {
     pub lifetime_params: LabeledTy<'tcx, &'tcx [OriginArg<'tcx>]>,
 }
 
-/// Metadata describing the lifetime parameters and fields of a `struct`.
+/// Metadata describing the lifetime parameters and fields of a
+/// [TyKind::Adt](`rustc_type_ir::TyKind::Adt`) field.
 #[derive(Clone, PartialEq, Eq, Default)]
 pub struct AdtMetadata<'tcx> {
     /// The lifetime parameters of a structure, including

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -42,20 +42,10 @@ pub struct FieldMetadata<'tcx> {
     /// The lifetime parameters of a field, e.g. if a struct
     /// `foo<'a, 'b>` is a field of `bar<'c, 'd>` as field: `foo<'c, 'd>`,
     /// the lifetime params would be a set {'c, 'd}
-    pub lifetime_params: IndexSet<OriginArg<'tcx>>,
+    pub lifetime_params: LabeledTy<'tcx, &'tcx [OriginArg<'tcx>]>,
     /// The type of the field when fully dereferenced, e.g.
     /// `&mut &mut foo_type` would have a type of `foo_type`
     pub fully_derefed_ty: Option<Ty<'tcx>>,
-}
-
-impl Default for FieldMetadata<'_> {
-    fn default() -> Self {
-        Self {
-            lifetime: IndexSet::new(),
-            lifetime_params: IndexSet::new(),
-            fully_derefed_ty: None,
-        }
-    }
 }
 
 /// Metadata describing the lifetime parameters and fields

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -76,7 +76,7 @@ pub enum OriginParam {
     Hypothetical(i64),
 }
 
-/// An origin parameter of a field type resolve in a MIR body
+/// An origin arg of a field type resolve in a MIR body
 /// that will get mapped to a concrete Origin to
 /// provide to polonius.
 #[derive(Hash, PartialEq, Eq, Clone, Copy)]

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -65,8 +65,7 @@ impl Default for AdtMetadata<'_> {
 }
 
 /// An origin parameter of a type to resolve in a MIR body
-/// that will get mapped to a concrete Origin to
-/// provide to polonius.
+/// that will get mapped to a concrete [`Origin`] to provide to polonius.
 #[derive(Hash, PartialEq, Eq, Clone, Copy)]
 pub enum OriginParam {
     /// An existing [`EarlyBoundRegion`], i.e. `'a` in `struct A<'a>`

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -87,7 +87,7 @@ pub enum OriginArg<'tcx> {
 }
 
 impl<'tcx> Debug for OriginArg<'tcx> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self {
             OriginArg::Actual(r) => write!(f, "{:}", r),
             OriginArg::Hypothetical(h) => write!(f, "'h{h:?}"),

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -71,7 +71,7 @@ impl Default for AdtMetadata<'_> {
 pub enum OriginParam {
     /// An existing [`EarlyBoundRegion`], i.e. `'a` in `struct A<'a>`
     Actual(EarlyBoundRegion),
-    /// A hypothesized region derived from a pointer type
+    /// A hypothesized region derived from a pointer type,
     /// e.g. `'h0` derived from the pointer in `*mut foo`
     Hypothetical(i64),
 }

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -303,7 +303,7 @@ fn run_polonius<'tcx>(
         (*did, perm)
     }).collect::<HashMap<_, _>>();
 
-    let mut loans = HashMap::<Local, Vec<(Path, Loan, BorrowKind)>>::new();
+    let mut loans = HashMap::new();
     // Populate `loan_issued_at` and `loans`.
     type_check::visit(
         tcx,

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -77,8 +77,7 @@ pub enum OriginParam {
 }
 
 /// An origin arg of a field type resolve in a MIR body
-/// that will get mapped to a concrete Origin to
-/// provide to polonius.
+/// that will get mapped to a concrete [`Origin`] to provide to polonius.
 #[derive(Hash, PartialEq, Eq, Clone, Copy)]
 pub enum OriginArg<'tcx> {
     /// An existing [`Region`], i.e. `'a` in `&'a foo`.

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -23,7 +23,7 @@ mod type_check;
 pub struct Label<'tcx> {
     /// The [`Origin`] of this type
     pub origin: Option<Origin>,
-    /// The [Origins](`Origin`) associated with each lifetime
+    /// The [`Origin`]s associated with each lifetime
     /// parameter of this type, if applicable
     pub origin_params: Option<&'tcx [(OriginParam, Origin)]>,
     pub perm: PermissionSet,

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -32,17 +32,17 @@ pub struct Label<'tcx> {
 pub type LTy<'tcx> = LabeledTy<'tcx, Label<'tcx>>;
 pub type LTyCtxt<'tcx> = LabeledTyCtxt<'tcx, Label<'tcx>>;
 
-/// Metadata describing lifetimes and lifetime parameters of a
+/// Metadata describing lifetimes and [`OriginArg`] of a
 /// [TyKind::Adt](`rustc_type_ir::TyKind::Adt`) field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldMetadata<'tcx> {
-    /// The lifetime parameters of a field, e.g. if a struct
+    /// The [`OriginArg`]s of a field, e.g. if a struct
     /// `foo<'a, 'b>` is a field of `bar<'c, 'd>` as field: `foo<'c, 'd>`,
-    /// the lifetime params would be a set {'c, 'd}. For a reference such
-    /// as &'r foo<'c, 'd>, the lifetime params in the label would be
+    /// the origin arguments would be a set {'c, 'd}. For a reference such
+    /// as &'r foo<'c, 'd>, the origin arguments in the label would be
     /// {'r}, and {'c, 'd} would be the label of the sole argument
     /// of the labeled reference type
-    pub lifetime_params: LabeledTy<'tcx, &'tcx [OriginArg<'tcx>]>,
+    pub origin_args: LabeledTy<'tcx, &'tcx [OriginArg<'tcx>]>,
 }
 
 /// Metadata describing the lifetime parameters and fields of a

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -32,8 +32,7 @@ pub struct Label<'tcx> {
 pub type LTy<'tcx> = LabeledTy<'tcx, Label<'tcx>>;
 pub type LTyCtxt<'tcx> = LabeledTyCtxt<'tcx, Label<'tcx>>;
 
-/// Metadata describing lifetimes and lifetime parameters
-/// of a struct field.
+/// Metadata describing lifetimes and lifetime parameters of a `struct` field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldMetadata<'tcx> {
     /// The lifetime parameters of a field, e.g. if a struct

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -294,15 +294,14 @@ fn run_polonius<'tcx>(
     }
 
     // Gather field permissions
-    let mut field_permissions: HashMap<DefId, PermissionSet> = HashMap::new();
-    for (did, lty) in field_tys {
+    let field_permissions = field_tys.iter().map(|(did, lty)| {
         let perm = if lty.label.is_none() {
             PermissionSet::empty()
         } else {
             hypothesis[lty.label]
         };
-        field_permissions.insert(*did, perm);
-    }
+        (*did, perm)
+    }).collect::<HashMap<_, _>>();
 
     let mut loans = HashMap::<Local, Vec<(Path, Loan, BorrowKind)>>::new();
     // Populate `loan_issued_at` and `loans`.

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -84,6 +84,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 */
                 for (field_lifetime_arg, field_struct_lifetime_param) in field_metadata
                     .lifetime_params
+                    .label
                     .iter()
                     .zip(field_adt_metadata.lifetime_params.iter())
                 {

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -99,7 +99,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                             lifetime argument `'b` (which is already paired with concrete lifetime
                             `'0`) and `Foo` lifetime parameter `'a`. This mapping is created below.
                         */
-                        let mut field_origin_param_map = IndexMap::new();
+                        let mut field_origin_param_map = vec![];
                         eprintln!("{:?}", fadt_def.did());
                         let field_adt_metadata = if let Some(field_adt_metadata) = self.adt_metadata.table.get(&fadt_def.did()) {
                             field_adt_metadata
@@ -131,7 +131,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                                         corresponding to its lifetime parameter {field_lifetime_param:?} within {base_adt_def:?}",
                                         field_def.name
                                     );
-                                field_origin_param_map.insert(*field_struct_lifetime_param, *og);
+                                field_origin_param_map.push((*field_struct_lifetime_param, *og));
                             }
                         }
                         let origin_params= self.ltcx.arena().alloc_from_iter(field_origin_param_map.into_iter());

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -408,7 +408,8 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     }
 }
 
-pub fn visit<'tcx>(
+#[allow(clippy::too_many_arguments)]
+pub fn visit_body<'tcx>(
     tcx: TyCtxt<'tcx>,
     ltcx: LTyCtxt<'tcx>,
     facts: &mut AllFacts,

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -42,7 +42,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                             base_adt_def: AdtDef,
                             field: Field,
                             field_ty: Ty<'tcx>| {
-            let mut base_origin_param_map: HashMap<OriginKind, Origin> = base_lty
+            let base_origin_param_map: HashMap<OriginKind, Origin> = base_lty
                 .label
                 .origin_params
                 .map(|params| HashMap::from_iter(params.to_vec()))

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -122,10 +122,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     }
                     _ => field_lifetimes.get_index(0).cloned(),
                 }
-                .and_then(|o| {
-                    eprintln!("field origin {o:?}, {base_origin_param_map:?}");
-                    base_origin_param_map.get(&o)
-                })
+                .and_then(|o| base_origin_param_map.get(&o))
                 .cloned();
 
                 Label {

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -100,7 +100,17 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                             `'0`) and `Foo` lifetime parameter `'a`. This mapping is created below.
                         */
                         let mut field_origin_param_map = IndexMap::new();
-                        let field_adt_metadata = &self.adt_metadata.table[&fadt_def.did()];
+                        eprintln!("{:?}", fadt_def.did());
+                        let field_adt_metadata = if let Some(field_adt_metadata) = self.adt_metadata.table.get(&fadt_def.did()) {
+                            field_adt_metadata
+                        } else {
+                            return Label {
+                                origin: None,
+                                origin_params: &[],
+                                perm
+                            };
+                        };
+
                         for (field_lifetime_arg, field_struct_lifetime_param) in flty
                             .label
                             .iter().zip(field_adt_metadata.lifetime_params.iter())

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -91,7 +91,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         if let Ok(param) = OriginParam::try_from(field_lifetime_arg) {
                             param
                         } else {
-                            continue;
+                            panic!("'static lifetimes are not yet supported")
                         };
 
                     if let Some((base_lifetime_param, og)) =
@@ -129,7 +129,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     }
                     _ => field_lifetimes.get_index(0).cloned(),
                 }
-                .and_then(|oa| OriginParam::try_from(&oa).ok())
+                .map(|oa| OriginParam::try_from(&oa).expect("'static lifetimes not yet supported"))
                 .and_then(|o| base_origin_param_map.get(&o))
                 .cloned();
 

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -297,19 +297,21 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             self.facts.subset_base.push((rv_origin, pl_origin, point));
         }
 
-        let pl_origin_params = pl_lty.label.origin_params;
-        let rv_origin_params = rv_lty.label.origin_params;
-        if let (Some(pl_origin_params), Some(rv_origin_params)) =
-            (pl_origin_params, rv_origin_params)
-        {
-            assert_eq!(pl_origin_params.len(), rv_origin_params.len());
-            for (pl_origin_param, rv_origin_param) in
-                pl_origin_params.iter().zip(rv_origin_params.iter())
+        for (pl_lty, rv_lty) in pl_lty.iter().zip(rv_lty.iter()) {
+            let pl_origin_params = pl_lty.label.origin_params;
+            let rv_origin_params = rv_lty.label.origin_params;
+            if let (Some(pl_origin_params), Some(rv_origin_params)) =
+                (pl_origin_params, rv_origin_params)
             {
-                let point = self.current_point(SubPoint::Mid);
-                self.facts
-                    .subset_base
-                    .push((rv_origin_param.1, pl_origin_param.1, point));
+                assert_eq!(pl_origin_params.len(), rv_origin_params.len());
+                for (pl_origin_param, rv_origin_param) in
+                    pl_origin_params.iter().zip(rv_origin_params.iter())
+                {
+                    let point = self.current_point(SubPoint::Mid);
+                    self.facts
+                        .subset_base
+                        .push((rv_origin_param.1, pl_origin_param.1, point));
+                }
             }
         }
     }

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -296,24 +296,25 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     fn do_assign(&mut self, pl_lty: LTy<'tcx>, rv_lty: LTy<'tcx>) {
         eprintln!("assign {:?} = {:?}", pl_lty, rv_lty);
 
+        let mut add_subset_base = |pl: Origin, rv: Origin| {
+            let point = self.current_point(SubPoint::Mid);
+            self.facts.subset_base.push((rv, pl, point));
+        };
+
         let pl_origin = pl_lty.label.origin;
         let rv_origin = rv_lty.label.origin;
         if let (Some(pl_origin), Some(rv_origin)) = (pl_origin, rv_origin) {
-            let point = self.current_point(SubPoint::Mid);
-            self.facts.subset_base.push((rv_origin, pl_origin, point));
+            add_subset_base(pl_origin, rv_origin);
         }
 
         for (pl_lty, rv_lty) in pl_lty.iter().zip(rv_lty.iter()) {
             let pl_origin_params = pl_lty.label.origin_params;
             let rv_origin_params = rv_lty.label.origin_params;
             assert_eq!(pl_origin_params.len(), rv_origin_params.len());
-            for (pl_origin_param, rv_origin_param) in
+            for (&(_, pl_origin), &(_, rv_origin)) in
                 pl_origin_params.iter().zip(rv_origin_params.iter())
             {
-                let point = self.current_point(SubPoint::Mid);
-                self.facts
-                    .subset_base
-                    .push((rv_origin_param.1, pl_origin_param.1, point));
+                add_subset_base(pl_origin, rv_origin)
             }
         }
     }

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -4,6 +4,7 @@ use crate::context::PermissionSet;
 use crate::util::{self, Callee};
 use crate::AdtMetadataTable;
 use assert_matches::assert_matches;
+use indexmap::IndexMap;
 use rustc_hir::def_id::DefId;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::{
@@ -42,13 +43,13 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                             base_adt_def: AdtDef,
                             field: Field,
                             field_ty: Ty<'tcx>| {
-            let base_origin_param_map: HashMap<OriginKind, Origin> = base_lty
+            let base_origin_param_map: IndexMap<OriginKind, Origin> = base_lty
                 .label
                 .origin_params
-                .map(|params| HashMap::from_iter(params.to_vec()))
+                .map(|params| IndexMap::from_iter(params.to_vec()))
                 .unwrap_or_default();
 
-            let mut field_origin_param_map = HashMap::new();
+            let mut field_origin_param_map = IndexMap::new();
 
             let field_def: &FieldDef = &base_adt_def.non_enum_variant().fields[field.index()];
             let perm = self.field_permissions[&field_def.did];

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -280,6 +280,22 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             let point = self.current_point(SubPoint::Mid);
             self.facts.subset_base.push((rv_origin, pl_origin, point));
         }
+
+        let pl_origin_params = pl_lty.label.origin_params;
+        let rv_origin_params = rv_lty.label.origin_params;
+        if let (Some(pl_origin_params), Some(rv_origin_params)) =
+            (pl_origin_params, rv_origin_params)
+        {
+            assert_eq!(pl_origin_params.len(), rv_origin_params.len());
+            for (pl_origin_param, rv_origin_param) in
+                pl_origin_params.iter().zip(rv_origin_params.iter())
+            {
+                let point = self.current_point(SubPoint::Mid);
+                self.facts
+                    .subset_base
+                    .push((rv_origin_param.1, pl_origin_param.1, point));
+            }
+        }
     }
 
     pub fn visit_statement(&mut self, stmt: &Statement<'tcx>) {

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -48,7 +48,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             let field_metadata = &base_metadata.field_info[&field_def.did];
 
             self.ltcx.relabel(
-                field_metadata.lifetime_params,
+                field_metadata.origin_args,
                 &mut |flty| match flty.kind() {
                     TyKind::Ref(..) | TyKind::RawPtr(..) => {
                         let origin = {
@@ -96,7 +96,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
                             We want to know that the lifetime `'?` gets resolved to the concrete
                             origin `'0`. To do this, a mapping needs to be made between `bar.foo`
-                            lifetime parameter `'b` (which is already paired with concrete lifetime
+                            lifetime argument `'b` (which is already paired with concrete lifetime
                             `'0`) and `Foo` lifetime parameter `'a`. This mapping is created below.
                         */
                         let mut field_origin_param_map = IndexMap::new();

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -413,7 +413,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
     }
 
     pub fn project(&self, lty: LTy<'tcx>, proj: &PlaceElem<'tcx>) -> LTy<'tcx> {
-        let adt_func = |adt_def: AdtDef, field: Field, _field_ty: Ty<'tcx>| {
+        let adt_func = |_lty: LTy, adt_def: AdtDef, field: Field, _field_ty: Ty<'tcx>| {
             let field_def = &adt_def.non_enum_variant().fields[field.index()];
             let field_def_name = field_def.name;
             eprintln!("projecting into {adt_def:?}.{field_def_name:}");

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -382,7 +382,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
     }
 
     pub fn project(&self, lty: LTy<'tcx>, proj: &PlaceElem<'tcx>) -> LTy<'tcx> {
-        let adt_func = |_lty: LTy, adt_def: AdtDef, field: Field, _field_ty: Ty<'tcx>| {
+        let adt_func = |_lty: LTy, adt_def: AdtDef, field: Field| {
             let field_def = &adt_def.non_enum_variant().fields[field.index()];
             let field_def_name = field_def.name;
             eprintln!("projecting into {adt_def:?}.{field_def_name:}");

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -164,14 +164,14 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         *next_ptr_id = counter;
     }
 
-    pub fn assn_ptr_to_field(&mut self, field: &FieldDef) {
+    pub fn assign_pointer_to_field(&mut self, field: &FieldDef) {
         let lty = self.assign_pointer_ids(self.tcx.type_of(field.did));
         self.field_tys.insert(field.did, lty);
     }
 
-    pub fn assn_ptr_to_fields(&mut self, did: DefId) {
+    pub fn assign_pointer_to_fields(&mut self, did: DefId) {
         for field in self.tcx.adt_def(did).all_fields() {
-            self.assn_ptr_to_field(field);
+            self.assign_pointer_to_field(field);
         }
     }
 }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -172,7 +172,10 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
     fn do_equivalence_nested(&mut self, pl_lty: LTy<'tcx>, rv_lty: LTy<'tcx>) {
         // Add equivalence constraints for all nested pointers beyond the top level.
-        assert_eq!(pl_lty.ty, rv_lty.ty);
+        assert_eq!(
+            self.acx.tcx().erase_regions(pl_lty.ty),
+            self.acx.tcx().erase_regions(rv_lty.ty)
+        );
         for (&pl_sub_lty, &rv_sub_lty) in pl_lty.args.iter().zip(rv_lty.args.iter()) {
             self.do_unify(pl_sub_lty, rv_sub_lty);
         }
@@ -203,7 +206,10 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     /// that position.  For example, given `lty1 = *mut /*l1*/ *const /*l2*/ u8` and `lty2 = *mut
     /// /*l3*/ *const /*l4*/ u8`, this function will unify `l1` with `l3` and `l2` with `l4`.
     fn do_unify(&mut self, lty1: LTy<'tcx>, lty2: LTy<'tcx>) {
-        assert_eq!(lty1.ty, lty2.ty);
+        assert_eq!(
+            self.acx.tcx().erase_regions(lty1.ty),
+            self.acx.tcx().erase_regions(lty2.ty)
+        );
         for (sub_lty1, sub_lty2) in lty1.iter().zip(lty2.iter()) {
             eprintln!("equate {:?} = {:?}", sub_lty1, sub_lty2);
             if sub_lty1.label != PointerId::NONE || sub_lty2.label != PointerId::NONE {

--- a/c2rust-analyze/src/labeled_ty.rs
+++ b/c2rust-analyze/src/labeled_ty.rs
@@ -127,7 +127,7 @@ impl<'tcx, L: Copy> LabeledTyCtxt<'tcx, L> {
         }
     }
 
-    fn arena(&self) -> &'tcx DroplessArena {
+    pub fn arena(&self) -> &'tcx DroplessArena {
         &self.tcx.arena.dropless
     }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -246,9 +246,8 @@ fn construct_adt_metadata(tcx: TyCtxt) -> AdtMetadataTable {
                     eprintln!("\t\tfound ADT field base type: {adt_field:?}");
                     for sub in substs.iter() {
                         if let GenericArgKind::Lifetime(r) = sub.unpack() {
-                            assert_matches!(r.kind(), ReEarlyBound(..) => {
-                                eprintln!("\tfound field lifetime {r:?} in {adt_def:?}.{adt_field:?}");
-                                adt_metadata_table.table.entry(*struct_did).and_modify(|adt| {
+                            eprintln!("\tfound field lifetime {r:?} in {adt_def:?}.{adt_field:?}");
+                            adt_metadata_table.table.entry(*struct_did).and_modify(|adt| {
                                     eprintln!("\t\t\tinserting {adt_field:?} lifetime param {r:?} into {adt_def:?}.{:} lifetime parameters", field.name);
 
                                     adt.field_info
@@ -257,7 +256,6 @@ fn construct_adt_metadata(tcx: TyCtxt) -> AdtMetadataTable {
                                         .lifetime_params
                                         .insert(OriginArg::Actual(r));
                                 });
-                            });
                         }
                     }
                     if let Some(adt_field_metadata) =

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -177,10 +177,8 @@ fn construct_adt_metadata<'tcx>(tcx: TyCtxt<'tcx>) -> AdtMetadataTable {
             for field in adt_def.all_fields() {
                 let field_ty: Ty = tcx.type_of(field.did);
                 eprintln!("\t{adt_def:?}.{:}", field.name);
-                let mut fully_derefed_field_ty = None;
                 let field_origin_args = ltcx.label(field_ty, &mut |ty| {
                     let mut field_origin_args = IndexSet::new();
-                    fully_derefed_field_ty = Some(ty);
                     match ty.kind() {
                         TyKind::RawPtr(ty) => {
                             eprintln!(

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -255,7 +255,7 @@ fn construct_adt_metadata<'tcx>(tcx: TyCtxt<'tcx>) -> AdtMetadataTable {
                     }
 
                     if field_origin_args.is_empty() {
-                        return &mut [];
+                        return &[];
                     }
                     let field_origin_args: Vec<_> = field_origin_args.into_iter().collect();
                     ltcx.arena().alloc_slice(&field_origin_args[..])

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -413,7 +413,7 @@ fn run(tcx: TyCtxt) {
         if !matches!(tcx.def_kind(did), Struct | Enum | Union) {
             continue;
         }
-        gacx.assn_ptr_to_fields(did);
+        gacx.assign_pointer_to_fields(did);
     }
 
     // Initial pass to assign local `PointerId`s and gather equivalence constraints, which state

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -165,6 +165,7 @@ fn construct_adt_metadata<'tcx>(tcx: TyCtxt<'tcx>) -> AdtMetadataTable {
             the metadata gathered for each struct reaches a fixed point.
         */
         loop_count += 1;
+        assert!(loop_count < 1000);
 
         eprintln!("---- running fixed point struct field analysis iteration #{loop_count:?} ----");
         let old_adt_metadata = adt_metadata_table.table.clone();

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -312,8 +312,8 @@ impl<'tcx> Debug for AdtMetadataTable<'tcx> {
                 }
                 if let Some(adt) = fmeta.fully_derefed_ty.and_then(|t| t.ty_adt_def()) {
                     write!(f, "{adt:?}")?;
-                    let fmeta = &self.table[&adt.did()];
-                    if !fmeta.lifetime_params.is_empty() {
+                    let f_adt_meta = &self.table[&adt.did()];
+                    if !f_adt_meta.lifetime_params.is_empty() {
                         write!(f, "<")?;
                         let f_params_str = fmeta
                             .lifetime_params
@@ -502,6 +502,7 @@ fn run(tcx: TyCtxt) {
     }
 
     let adt_metadata = construct_adt_metadata(tcx);
+    eprintln!("=== ADT Metadata ===");
     eprintln!("{adt_metadata:?}");
 
     let mut loop_count = 0;

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -14,6 +14,7 @@ extern crate rustc_span;
 extern crate rustc_target;
 extern crate rustc_type_ir;
 
+use crate::borrowck::{AdtMetadata, OriginKind};
 use crate::context::{
     AnalysisCtxt, AnalysisCtxtData, FlagSet, GlobalAnalysisCtxt, GlobalAssignment, LFnSig, LTy,
     LTyCtxt, LocalAssignment, PermissionSet, PointerId,
@@ -21,15 +22,16 @@ use crate::context::{
 use crate::dataflow::DataflowConstraints;
 use crate::equiv::{GlobalEquivSet, LocalEquivSet};
 use crate::util::Callee;
+use rustc_ast::Mutability;
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::LocalDefId;
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::{
     AggregateKind, BindingForm, Body, LocalDecl, LocalInfo, LocalKind, Location, Operand, Rvalue,
     StatementKind,
 };
-use rustc_middle::ty::{Ty, TyCtxt, TyKind, WithOptConstParam};
+use rustc_middle::ty::{GenericArgKind, Ty, TyCtxt, TyKind, WithOptConstParam};
 use rustc_span::Span;
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -99,6 +101,217 @@ impl<T> DerefMut for MaybeUnset<T> {
     }
 }
 
+fn construct_adt_metadata(tcx: TyCtxt) -> HashMap<DefId, AdtMetadata> {
+    // actual and hypothetical lifetime parameters for each struct
+    let mut adt_metadata = HashMap::<DefId, AdtMetadata>::new();
+
+    let struct_dids: Vec<_> = tcx
+        .hir_crate_items(())
+        .definitions()
+        .filter_map(|ldid: LocalDefId| {
+            use DefKind::*;
+            let did = ldid.to_def_id();
+            if matches!(tcx.def_kind(did), Struct | Enum | Union) {
+                return Some(did);
+            }
+
+            None
+        })
+        .collect();
+
+    // Gather known lifetime parameters for each struct
+    for struct_did in &struct_dids {
+        let struct_ty = tcx.type_of(struct_did);
+        if let TyKind::Adt(adt_def, substs) = struct_ty.kind() {
+            adt_metadata.insert(adt_def.did(), AdtMetadata::default());
+            eprintln!("gathering known lifetimes for {adt_def:?}");
+            for sub in substs.iter() {
+                if let GenericArgKind::Lifetime(r) = sub.unpack() {
+                    eprintln!("\tfound lifetime {r:?} in {adt_def:?}");
+                    let _ = adt_metadata.entry(adt_def.did()).and_modify(|metadata| {
+                        metadata.lifetime_params.insert(OriginKind::Actual(r));
+                    });
+                }
+            }
+        } else {
+            panic!("{struct_ty:?} is not a struct");
+        }
+    }
+
+    let mut loop_count = 0;
+    loop {
+        /*
+            This loop iterates over all structs and gathers metadata for each.
+            If there were no recursive or mutually-recursive data structures,
+            this loop would only need one iteration to complete. To support
+            recursive and mutually-recursive structs, the loop iterates until
+            the metadata gathered for each struct reaches a fixed point.
+        */
+        loop_count += 1;
+
+        eprintln!("---- running fixed point struct field analysis iteration #{loop_count:?} ----");
+        let old_adt_metadata = adt_metadata.clone();
+        let mut next_hypo_origin_id = 0;
+
+        // for each struct, gather lifetime information (actual and hypothetical)
+        for struct_did in &struct_dids {
+            let adt_def = tcx.adt_def(struct_did);
+            eprintln!("gathering lifetimes and lifetime parameters for {adt_def:?}");
+            for field in adt_def.all_fields() {
+                let field_ty: Ty = tcx.type_of(field.did);
+                eprintln!("\t{adt_def:?}.{:}", field.name);
+                // iterate over dereferencable field types, e.g. &mut *mut *const &const i32
+                // and account for each in this struct's lifetime parameters
+                let mut fully_derefed_field_ty = field_ty;
+                loop {
+                    match fully_derefed_field_ty.kind() {
+                        TyKind::RawPtr(ty) => {
+                            eprintln!(
+                                "\t\tfound pointer that requires hypothetical lifetime: *{:}",
+                                if let Mutability::Mut = ty.mutbl {
+                                    "mut"
+                                } else {
+                                    "const"
+                                }
+                            );
+                            adt_metadata.entry(*struct_did).and_modify(|adt| {
+                                let origin = OriginKind::Hypothetical(next_hypo_origin_id);
+                                eprintln!("\t\t\tinserting origin {origin:?} into {adt_def:?}");
+
+                                adt.lifetime_params.insert(origin);
+                                next_hypo_origin_id += 1;
+                                adt.field_info
+                                    .entry(field.did)
+                                    .or_default()
+                                    .lifetime
+                                    .insert(origin);
+                            });
+                            fully_derefed_field_ty = ty.ty;
+                        }
+                        TyKind::Ref(reg, ty, _mutability) => {
+                            eprintln!("\t\tfound reference field lifetime: {reg:}");
+                            let origin = OriginKind::Actual(*reg);
+                            adt_metadata.entry(*struct_did).and_modify(|adt| {
+                                eprintln!("\t\t\tinserting origin {origin:?} into {adt_def:?}");
+                                adt.lifetime_params.insert(origin);
+                                adt.field_info
+                                    .entry(field.did)
+                                    .or_default()
+                                    .lifetime
+                                    .insert(origin);
+                            });
+                            fully_derefed_field_ty = *ty;
+                        }
+                        _ => break,
+                    }
+                }
+
+                adt_metadata.entry(*struct_did).and_modify(|adt| {
+                    adt.field_info
+                        .entry(field.did)
+                        .or_default()
+                        .fully_derefed_ty = Some(fully_derefed_field_ty);
+                });
+
+                if let TyKind::Adt(adt_field, substs) = fully_derefed_field_ty.kind() {
+                    eprintln!("\t\tfound ADT field base type: {adt_field:?}");
+                    for sub in substs.iter() {
+                        if let GenericArgKind::Lifetime(r) = sub.unpack() {
+                            eprintln!("\tfound field lifetime {r:?} in {adt_def:?}.{adt_field:?}");
+                            adt_metadata.entry(*struct_did).and_modify(|adt| {
+                                eprintln!("\t\t\tinserting {adt_field:?} lifetime param {r:?} into {adt_def:?}.{:} lifetime parameters", field.name);
+
+                                adt.field_info
+                                    .entry(field.did)
+                                    .or_default()
+                                    .lifetime_params
+                                    .insert(OriginKind::Actual(r));
+                            });
+                        }
+                    }
+                    if let Some(adt_field_metadata) = adt_metadata.get(&adt_field.did()).cloned() {
+                        for adt_field_lifetime_param in adt_field_metadata.lifetime_params.iter() {
+                            adt_metadata.entry(*struct_did).and_modify(|adt| {
+                                if let OriginKind::Hypothetical(..) = adt_field_lifetime_param {
+                                    eprintln!("\t\t\tbubbling {adt_field:?} origin {adt_field_lifetime_param:?} up into {adt_def:?} origins");
+                                    adt.lifetime_params.insert(*adt_field_lifetime_param);
+                                    adt.field_info
+                                    .entry(field.did)
+                                    .or_default()
+                                    .lifetime_params
+                                    .insert(*adt_field_lifetime_param);
+                                }
+                            });
+                        }
+                    }
+                    // add a metadata entry for the struct field matching the metadata entry
+                    // for the struct definition of said field
+                    adt_metadata.insert(field.did, adt_metadata[&adt_field.did()].clone());
+                }
+            }
+
+            eprintln!();
+        }
+
+        if adt_metadata == old_adt_metadata {
+            eprintln!("reached a fixed point in struct lifetime reconciliation\n");
+            break;
+        }
+    }
+
+    print_adt_metadata(tcx, &adt_metadata, &struct_dids);
+
+    adt_metadata
+}
+
+fn print_adt_metadata(
+    tcx: TyCtxt,
+    adt_metadata: &HashMap<DefId, AdtMetadata>,
+    struct_dids: &Vec<DefId>,
+) {
+    eprintln!("--- ADT actual/hypothetical lifetimes ---");
+    for k in struct_dids {
+        let adt = &adt_metadata[k];
+        eprint!("struct {:}", tcx.item_name(*k));
+        eprint!("<");
+        let lifetime_params_str = adt
+            .lifetime_params
+            .iter()
+            .map(|p| format!("{:?}", p))
+            .collect::<Vec<_>>()
+            .join(",");
+        eprint!("{lifetime_params_str:}");
+        eprintln!("> {{");
+        for (fdid, f) in &adt.field_info {
+            eprint!("\t{:}: ", tcx.item_name(*fdid));
+            for origin in &f.lifetime {
+                eprint!("&{origin:?} ");
+            }
+            if let Some(adt) = f.fully_derefed_ty.and_then(|t| t.ty_adt_def()) {
+                eprint!("{adt:?}");
+                let fmeta = &adt_metadata[&adt.did()];
+                if !fmeta.lifetime_params.is_empty() {
+                    eprint!("<");
+                    let f_params_str = f
+                        .lifetime_params
+                        .iter()
+                        .map(|p| format!("{:?}", p))
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    eprint!("{f_params_str:}");
+                    eprint!(">");
+                }
+            } else {
+                eprint!("{:?}", f.fully_derefed_ty.unwrap());
+            }
+            eprintln!();
+        }
+
+        eprintln!("}}\n");
+    }
+    eprintln!();
+}
+
 fn run(tcx: TyCtxt) {
     let mut gacx = GlobalAnalysisCtxt::new(tcx);
     let mut func_info = HashMap::new();
@@ -157,7 +370,7 @@ fn run(tcx: TyCtxt) {
         if !matches!(tcx.def_kind(did), Struct | Enum | Union) {
             continue;
         }
-        gacx.label_struct_fields(did);
+        gacx.assn_ptr_to_fields(did);
     }
 
     // Initial pass to assign local `PointerId`s and gather equivalence constraints, which state
@@ -264,6 +477,8 @@ fn run(tcx: TyCtxt) {
         info.lasn.set(lasn);
     }
 
+    let adt_metadata = construct_adt_metadata(tcx);
+
     let mut loop_count = 0;
     loop {
         // Loop until the global assignment reaches a fixpoint.  The inner loop also runs until a
@@ -279,6 +494,7 @@ fn run(tcx: TyCtxt) {
             let mir = tcx.mir_built(ldid_const);
             let mir = mir.borrow();
 
+            let field_tys = gacx.field_tys.clone();
             let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
             let mut asn = gasn.and(&mut info.lasn);
 
@@ -292,6 +508,8 @@ fn run(tcx: TyCtxt) {
                 &mut asn.perms_mut(),
                 name.as_str(),
                 &mir,
+                &adt_metadata,
+                field_tys,
             );
 
             info.acx_data.set(acx.into_data());

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -36,7 +36,7 @@ use rustc_middle::mir::{
 };
 use rustc_middle::ty::{GenericArgKind, Ty, TyCtxt, TyKind, WithOptConstParam};
 use rustc_span::Span;
-use rustc_type_ir::RegionKind::ReEarlyBound;
+use rustc_type_ir::RegionKind::{ReEarlyBound, ReStatic};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt::Debug;
@@ -212,6 +212,7 @@ fn construct_adt_metadata<'tcx>(tcx: TyCtxt<'tcx>) -> AdtMetadataTable {
                         }
                         TyKind::Ref(reg, ty, _mutability) => {
                             eprintln!("\t\tfound reference field lifetime: {reg:}");
+                            assert_matches!(reg.kind(), ReEarlyBound(..) | ReStatic);
                             let origin_arg = OriginArg::Actual(*reg);
                             adt_metadata_table
                                 .table
@@ -238,6 +239,7 @@ fn construct_adt_metadata<'tcx>(tcx: TyCtxt<'tcx>) -> AdtMetadataTable {
                             if let GenericArgKind::Lifetime(r) = sub.unpack() {
                                 eprintln!("\tfound field lifetime {r:?} in {adt_def:?}.{adt_field:?}");
                                 eprintln!("\t\t\tinserting {adt_field:?} lifetime param {r:?} into {adt_def:?}.{:} lifetime parameters", field.name);
+                                assert_matches!(r.kind(), ReEarlyBound(..) | ReStatic);
                                 field_lifetime_params.insert(OriginArg::Actual(r));
                             }
                         }

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -257,7 +257,7 @@ fn builtin_callee<'tcx>(
 pub fn lty_project<'tcx, L: Debug>(
     lty: LabeledTy<'tcx, L>,
     proj: &PlaceElem<'tcx>,
-    adt_func: impl Fn(AdtDef<'tcx>, Field) -> LabeledTy<'tcx, L>,
+    mut adt_func: impl FnMut(AdtDef<'tcx>, Field, Ty<'tcx>) -> LabeledTy<'tcx, L>,
 ) -> LabeledTy<'tcx, L> {
     match *proj {
         ProjectionElem::Deref => {
@@ -265,9 +265,9 @@ pub fn lty_project<'tcx, L: Debug>(
             assert_eq!(lty.args.len(), 1);
             lty.args[0]
         }
-        ProjectionElem::Field(f, _) => match lty.kind() {
+        ProjectionElem::Field(f, field_ty) => match lty.kind() {
             TyKind::Tuple(_) => lty.args[f.index()],
-            TyKind::Adt(def, _) => adt_func(*def, f),
+            TyKind::Adt(def, _) => adt_func(*def, f, field_ty),
             _ => panic!("Field projection is unsupported on type {:?}", lty),
         },
         ProjectionElem::Index(..) | ProjectionElem::ConstantIndex { .. } => {

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -257,7 +257,7 @@ fn builtin_callee<'tcx>(
 pub fn lty_project<'tcx, L: Debug>(
     lty: LabeledTy<'tcx, L>,
     proj: &PlaceElem<'tcx>,
-    mut adt_func: impl FnMut(AdtDef<'tcx>, Field, Ty<'tcx>) -> LabeledTy<'tcx, L>,
+    mut adt_func: impl FnMut(LabeledTy<'tcx, L>, AdtDef<'tcx>, Field, Ty<'tcx>) -> LabeledTy<'tcx, L>,
 ) -> LabeledTy<'tcx, L> {
     match *proj {
         ProjectionElem::Deref => {
@@ -267,7 +267,7 @@ pub fn lty_project<'tcx, L: Debug>(
         }
         ProjectionElem::Field(f, field_ty) => match lty.kind() {
             TyKind::Tuple(_) => lty.args[f.index()],
-            TyKind::Adt(def, _) => adt_func(*def, f, field_ty),
+            TyKind::Adt(def, _) => adt_func(lty, *def, f, field_ty),
             _ => panic!("Field projection is unsupported on type {:?}", lty),
         },
         ProjectionElem::Index(..) | ProjectionElem::ConstantIndex { .. } => {

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -257,7 +257,7 @@ fn builtin_callee<'tcx>(
 pub fn lty_project<'tcx, L: Debug>(
     lty: LabeledTy<'tcx, L>,
     proj: &PlaceElem<'tcx>,
-    mut adt_func: impl FnMut(LabeledTy<'tcx, L>, AdtDef<'tcx>, Field, Ty<'tcx>) -> LabeledTy<'tcx, L>,
+    mut adt_func: impl FnMut(LabeledTy<'tcx, L>, AdtDef<'tcx>, Field) -> LabeledTy<'tcx, L>,
 ) -> LabeledTy<'tcx, L> {
     match *proj {
         ProjectionElem::Deref => {
@@ -265,9 +265,9 @@ pub fn lty_project<'tcx, L: Debug>(
             assert_eq!(lty.args.len(), 1);
             lty.args[0]
         }
-        ProjectionElem::Field(f, field_ty) => match lty.kind() {
+        ProjectionElem::Field(f, _) => match lty.kind() {
             TyKind::Tuple(_) => lty.args[f.index()],
-            TyKind::Adt(def, _) => adt_func(lty, *def, f, field_ty),
+            TyKind::Adt(def, _) => adt_func(lty, *def, f),
             _ => panic!("Field projection is unsupported on type {:?}", lty),
         },
         ProjectionElem::Index(..) | ProjectionElem::ConstantIndex { .. } => {

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -1,0 +1,45 @@
+pub struct Data<'d> {
+    // final lifetime parameters: Data<'d, 'h0, 'h1, 'h2>
+
+    // 1: hypothetical pointer field lifetime 'h0 -> Data<'d, 'h0>
+    pub pi: *mut i32, // &'h0 i32
+
+    // 2: hypothetical pointer field lifetime 'h1 -> Data<'d, 'h0, 'h1>
+    // 3: A has no new parameters to bubble up
+    // 8: A has new lifetime param 'h2 -> Data<'d, 'h0, 'h1, 'h2>
+    pub pa: *mut A<'d>, // &'h1 A<'a, 'h0, 'h1, 'h2>
+
+    // 4: A has no new parameters to bubble up
+    pub a: A<'d>, // A<'a, 'h0, 'h1, 'h2>
+}
+
+pub struct A<'a> {
+    // final lifetime parameters: A<'a, 'h0, 'h1, 'h2>
+
+    // 5: Data has new lifetime params 'h0 and 'h1 -> A<'a, 'h0, 'h1>
+    // 9: Data has new lifetime param 'h2, but 'h2 is already in A
+    pub rd: &'a Data<'a>, // &'a Data<'a, 'h0, 'h1, 'h2>
+
+    // 6: hypothetical pointer field lifetime 'h2 -> A<'a, 'h0, 'h1, 'h2>
+    // 7: A has new lifetime params to bubble up, but they're already present
+    pub pra: *mut &'a mut A<'a>, // &'h2 &'a A<'a, 'h0, 'h1, 'h2>
+}
+
+// CHECK-LABEL: final labeling for "_field_access"
+// CHECK-DAG: ([[#@LINE+3]]: ppd): addr_of = UNIQUE, type = READ | WRITE | UNIQUE
+// CHECK-DAG: ([[#@LINE+2]]: ra): &mut A
+// CHECK-DAG: ([[#@LINE+1]]: ppd): &mut &mut Data
+unsafe fn _field_access<'d>(ra: &'d mut A<'d>, ppd: *mut *mut Data<'d>) {
+    // CHECK-DAG: ([[#@LINE+2]]: rd): addr_of = UNIQUE, type = READ | UNIQUE
+    // CHECK-DAG: ([[#@LINE+1]]: rd): &Data
+    let rd = (*(**ppd).a.pra).rd;
+
+    // CHECK-DAG: ([[#@LINE+2]]: pi): addr_of = UNIQUE, type = READ | WRITE | UNIQUE
+    // CHECK-DAG: ([[#@LINE+1]]: pi): &mut i32
+    let pi = rd.pi;
+    *pi = 3;
+    let _i = *pi;
+
+    *(*(**ppd).pa).pra = ra;
+    (*(**ppd).pa).pra = (*(**ppd).pa).pra;
+}

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -1,28 +1,32 @@
+// CHECK-LABEL: === ADT Metadata ===
+// CHECK-DAG: struct Data<'d,'h0,'h1,'h2> {
 pub struct Data<'d> {
-    // final lifetime parameters: Data<'d, 'h0, 'h1, 'h2>
-
     // 1: hypothetical pointer field lifetime 'h0 -> Data<'d, 'h0>
-    pub pi: *mut i32, // &'h0 i32
+    // CHECK-DAG: pi: &'h0 i32
+    pub pi: *mut i32,
 
     // 2: hypothetical pointer field lifetime 'h1 -> Data<'d, 'h0, 'h1>
     // 3: A has no new parameters to bubble up
     // 8: A has new lifetime param 'h2 -> Data<'d, 'h0, 'h1, 'h2>
-    pub pa: *mut A<'d>, // &'h1 A<'a, 'h0, 'h1, 'h2>
+    // CHECK-DAG: pa: &'h1 A<'d,'h0,'h1,'h2>
+    pub pa: *mut A<'d>,
 
     // 4: A has no new parameters to bubble up
-    pub a: A<'d>, // A<'a, 'h0, 'h1, 'h2>
+    // CHECK-DAG: a: A<'d,'h0,'h1,'h2>
+    pub a: A<'d>,
 }
 
+// CHECK-DAG: struct A<'a,'h0,'h1,'h2> {
 pub struct A<'a> {
-    // final lifetime parameters: A<'a, 'h0, 'h1, 'h2>
-
     // 5: Data has new lifetime params 'h0 and 'h1 -> A<'a, 'h0, 'h1>
     // 9: Data has new lifetime param 'h2, but 'h2 is already in A
-    pub rd: &'a Data<'a>, // &'a Data<'a, 'h0, 'h1, 'h2>
+    // CHECK-DAG: rd: &'a Data<'a,'h0,'h1,'h2>
+    pub rd: &'a Data<'a>,
 
     // 6: hypothetical pointer field lifetime 'h2 -> A<'a, 'h0, 'h1, 'h2>
     // 7: A has new lifetime params to bubble up, but they're already present
-    pub pra: *mut &'a mut A<'a>, // &'h2 &'a A<'a, 'h0, 'h1, 'h2>
+    // CHECK-DAG: pra: &'h2 &'a A<'a,'h0,'h1,'h2>
+    pub pra: *mut &'a mut A<'a>,
 }
 
 // CHECK-LABEL: final labeling for "_field_access"

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -30,18 +30,19 @@ pub struct A<'a> {
 }
 
 // let rd = (*(**ppd).a.pra).rd
-// CHECK-DAG: Label { origin: Some(Origin([[REF_D_ORIGIN:[0-9]+]])), origin_params: Some([('d, Origin([[REF_D_ORIGIN]])), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin({{[0-9]+}}))]){{.*}}}#&Data
-// CHECK-DAG: Label { origin: None, origin_params: Some([('d, Origin([[REF_D_ORIGIN]])), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin({{[0-9]+}}))]){{.*}}}#Data
+// CHECK-DAG: Label { origin: Some(Origin([[REF_D_ORIGIN:[0-9]+]])), origin_params: None{{.*}}}#&'a Data
+// CHECK-DAG: Label { origin: None, origin_params: Some([('d, Origin([[REF_D_ORIGIN]])){{.*}}}#Data
 // CHECK-DAG: assign Label { origin: Some(Origin({{[0-9]+}})){{.*}} = Label { origin: Some(Origin([[REF_D_ORIGIN]]))
 
 // *(*(**ppd).pa).pra = ra
-// CHECK-DAG: Label { origin: Some(Origin([[REF_A_ORIGIN:[0-9]+]])), origin_params: Some([('a, Origin([[REF_A_ORIGIN]])), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin({{[0-9]+}}))]){{.*}}}#&mut A
-// CHECK-DAG: Label { origin: None, origin_params: Some([('a, Origin([[REF_A_ORIGIN]])), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin({{[0-9]+}}))]){{.*}}}#A
+// CHECK-DAG: Label { origin: Some(Origin([[REF_A_ORIGIN:[0-9]+]])), origin_params: None{{.*}}}#&'a mut A
+// CHECK-DAG: Label { origin: None, origin_params: Some([('a, Origin([[REF_A_ORIGIN]])){{.*}}#A
 // CHECK-DAG: assign Label { origin: Some(Origin([[REF_A_ORIGIN]]))
 
 // (*(**ppd).pa).pra = (*(**ppd).pa).pra
-// CHECK-DAG: Label { origin: Some(Origin([[P_REF_A_ORIGIN:[0-9]+]])), origin_params: Some([('a, Origin({{[0-9]+}})), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin([[P_REF_A_ORIGIN]]))]){{.*}}}#*mut &mut A
-// CHECK-DAG: Label { origin: None, origin_params: Some([('a, Origin({{[0-9]+}})), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin([[P_REF_A_ORIGIN]]))]){{.*}}}#A
+// CHECK-DAG: Label { origin: Some(Origin([[P_REF_A_ORIGIN:[0-9]+]])), origin_params: None{{.*}}}#*mut &'a mut A
+// CHECK-DAG: Label { origin: Some(Origin([[REF_A_ORIGIN:[0-9]+]])), origin_params: None{{.*}}}#&'a mut A
+// CHECK-DAG: Label { origin: None, origin_params: Some([('a, Origin([[REF_A_ORIGIN]])){{.*}}('h2, Origin([[P_REF_A_ORIGIN]]))]){{.*}}}#A
 // CHECK-DAG: assign Label { origin: Some(Origin([[P_REF_A_ORIGIN]]))
 
 // CHECK-LABEL: final labeling for "_field_access"

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -36,19 +36,19 @@ struct VecTup<'a> {
 }
 
 // let rd = (*(**ppd).a.pra).rd
-// CHECK-DAG: Label { origin: Some(Origin([[REF_D_ORIGIN:[0-9]+]])), origin_params: None{{.*}}}#&'a Data
-// CHECK-DAG: Label { origin: None, origin_params: Some([('d, Origin([[REF_D_ORIGIN]])){{.*}}}#Data
+// CHECK-DAG: Label { origin: Some(Origin([[REF_D_ORIGIN:[0-9]+]])), origin_params: []{{.*}}}#&'a Data
+// CHECK-DAG: Label { origin: None, origin_params: [('d, Origin([[REF_D_ORIGIN]]){{.*}}}#Data
 // CHECK-DAG: assign Label { origin: Some(Origin({{[0-9]+}})){{.*}} = Label { origin: Some(Origin([[REF_D_ORIGIN]]))
 
 // *(*(**ppd).pa).pra = ra
-// CHECK-DAG: Label { origin: Some(Origin([[REF_A_ORIGIN:[0-9]+]])), origin_params: None{{.*}}}#&'a mut A
-// CHECK-DAG: Label { origin: None, origin_params: Some([('a, Origin([[REF_A_ORIGIN]])){{.*}}#A
+// CHECK-DAG: Label { origin: Some(Origin([[REF_A_ORIGIN:[0-9]+]])), origin_params: []{{.*}}}#&'a mut A
+// CHECK-DAG: Label { origin: None, origin_params: [('a, Origin([[REF_A_ORIGIN]]){{.*}}#A
 // CHECK-DAG: assign Label { origin: Some(Origin([[REF_A_ORIGIN]]))
 
 // (*(**ppd).pa).pra = (*(**ppd).pa).pra
-// CHECK-DAG: Label { origin: Some(Origin([[P_REF_A_ORIGIN:[0-9]+]])), origin_params: None{{.*}}}#*mut &'a mut A
-// CHECK-DAG: Label { origin: Some(Origin([[REF_A_ORIGIN:[0-9]+]])), origin_params: None{{.*}}}#&'a mut A
-// CHECK-DAG: Label { origin: None, origin_params: Some([('a, Origin([[REF_A_ORIGIN]])){{.*}}('h2, Origin([[P_REF_A_ORIGIN]]))]){{.*}}}#A
+// CHECK-DAG: Label { origin: Some(Origin([[P_REF_A_ORIGIN:[0-9]+]])), origin_params: []{{.*}}}#*mut &'a mut A
+// CHECK-DAG: Label { origin: Some(Origin([[REF_A_ORIGIN:[0-9]+]])), origin_params: []{{.*}}}#&'a mut A
+// CHECK-DAG: Label { origin: None, origin_params: [('a, Origin([[REF_A_ORIGIN]])){{.*}}('h2, Origin([[P_REF_A_ORIGIN]]))]{{.*}}}#A
 // CHECK-DAG: assign Label { origin: Some(Origin([[P_REF_A_ORIGIN]]))
 
 // CHECK-LABEL: final labeling for "_field_access"

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -29,6 +29,21 @@ pub struct A<'a> {
     pub pra: *mut &'a mut A<'a>,
 }
 
+// let rd = (*(**ppd).a.pra).rd
+// CHECK-DAG: Label { origin: Some(Origin([[REF_D_ORIGIN:[0-9]+]])), origin_params: Some([('d, Origin([[REF_D_ORIGIN]])), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin({{[0-9]+}}))]){{.*}}}#&Data
+// CHECK-DAG: Label { origin: None, origin_params: Some([('d, Origin([[REF_D_ORIGIN]])), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin({{[0-9]+}}))]){{.*}}}#Data
+// CHECK-DAG: assign Label { origin: Some(Origin({{[0-9]+}})){{.*}} = Label { origin: Some(Origin([[REF_D_ORIGIN]]))
+
+// *(*(**ppd).pa).pra = ra
+// CHECK-DAG: Label { origin: Some(Origin([[REF_A_ORIGIN:[0-9]+]])), origin_params: Some([('a, Origin([[REF_A_ORIGIN]])), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin({{[0-9]+}}))]){{.*}}}#&mut A
+// CHECK-DAG: Label { origin: None, origin_params: Some([('a, Origin([[REF_A_ORIGIN]])), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin({{[0-9]+}}))]){{.*}}}#A
+// CHECK-DAG: assign Label { origin: Some(Origin([[REF_A_ORIGIN]]))
+
+// (*(**ppd).pa).pra = (*(**ppd).pa).pra
+// CHECK-DAG: Label { origin: Some(Origin([[P_REF_A_ORIGIN:[0-9]+]])), origin_params: Some([('a, Origin({{[0-9]+}})), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin([[P_REF_A_ORIGIN]]))]){{.*}}}#*mut &mut A
+// CHECK-DAG: Label { origin: None, origin_params: Some([('a, Origin({{[0-9]+}})), ('h0, Origin({{[0-9]+}})), ('h1, Origin({{[0-9]+}})), ('h2, Origin([[P_REF_A_ORIGIN]]))]){{.*}}}#A
+// CHECK-DAG: assign Label { origin: Some(Origin([[P_REF_A_ORIGIN]]))
+
 // CHECK-LABEL: final labeling for "_field_access"
 // CHECK-DAG: ([[#@LINE+3]]: ppd): addr_of = UNIQUE, type = READ | WRITE | UNIQUE
 // CHECK-DAG: ([[#@LINE+2]]: ra): &mut A

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -29,10 +29,10 @@ pub struct A<'a> {
     pub pra: *mut &'a mut A<'a>,
 }
 
-// CHECK-DAG: struct VecTup<'a,'h3,'h4> {
+// CHECK-DAG: struct VecTup<'a,'h3,'h4,'h0,'h1,'h2> {
 struct VecTup<'a> {
-    // CHECK-DAG: bar: &'h3 std::vec::Vec<(VecTup<'a,'h3,'h4>,&'h4 i32),std::alloc::Global>
-    bar: *mut Vec<(VecTup<'a>, *mut i32)>,
+    // CHECK-DAG: bar: &'h3 std::vec::Vec<(VecTup<'a,'h3,'h4,'h0,'h1,'h2>,&'h4 A<'a,'h0,'h1,'h2>),std::alloc::Global>
+    bar: *mut Vec<(VecTup<'a>, *mut A<'a>)>,
 }
 
 // let rd = (*(**ppd).a.pra).rd

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -29,6 +29,12 @@ pub struct A<'a> {
     pub pra: *mut &'a mut A<'a>,
 }
 
+// CHECK-DAG: struct VecTup<'a,'h3,'h4> {
+struct VecTup<'a> {
+    // CHECK-DAG: bar: &'h3 std::vec::Vec<(VecTup<'a,'h3,'h4>,&'h4 i32),std::alloc::Global>
+    bar: *mut Vec<(VecTup<'a>, *mut i32)>,
+}
+
 // let rd = (*(**ppd).a.pra).rd
 // CHECK-DAG: Label { origin: Some(Origin([[REF_D_ORIGIN:[0-9]+]])), origin_params: None{{.*}}}#&'a Data
 // CHECK-DAG: Label { origin: None, origin_params: Some([('d, Origin([[REF_D_ORIGIN]])){{.*}}}#Data


### PR DESCRIPTION
This adds support for generating concrete `Origin`s to pass to Polonius for each ADT lifetime parameter and resolving lifetime parameters to those `Origin`s when visiting the MIR body. It also adds support for ADT field pointer permissions.

There are three stages to making this possible:
1. gather hypothetical (i.e. pointer-based) and actual (reference-based) lifetimes
2. generating concrete origins
3. resolving lifetime parameters when visiting the MIR body

Stage 1 runs in a loop and gathers ADT metadata. The loop terminates when a fixed point is reached, as determined by changes in the ADT metadata. This approach is to handle ADTs that are recursive and/or mutually recursive.

Stage 2 generates one concrete `Origin` per ADT lifetime parameter, per MIR local. When grabbing the `Origin` of a given struct field, even nested ones, it is one of these concrete origins that will be returned.

Stage 3 traces the concrete `Origin`s generated for each ADT lifetime parameter all the way to the last projection / field access. It does this by updating a mapping for each projection element visited.