### PR TITLE
Add a `c2rust-analyze` test for `lighttpd-minimal`

### DIFF
--- a/c2rust-analyze/tests/lighttpd.rs
+++ b/c2rust-analyze/tests/lighttpd.rs
@@ -1,0 +1,23 @@
+use std::process::Command;
+
+#[test]
+fn test_lighttpd_minimal() {
+    let dir = env!("CARGO_MANIFEST_DIR");
+    let lib_dir = env!("C2RUST_TARGET_LIB_DIR");
+    let mut cmd = Command::new("cargo");
+    let path = "analysis/tests/lighttpd-minimal/src/main.rs";
+    cmd.arg("run")
+        .arg("--manifest-path")
+        .arg(format!("{dir}/Cargo.toml"))
+        .arg("--")
+        .arg(format!("{dir}/../{path}"))
+        .arg("-L")
+        .arg(lib_dir)
+        .arg("--crate-type")
+        .arg("rlib");
+    let status = cmd.status().unwrap();
+    assert!(
+        status.success(),
+        "{path:?}: c2rust-analyze failed with status {status:?}",
+    );
+}


### PR DESCRIPTION
This adds a `c2rust-analyze` test for `lighttpd-minimal` that just checks that `c2rust-analyze` runs without error on it.