### PR TITLE
Install `FileCheck` for older (`apt`-based) distros

### DIFF
--- a/scripts/provision_deb.sh
+++ b/scripts/provision_deb.sh
@@ -56,6 +56,16 @@ packages=(
     zlib1g-dev
 )
 
+if ! [[ -x "$(llvm-config --bindir)/FileCheck" ]]; then
+	IFS="." read -r major minor patch <<< "$(llvm-config --version)"
+    if [[ ${major} -gt 6 ]]; then
+        tools="llvm-${major}-tools"
+    else
+        tools="llvm-${major}.${minor}-tools"
+    fi
+    packages+=("${tools}")
+fi
+
 apt-get install -qq "${packages[@]}"
 
 apt-get clean # clear apt-caches to reduce image size

--- a/scripts/provision_deb.sh
+++ b/scripts/provision_deb.sh
@@ -30,31 +30,33 @@ apt-get install -y --no-install-recommends \
     apt-utils \
     apt-transport-https \
     ca-certificates
-# gnupg2: required for gnupg2 key retrieval
-# llvm: required for llvm-config
-apt-get install -qq \
-    clang \
-    cmake \
-    curl \
-    dirmngr \
-    git \
-    gnupg2 \
-    gperf \
-    htop \
-    libclang-dev \
-    libssl-dev \
-    llvm \
-    ninja-build \
-    pkg-config \
-    python-dev \
-    python3-pip \
-    python3-setuptools \
-    software-properties-common \
-    strace \
-    unzip \
-    libncurses5-dev \
-    luarocks \
+
+packages=(
+    clang
+    cmake
+    curl
+    dirmngr
+    git
+    gnupg2 # required for gnupg2 key retrieval
+    gperf
+    htop
+    libclang-dev
+    libssl-dev
+    llvm # required for llvm-config
+    ninja-build
+    pkg-config
+    python-dev
+    python3-pip
+    python3-setuptools
+    software-properties-common
+    strace
+    unzip
+    libncurses5-dev
+    luarocks
     zlib1g-dev
+)
+
+apt-get install -qq "${packages[@]}"
 
 apt-get clean # clear apt-caches to reduce image size
 


### PR DESCRIPTION
- Fixes #593, along with the changes just merged in #767.

This installs `FileCheck` for older (`apt`-based) distros so that we can use `FileCheck` in testing without having to disable it anywhere.  Notably, we can use `FileCheck` for `c2rust-analyze` tests.

These older distros/default LLVM versions require the `llvm-${major}-tools` or `llvm-${major}.${minor}-tools` packages, while newer ones install `FileCheck` automatically, so this adds the installation of the older versions if `FileCheck` is not found in the expected location, `$(llvm-config --bindir)/FileCheck`, using the same `llvm-config` resolution used elsewhere.

This changes the docker builds, so we'll need a `./scripts/docker_build.sh push-all`.

This also adds an array of packages in the script, which makes adding to it easier, as well as allowing for inline comments (which don't work with `\` line continuation).