### PR TITLE
Remove the `#` from `FileCheck` commands so it works on older LLVMs

### DIFF
--- a/c2rust-analyze/tests/filecheck/aggregate1.rs
+++ b/c2rust-analyze/tests/filecheck/aggregate1.rs
@@ -1,16 +1,16 @@
 
 // CHECK-LABEL: final labeling for "aggregate1_array"
-// CHECK-DAG: ([[#@LINE+1]]: p): &std::cell::Cell<i32>
+// CHECK-DAG: ([[@LINE+1]]: p): &std::cell::Cell<i32>
 pub unsafe fn aggregate1_array(p: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: arr): [&std::cell::Cell<i32>; 3]
+    // CHECK-DAG: ([[@LINE+1]]: arr): [&std::cell::Cell<i32>; 3]
     let arr = [p, p, p];
     *arr[0] = 1;
 }
 
 // CHECK-LABEL: final labeling for "aggregate1_array1"
-// CHECK-DAG: ([[#@LINE+1]]: p): &mut i32
+// CHECK-DAG: ([[@LINE+1]]: p): &mut i32
 pub unsafe fn aggregate1_array1(p: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: arr): [&mut i32; 1]
+    // CHECK-DAG: ([[@LINE+1]]: arr): [&mut i32; 1]
     let arr = [p];
     *arr[0] = 1;
 }

--- a/c2rust-analyze/tests/filecheck/alias1.rs
+++ b/c2rust-analyze/tests/filecheck/alias1.rs
@@ -2,24 +2,24 @@ use std::ptr;
 
 // CHECK-LABEL: final labeling for "alias1_good"
 pub unsafe fn alias1_good() {
-    // CHECK-DAG: ([[#@LINE+1]]: mut x): addr_of = READ | WRITE | UNIQUE,
+    // CHECK-DAG: ([[@LINE+1]]: mut x): addr_of = READ | WRITE | UNIQUE,
     let mut x = 0;
-    // CHECK-DAG: ([[#@LINE+1]]: p): {{.*}}type = UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE#
     let p = ptr::addr_of_mut!(x);
-    // CHECK-DAG: ([[#@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
     let q = ptr::addr_of_mut!(x);
     *q = 1;
 }
 
 // CHECK-LABEL: final labeling for "alias1_bad"
 pub unsafe fn alias1_bad() {
-    // CHECK-DAG: ([[#@LINE+2]]: mut x): addr_of = READ | WRITE,
-    // CHECK-DAG: ([[#@LINE+1]]: mut x): addr_of flags = CELL,
+    // CHECK-DAG: ([[@LINE+2]]: mut x): addr_of = READ | WRITE,
+    // CHECK-DAG: ([[@LINE+1]]: mut x): addr_of flags = CELL,
     let mut x = 0;
-    // CHECK-DAG: ([[#@LINE+1]]: p): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE#
     let p = ptr::addr_of_mut!(x);
-    // CHECK-DAG: ([[#@LINE+2]]: q): {{.*}}type = (empty)#
-    // CHECK-DAG: ([[#@LINE+1]]: q): {{.*}}type flags = CELL#
+    // CHECK-DAG: ([[@LINE+2]]: q): {{.*}}type = (empty)#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type flags = CELL#
     let q = ptr::addr_of_mut!(x);
     *p = 1;
 }

--- a/c2rust-analyze/tests/filecheck/alias2.rs
+++ b/c2rust-analyze/tests/filecheck/alias2.rs
@@ -1,43 +1,43 @@
 use std::ptr;
 
 // CHECK-LABEL: final labeling for "alias2_copy_good"
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE#
 pub unsafe fn alias2_copy_good(x: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: p): {{.*}}type = UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE#
     let p = x;
-    // CHECK-DAG: ([[#@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
     let q = x;
     *q = 1;
 }
 
 // CHECK-LABEL: final labeling for "alias2_addr_of_good"
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE#
 pub unsafe fn alias2_addr_of_good(x: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: p): {{.*}}type = UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE#
     let p = ptr::addr_of_mut!(*x);
