### PR TITLE
Add `repo_activity_summary.py` to summarize PR/issues during a time period

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ marks.*.json
 
 # Outputs of `c2rust-analyze`
 inspect/
+
+# `scripts/repo_activity_summary.py`'s cache
+.repo/

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -244,11 +244,12 @@ def main() -> None:
         for by in (by_collaborators, by_community):
             by_them = [t for t in in_time_range if by(t.author)]
             by_name = by.__name__.replace("_", " ")
-            print(f"\t{by_name}: {time_name} {len(by_them)} {T.name()}s")
+            print(f"\t{by_name}: {len(by_them)}")
             if args.list:
                 for t in by_them:
                     time = get_time(t).strftime(args.datetime_format)
                     print(f"\t\t#{t.number} ({time_name} {time}) by @{t.author.login} ({t.author.name}): {t.title}")
+        
 
     summarize(PR, opened)
     summarize(PR, merged)

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -19,6 +19,7 @@ class Args:
     after: Optional[datetime] = None
     before: Optional[datetime] = None
     list: bool = False
+    datetime_format: str = "%c"
 
 
 def detect_repo() -> str:
@@ -154,6 +155,7 @@ def main() -> None:
     parser.add_argument("--after", type=dateutil.parser.parse, help="summarize after this date")
     parser.add_argument("--before", type=dateutil.parser.parse, help="summarize before this date")
     parser.add_argument("--list", type=bool, help="list each PR/issue")
+    parser.add_argument("--datetime-format", type=str, help="a strftime format string", default="%c")
     args = Args(**parser.parse_args().__dict__)
     print(args)
 
@@ -210,7 +212,7 @@ def main() -> None:
         print(f"{time_name} {len(filtered)} {T.name()}s")
         if args.list:
             for t in filtered:
-                time = get_time(t).strftime("%c")
+                time = get_time(t).strftime(args.datetime_format)
                 print(f"\t#{t.number} ({time_name} {time}) by @{t.author.login} ({t.author.name}): {t.title}")
 
     summarize(PR, opened)

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -154,7 +154,7 @@ def main() -> None:
     parser.add_argument("--repo", type=str, help="the GitHub repo (defaults to the current repo)")
     parser.add_argument("--after", type=dateutil.parser.parse, help="summarize after this date")
     parser.add_argument("--before", type=dateutil.parser.parse, help="summarize before this date")
-    parser.add_argument("--list", type=bool, help="list each PR/issue")
+    parser.add_argument("--list", default=False, action='store_true', help="list each PR/issue")
     parser.add_argument("--datetime-format", type=str, help="a strftime format string", default="%c")
     args = Args(**parser.parse_args().__dict__)
     print(args)

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -116,6 +116,19 @@ class PR(Issue):
         else:
             self.mergedAt = mergedAt
 
+@dataclass
+class TimeRange:
+    start: Optional[datetime] = None
+    end: Optional[datetime] = None
+    
+    def __contains__(self, time: Optional[datetime]) -> bool:
+        if time is None:
+            return False
+        if self.start is not None and time <= self.start:
+            return False
+        if self.end is not None and time >= self.end:
+            return False
+        return True
 
 def main() -> None:
     parser = ArgumentParser(description="summarize repo activity (PR/issues) during a time period (requires gh)")
@@ -130,6 +143,8 @@ def main() -> None:
         repo = detect_repo()
     else:
         repo = args.repo
+
+    time_range = TimeRange(start=args.after, end=args.before)
 
     gh = pb.local["gh"]
 

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 
 from argparse import ArgumentParser
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import dataclasses
 from datetime import datetime
+import json
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 from urllib.parse import urlparse
 import dateutil.parser
 import plumbum as pb
+
 
 @dataclass
 class Args:
@@ -16,12 +19,103 @@ class Args:
     before: Optional[datetime] = None
     list: bool = False
 
+
 def detect_repo() -> str:
     git = pb.local["git"]
     remote_url = urlparse(git["config", "--get", "remote.origin.url"]())
     assert remote_url.netloc == "github.com"
     remote_path = Path(remote_url.path)
     return str(remote_path.with_suffix("")).lstrip("/")
