### PR TITLE
Fix a bug from #770 (need separate `apt-get install`s to access `llvm-config`)

### DIFF
--- a/scripts/provision_deb.sh
+++ b/scripts/provision_deb.sh
@@ -47,6 +47,10 @@ packages=(
     zlib1g-dev
 )
 
+apt-get install -qq "${packages[@]}"
+
+# needs `llvm-config` from `llvm` package,
+# so the main packages need to be installed first
 if ! [[ -x "$(llvm-config --bindir)/FileCheck" ]]; then
 	IFS="." read -r major minor patch <<< "$(llvm-config --version)"
     if [[ ${major} -gt 6 ]]; then
@@ -54,10 +58,8 @@ if ! [[ -x "$(llvm-config --bindir)/FileCheck" ]]; then
     else
         tools="llvm-${major}.${minor}-tools"
     fi
-    packages+=("${tools}")
+    apt-get install -qq "${tools}"
 fi
-
-apt-get install -qq "${packages[@]}"
 
 apt-get clean # clear apt-caches to reduce image size
 


### PR DESCRIPTION
Use a separate `apt-get install` for installing `FileCheck`, as the detection needs `llvm-config`, which needs `llvm` to be installed first.

This fixes a bug from #770.