### PR TITLE
Fix types in Python scripts

### DIFF
--- a/scripts/cborpp.py
+++ b/scripts/cborpp.py
@@ -16,7 +16,7 @@ except ImportError:
     sys.exit(errno.ENOENT)
 
 
-def _parse_args():
+def _parse_args() -> argparse.Namespace:
     """
     define and parse command line arguments here.
     """
@@ -142,7 +142,7 @@ TAGS = {
 }
 
 
-def _main():
+def _main() -> None:
     args = _parse_args()
     try:
         array = cbor2.load(args.cbor)

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -198,6 +198,15 @@ class Config:
 config = Config()
 
 
+def get_host_triplet() -> str:
+    if on_linux():
+        return "x86_64-unknown-linux-gnu"
+    elif on_mac():
+        return "x86_64-apple-darwin"
+    else:
+        assert False, "not implemented"
+
+
 def update_or_init_submodule(submodule_path: str) -> None:
     git = get_cmd_or_die("git")
     invoke_quietly(git, "submodule", "update", "--init", submodule_path)

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -333,7 +333,7 @@ def ensure_dir(path: str) -> None:
         logging.debug("creating dir %s", path)
         os.makedirs(path, mode=0o744)
     if not os.path.isdir(path):
-        die("%s is not a directory", path)
+        die("%s is not a directory" % path)
 
 
 def is_elf_exe(path: str) -> bool:
@@ -556,9 +556,9 @@ def check_sig(afile: str, asigfile: str) -> None:
                 logging.warning("could not remove %s: not found.", f)
 
     if not os.path.isfile(afile):
-        die("archive file not found: %s", afile)
+        die("archive file not found: %s" % afile)
     if not os.path.isfile(asigfile):
-        die("signature file not found: %s", asigfile)
+        die("signature file not found: %s" % asigfile)
 
     # check that archive matches signature
     try:

--- a/scripts/convert_build_commands.py
+++ b/scripts/convert_build_commands.py
@@ -37,7 +37,7 @@ def convert_entries(entries: List[Dict[str, Any]],
             if arg in {"-D", "-U", "-I", "-include"}:
                 # TODO: use the full list of `Separate` options from gcc
                 ei.new_args.append(arg)
-                ei.append(next(arg_iter))
+                ei.new_args.append(next(arg_iter))
 
             elif arg == "-c":
                 ei.compile_only = True

--- a/scripts/convert_build_commands.py
+++ b/scripts/convert_build_commands.py
@@ -5,25 +5,27 @@ import glob
 import json
 import os
 import sys
+from typing import Any, Dict, List, Optional
 
-def get_fake():
-    get_fake.ctr += 1
-    return get_fake.ctr
-get_fake.ctr = -1
+def get_fake() -> int:
+    get_fake.ctr += 1  # type: ignore
+    return get_fake.ctr  # type: ignore
+get_fake.ctr = -1  # type: ignore
 
 class EntryInfo:
-    def __init__(self, e):
+    def __init__(self, e: Dict[str, Any]):
         self.entry = e
-        self.new_args = []
-        self.c_inputs = []
-        self.rest_inputs = []
-        self.libs = []
-        self.lib_dirs = []
+        self.new_args: List[str] = []
+        self.c_inputs: List[str] = []
+        self.rest_inputs: List[str] = []
+        self.libs: List[str] = []
+        self.lib_dirs: List[str] = []
         self.compile_only = False
         self.shared_lib = False
         self.output = None
 
-def convert_entries(entries, out_dir=None):
+def convert_entries(entries: List[Dict[str, Any]],
+        out_dir: Optional[str] = None) -> List[Dict[str, Any]]:
     entry_infos = []
     for entry in entries:
         old_args, entry["arguments"] = entry["arguments"], []
@@ -43,6 +45,7 @@ def convert_entries(entries, out_dir=None):
             elif arg == "-o":
                 ei.output = next(arg_iter)
                 ei.new_args.append(arg)
+                assert ei.output is not None
                 ei.new_args.append(ei.output)
 
             elif arg[:2] == "-o":
@@ -120,7 +123,7 @@ def convert_entries(entries, out_dir=None):
     return new_entries
 
 
-def main():
+def main() -> None:
     if len(sys.argv) != 3:
         sys.exit("Usage: convert_build_commands <build commands directory> <compilation database file>")
 

--- a/scripts/csmith.py
+++ b/scripts/csmith.py
@@ -27,7 +27,7 @@ C_COMPILER = "clang"
 RUST_COMPILER = "rustc"
 CSMITH_TIMEOUT = 5 # seconds to wait for C compiled executable to run
 
-def validate_csmith_home():
+def validate_csmith_home() -> None:
     """Check that csmith.h can be found in CSMITH_HOME."""
     csmith_header = os.path.join(CSMITH_HOME, 'csmith.h')
     if not os.access(csmith_header, os.R_OK):
@@ -36,7 +36,7 @@ def validate_csmith_home():
               'directory containing this header.')
         exit(1)
 
