### PR TITLE
Prohibit function call macro to const translation

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2235,13 +2235,16 @@ impl<'c> Translation<'c> {
                 // This actually should be catched by `to_unsafe_pure_expr` see below
                 // but a function call expression is translated as having no sideeffects by `convert_expr` (above)
                 // which is not necessarily correct, we just might not know them (e.g only decl in header exists).
-                // So we catch this here until there is a way to express unknown sideeffects of an expression. 
+                // So we catch this here until there is a way to express unknown sideeffects of an expression.
                 let expr = match expr.result_map(|v| {
-                    if matches!(*v, Expr::Call(_)) {Err(())}
-                    else {Ok(v)}
+                    if matches!(*v, Expr::Call(_)) {
+                        Err(())
+                    } else {
+                        Ok(v)
+                    }
                 }) {
                     Ok(v) => v,
-                    Err(_) => return Err(format_err!("Can not expand macro to function call"))
+                    Err(_) => return Err(format_err!("Can not expand macro to function call")),
                 };
 
                 // Join ty and cur_ty to the smaller of the two types. If the

--- a/tests/macros/src/define.c
+++ b/tests/macros/src/define.c
@@ -80,3 +80,17 @@ int test_switch(int x) {
 
   return 0;
 }
+
+// This must not be translated into a const expression in rust
+// even with translate_const_macros
+// The generated code will simply not compile if it still does
+#define TEST_CALL_MACRO (not_pure_fn())
+
+static global = 6;
+int not_pure_fn() {
+    return global;
+}
+
+int test_no_const_fn_call() {
+  return TEST_CALL_MACRO;
+}

--- a/tests/macros/src/test_define.rs
+++ b/tests/macros/src/test_define.rs
@@ -1,6 +1,7 @@
 use crate::define::{rust_fns, rust_stmt_expr_inc};
 use crate::define::{rust_reference_define, TEST_CONST1, TEST_CONST2, TEST_PARENS};
 use crate::define::{rust_test_zstd, ZSTD_WINDOWLOG_MAX_32, ZSTD_WINDOWLOG_MAX_64};
+use crate::define::{rust_test_no_const_fn_call};
 use libc::{c_int, c_uint, c_ulong};
 
 #[link(name = "test")]
@@ -23,4 +24,10 @@ pub fn test_macro_stmt_expr() {
     let ret = unsafe { rust_stmt_expr_inc() };
 
     assert_eq!(ret, 2);
+}
+
+pub fn test_no_const_fn_call() {
+    let ret = unsafe {rust_test_no_const_fn_call()};
+
+    assert_eq!(ret, 6);
 }


### PR DESCRIPTION
closes https://github.com/immunant/c2rust/issues/803

Tackles the issue, that C macros consisting of a function call are translated to rust `const` expressions which do not compile and are not semantically equivalent.  

As described in the code comment there might be a more thorough way to do this but that would, as far as i can tell, at the least require some redesigning of how C2rust handles/represents sideeffects and only would increase performance a bit in a special case, as described in the issue. So for now this here might suffice. 

The fix I wrote here stops C2Rust from producing code that does not compile in this case and achieves the behavior that one would expect: All occurrences of the macro in code are replaced by the function call. 

I also added corresponding test for this situation.