### PR TITLE
Use `workspace.package` inheritance for most package fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-analysis-rt"
-version = "0.1.0"
+version = "0.16.0"
 dependencies = [
  "bincode",
  "enum_dispatch",
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-analyze"
-version = "0.1.0"
+version = "0.16.0"
 dependencies = [
  "assert_matches",
  "bitflags",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-asm-casts"
-version = "0.2.0"
+version = "0.16.0"
 
 [[package]]
 name = "c2rust-ast-builder"
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-bitfields"
-version = "0.3.0"
+version = "0.16.0"
 dependencies = [
  "c2rust-bitfields-derive",
  "libc",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-bitfields-derive"
-version = "0.2.1"
+version = "0.16.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -218,14 +218,14 @@ dependencies = [
 
 [[package]]
 name = "c2rust-build-paths"
-version = "0.1.0"
+version = "0.16.0"
 dependencies = [
  "print_bytes",
 ]
 
 [[package]]
 name = "c2rust-instrument"
-version = "0.1.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-pdg"
-version = "0.1.0"
+version = "0.16.0"
 dependencies = [
  "bincode",
  "c2rust-analysis-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,16 @@ exclude = [
     "tests",
 ]
 
+[workspace.package]
+version = "0.16.0"
+authors = ["The C2Rust Project Developers <c2rust@immunant.com>"]
+edition = "2021"
+readme = "README.md"
+homepage = "https://c2rust.com/"
+repository = "https://github.com/immunant/c2rust/"
+license = "BSD-3-Clause"
+keywords = ["transpiler", "migration", "translation", "c"]
+categories = ["development-tools", "development-tools::ffi", "command-line-utilities"]
+
 [profile.dev.package."*"]
 opt-level = 3

--- a/analysis/runtime/Cargo.toml
+++ b/analysis/runtime/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "c2rust-analysis-rt"
-version = "0.1.0"
-authors = ["The C2Rust Development Team <c2rust@immunant.com>",
-           "Stephen Crane <sjc@immunant.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "C2Rust runtime for recording dynamic analysis, targeted by c2rust-instrument and consumed by c2rust-pdg"
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/analysis/tests/lighttpd-minimal/Cargo.toml
+++ b/analysis/tests/lighttpd-minimal/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.1.0" }
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.16.0" }
 
 [features]
 miri = []

--- a/analysis/tests/lighttpd/Cargo.toml
+++ b/analysis/tests/lighttpd/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.1.0" }
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.16.0" }
 
 [features]
 miri = []

--- a/analysis/tests/misc/Cargo.toml
+++ b/analysis/tests/misc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.1.0" }
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.16.0" }
 
 [features]
 miri = []

--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "c2rust-analyze"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "C2Rust analysis implementation for lifting unsafe Rust to safe Rust"
+readme = "README.md"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 polonius-engine = "0.13.0"

--- a/c2rust-asm-casts/Cargo.toml
+++ b/c2rust-asm-casts/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "c2rust-asm-casts"
-version = "0.2.0"
-authors = ["The C2Rust Project Developers <c2rust@immunant.com>"]
-edition = "2021"
-license = "BSD-3-Clause"
-homepage = "https://c2rust.com/"
-repository = "https://github.com/immunant/c2rust/tree/master/c2rust-asm-casts"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "Type cast helpers for use with C2Rust's inline assembly implementation"
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]

--- a/c2rust-ast-builder/Cargo.toml
+++ b/c2rust-ast-builder/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "c2rust-ast-builder"
-version = "0.16.0"
-authors = [
-  "The C2Rust Project Developers <c2rust@immunant.com>",
-  "Eric Mertens <emertens@galois.com>",
-]
-license = "BSD-3-Clause"
-homepage = "https://c2rust.com/"
-repository = "https://github.com/immunant/c2rust"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "Rust AST builder support crate for the C2Rust project"
-edition = "2021"
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 proc-macro2 = { version = "1.0", features = ["span-locations"]}

--- a/c2rust-ast-exporter/Cargo.toml
+++ b/c2rust-ast-exporter/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
 name = "c2rust-ast-exporter"
-version = "0.16.0"
-authors = [
-        "The C2Rust Project Developers <c2rust@immunant.com>",
-        "Eric Mertens <emertens@galois.com>",
-        "Alec Theriault <atheriault@galois.com>",
-]
-links = "clangAstExporter"
-license = "BSD-3-Clause"
-homepage = "https://c2rust.com/"
-repository = "https://github.com/immunant/c2rust"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "Clang AST extraction API for use in the C2Rust project"
-edition = "2021"
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+links = "clangAstExporter"
 
 [dependencies]
 libc = "0.2"

--- a/c2rust-ast-printer/Cargo.toml
+++ b/c2rust-ast-printer/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "c2rust-ast-printer"
-version = "0.16.0"
-authors = ["The Rust Project Developers", "Stephen Crane <sjc@immunant.com>"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/immunant/c2rust"
+version.workspace = true
+authors = ["The C2Rust Project Developers <c2rust@immunant.com>", "The Rust Project Developers"]
+edition.workspace = true
 description = "Customized version of libsyntax rust pretty-printer"
+readme = "README.md"
+homepage.workspace = true
+repository.workspace = true
+license = "MIT OR Apache-2.0"
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 log = "0.4"

--- a/c2rust-bitfields-derive/Cargo.toml
+++ b/c2rust-bitfields-derive/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "c2rust-bitfields-derive"
-version = "0.2.1"
-authors = [
-    "The C2Rust Project Developers <c2rust@immunant.com>",
-    "Daniel Kolsoi <djk@immunant.com>",
-]
-license = "BSD-3-Clause"
-homepage = "https://c2rust.com/"
-repository = "https://github.com/immunant/c2rust/tree/master/c2rust-bitfields-derive"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "C-compatible struct bitfield derive implementation used in the C2Rust project"
 readme = "README.md"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/c2rust-bitfields/Cargo.toml
+++ b/c2rust-bitfields/Cargo.toml
@@ -1,19 +1,18 @@
 [package]
 name = "c2rust-bitfields"
-version = "0.3.0"
-authors = [
-    "The C2Rust Project Developers <c2rust@immunant.com>",
-    "Daniel Kolsoi <djk@immunant.com>",
-]
-license = "BSD-3-Clause"
-homepage = "https://c2rust.com/"
-repository = "https://github.com/immunant/c2rust/tree/master/c2rust-bitfields"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "C-compatible struct bitfield implementation used in the C2Rust project"
 readme = "README.md"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-c2rust-bitfields-derive = { version = "0.2", path = "../c2rust-bitfields-derive" }
+c2rust-bitfields-derive = { version = "0.16.0", path = "../c2rust-bitfields-derive" }
 
 [dev-dependencies]
 libc = "0.2"

--- a/c2rust-build-paths/Cargo.toml
+++ b/c2rust-build-paths/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "c2rust-build-paths"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "C2Rust utilities related to build paths, primarily at build time"
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 print_bytes = "1.1"

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -1,22 +1,21 @@
 [package]
 name = "c2rust-transpile"
-version = "0.16.0"
-authors = [
-  "The C2Rust Project Developers <c2rust@immunant.com>",
-  "Eric Mertens <emertens@galois.com>",
-  "Alec Theriault <atheriault@galois.com>",
-]
-license = "BSD-3-Clause"
-homepage = "https://c2rust.com/"
-repository = "https://github.com/immunant/c2rust"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "C2Rust transpiler implementation"
-edition = "2021"
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 c2rust-ast-builder = { version = "0.16.0", path = "../c2rust-ast-builder" }
 c2rust-ast-exporter = { version = "0.16.0", path = "../c2rust-ast-exporter" }
 c2rust-ast-printer = { version = "0.16.0", path = "../c2rust-ast-printer" }
-c2rust-bitfields = { version = "0.3.0", path = "../c2rust-bitfields" }
+c2rust-bitfields = { version = "0.16.0", path = "../c2rust-bitfields" }
 colored = "2.0"
 dtoa = "1.0"
 failure = "0.1.5"

--- a/c2rust/Cargo.toml
+++ b/c2rust/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "c2rust"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "C to Rust translation, refactoring, and cross-checking"
-version = "0.16.0"
-authors = ["The C2Rust Project Developers <c2rust@immunant.com>"]
-license = "BSD-3-Clause"
-homepage = "https://c2rust.com/"
-repository = "https://github.com/immunant/c2rust"
-edition = "2021"
-categories = ["development-tools", "development-tools::ffi", "command-line-utilities"]
-keywords = ["transpiler", "migration", "translation", "c"]
 readme = "README.md"
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 default-run = "c2rust"
 
 [badges]

--- a/dynamic_instrumentation/Cargo.toml
+++ b/dynamic_instrumentation/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "c2rust-instrument"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "C2Rust instrumentation of Rust code for dynamic analysis"
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 anyhow = "1.0"

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "c2rust-pdg"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 description = "Pointer Derivation Graph used for dynamic analysis by C2Rust"
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 bincode = "1.0"


### PR DESCRIPTION
This uses `workspace.package` inheritance for most package fields to standardize and sync fields.

Most packages repeat a lot of the package fields with minor variations, or omit them entirely (including ones like `license` that are mandatory for publishing).  This uses `cargo`'s [workspace inheritance](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table) to set defaults in the workspace root's `Cargo.toml`, which are then either explicitly inherited in each `Cargo.toml` or overrided.

The defaults used here are:

```toml
version = "0.16.0"
authors = ["The C2Rust Project Developers <c2rust@immunant.com>"]
edition = "2021"
license = "BSD-3-Clause"
homepage = "https://c2rust.com/"
repository = "https://github.com/immunant/c2rust/"
readme = "README.md"
categories = ["development-tools", "development-tools::ffi", "command-line-utilities"]
keywords = ["transpiler", "migration", "translation", "c"]
```

which are taken mostly from `c2rust/Cargo.toml`.  `description` (a required field for publishing) is omitted as that should be unique for each package.

The major benefit of this is that we standardize the fields and have a single source of truth, which is especially useful for something like `version`, which we want to update in sync.

The changes caused by this "standardization" are:
* All versions are changed to `0.16.0`, the current version.
* The `authors` are standardized on `["The C2Rust Project Developers <c2rust@immunant.com>"]`.  Previously, they would sometimes include specific developers, but it was somewhat haphazard and not updated when new people worked on them.  I think it's much simpler to standardize on this general author.
  * The exception is `c2rust-ast-printer/Cargo.toml`, which is forked from `libsyntax` and thus also credits "The Rust Project Developers".
* `homepage`, `repository`, `readme`, `categories`, `keywords` are all set the same for each package, with the exception of `readme`, which is set to `readme = "README.md"` (the local one) if it exists.

Note that `c2rust-macros` and `c2rust-refactor` are not updated at all, as they are no longer part of the workspace.

This greatly simplifies things for the upcoming `0.17` release, as it
* unifies versions for all packages intended to be published
* sets the `license` and `homepage`/`repository` fields for all new packages, which are required to publish them (`description` is also needed, but I don't think that it good to inherit; we should fix that in a separate PR)