-def create_compile_commands(dirname, output_c_name):
+def create_compile_commands(dirname: str, output_c_name: str) -> str:
     """Create a compile commands file suitable for compiling the given csmith source file."""
 
     compile_commands_settings = [{
@@ -53,21 +53,21 @@ def create_compile_commands(dirname, output_c_name):
 
     return compile_commands_name
 
-def generate_c_source(dirname, output_c_name):
+def generate_c_source(dirname: str, output_c_name: str) -> None:
     """Generate a C source file using csmith."""
 
     with open(output_c_name, 'w') as output_c:
         logging.info("Generating C source file with csmith")
         subprocess.run(CSMITH_CMD, cwd=dirname, stdout=output_c, check=True)
 
-def transpile_file(dirname, output_c_name):
+def transpile_file(dirname: str, output_c_name: str) -> None:
     """Translate the given C file to Rust."""
 
     compile_commands_name = create_compile_commands(dirname, output_c_name)
     common.transpile(compile_commands_name,
                      emit_build_files=False)
 
-def compile_c_file(output_c_name, output_c_exe_name):
+def compile_c_file(output_c_name: str, output_c_exe_name: str) -> None:
     """Compile the given C source file to produce the given executable."""
 
     logging.info("Compiling C source file with clang")
@@ -82,7 +82,7 @@ def compile_c_file(output_c_name, output_c_exe_name):
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL)
 
-def execute_driver(exe_name):
+def execute_driver(exe_name: str) -> bytes:
     """Execute the given executable and return its stdout output."""
 
     logging.info("Executing: %s", exe_name)
@@ -95,7 +95,7 @@ def execute_driver(exe_name):
     logging.info("Execution finished: %s", expected_output)
     return expected_output
 
-def compile_rust_file(output_c_name, output_rs_name, output_rs_exec_name):
+def compile_rust_file(output_c_name: str, output_rs_name: str, output_rs_exec_name: str) -> None:
     """Compile the given Rust source file."""
 
     logging.info("Compiling translated Rust")
@@ -108,7 +108,7 @@ def compile_rust_file(output_c_name, output_rs_name, output_rs_exec_name):
         copyfile(output_rs_name, 'output.rs')
         raise
 
-def main():
+def main() -> None:
     """Generate a new csmith test case and compare its execution to the translated Rust version."""
 
     validate_csmith_home()

--- a/scripts/integration_test_translator.py
+++ b/scripts/integration_test_translator.py
@@ -106,12 +106,12 @@ def _test_minimal(code_snippet: str) -> bool:
     return True  # if we get this far, test passed
 
 
-def test_minimal(_: argparse.Namespace) -> None:
-    _test_minimal(minimal_snippet)
+def test_minimal(_: argparse.Namespace) -> bool:
+    return _test_minimal(minimal_snippet)
 
 
-def test_hello_world(_: argparse.Namespace) -> None:
-    _test_minimal(hello_world_snippet)
+def test_hello_world(_: argparse.Namespace) -> bool:
+    return _test_minimal(hello_world_snippet)
 
 
 def test_json_c(args: argparse.Namespace) -> bool:

--- a/scripts/link_manual.py
+++ b/scripts/link_manual.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os.path
+from typing import List
 
 from common import (
     get_cmd_or_die,
@@ -11,7 +12,7 @@ from common import (
 EXTENSIONS = ['*.md', '*.png', '*.html', '*.css']
 
 
-def list_files(untracked=False):
+def list_files(untracked: bool = False) -> List[str]:
     git = get_cmd_or_die('git')
     args = ['ls-files', '--cached', '--exclude-standard']
     if untracked:
@@ -21,7 +22,7 @@ def list_files(untracked=False):
     return [f for f in files if not os.path.islink(f)]
 
 
-def _main():
+def _main() -> None:
     candidates = list_files()
     for f in candidates:
         # skip files in manual/

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -50,7 +50,7 @@ CRATES = [
 def confirm(prompt: str) -> bool:
     response = input(prompt + ' [y/N] ')
     try:
-        return strtobool(response)
+        return bool(strtobool(response))
     except ValueError:
         pass
     return False

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -137,7 +137,8 @@ class Driver:
         print(cmd)
         result = True
         if not dry_run:
-            result = invoke(cmd)
+            code, stdout, stderr = invoke(cmd)
+            result = code == 0
         print()
         return result
 

--- a/scripts/print_clang_ast.py
+++ b/scripts/print_clang_ast.py
@@ -5,11 +5,11 @@ import sys
 import json
 import logging
 import subprocess
-from typing import List
+from typing import Any, Dict, List
 from common import setup_logging, die, get_cmd_or_die
 
 
-def dump_ast(cmd):
+def dump_ast(cmd: Dict[str, Any]) -> None:
     args: List[str] = cmd["arguments"]
     assert len(args) >= 3 and args[1] == "-c"
     args[0] = "clang"
@@ -26,7 +26,7 @@ def dump_ast(cmd):
         os.chdir(olddir)
 
 
-def main():
+def main() -> None:
     setup_logging()
     if not len(sys.argv) == 3:
         print(

--- a/scripts/query_toml.py
+++ b/scripts/query_toml.py
@@ -15,7 +15,7 @@ def query_toml(path: Path, query: Iterable[str]) -> Any:
     return result
 
 
-def main():
+def main() -> None:
     parser = ArgumentParser()
     parser.add_argument("query", type=str, help="the TOML query, with fields separated by .")
     parser.add_argument("path", type=Path, help="the path to a TOML file")

--- a/scripts/test_rust_refactor.py
+++ b/scripts/test_rust_refactor.py
@@ -86,7 +86,7 @@ def run_tests(testcases: List[str]) -> None:
                         logging.debug("".join(lines))
 
 
-def main():
+def main() -> None:
     # TODO: implement rustfmt and diff actions from `run-test.sh`
 
     setup_logging()

--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -416,7 +416,7 @@ class TestDirectory:
 
             try:
                 logging.debug("translating %s", c_file_short)
-                translated_rust_file = c_file.translate(self.generated_files["cc_db"],
+                translated_rust_file = c_file.translate(self.generated_files["cc_db"][0],
                                                         ld_lib_path,
                                                         extra_args=target_args(self.target))
             except NonZeroReturn as exception:

--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -151,7 +151,7 @@ def build_static_library(c_files: Iterable[CFile],
     os.chdir(output_path)
 
     # create .o files
-    args = ["-c", "-fPIC"]
+    args = ["-c", "-fPIC", "-Wno-error=int-conversion"]
     args += target_args(target)
     paths = [c_file.path for c_file in c_files]
 


### PR DESCRIPTION
Some of these type errors are associated with real bugs, and partially this is just fighting bitrot. These scripts are supposed to be used for our release process, so cleaning them up is one step towards actually getting a new release out.

It would be nice to run mypy (`mypy --ignore-missing-imports --disallow-untyped-defs scripts/*.py`) in CI, but that requires dealing with python packaging for distros, which is a nightmare and imo not worth holding up real fixes for.