+
+
+Json = Dict[str, Any]
+
+
+@dataclass
+class User:
+    login: str
+    name: Optional[str]
+    is_bot: bool
+
+    def __init__(
+        self,
+        login: str,
+        name: Optional[str] = None,
+        is_bot: bool = False,
+        **_kwargs: Json,
+    ) -> None:
+        self.login = login
+        self.name = name
+        self.is_bot = is_bot
+
+@dataclass
+class Issue:
+    number: int
+    author: User
+    title: str
+    url: str
+    createdAt: datetime
+    updatedAt: datetime
+    closedAt: Optional[datetime]
+
+    def __init__(
+            self,
+            number: int,
+            author: Union[User, Json],
+            title: str,
+            url: str,
+            createdAt: Union[datetime, str],
+            updatedAt: Union[datetime, str],
+            closedAt: Optional[Union[datetime, str]],
+    ) -> None:
+        self.number = number
+        if not isinstance(author, User):
+            author = User(**author)
+        self.author = author
+        self.title = title
+        self.url = url
+        if not isinstance(createdAt, datetime):
+            self.createdAt = dateutil.parser.parse(createdAt)
+        else:
+            self.createdAt = createdAt
+        if not isinstance(updatedAt, datetime):
+            self.updatedAt = dateutil.parser.parse(updatedAt)
+        else:
+            self.updatedAt = updatedAt
+        if closedAt is not None and not isinstance(closedAt, datetime):
+            self.closedAt = dateutil.parser.parse(closedAt)
+        else:
+            self.closedAt = closedAt
+
+
+@dataclass
+class PR(Issue):
+    mergedAt: Optional[datetime]
+
+    def __init__(
+            self,
+            number: int,
+            author: Union[User, Json],
+            title: str,
+            url: str,
+            createdAt: Union[datetime, str],
+            updatedAt: Union[datetime, str],
+            closedAt: Optional[Union[datetime, str]], mergedAt: Optional[Union[datetime, str]],
+            ) -> None:
+        super().__init__(
+            number=number,
+            author=author,
+            title=title,
+            url=url,
+            createdAt=createdAt,
+            updatedAt=updatedAt,
+            closedAt=closedAt,
+        )
+        if mergedAt is not None and not isinstance(mergedAt, datetime):
+            self.mergedAt = dateutil.parser.parse(mergedAt)
+        else:
+            self.mergedAt = mergedAt
+
 
 def main() -> None:
     parser = ArgumentParser(description="summarize repo activity (PR/issues) during a time period (requires gh)")
@@ -36,8 +130,32 @@ def main() -> None:
         repo = detect_repo()
     else:
         repo = args.repo
-    
-    print(repo)
+
+    gh = pb.local["gh"]
+
+    T = TypeVar("T", Issue, PR)
+
+    def list(T: Type[T]) -> List[T]:
+        response_str = gh[
+            T.__name__.lower(),
+            "list",
+            "--repo", repo,
+            "--state", "all",
+            "--limit", int(1e6),
+            "--json", ",".join(field.name for field in dataclasses.fields(T)),
+        ]()
+        response_json = json.loads(response_str)
+        return [T(**item) for item in response_json]
+
+    def list_collaborators() -> List[User]:
+        response_str = gh["api", "-H", "Accept: application/vnd.github+json", f"/repos/{repo}/collaborators", "--jq", "[.[] | {login}]"]()
+        response_json = json.loads(response_str)
+        return [User(**item) for item in response_json]
+
+    print(list_collaborators())
+    print(list(PR))
+    print(list(Issue))
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -205,8 +205,13 @@ def main() -> None:
         return t.mergedAt
 
     def summarize(T: Type[T], get_time: Callable[[T], Optional[datetime]]) -> None:
+        time_name = get_time.__name__
         filtered = filter(list(T), get_time)
