### PR TITLE
Re-enable `c2rust-analyze` tests in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,7 @@ jobs:
       export CARGO_HOME=$AGENT_TEMPDIRECTORY/.cargo
       export RUSTFLAGS="-D warnings"
       export RUSTDOCFLAGS="-D warnings"
-      cargo test --release --exclude c2rust-analyze --workspace
+      cargo test --release --workspace
     displayName: 'cargo test'
   
   - script: |
@@ -150,7 +150,7 @@ jobs:
       export LLVM_CONFIG_PATH=$(brew --prefix llvm)/bin/llvm-config
       export RUSTFLAGS="-D warnings"
       export RUSTDOCFLAGS="-D warnings"
-      cargo test --release --exclude c2rust-analyze --workspace
+      cargo test --release --workspace
     displayName: 'cargo test'
 
   - script: |

--- a/scripts/run_ci_checks.sh
+++ b/scripts/run_ci_checks.sh
@@ -37,7 +37,7 @@ build() {
 }
 
 test() {
-    cargo test --release --exclude c2rust-analyze --workspace
+    cargo test --release --workspace
 }
 
 # `test_translator.py` compiles translated code,


### PR DESCRIPTION
- Fixes #608.

Depends on:
- #770
- #799

Once #770 lands, `FileCheck` will be installed everywhere, so we can finally re-enable the `c2rust-analyze` tests, which use `FileCheck`, in CI.  This is getting increasingly important as we more rapidly work on `c2rust-analyze`.