### PR TITLE
revert changes introduced in #732

### DIFF
--- a/analysis/tests/lighttpd-minimal/src/main.rs
+++ b/analysis/tests/lighttpd-minimal/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(rustc_private)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 #![allow(unused_mut)]

--- a/analysis/tests/lighttpd/src/main.rs
+++ b/analysis/tests/lighttpd/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(rustc_private)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]

--- a/analysis/tests/misc/src/main.rs
+++ b/analysis/tests/misc/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(rustc_private)]
 #![feature(c_variadic)]
 
 #[path = "pointers.rs"]


### PR DESCRIPTION
Reverts #732. `#![feature(rustc_private)]` is necessary to execute `c2rust-analyze`, as it utilizes `rustc` directly (see comment [here](https://github.com/immunant/c2rust/pull/772#issuecomment-1375289168)). This restores functionality in preparation for #772.