### PR TITLE
Switch `tinycbor` download to use `git` with a stable tag and commit hash vs. the unstable compressed release hash

### DIFF
--- a/c2rust-ast-exporter/src/CMakeLists.txt
+++ b/c2rust-ast-exporter/src/CMakeLists.txt
@@ -4,17 +4,22 @@ project(ASTExporter)
 #################################################
 # TinyCBOR                                      #
 #################################################
-set(TINYCBOR_URL "https://github.com/intel/tinycbor/archive/v0.6.0.tar.gz"
-    CACHE STRING "tinycbor download URL")
-set(TINYCBOR_MD5 "3663e683dbf03f49cb7057ed316a7563" CACHE STRING "tinycbor archive md5 sum")
+
+set(TINYCBOR_REPO "https://github.com/intel/tinycbor.git" CACHE STRING "tinycbor git repo URL")
+
+# v0.6.3 tag, but using the commit hash instead (of the tarball hash) for integrity checks
+# unlike a .tar.gz MD5 hash, this SHA-1 commit hash should stay stable regardless of compression/archiving
+# (GitHub has changed this), and still retains the integrity check
+set(TINYCBOR_TAG "d393c16f3eb30d0c47e6f9d92db62272f0ec4dc7" CACHE STRING "tinycbor git tag/branch/commit hash")
+
 set(TINYCBOR_PREFIX "${CMAKE_BINARY_DIR}/tinycbor" CACHE STRING "tinycbor install prefix")
 
 include(ExternalProject)
 ExternalProject_Add(tinycbor_build
             PREFIX ${TINYCBOR_PREFIX}
             INSTALL_DIR ${CMAKE_BINARY_DIR}
-            URL ${TINYCBOR_URL}
-            URL_HASH MD5=${TINYCBOR_MD5}
+            GIT_REPOSITORY ${TINYCBOR_REPO}
+            GIT_TAG ${TINYCBOR_TAG}
             # the fd redirection here fails when the build run inside Cargo.
             # patch from upstream:
             # https://github.com/intel/tinycbor/commit/6176e0a28d7c5ef3a5e9cbd02521999c412de72c

--- a/scripts/provision_dnf.sh
+++ b/scripts/provision_dnf.sh
@@ -16,6 +16,7 @@ dnf install --quiet --assumeyes \
     clang-devel \
     cmake \
     diffutils \
+    git \
     libquadmath-devel \
     llvm-devel \
     make \

--- a/scripts/provision_yum.sh
+++ b/scripts/provision_yum.sh
@@ -13,7 +13,7 @@ fi
 # required to install ninja-build
 yum install --quiet --assumeyes epel-release
 # NOTE: CentOS version of cmake is too old
-yum install --quiet --assumeyes which ninja-build make cmake libquadmath-devel strace
+yum install --quiet --assumeyes which git ninja-build make cmake libquadmath-devel strace
 
 yum install --quiet --assumeyes luarocks
 


### PR DESCRIPTION
CI keeps breaking due GitHub changing the compression on release tarballs, which results in different checksum hashes, which we use for integrity checks for the `tinycbor` dependency.  This has happened twice in the last day now (first fixed with #808, which just updated the hash).  Since it keeps happening (and who knows how many more times), I think it's better to switch to this approach (which I had implemented a while ago but never merged), which uses `cmake`'s `git` support to clone the `tinycbor` `git` repository at a certain release tag and also provide a commit hash for integrity checks.  This has the benefits of:
- using a source-based (commit) hash rather than a binary-based (`.tar.gz`) hash
    - this is really the main benefit, as it should be completely stable
- using SHA-1 instead of MD5
- being a bit easier to upgrade versions, since we just change the tag and its commit hash

This also requires adding `git` as a dependency in the Docker containers.  It's already a dependency in the `apt`-based ones, so this also adds it for the others.  This is also incidentally useful for local testing, where having `git` is useful.  This needs a Docker push, so I'll do that once this is approved.