-        print(f"{get_time.__name__} {len(filtered)} {T.name()}s")
+        print(f"{time_name} {len(filtered)} {T.name()}s")
+        if args.list:
+            for t in filtered:
+                time = get_time(t).strftime("%c")
+                print(f"\t#{t.number} ({time_name} {time}) by @{t.author.login} ({t.author.name}): {t.title}")
 
     summarize(PR, opened)
     summarize(PR, merged)

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -174,9 +174,10 @@ def main() -> None:
     else:
         repo = args.repo
 
-    args.after = localize_tz(args.after)
-    args.before = localize_tz(args.before)
-    time_range = TimeRange(start=args.after, end=args.before)
+    time_range = TimeRange(
+        start=localize_tz(args.after),
+        end=localize_tz(args.before),
+    )
 
     gh = pb.local["gh"]
 
@@ -205,7 +206,14 @@ def main() -> None:
 
     @cache
     def collaborators() -> List[User]:
-        response_str = gh["api", "-H", "Accept: application/vnd.github+json", f"/repos/{repo}/collaborators", "--jq", "[.[] | {login}]"]()
+        response_str = gh[
+            "api",
+            "-H",
+            "Accept: application/vnd.github+json",
+            f"/repos/{repo}/collaborators",
+            "--jq",
+            "[.[] | {login}]",
+        ]()
         response_json = json.loads(response_str)
         return [User(**item) for item in response_json]
 

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -239,7 +239,7 @@ def main() -> None:
         time_name = get_time.__name__
 
         in_time_range = [t for t in list(T) if get_time(t) in time_range]
-        print(f"{time_name} {len(in_time_range)} {T.name()}s")
+        print(f"\n{time_name} {len(in_time_range)} {T.name()}s")
 
         for by in (by_collaborators, by_community):
             by_them = [t for t in in_time_range if by(t.author)]

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+import dateutil.parser
+
+@dataclass
+class Args:
+    repo: Optional[str] = None
+    after: Optional[datetime] = None
+    before: Optional[datetime] = None
+    list: bool = False
+
+def main() -> None:
+    parser = ArgumentParser(description="summarize repo activity (PR/issues) during a time period (requires gh)")
+    parser.add_argument("--repo", type=str, help="the GitHub repo (defaults to the current repo)")
+    parser.add_argument("--after", type=dateutil.parser.parse, help="summarize after this date")
+    parser.add_argument("--before", type=dateutil.parser.parse, help="summarize before this date")
+    parser.add_argument("--list", type=bool, help="list each PR/issue")
+    args = Args(**parser.parse_args().__dict__)
+    print(args)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 
-from argparse import ArgumentParser
-from dataclasses import dataclass, field
 import dataclasses
+import json
+from argparse import ArgumentParser
+from dataclasses import dataclass
 from datetime import datetime
 from functools import cache
-import json
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 from urllib.parse import urlparse
+
 import dateutil.parser
 import plumbum as pb
-
 
 Json = Dict[str, Any]
 

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -49,6 +49,14 @@ class User:
         self.login = login
         self.name = name
         self.is_bot = is_bot
+    
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, User):
+            return NotImplemented
+        return self.login == other.login
+    
+    def __hash__(self) -> int:
+        return hash(self.login)
 
 
 @dataclass

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -130,6 +130,11 @@ class TimeRange:
             return False
         return True
 
+def localize_tz(dt: Optional[datetime]) -> Optional[datetime]:
+    if dt is None:
+        return None
+    return dt.astimezone(tz=dt.tzinfo)
+
 def main() -> None:
     parser = ArgumentParser(description="summarize repo activity (PR/issues) during a time period (requires gh)")
     parser.add_argument("--repo", type=str, help="the GitHub repo (defaults to the current repo)")
@@ -144,6 +149,8 @@ def main() -> None:
     else:
         repo = args.repo
 
+    args.after = localize_tz(args.after)
+    args.before = localize_tz(args.before)
     time_range = TimeRange(start=args.after, end=args.before)
 
     gh = pb.local["gh"]

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -6,7 +6,7 @@ import dataclasses
 from datetime import datetime
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Type, TypeVar, Union
 from urllib.parse import urlparse
 import dateutil.parser
 import plumbum as pb