-    // CHECK-DAG: ([[#@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
     let q = ptr::addr_of_mut!(*x);
     *q = 1;
 }
 
 // CHECK-LABEL: final labeling for "alias2_copy_bad"
-// CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = READ | WRITE#
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type flags = CELL#
+// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type flags = CELL#
 pub unsafe fn alias2_copy_bad(x: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: p): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE#
     let p = x;
-    // CHECK-DAG: ([[#@LINE+1]]: q): {{.*}}type = (empty)#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = (empty)#
     let q = x;
     *p = 1;
 }
 
 // CHECK-LABEL: final labeling for "alias2_addr_of_bad"
-// CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = READ | WRITE#
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type flags = CELL#
+// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type flags = CELL#
 pub unsafe fn alias2_addr_of_bad(x: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: p): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE#
     let p = ptr::addr_of_mut!(*x);
-    // CHECK-DAG: ([[#@LINE+1]]: q): {{.*}}type = (empty)#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = (empty)#
     let q = ptr::addr_of_mut!(*x);
     *p = 1;
 }

--- a/c2rust-analyze/tests/filecheck/alias3.rs
+++ b/c2rust-analyze/tests/filecheck/alias3.rs
@@ -1,27 +1,27 @@
 use std::ptr;
 
 // CHECK-LABEL: final labeling for "alias3_copy_bad1"
-// CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = READ | WRITE#
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type flags = CELL#
+// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type flags = CELL#
 pub unsafe fn alias3_copy_bad1(x: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+2]]: p): {{.*}}type = READ#
-    // CHECK-DAG: ([[#@LINE+1]]: p): {{.*}}type flags = CELL#
+    // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type flags = CELL#
     let p = x;
-    // CHECK-DAG: ([[#@LINE+2]]: q): {{.*}}type = READ | WRITE#
-    // CHECK-DAG: ([[#@LINE+1]]: q): {{.*}}type flags = CELL#
+    // CHECK-DAG: ([[@LINE+2]]: q): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type flags = CELL#
     let q = x;
     *q = *p;
 }
 
 // CHECK-LABEL: final labeling for "alias3_copy_bad2"
-// CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = READ | WRITE#
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type flags = CELL#
+// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type flags = CELL#
 pub unsafe fn alias3_copy_bad2(x: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+2]]: p): {{.*}}type = READ | WRITE#
-    // CHECK-DAG: ([[#@LINE+1]]: p): {{.*}}type flags = CELL#
+    // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type flags = CELL#
     let p = x;
-    // CHECK-DAG: ([[#@LINE+2]]: q): {{.*}}type = READ#
-    // CHECK-DAG: ([[#@LINE+1]]: q): {{.*}}type flags = CELL#
+    // CHECK-DAG: ([[@LINE+2]]: q): {{.*}}type = READ#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type flags = CELL#
     let q = x;
     *p = *q;
 }

