### PR TITLE
c2rust-ast-exporter: update tinycbor

### DIFF
--- a/c2rust-ast-exporter/src/CMakeLists.txt
+++ b/c2rust-ast-exporter/src/CMakeLists.txt
@@ -4,9 +4,9 @@ project(ASTExporter)
 #################################################
 # TinyCBOR                                      #
 #################################################
-set(TINYCBOR_URL "https://github.com/intel/tinycbor/archive/v0.5.3.tar.gz"
+set(TINYCBOR_URL "https://github.com/intel/tinycbor/archive/v0.6.0.tar.gz"
     CACHE STRING "tinycbor download URL")
-set(TINYCBOR_MD5 "2cd3af70d8749a7ddd5a8d04d09ea8f6" CACHE STRING "tinycbor archive md5 sum")
+set(TINYCBOR_MD5 "44eea4241ca98db5a601fa0734d64a0d" CACHE STRING "tinycbor archive md5 sum")
 set(TINYCBOR_PREFIX "${CMAKE_BINARY_DIR}/tinycbor" CACHE STRING "tinycbor install prefix")
 
 include(ExternalProject)


### PR DESCRIPTION
Somehow the md5sum of the tinycbor v0.5.3 `.tar.gz` archive from github has changed (but the decompressed .tar is identical to before, md5sum `206885d49c184edfed363b4f7d3227f3`). We need to fix the CI breakage from the hash changing, but while we're at it, we might as well just update the library to v0.6.0. We updated our Rust deps in prep for release, so this is a good time to go ahead with tinycbor too.