@@ -174,9 +174,30 @@ def main() -> None:
         response_json = json.loads(response_str)
         return [User(**item) for item in response_json]
 
-    print(list_collaborators())
-    print(list(PR))
-    print(list(Issue))
+    collaborators = list_collaborators()
+    prs = list(PR)
+    issues = list(Issue)
+
+    def filter(all: Iterable[T], get_time: Callable[[T], Optional[datetime]]) -> List[T]:
+        return [t for t in all if get_time(t) in time_range]
+    
+    def opened(t: T) -> datetime:
+        return t.createdAt
+
+    def updated(t: T) -> datetime:
+        return t.updatedAt
+
+    def closed(t: T) -> Optional[datetime]:
+        return t.closedAt
+    
+    def merged(t: PR) -> Optional[datetime]:
+        return t.mergedAt
+
+    print(len(filter(prs, opened)))
+    print(len(filter(prs, merged)))
+
+    print(len(filter(issues, opened)))
+    print(len(filter(issues, closed)))
 
 
 if __name__ == "__main__":

--- a/scripts/repo_activity_summary.py
+++ b/scripts/repo_activity_summary.py
@@ -199,9 +199,6 @@ def main() -> None:
         response_json = json.loads(response_str)
         return [User(**item) for item in response_json]
 
-    def filter(all: Iterable[T], get_time: Callable[[T], Optional[datetime]]) -> List[T]:
-        return [t for t in all if get_time(t) in time_range]
-
     def opened(t: T) -> datetime:
         return t.createdAt
 
@@ -216,10 +213,12 @@ def main() -> None:
 
     def summarize(T: Type[T], get_time: Callable[[T], Optional[datetime]]) -> None:
         time_name = get_time.__name__
-        filtered = filter(list(T), get_time)
-        print(f"{time_name} {len(filtered)} {T.name()}s")
+
+        in_time_range = [t for t in list(T) if get_time(t) in time_range]
+        print(f"{time_name} {len(in_time_range)} {T.name()}s")
+
         if args.list:
-            for t in filtered:
+            for t in in_time_range:
                 time = get_time(t).strftime(args.datetime_format)
                 print(f"\t#{t.number} ({time_name} {time}) by @{t.author.login} ({t.author.name}): {t.title}")
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -6,6 +6,7 @@ pip
 plumbum >= 1.6.3
 psutil
 pygments
+python-dateutil
 typing;python_version<"3.5"
 scan-build
 pyyaml


### PR DESCRIPTION
This adds the `repo_activity_summary.py` script, which summarizes PR/issues during a time period.

We've needed to do this repeatedly for showing progress and activity in the repo, including by the community, in presentations, so this automates it and gets it precisely right.

It uses the GitHub CLI `gh` to query the GitHub API and summarize all the opened/merged PRs and opened/closed issues, including grouping them between collaborators vs. the community.

## Usage

```sh
❯ ./scripts/repo_activity_summary.py --help
usage: repo_activity_summary.py [-h] [--repo REPO] [--after AFTER] [--before BEFORE] [--list] [--datetime-format DATETIME_FORMAT] [--cache]

summarize repo activity (PR/issues) during a time period (requires gh)

options:
  -h, --help            show this help message and exit
  --repo REPO           the GitHub repo (defaults to the current repo)
  --after AFTER         summarize after this date
  --before BEFORE       summarize before this date
  --list                list each PR/issue
  --datetime-format DATETIME_FORMAT
                        a strftime format string
  --cache               cache gh API results
```

## Example

```sh
❯ ./scripts/repo_activity_summary.py --after 9/9/2022

opened 74 PRs
        by collaborators: 62
        by community: 12

merged 54 PRs
        by collaborators: 48
        by community: 6

opened 55 issues
        by collaborators: 24
        by community: 31

closed 24 issues
        by collaborators: 8
        by community: 16
```