### PR TITLE
Remove the `apt-get` retry loop in `provision_dep.sh`

### DIFF
--- a/scripts/provision_deb.sh
+++ b/scripts/provision_deb.sh
@@ -15,16 +15,7 @@ SCRIPT_DIR="$(dirname "$0")"
 # Configure apt to avoid to avoid provisioning slowdowns
 echo "Acquire::ForceIPv4 \"true\";" > /etc/apt/apt.conf.d/99force-ipv4
 
-# Retry the `apt-get update` command a few times upon failure
-# to work around transient network problems in CI.
-n=0
-tries=5
-until [ $n -ge $tries ]
-do
-    apt-get update -qq && break
-    n=$[$n+1]
-    sleep 30
-done
+apt-get update -qq
 
 apt-get install -y --no-install-recommends \
     apt-utils \


### PR DESCRIPTION
Remove the `apt-get` retry loop in `provision_dep.sh`.

It used to be there as the script ran in CI, but it no longer is, so we don't need to retry anymore.
See https://github.com/immunant/c2rust/pull/770#discussion_r1065225015.