### PR TITLE
Don't print all the `c2rust-analzye` output for the `lighttpd-minimal` test in `cargo test`

### DIFF
--- a/c2rust-analyze/tests/lighttpd.rs
+++ b/c2rust-analyze/tests/lighttpd.rs
@@ -15,7 +15,8 @@ fn test_lighttpd_minimal() {
         .arg(lib_dir)
         .arg("--crate-type")
         .arg("rlib");
-    let status = cmd.status().unwrap();
+    let output = cmd.output().unwrap();
+    let status = output.status;
     assert!(
         status.success(),
         "{path:?}: c2rust-analyze failed with status {status:?}",


### PR DESCRIPTION
Use `.output()` instead of `.status()` for the `c2rust-analyze` `lighttpd-minimal` test so that the output isn't piped through in `cargo test`.