### PR TITLE
(`c2rust-analyze`) Rename `Callee::{MiscBuiltin => Trivial}` and expand it to any trivial library function

### DIFF
--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -369,7 +369,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     Some(Callee::SliceAsPtr { .. }) => {
                         // TODO: handle this like a cast
                     }
-                    Some(Callee::MiscBuiltin) => {}
+                    Some(Callee::Trivial) => {}
                     Some(Callee::Other { .. }) => {
                         // TODO
                     }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -292,7 +292,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         self.do_assign_pointer_ids(pl_lty.label, rv_lty.label);
                     }
 
-                    Some(Callee::MiscBuiltin) => {}
+                    Some(Callee::Trivial) => {}
 
                     Some(Callee::Malloc) => {
                         self.visit_place(destination, Mutability::Mut);

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -89,14 +89,17 @@ pub enum Callee<'tcx> {
         mutbl: Mutability,
     },
 
-    /// A [`Trivial`] library function that requires no special handling.
+    /// A [`Trivial`] library function is one that has no effect on pointer permissions in its caller.
+    ///
+    /// Thus, a [`Trivial`] function call requires no special handling.
     ///
     /// A function is [`Trivial`] if it has no argument or return types that are or contain a pointer.
     /// Note that "contains a pointer" is calculated recursively.
     /// There must not be any raw pointer accessible from that type.
     ///
-    /// Int-to-ptr casts a la [`std::ptr::from_exposed_addr`] are not considered for this,
-    /// as doing so is very difficult and out of scope for now.
+    /// We ignore the possibility that a function may perform
+    /// int-to-ptr casts (a la [`std::ptr::from_exposed_addr`]) internally,
+    /// as handling such casts is very difficult and out of scope for now.
     ///
     /// References are allowed, because the existence of that reference in the first place
     /// carries much stronger semantics, so in the case that the reference is casted to a raw pointer,


### PR DESCRIPTION
This renames `Callee::{MiscBuiltin => Trivial}` and expands it to any trivial library function.

The meaning of `MiscBuiltin`/`Trivial` is in that it has no effect on pointer permissions in its caller and thus requires no special handling, i.e. it is trivial. Thus, `Trivial` is a much more appropriate name than `Misc`.

This also expands the definition of `Trivial` to non-builtins, including any "library"/external function that takes or returns no pointers, as they are all trivial.

This is a small change before my fix for #794.