--- a/c2rust-analyze/tests/filecheck/alloc.rs
+++ b/c2rust-analyze/tests/filecheck/alloc.rs
@@ -26,7 +26,7 @@ extern "C" {
 
 // CHECK-LABEL: final labeling for "calloc1"
 unsafe extern "C" fn calloc1() -> *mut i32 {
-    // CHECK-DAG: ([[#@LINE+1]]: i): addr_of = UNIQUE
+    // CHECK-DAG: ([[@LINE+1]]: i): addr_of = UNIQUE
     let i = c2rust_test_typed_calloc(
         1 as libc::c_int as libc::c_ulong,
         ::std::mem::size_of::<i32>() as libc::c_ulong,
@@ -38,7 +38,7 @@ unsafe extern "C" fn calloc1() -> *mut i32 {
 
 // CHECK-LABEL: final labeling for "malloc1"
 pub unsafe extern "C" fn malloc1(mut cnt: libc::c_int) -> *mut i32 {
-    // CHECK-DAG: ([[#@LINE+1]]: i): addr_of = UNIQUE, type = READ
+    // CHECK-DAG: ([[@LINE+1]]: i): addr_of = UNIQUE, type = READ
     let i = c2rust_test_typed_malloc(::std::mem::size_of::<i32>() as libc::c_ulong);
     let x = *i;
     return i;
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn malloc1(mut cnt: libc::c_int) -> *mut i32 {
 
 // CHECK-LABEL: final labeling for "free1"
 unsafe extern "C" fn free1(mut i: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: i): {{.*}}type = UNIQUE | FREE#
+    // CHECK-DAG: ([[@LINE+1]]: i): {{.*}}type = UNIQUE | FREE#
     c2rust_test_typed_free(i);
 }
 
@@ -54,12 +54,12 @@ unsafe extern "C" fn free1(mut i: *mut i32) {
 unsafe extern "C" fn realloc1(mut i: *mut i32, len: libc::c_ulong) {
     let mut capacity = 1;
     let mut x = 1;
-    // CHECK-DAG: ([[#@LINE+1]]: mut elem): addr_of = UNIQUE, type = READ | WRITE | OFFSET_ADD | OFFSET_SUB
+    // CHECK-DAG: ([[@LINE+1]]: mut elem): addr_of = UNIQUE, type = READ | WRITE | OFFSET_ADD | OFFSET_SUB
     let mut elem = i;
     loop {
         if x == capacity {
             capacity *= 2;
-            // CHECK-DAG: ([[#@LINE+1]]: i): addr_of = UNIQUE, type = FREE
+            // CHECK-DAG: ([[@LINE+1]]: i): addr_of = UNIQUE, type = FREE
             i = c2rust_test_typed_realloc(i, ::std::mem::size_of::<i32>() as libc::c_ulong);
         }
         *elem = 1;

--- a/c2rust-analyze/tests/filecheck/as_ptr.rs
+++ b/c2rust-analyze/tests/filecheck/as_ptr.rs
@@ -1,33 +1,33 @@
-// CHECK-DAG: ([[#@LINE+1]]: x): &[i32]
+// CHECK-DAG: ([[@LINE+1]]: x): &[i32]
 pub unsafe fn slice_as_ptr_load(x: &[i32]) -> i32 {
-    // CHECK-DAG: ([[#@LINE+1]]: p): &i32
+    // CHECK-DAG: ([[@LINE+1]]: p): &i32
     let p = x.as_ptr();
     *p
 }
 
 // FIXME: currently misinferred as &[[i32; 10]]
-// COM: CHECK-DAG: ([[#@LINE+1]]: x): &[i32]
+// COM: CHECK-DAG: ([[@LINE+1]]: x): &[i32]
 pub unsafe fn slice_as_ptr_offset_load(x: &[i32]) -> i32 {
-    // CHECK-DAG: ([[#@LINE+1]]: p): &[i32]
+    // CHECK-DAG: ([[@LINE+1]]: p): &[i32]
     let p = x.as_ptr();
-    // CHECK-DAG: ([[#@LINE+1]]: q): &i32
+    // CHECK-DAG: ([[@LINE+1]]: q): &i32
     let q = p.offset(2);
     *q
 }
 
-// CHECK-DAG: ([[#@LINE+1]]: x): &[i32; 10]
+// CHECK-DAG: ([[@LINE+1]]: x): &[i32; 10]
 pub unsafe fn array_as_ptr_load(x: &[i32; 10]) -> i32 {
-    // CHECK-DAG: ([[#@LINE+1]]: p): &i32
+    // CHECK-DAG: ([[@LINE+1]]: p): &i32
     let p = x.as_ptr();
     *p
 }
 
 // FIXME: currently misinferred as &[[i32; 10]]
-// COM: CHECK-DAG: ([[#@LINE+1]]: x): &[i32; 10]
+// COM: CHECK-DAG: ([[@LINE+1]]: x): &[i32; 10]
 pub unsafe fn array_as_ptr_offset_load(x: &[i32; 10]) -> i32 {
-    // CHECK-DAG: ([[#@LINE+1]]: p): &[i32]
+    // CHECK-DAG: ([[@LINE+1]]: p): &[i32]
     let p = x.as_ptr();
-    // CHECK-DAG: ([[#@LINE+1]]: q): &i32
+    // CHECK-DAG: ([[@LINE+1]]: q): &i32
     let q = p.offset(2);
     *q
 }

--- a/c2rust-analyze/tests/filecheck/call1.rs
+++ b/c2rust-analyze/tests/filecheck/call1.rs
@@ -6,39 +6,39 @@
 // CHECK: reached fixpoint in 2 iterations
 
 // CHECK-LABEL: final labeling for "call1"
-// CHECK-DAG: ([[#@LINE+1]]: x): &mut i32
+// CHECK-DAG: ([[@LINE+1]]: x): &mut i32
 pub unsafe fn call1(x: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: p): &mut i32
+    // CHECK-DAG: ([[@LINE+1]]: p): &mut i32
     let p = x;
     write(p);
-    // CHECK-DAG: ([[#@LINE+1]]: q): &i32
+    // CHECK-DAG: ([[@LINE+1]]: q): &i32
     let q = x;
     let y = read(q);
 }
 
 pub unsafe fn call2(x: *mut i32) {
-    // CHECK-DAG: ([[#@LINE+1]]: p): &mut i32
+    // CHECK-DAG: ([[@LINE+1]]: p): &mut i32
     let p = x;
     write(p);
-    // CHECK-DAG: ([[#@LINE+1]]: q): &mut i32
+    // CHECK-DAG: ([[@LINE+1]]: q): &mut i32
     let q = x;
     non_unique(q);
 }
 
 // CHECK-LABEL: final labeling for "write"
-// CHECK-DAG: ([[#@LINE+1]]: x): &mut i32
+// CHECK-DAG: ([[@LINE+1]]: x): &mut i32
 unsafe fn write(x: *mut i32) {
     *x = 1;
 }
 
 // CHECK-LABEL: final labeling for "read"
-// CHECK-DAG: ([[#@LINE+1]]: x): &i32
+// CHECK-DAG: ([[@LINE+1]]: x): &i32
 unsafe fn read(x: *mut i32) -> i32 {
     *x
 }
 
 // CHECK-LABEL: final labeling for "non_unique"
-// CHECK-DAG: ([[#@LINE+1]]: x): &std::cell::Cell<i32>
+// CHECK-DAG: ([[@LINE+1]]: x): &std::cell::Cell<i32>
 unsafe fn non_unique(x: *mut i32) {
     let y = x;
     *y = 1;

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -52,16 +52,16 @@ struct VecTup<'a> {
 // CHECK-DAG: assign Label { origin: Some(Origin([[P_REF_A_ORIGIN]]))
 
 // CHECK-LABEL: final labeling for "_field_access"
-// CHECK-DAG: ([[#@LINE+3]]: ppd): addr_of = UNIQUE, type = READ | WRITE | UNIQUE
-// CHECK-DAG: ([[#@LINE+2]]: ra): &mut A
-// CHECK-DAG: ([[#@LINE+1]]: ppd): &mut &mut Data
+// CHECK-DAG: ([[@LINE+3]]: ppd): addr_of = UNIQUE, type = READ | WRITE | UNIQUE
+// CHECK-DAG: ([[@LINE+2]]: ra): &mut A
+// CHECK-DAG: ([[@LINE+1]]: ppd): &mut &mut Data
 unsafe fn _field_access<'d>(ra: &'d mut A<'d>, ppd: *mut *mut Data<'d>) {
-    // CHECK-DAG: ([[#@LINE+2]]: rd): addr_of = UNIQUE, type = READ | UNIQUE
-    // CHECK-DAG: ([[#@LINE+1]]: rd): &Data
+    // CHECK-DAG: ([[@LINE+2]]: rd): addr_of = UNIQUE, type = READ | UNIQUE
+    // CHECK-DAG: ([[@LINE+1]]: rd): &Data
     let rd = (*(**ppd).a.pra).rd;
 
-    // CHECK-DAG: ([[#@LINE+2]]: pi): addr_of = UNIQUE, type = READ | WRITE | UNIQUE
-    // CHECK-DAG: ([[#@LINE+1]]: pi): &mut i32
+    // CHECK-DAG: ([[@LINE+2]]: pi): addr_of = UNIQUE, type = READ | WRITE | UNIQUE
+    // CHECK-DAG: ([[@LINE+1]]: pi): &mut i32
     let pi = rd.pi;
     *pi = 3;
     let _i = *pi;

--- a/c2rust-analyze/tests/filecheck/insertion_sort.rs
+++ b/c2rust-analyze/tests/filecheck/insertion_sort.rs
@@ -6,26 +6,26 @@ extern crate libc;
 
 #[no_mangle]
 // CHECK-LABEL: final labeling for "insertion_sort"
-// CHECK-DAG: ([[#@LINE+1]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
 pub unsafe extern "C" fn insertion_sort(n: libc::c_int, p: *mut libc::c_int) {
     let mut i: libc::c_int = 1 as libc::c_int;
     while i < n {
-        // CHECK-DAG: ([[#@LINE+2]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-        // CHECK-DAG: ([[#@LINE+1]]: p.offset(i as isize)): {{.*}}type = READ | UNIQUE#
+        // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+        // CHECK-DAG: ([[@LINE+1]]: p.offset(i as isize)): {{.*}}type = READ | UNIQUE#
         let tmp: libc::c_int = *p.offset(i as isize);
         let mut j: libc::c_int = i;
-        // CHECK-DAG: ([[#@LINE+2]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-        // CHECK-DAG: ([[#@LINE+1]]: p.offset{{.*}}): {{.*}}type = READ | UNIQUE#
+        // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+        // CHECK-DAG: ([[@LINE+1]]: p.offset{{.*}}): {{.*}}type = READ | UNIQUE#
         while j > 0 as libc::c_int && *p.offset((j - 1 as libc::c_int) as isize) > tmp {
-            // CHECK-DAG: ([[#@LINE+4]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-            // CHECK-DAG: ([[#@LINE+3]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-            // CHECK-DAG: ([[#@LINE+2]]: p.offset((j {{.*}}): {{.*}}type = READ | UNIQUE#
-            // CHECK-DAG: ([[#@LINE+1]]: p.offset(j {{.*}}): {{.*}}type = READ | WRITE | UNIQUE#
+            // CHECK-DAG: ([[@LINE+4]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+            // CHECK-DAG: ([[@LINE+3]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+            // CHECK-DAG: ([[@LINE+2]]: p.offset((j {{.*}}): {{.*}}type = READ | UNIQUE#
+            // CHECK-DAG: ([[@LINE+1]]: p.offset(j {{.*}}): {{.*}}type = READ | WRITE | UNIQUE#
             *p.offset(j as isize) = *p.offset((j - 1 as libc::c_int) as isize);
             j -= 1
         }
-        // CHECK-DAG: ([[#@LINE+2]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-        // CHECK-DAG: ([[#@LINE+1]]: p.offset(j {{.*}}): {{.*}}type = READ | WRITE | UNIQUE#
+        // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+        // CHECK-DAG: ([[@LINE+1]]: p.offset(j {{.*}}): {{.*}}type = READ | WRITE | UNIQUE#
         *p.offset(j as isize) = tmp;
         i += 1
     }

--- a/c2rust-analyze/tests/filecheck/offset1.rs
+++ b/c2rust-analyze/tests/filecheck/offset1.rs
@@ -1,18 +1,18 @@
 use std::ptr;
 
 // CHECK-LABEL: final labeling for "offset1_const"
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
 pub unsafe fn offset1_const(x: *mut i32) -> i32 {
-    // CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[#@LINE+1]]: x.offset(1)): {{.*}}type = READ | UNIQUE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+    // CHECK-DAG: ([[@LINE+1]]: x.offset(1)): {{.*}}type = READ | UNIQUE#
     *x.offset(1)
 }
 
 // CHECK-LABEL: final labeling for "offset1_unknown"
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
 pub unsafe fn offset1_unknown(x: *mut i32, off: isize) -> i32 {
-    // CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[#@LINE+1]]: x.offset(off)): {{.*}}type = READ | UNIQUE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+    // CHECK-DAG: ([[@LINE+1]]: x.offset(off)): {{.*}}type = READ | UNIQUE#
     *x.offset(off)
 }
 
@@ -23,18 +23,18 @@ pub unsafe fn offset1_usize(x: *mut i32, off: usize) -> i32 {
 */
 
 // CHECK-LABEL: final labeling for "offset1_immut"
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
 pub unsafe fn offset1_immut(x: *const i32, off: isize) -> i32 {
-    // CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[#@LINE+1]]: x.offset(off)): {{.*}}type = READ | UNIQUE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+    // CHECK-DAG: ([[@LINE+1]]: x.offset(off)): {{.*}}type = READ | UNIQUE#
     *x.offset(off)
 }
 
 // CHECK-LABEL: final labeling for "offset1_double"
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
 pub unsafe fn offset1_double(x: *mut i32, off: isize) -> i32 {
-    // CHECK-DAG: ([[#@LINE+3]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[#@LINE+2]]: x.offset(off)): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[#@LINE+1]]: x.offset{{.*}}...{{.*}}): {{.*}}type = READ | UNIQUE#
+    // CHECK-DAG: ([[@LINE+3]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+    // CHECK-DAG: ([[@LINE+2]]: x.offset(off)): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+    // CHECK-DAG: ([[@LINE+1]]: x.offset{{.*}}...{{.*}}): {{.*}}type = READ | UNIQUE#
     *x.offset(off).offset(off)
 }

--- a/c2rust-analyze/tests/filecheck/offset2.rs
+++ b/c2rust-analyze/tests/filecheck/offset2.rs
@@ -1,25 +1,25 @@
 use std::ptr;
 
 // CHECK-LABEL: final labeling for "offset2_good"
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
 pub unsafe fn offset2_good(x: *mut i32, off: isize) {
-    // CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[#@LINE+1]]: p): {{.*}}type = UNIQUE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = UNIQUE | OFFSET_ADD | OFFSET_SUB#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE#
     let p = x.offset(off);
-    // CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[#@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
     let q = x.offset(off);
     *q = 1;
 }
 
 // CHECK-LABEL: final labeling for "offset2_bad"
-// CHECK-DAG: ([[#@LINE+1]]: x): {{.*}}type = READ | WRITE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | OFFSET_ADD | OFFSET_SUB#
 pub unsafe fn offset2_bad(x: *mut i32, off: isize) {
-    // CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = READ | WRITE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[#@LINE+1]]: p): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE | OFFSET_ADD | OFFSET_SUB#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE#
     let p = x.offset(off);
-    // CHECK-DAG: ([[#@LINE+2]]: x): {{.*}}type = OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[#@LINE+1]]: q): {{.*}}type = (empty)#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = OFFSET_ADD | OFFSET_SUB#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = (empty)#
     let q = x.offset(off);
     *p = 1;
 }

--- a/c2rust-analyze/tests/filecheck/ptrptr1.rs
+++ b/c2rust-analyze/tests/filecheck/ptrptr1.rs
@@ -1,12 +1,12 @@
 
 // CHECK-LABEL: final labeling for "ptrptr1_backward"
-// CHECK-DAG: ([[#@LINE+4]]: x): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL:[lg][0-9]+]]#*mut i32[NONE#i32[]]]
-// CHECK-DAG: ([[#@LINE+3]]: y): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
-// CHECK-DAG: ([[#@LINE+2]]: x): &mut &mut i32
-// CHECK-DAG: ([[#@LINE+1]]: y): &mut &mut i32
+// CHECK-DAG: ([[@LINE+4]]: x): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL:[lg][0-9]+]]#*mut i32[NONE#i32[]]]
+// CHECK-DAG: ([[@LINE+3]]: y): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
+// CHECK-DAG: ([[@LINE+2]]: x): &mut &mut i32
+// CHECK-DAG: ([[@LINE+1]]: y): &mut &mut i32
 pub unsafe fn ptrptr1_backward(cond: bool, x: *mut *mut i32, y: *mut *mut i32) {
-    // CHECK-DAG: ([[#@LINE+2]]: z): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
-    // CHECK-DAG: ([[#@LINE+1]]: z): &mut &mut i32
+    // CHECK-DAG: ([[@LINE+2]]: z): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
+    // CHECK-DAG: ([[@LINE+1]]: z): &mut &mut i32
     let z = if cond {
         x
     } else {
@@ -16,13 +16,13 @@ pub unsafe fn ptrptr1_backward(cond: bool, x: *mut *mut i32, y: *mut *mut i32) {
 }
 
 // CHECK-LABEL: final labeling for "ptrptr1_bidir"
-// CHECK-DAG: ([[#@LINE+4]]: x): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL:[lg][0-9]+]]#*mut i32[NONE#i32[]]]
-// CHECK-DAG: ([[#@LINE+3]]: y): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
-// CHECK-DAG: ([[#@LINE+2]]: x): &mut &mut i32
-// CHECK-DAG: ([[#@LINE+1]]: y): &&mut i32
+// CHECK-DAG: ([[@LINE+4]]: x): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL:[lg][0-9]+]]#*mut i32[NONE#i32[]]]
+// CHECK-DAG: ([[@LINE+3]]: y): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
+// CHECK-DAG: ([[@LINE+2]]: x): &mut &mut i32
+// CHECK-DAG: ([[@LINE+1]]: y): &&mut i32
 pub unsafe fn ptrptr1_bidir(cond: bool, x: *mut *mut i32, y: *mut *mut i32) {
-    // CHECK-DAG: ([[#@LINE+2]]: z): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
-    // CHECK-DAG: ([[#@LINE+1]]: z): &&mut i32
+    // CHECK-DAG: ([[@LINE+2]]: z): {{.*}}type = {{[lg][0-9]+}}#*mut *mut i32{{\[}}[[LABEL]]#*mut i32[NONE#i32[]]]
+    // CHECK-DAG: ([[@LINE+1]]: z): &&mut i32
     let z = if cond {
         x
     } else {


### PR DESCRIPTION
- Fixes #799.

This removes the `#` from `FileCheck` commands so it works on older LLVMs.

This feature, ("[numeric substitution blocks](https://llvm.org/docs/CommandGuide/FileCheck.html#filecheck-numeric-substitution-blocks)"), used for the `#`, is apparently not present in `FileCheck` from LLVM 7, which is what's used (by default) in Ubuntu 18 and Debian 10.

But I don't think we're actually trying to do anything fancy and numeric with these checks, so perhaps we can just drop the `#`. It looks like this might work based on the difference between [LLVM 7 docs](https://releases.llvm.org/7.0.0/docs/CommandGuide/FileCheck.html#filecheck-expressions) and [current ones](https://llvm.org/docs/CommandGuide/FileCheck.html#filecheck-pseudo-numeric-variables).