### PR TITLE
Replace negation and unsigned casts with `.unsigned_abs()` to avoid overflows

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3986,7 +3986,7 @@ impl<'c> Translation<'c> {
 
             ConstIntExpr::I(n) => mk().unary_expr(
                 UnOp::Neg(Default::default()),
-                mk().lit_expr(mk().int_unsuffixed_lit((-n) as u128)),
+                mk().lit_expr(mk().int_unsuffixed_lit(n.unsigned_abs() as u128)),
             ),
         };
         Ok(expr)

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -404,7 +404,7 @@ pub fn signed_int_expr(value: i64) -> Box<Expr> {
     if value < 0 {
         mk().unary_expr(
             UnOp::Neg(Default::default()),
-            mk().lit_expr(mk().int_lit((-value) as u128, "")),
+            mk().lit_expr(mk().int_lit(u128::from(value.unsigned_abs()), "")),
         )
     } else {
         mk().lit_expr(mk().int_lit(value as u128, ""))


### PR DESCRIPTION
- Fixes #795.

This fixes instances of `\(?-[a-zA-Z_]+\)? as ` in which `(-value) as U` is done, where `value` is signed and `U` is unsigned.  This overflows (and panics in debug mode) on the minimum value.  What we want instead is `value.unsigned_abs()`, which does the negation and unsigned cast in one safe operation.

Note: I've replaced the `as u128` with `u128::from(..)` as it is considered more robust form but would not mind sticking with original cast style for code uniformity if required.