### PR TITLE
Update `rustc` version incrementally to `nightly-2022-12-06`

### DIFF
--- a/analysis/runtime/src/events.rs
+++ b/analysis/runtime/src/events.rs
@@ -89,31 +89,31 @@ impl Debug for EventKind {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         use EventKind::*;
         match *self {
-            CopyPtr(ptr) => write!(f, "copy(0x{:x})", ptr),
-            Field(ptr, id) => write!(f, "field(0x{:x}, {})", ptr, id),
+            CopyPtr(ptr) => write!(f, "copy(0x{ptr:x})"),
+            Field(ptr, id) => write!(f, "field(0x{ptr:x}, {id})"),
             Alloc { size, ptr } => {
-                write!(f, "malloc({}) -> 0x{:x}", size, ptr)
+                write!(f, "malloc({size}) -> 0x{ptr:x}")
             }
-            Free { ptr } => write!(f, "free(0x{:x})", ptr),
+            Free { ptr } => write!(f, "free(0x{ptr:x})"),
             Realloc {
                 old_ptr,
                 size,
                 new_ptr,
-            } => write!(f, "realloc(0x{:x}, {}) -> 0x{:x}", old_ptr, size, new_ptr),
-            Ret(ptr) => write!(f, "ret(0x{:x})", ptr),
+            } => write!(f, "realloc(0x{old_ptr:x}, {size}) -> 0x{new_ptr:x}"),
+            Ret(ptr) => write!(f, "ret(0x{ptr:x})"),
             Done => write!(f, "done"),
             BeginFuncBody => write!(f, "begin func body"),
-            LoadAddr(ptr) => write!(f, "load(0x{:x})", ptr),
-            StoreAddr(ptr) => write!(f, "store(0x{:x})", ptr),
-            StoreAddrTaken(ptr) => write!(f, "store(0x{:x})", ptr),
+            LoadAddr(ptr) => write!(f, "load(0x{ptr:x})"),
+            StoreAddr(ptr) => write!(f, "store(0x{ptr:x})"),
+            StoreAddrTaken(ptr) => write!(f, "store(0x{ptr:x})"),
             CopyRef => write!(f, "copy_ref"),
-            AddrOfLocal(ptr, _) => write!(f, "addr_of_local = 0x{:x}", ptr),
-            ToInt(ptr) => write!(f, "to_int(0x{:x})", ptr),
-            FromInt(ptr) => write!(f, "from_int(0x{:x})", ptr),
-            LoadValue(ptr) => write!(f, "load_value(0x{:x})", ptr),
-            StoreValue(ptr) => write!(f, "store_value(0x{:x})", ptr),
+            AddrOfLocal(ptr, _) => write!(f, "addr_of_local = 0x{ptr:x}"),
+            ToInt(ptr) => write!(f, "to_int(0x{ptr:x})"),
+            FromInt(ptr) => write!(f, "from_int(0x{ptr:x})"),
+            LoadValue(ptr) => write!(f, "load_value(0x{ptr:x})"),
+            StoreValue(ptr) => write!(f, "store_value(0x{ptr:x})"),
             Offset(ptr, offset, new_ptr) => {
-                write!(f, "offset(0x{:x}, {:?}, 0x{:x})", ptr, offset, new_ptr)
+                write!(f, "offset(0x{ptr:x}, {offset:?}, 0x{new_ptr:x})")
             }
         }
     }

--- a/analysis/runtime/src/handlers.rs
+++ b/analysis/runtime/src/handlers.rs
@@ -115,21 +115,21 @@ pub fn ptr_field(mir_loc: MirLocId, ptr: usize, field_id: u32) {
 pub fn ptr_copy(mir_loc: MirLocId, ptr: usize) {
     RUNTIME.send_event(Event {
         mir_loc,
-        kind: EventKind::CopyPtr(ptr as usize),
+        kind: EventKind::CopyPtr(ptr),
     });
 }
 
 pub fn ptr_contrive(mir_loc: MirLocId, ptr: usize) {
     RUNTIME.send_event(Event {
         mir_loc,
-        kind: EventKind::FromInt(ptr as usize),
+        kind: EventKind::FromInt(ptr),
     });
 }
 
 pub fn ptr_to_int(mir_loc: MirLocId, ptr: usize) {
     RUNTIME.send_event(Event {
         mir_loc,
-        kind: EventKind::ToInt(ptr as usize),
+        kind: EventKind::ToInt(ptr),
     });
 }
 

--- a/analysis/runtime/src/mir_loc.rs
+++ b/analysis/runtime/src/mir_loc.rs
@@ -81,7 +81,7 @@ impl Display for MirPlace {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{:?}", self.local)?;
         for p in &self.projection {
-            write!(f, ".{}", p)?;
+            write!(f, ".{p}")?;
         }
         Ok(())
     }
@@ -89,7 +89,7 @@ impl Display for MirPlace {
 
 impl Debug for MirPlace {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/analysis/runtime/src/runtime/backend.rs
+++ b/analysis/runtime/src/runtime/backend.rs
@@ -120,7 +120,7 @@ impl Detect for LogBackend {
             .write(true)
             .append(append)
             .truncate(!append)
-            .open(&path)?;
+            .open(path)?;
         let writer = BufWriter::new(file);
         Ok(Self { writer })
     }

--- a/c2rust-analyze/src/borrowck/def_use.rs
+++ b/c2rust-analyze/src/borrowck/def_use.rs
@@ -157,7 +157,7 @@ impl<'tcx> Visitor<'tcx> for DefUseVisitor<'tcx, '_> {
 
     fn visit_statement(&mut self, stmt: &Statement<'tcx>, location: Location) {
         self.super_statement(stmt, location);
-        eprintln!("visit stmt {:?} at {:?}", stmt, location);
+        eprintln!("visit stmt {stmt:?} at {location:?}");
 
         if let StatementKind::StorageDead(local) = stmt.kind {
             // Observed: `StorageDead` emits `path_moved_at_base` at the `Mid` point.

--- a/c2rust-analyze/src/borrowck/dump.rs
+++ b/c2rust-analyze/src/borrowck/dump.rs
@@ -205,7 +205,7 @@ impl<K: Render + Ord, V: Render> OutputTable for FxHashMap<K, V> {
 
 impl OutputTable for bool {
     fn write(&self, out: &mut dyn Write, _maps: &AtomMaps) -> Result<(), Box<dyn Error>> {
-        writeln!(out, "{}", self)?;
+        writeln!(out, "{self}")?;
         Ok(())
     }
 }
@@ -332,7 +332,7 @@ impl Render for Loan {
 impl Render for Point {
     fn to_string(&self, maps: &AtomMaps) -> String {
         let (bb, idx, sub) = maps.get_point(*self);
-        format!("{:?}({:?}[{}])", sub, bb, idx)
+        format!("{sub:?}({bb:?}[{idx}])")
     }
 }
 

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -216,7 +216,7 @@ fn run_polonius<'tcx>(
     //pretty::write_mir_fn(tcx, mir, &mut |_, _| Ok(()), &mut std::io::stdout()).unwrap();
 
     // Populate `cfg_edge`
-    for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
+    for (bb, bb_data) in mir.basic_blocks.iter_enumerated() {
         eprintln!("{:?}:", bb);
 
         for idx in 0..bb_data.statements.len() {

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -433,7 +433,7 @@ pub fn visit_body<'tcx>(
         adt_metadata,
     };
 
-    for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
+    for (bb, bb_data) in mir.basic_blocks.iter_enumerated() {
         for (idx, stmt) in bb_data.statements.iter().enumerate() {
             tc.current_location = Location {
                 block: bb,

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -155,7 +155,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         for proj in pl.projection {
             lty = util::lty_project(lty, &proj, &mut adt_func);
         }
-        eprintln!("final label for {pl:?}: {:?}", lty);
+        eprintln!("final label for {pl:?}: {lty:?}");
         lty
     }
 
@@ -182,7 +182,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             .push((path, loan, borrow_kind));
         let point = self.current_point(SubPoint::Mid);
         self.facts.loan_issued_at.push((origin, loan, point));
-        eprintln!("issued loan {:?} = {:?} ({:?})", loan, pl, borrow_kind);
+        eprintln!("issued loan {loan:?} = {pl:?} ({borrow_kind:?})");
         origin
     }
 
@@ -289,7 +289,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     // relations between the regions of the array and the regions of its elements
                     self.ltcx.label(ty, &mut |_ty| Label::default())
                 }
-                _ => panic!("unsupported rvalue AggregateKind {:?}", kind),
+                _ => panic!("unsupported rvalue AggregateKind {kind:?}"),
             },
 
             Rvalue::Len(..) => {
@@ -299,12 +299,12 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
             Rvalue::UnaryOp(_, ref op) => self.visit_operand(op),
 
-            ref rv => panic!("unsupported rvalue {:?}", rv),
+            ref rv => panic!("unsupported rvalue {rv:?}"),
         }
     }
 
     fn do_assign(&mut self, pl_lty: LTy<'tcx>, rv_lty: LTy<'tcx>) {
-        eprintln!("assign {:?} = {:?}", pl_lty, rv_lty);
+        eprintln!("assign {pl_lty:?} = {rv_lty:?}");
 
         let mut add_subset_base = |pl: Origin, rv: Origin| {
             let point = self.current_point(SubPoint::Mid);

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -261,10 +261,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
                 let (pointee_lty, proj, ptr) = match desc {
                     RvalueDesc::Project { base, proj } => {
                         let base_lty = self.type_of(base);
-                        eprintln!(
-                            "rvalue = {:?}, desc = {:?}, base_lty = {:?}",
-                            rv, desc, base_lty
-                        );
+                        eprintln!("rvalue = {rv:?}, desc = {desc:?}, base_lty = {base_lty:?}");
                         (
                             self.project(base_lty, &PlaceElem::Deref),
                             proj,
@@ -502,8 +499,7 @@ fn label_no_pointers<'tcx>(acx: &AnalysisCtxt<'_, 'tcx>, ty: Ty<'tcx>) -> LTy<'t
     acx.lcx().label(ty, &mut |inner_ty| {
         assert!(
             !matches!(inner_ty.kind(), TyKind::Ref(..) | TyKind::RawPtr(..)),
-            "unexpected pointer type in {:?}",
-            ty,
+            "unexpected pointer type in {ty:?}",
         );
         PointerId::NONE
     })

--- a/c2rust-analyze/src/dataflow/mod.rs
+++ b/c2rust-analyze/src/dataflow/mod.rs
@@ -40,11 +40,11 @@ impl DataflowConstraints {
         eprintln!("=== propagating ===");
         eprintln!("constraints:");
         for c in &self.constraints {
-            eprintln!("  {:?}", c);
+            eprintln!("  {c:?}");
         }
         eprintln!("hypothesis:");
         for (id, p) in hypothesis.iter() {
-            eprintln!("  {}: {:?}", id, p);
+            eprintln!("  {id}: {p:?}");
         }
 
         struct PropagatePerms;

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -50,7 +50,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     }
 
     fn record_access(&mut self, ptr: PointerId, mutbl: Mutability) {
-        eprintln!("record_access({:?}, {:?})", ptr, mutbl);
+        eprintln!("record_access({ptr:?}, {mutbl:?})");
         if ptr == PointerId::NONE {
             return;
         }
@@ -155,7 +155,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 }
             }
 
-            _ => panic!("TODO: handle assignment of {:?}", rv),
+            _ => panic!("TODO: handle assignment of {rv:?}"),
         }
     }
 
@@ -211,7 +211,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             self.acx.tcx().erase_regions(lty2.ty)
         );
         for (sub_lty1, sub_lty2) in lty1.iter().zip(lty2.iter()) {
-            eprintln!("equate {:?} = {:?}", sub_lty1, sub_lty2);
+            eprintln!("equate {sub_lty1:?} = {sub_lty2:?}");
             if sub_lty1.label != PointerId::NONE || sub_lty2.label != PointerId::NONE {
                 assert!(sub_lty1.label != PointerId::NONE);
                 assert!(sub_lty2.label != PointerId::NONE);
@@ -221,7 +221,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     }
 
     pub fn visit_statement(&mut self, stmt: &Statement<'tcx>, loc: Location) {
-        eprintln!("visit_statement({:?})", stmt);
+        eprintln!("visit_statement({stmt:?})");
         // TODO(spernsteiner): other `StatementKind`s will be handled in the future
         #[allow(clippy::single_match)]
         match stmt.kind {

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -383,7 +383,7 @@ pub fn visit<'tcx>(
         equiv_constraints: Vec::new(),
     };
 
-    for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
+    for (bb, bb_data) in mir.basic_blocks.iter_enumerated() {
         for (i, stmt) in bb_data.statements.iter().enumerate() {
             tc.visit_statement(
                 stmt,

--- a/c2rust-analyze/src/expr_rewrite.rs
+++ b/c2rust-analyze/src/expr_rewrite.rs
@@ -140,7 +140,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             StatementKind::Retag(..) => {}
             StatementKind::AscribeUserType(..) => {}
             StatementKind::Coverage(..) => {}
-            StatementKind::CopyNonOverlapping(..) => todo!("statement {:?}", stmt),
+            StatementKind::Intrinsic(..) => todo!("statement {:?}", stmt),
             StatementKind::Nop => {}
         }
     }

--- a/c2rust-analyze/src/expr_rewrite.rs
+++ b/c2rust-analyze/src/expr_rewrite.rs
@@ -402,7 +402,7 @@ pub fn gen_expr_rewrites<'tcx>(
 
     let mut v = ExprRewriteVisitor::new(acx, asn, &mut out, mir);
 
-    for (bb_id, bb) in mir.basic_blocks().iter_enumerated() {
+    for (bb_id, bb) in mir.basic_blocks.iter_enumerated() {
         for (i, stmt) in bb.statements.iter().enumerate() {
             let loc = Location {
                 block: bb_id,

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -306,7 +306,7 @@ impl<'tcx> Debug for AdtMetadataTable<'tcx> {
                     let params = lty
                         .label
                         .iter()
-                        .map(|p| format!("{:?}", p))
+                        .map(|p| format!("{p:?}"))
                         .into_iter()
                         .chain(args.into_iter())
                         .collect::<Vec<_>>()
@@ -335,7 +335,7 @@ impl<'tcx> Debug for AdtMetadataTable<'tcx> {
                 let lifetime_params_str = adt
                     .lifetime_params
                     .iter()
-                    .map(|p| format!("{:?}", p))
+                    .map(|p| format!("{p:?}"))
                     .collect::<Vec<_>>()
                     .join(",");
                 write!(f, "{lifetime_params_str:}")?;
@@ -387,7 +387,7 @@ fn run(tcx: TyCtxt) {
     let all_fn_ldids = fn_body_owners_postorder(tcx);
     eprintln!("callgraph traversal order:");
     for &ldid in &all_fn_ldids {
-        eprintln!("  {:?}", ldid);
+        eprintln!("  {ldid:?}");
     }
 
     // Assign global `PointerId`s for all pointers that appear in function signatures.
@@ -565,7 +565,7 @@ fn run(tcx: TyCtxt) {
             break;
         }
     }
-    eprintln!("reached fixpoint in {} iterations", loop_count);
+    eprintln!("reached fixpoint in {loop_count} iterations");
 
     // Print results for each function in `all_fn_ldids`, going in declaration order.  Concretely,
     // we iterate over `body_owners()`, which is a superset of `all_fn_ldids`, and filter based on
@@ -586,7 +586,7 @@ fn run(tcx: TyCtxt) {
 
         // Print labeling and rewrites for the current function.
 
-        eprintln!("\nfinal labeling for {:?}:", name);
+        eprintln!("\nfinal labeling for {name:?}:");
         let lcx1 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
         let lcx2 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
         for (local, decl) in mir.local_decls.iter_enumerated() {
@@ -633,7 +633,7 @@ fn run(tcx: TyCtxt) {
             );
         }
 
-        eprintln!("\ntype assignment for {:?}:", name);
+        eprintln!("\ntype assignment for {name:?}:");
         for (local, decl) in mir.local_decls.iter_enumerated() {
             // TODO: apply `Cell` if `addr_of_local` indicates it's needed
             let ty = type_desc::convert_type(&acx, acx.local_tys[local], &asn);
@@ -650,7 +650,7 @@ fn run(tcx: TyCtxt) {
                 rw.loc.sub,
             );
             for kind in &rw.kinds {
-                eprintln!("  {:?}", kind);
+                eprintln!("  {kind:?}");
             }
         }
     }
@@ -721,7 +721,7 @@ fn describe_span(tcx: TyCtxt, span: Span) -> String {
         (&s[..], "", "")
     };
     let line = tcx.sess.source_map().lookup_char_pos(span.lo()).line;
-    format!("{}: {}{}{}", line, src1, src2, src3)
+    format!("{line}: {src1}{src2}{src3}")
 }
 
 /// Return all `LocalDefId`s for all `fn`s that are `body_owners`, ordered according to a postorder
@@ -743,10 +743,7 @@ fn fn_body_owners_postorder(tcx: TyCtxt) -> Vec<LocalDefId> {
         match tcx.def_kind(root_ldid) {
             DefKind::Fn | DefKind::AssocFn => {}
             DefKind::AnonConst | DefKind::Const => continue,
-            dk => panic!(
-                "unexpected def_kind {:?} for body_owner {:?}",
-                dk, root_ldid
-            ),
+            dk => panic!("unexpected def_kind {dk:?} for body_owner {root_ldid:?}"),
         }
 
         stack.push(Visit::Pre(root_ldid));

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -449,7 +449,7 @@ fn run(tcx: TyCtxt) {
             assert_eq!(local, l);
         }
 
-        for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
+        for (bb, bb_data) in mir.basic_blocks.iter_enumerated() {
             for (i, stmt) in bb_data.statements.iter().enumerate() {
                 let rv = match stmt.kind {
                     StatementKind::Assign(ref x) => &x.1,

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -56,7 +56,7 @@ impl fmt::Display for PointerId {
 
 impl fmt::Debug for PointerId {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self)
+        write!(fmt, "{self}")
     }
 }
 

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -73,7 +73,7 @@ fn mk_cell<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Ty<'tcx> {
         .expect("failed to find module `core::cell`");
     let cell_mod = match cell_mod_child.res {
         Res::Def(DefKind::Mod, did) => did,
-        ref r => panic!("unexpected resolution {:?} for `core::cell`", r),
+        ref r => panic!("unexpected resolution {r:?} for `core::cell`"),
     };
 
     let cell_struct_child = tcx
@@ -83,7 +83,7 @@ fn mk_cell<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Ty<'tcx> {
         .expect("failed to find struct `core::cell::Cell`");
     let cell_struct = match cell_struct_child.res {
         Res::Def(DefKind::Struct, did) => did,
-        ref r => panic!("unexpected resolution {:?} for `core::cell::Cell`", r),
+        ref r => panic!("unexpected resolution {r:?} for `core::cell::Cell`"),
     };
 
     let cell_adt = tcx.adt_def(cell_struct);

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -287,5 +287,6 @@ pub fn lty_project<'tcx, L: Debug>(
         }
         ProjectionElem::Subslice { .. } => todo!("type_of Subslice"),
         ProjectionElem::Downcast(..) => todo!("type_of Downcast"),
+        ProjectionElem::OpaqueCast(..) => todo!("type_of OpaqueCast"),
     }
 }

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -278,7 +278,7 @@ pub fn lty_project<'tcx, L: Debug>(
         ProjectionElem::Field(f, _) => match lty.kind() {
             TyKind::Tuple(_) => lty.args[f.index()],
             TyKind::Adt(def, _) => adt_func(lty, *def, f),
-            _ => panic!("Field projection is unsupported on type {:?}", lty),
+            _ => panic!("Field projection is unsupported on type {lty:?}"),
         },
         ProjectionElem::Index(..) | ProjectionElem::ConstantIndex { .. } => {
             assert!(matches!(lty.kind(), TyKind::Array(..) | TyKind::Slice(..)));

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -15,7 +15,7 @@ fn filecheck() {
         .unwrap_or_else(|| {
             let llvm_config = find_llvm_config().expect("llvm-config not found");
             let output = Command::new(llvm_config)
-                .args(&["--bindir"])
+                .args(["--bindir"])
                 .output()
                 .ok()
                 .filter(|output| output.status.success())

--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -225,7 +225,7 @@ impl<'a> Make<Visibility> for &'a str {
                 in_token: None,
                 path: Box::new(mk().path("super")),
             }),
-            _ => panic!("unrecognized string for Visibility: {:?}", self),
+            _ => panic!("unrecognized string for Visibility: {self:?}"),
         }
     }
 }
@@ -257,7 +257,7 @@ impl<'a> Make<Mutability> for &'a str {
         match self {
             "" | "imm" | "immut" | "immutable" => Mutability::Immutable,
             "mut" | "mutable" => Mutability::Mutable,
-            _ => panic!("unrecognized string for Mutability: {:?}", self),
+            _ => panic!("unrecognized string for Mutability: {self:?}"),
         }
     }
 }
@@ -267,7 +267,7 @@ impl<'a> Make<Unsafety> for &'a str {
         match self {
             "" | "safe" | "normal" => Unsafety::Normal,
             "unsafe" => Unsafety::Unsafe,
-            _ => panic!("unrecognized string for Unsafety: {:?}", self),
+            _ => panic!("unrecognized string for Unsafety: {self:?}"),
         }
     }
 }
@@ -277,7 +277,7 @@ impl<'a> Make<Constness> for &'a str {
         match self {
             "" | "normal" | "not-const" => Constness::NotConst,
             "const" => Constness::Const,
-            _ => panic!("unrecognized string for Constness: {:?}", self),
+            _ => panic!("unrecognized string for Constness: {self:?}"),
         }
     }
 }
@@ -288,7 +288,7 @@ impl<'a> Make<UnOp> for &'a str {
             "deref" | "*" => UnOp::Deref(Default::default()),
             "not" | "!" => UnOp::Not(Default::default()),
             "neg" | "-" => UnOp::Neg(Default::default()),
-            _ => panic!("unrecognized string for UnOp: {:?}", self),
+            _ => panic!("unrecognized string for UnOp: {self:?}"),
         }
     }
 }
@@ -777,10 +777,7 @@ impl Builder {
             match a {
                 GenericArgument::Type(t) => GenericMethodArgument::Type(t),
                 GenericArgument::Const(c) => GenericMethodArgument::Const(c),
-                _ => panic!(
-                    "non-type-or-const generic argument found in method arguments: {:?}",
-                    a
-                ),
+                _ => panic!("non-type-or-const generic argument found in method arguments: {a:?}"),
             }
         }
         let turbofish = match seg.arguments {
@@ -1101,15 +1098,15 @@ impl Builder {
     // Literals
 
     pub fn int_lit(self, i: u128, ty: &str) -> Lit {
-        Lit::Int(LitInt::new(&format!("{}{}", i, ty), self.span))
+        Lit::Int(LitInt::new(&format!("{i}{ty}"), self.span))
     }
 
     pub fn int_unsuffixed_lit(self, i: u128) -> Lit {
-        Lit::Int(LitInt::new(&format!("{}", i), self.span))
+        Lit::Int(LitInt::new(&format!("{i}"), self.span))
     }
 
     pub fn float_lit(self, s: &str, ty: &str) -> Lit {
-        Lit::Float(LitFloat::new(&format!("{}{}", s, ty), self.span))
+        Lit::Float(LitFloat::new(&format!("{s}{ty}"), self.span))
     }
 
     pub fn float_unsuffixed_lit(self, s: &str) -> Lit {

--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -253,7 +253,7 @@ impl LLVMInfo {
         let lib_dir = {
             let path_str = env::var("LLVM_LIB_DIR")
                 .ok()
-                .or_else(|| invoke_command(llvm_config.as_deref(), &["--libdir"]))
+                .or_else(|| invoke_command(llvm_config.as_deref(), ["--libdir"]))
                 .expect(llvm_config_missing);
             String::from(
                 Path::new(&path_str)
@@ -263,7 +263,7 @@ impl LLVMInfo {
             )
         };
 
-        let llvm_shared_libs = invoke_command(llvm_config.as_deref(), &["--libs", "--link-shared"]);
+        let llvm_shared_libs = invoke_command(llvm_config.as_deref(), ["--libs", "--link-shared"]);
 
         // <sysroot>/lib/rustlib/<target>/lib/ contains a libLLVM DSO for the
         // rust compiler. On MacOS, this lib is named libLLVM.dylib, which will
@@ -288,7 +288,7 @@ impl LLVMInfo {
                 dylib_file.push_str(dylib_suffix);
                 let sysroot = invoke_command(
                     env::var_os("RUSTC").map(PathBuf::from).as_deref(),
-                    &["--print=sysroot"],
+                    ["--print=sysroot"],
                 )
                 .unwrap();
 
@@ -323,7 +323,7 @@ impl LLVMInfo {
 
         let llvm_major_version = {
             let version =
-                invoke_command(llvm_config.as_deref(), &["--version"]).expect(llvm_config_missing);
+                invoke_command(llvm_config.as_deref(), ["--version"]).expect(llvm_config_missing);
             let emsg = format!("invalid version string {}", version);
             version
                 .split('.')
@@ -362,7 +362,7 @@ impl LLVMInfo {
         libs.extend(
             env::var("LLVM_SYSTEM_LIBS")
                 .ok()
-                .or_else(|| invoke_command(llvm_config.as_deref(), &["--system-libs", link_mode]))
+                .or_else(|| invoke_command(llvm_config.as_deref(), ["--system-libs", link_mode]))
                 .unwrap_or_default()
                 .split_whitespace()
                 .map(|lib| String::from(lib.trim_start_matches("-l"))),

--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -83,7 +83,7 @@ fn generate_bindings() -> Result<(), &'static str> {
         .clang_arg("-xc++")
         // Finish the builder and generate the bindings.
         .generate()
-        .or(Err("Unable to generate AST bindings"))?;
+        .map_err(|_| "Unable to generate AST bindings")?;
 
     let cppbindings = bindgen::Builder::default()
         .header("src/ExportResult.hpp")
@@ -95,7 +95,7 @@ fn generate_bindings() -> Result<(), &'static str> {
         .clang_arg("-std=c++11")
         // Finish the builder and generate the bindings.
         .generate()
-        .or(Err("Unable to generate ExportResult bindings"))?;
+        .map_err(|_| "Unable to generate ExportResult bindings")?;
 
     // Write the bindings to the $OUT_DIR/bindings.rs file.
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/c2rust-ast-exporter/src/lib.rs
+++ b/c2rust-ast-exporter/src/lib.rs
@@ -39,7 +39,7 @@ pub fn get_untyped_ast(
 
     match clang_ast::process(items) {
         Ok(cxt) => Ok(cxt),
-        Err(e) => Err(Error::new(ErrorKind::InvalidData, format!("{:}", e))),
+        Err(e) => Err(Error::new(ErrorKind::InvalidData, format!("{e:}"))),
     }
 }
 
@@ -112,7 +112,7 @@ unsafe fn marshal_result(result: *const ffi::ExportResult) -> HashMap<String, Ve
         // Convert CBOR bytes
         let csize = *res.sizes.offset(i);
         let cbytes = *res.bytes.offset(i);
-        let bytes = slice::from_raw_parts(cbytes, csize as usize);
+        let bytes = slice::from_raw_parts(cbytes, csize);
         let mut v = Vec::new();
         v.extend_from_slice(bytes);
 

--- a/c2rust-bitfields-derive/src/lib.rs
+++ b/c2rust-bitfields-derive/src/lib.rs
@@ -86,7 +86,7 @@ fn parse_bitfield_attr(
             missing_fields.push("bits");
         }
 
-        let err_str = format!("Missing bitfield params: {:?}", missing_fields);
+        let err_str = format!("Missing bitfield params: {missing_fields:?}");
         let span = attr.path.segments.span();
 
         return Err(Error::new(span, err_str));
@@ -198,7 +198,7 @@ fn bitfield_struct_impl(struct_item: ItemStruct) -> Result<TokenStream, Error> {
         .iter()
         .map(|field_ident| {
             let span = Span::call_site().into();
-            let setter_name = &format!("set_{}", field_ident);
+            let setter_name = &format!("set_{field_ident}");
 
             Ident::new(setter_name, span)
         })

--- a/c2rust-build-paths/src/lib.rs
+++ b/c2rust-build-paths/src/lib.rs
@@ -21,7 +21,7 @@ impl SysRoot {
     pub fn resolve() -> Self {
         let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
         let output = Command::new(rustc)
-            .args(&["--print", "sysroot"])
+            .args(["--print", "sysroot"])
             .output()
             .expect("could not invoke `rustc` to find rust sysroot");
         // trim, but `str::trim` doesn't exist on `[u8]`

--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -318,11 +318,11 @@ fn maybe_write_to_file(output_path: &Path, output: String, overwrite: bool) -> O
 
     let mut file = match File::create(output_path) {
         Ok(file) => file,
-        Err(e) => panic!("Unable to open file for writing: {}", e),
+        Err(e) => panic!("Unable to open file for writing: {e}"),
     };
     match file.write_all(output.as_bytes()) {
         Ok(()) => (),
-        Err(e) => panic!("Unable to write translation to file: {}", e),
+        Err(e) => panic!("Unable to write translation to file: {e}"),
     };
 
     Some(PathBuf::from(output_path))

--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -67,10 +67,10 @@ pub struct CrateConfig<'lcmd> {
 /// Emit `Cargo.toml` and `lib.rs` for a library or `main.rs` for a binary.
 /// Returns the path to `lib.rs` or `main.rs` (or `None` if the output file
 /// existed already).
-pub fn emit_build_files<'lcmd>(
+pub fn emit_build_files(
     tcfg: &TranspilerConfig,
     build_dir: &Path,
-    crate_cfg: Option<CrateConfig<'lcmd>>,
+    crate_cfg: Option<CrateConfig>,
     workspace_members: Option<Vec<String>>,
 ) -> Option<PathBuf> {
     let mut reg = Handlebars::new();
@@ -264,11 +264,11 @@ fn emit_rust_toolchain(tcfg: &TranspilerConfig, build_dir: &Path) {
     maybe_write_to_file(&output_path, output, tcfg.overwrite_existing);
 }
 
-fn emit_cargo_toml<'lcmd>(
+fn emit_cargo_toml(
     tcfg: &TranspilerConfig,
     reg: &Handlebars,
     build_dir: &Path,
-    crate_cfg: &Option<CrateConfig<'lcmd>>,
+    crate_cfg: &Option<CrateConfig>,
     workspace_members: Option<Vec<String>>,
 ) {
     // rust_checks_path is gone because we don't want to refer to the source

--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -83,7 +83,7 @@ pub fn emit_build_files<'lcmd>(
         .unwrap();
 
     if !build_dir.exists() {
-        fs::create_dir_all(&build_dir)
+        fs::create_dir_all(build_dir)
             .unwrap_or_else(|_| panic!("couldn't create build directory: {}", build_dir.display()));
     }
 
@@ -316,7 +316,7 @@ fn maybe_write_to_file(output_path: &Path, output: String, overwrite: bool) -> O
         return None;
     }
 
-    let mut file = match File::create(&output_path) {
+    let mut file = match File::create(output_path) {
         Ok(file) => file,
         Err(e) => panic!("Unable to open file for writing: {}", e),
     };

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -89,8 +89,7 @@ impl IdMapper {
                 let inserted = self.old_to_new.insert(old_id, new_id).is_some();
                 assert!(
                     !inserted,
-                    "get_or_create_new: overwrote an old id at {}",
-                    old_id
+                    "get_or_create_new: overwrote an old id at {old_id}"
                 );
                 new_id
             }
@@ -109,8 +108,7 @@ impl IdMapper {
             let inserted = self.old_to_new.insert(other_old_id, new_id).is_some();
             assert!(
                 !inserted,
-                "get_or_create_new: overwrote an old id at {}",
-                other_old_id
+                "get_or_create_new: overwrote an old id at {other_old_id}"
             );
             new_id
         })
@@ -162,7 +160,7 @@ fn parse_cast_kind(kind: &str) -> CastKind {
         "BuiltinFnToFnPtr" => CastKind::BuiltinFnToFnPtr,
         "ConstCast" => CastKind::ConstCast,
         "VectorSplat" => CastKind::VectorSplat,
-        k => panic!("Unsupported implicit cast: {}", k),
+        k => panic!("Unsupported implicit cast: {k}"),
     }
 }
 
@@ -263,7 +261,7 @@ impl ConversionContext {
                     "{}",
                     TranslationError::new(
                         None,
-                        err_msg(format!("Missing top-level node with id: {}", top_node)).context(
+                        err_msg(format!("Missing top-level node with id: {top_node}")).context(
                             TranslationErrorKind::InvalidClangAst(
                                 ClangAstParseErrorKind::MissingNode,
                             )
@@ -282,10 +280,11 @@ impl ConversionContext {
                         "{}",
                         TranslationError::new(
                             display_loc(untyped_context, &Some(node.loc)),
-                            err_msg(format!("Missing child {} of node {:?}", child, node,))
-                                .context(TranslationErrorKind::InvalidClangAst(
+                            err_msg(format!("Missing child {child} of node {node:?}",)).context(
+                                TranslationErrorKind::InvalidClangAst(
                                     ClangAstParseErrorKind::MissingChild,
-                                )),
+                                )
+                            ),
                         ),
                     );
                     invalid_clang_ast = true;
@@ -300,10 +299,11 @@ impl ConversionContext {
                         "{}",
                         TranslationError::new(
                             display_loc(untyped_context, &Some(node.loc)),
-                            err_msg(format!("Missing type {} for node: {:?}", type_id, node,))
-                                .context(TranslationErrorKind::InvalidClangAst(
+                            err_msg(format!("Missing type {type_id} for node: {node:?}",)).context(
+                                TranslationErrorKind::InvalidClangAst(
                                     ClangAstParseErrorKind::MissingType,
-                                )),
+                                )
+                            ),
                         ),
                     );
                     invalid_clang_ast = true;
@@ -752,7 +752,7 @@ impl ConversionContext {
                         Some("noreturn") => Some(Attribute::NoReturn),
                         Some("nullable") => Some(Attribute::Nullable),
                         Some("notnull") => Some(Attribute::NotNull),
-                        Some(other) => panic!("Unknown type attribute: {}", other),
+                        Some(other) => panic!("Unknown type attribute: {other}"),
                     };
 
                     let ty = CTypeKind::Attributed(ty, kind);
@@ -815,10 +815,7 @@ impl ConversionContext {
                     self.processed_nodes.insert(new_id, OTHER_TYPE);
                 }
 
-                t => panic!(
-                    "Type conversion not implemented for {:?} expecting {:?}",
-                    t, expected_ty
-                ),
+                t => panic!("Type conversion not implemented for {t:?} expecting {expected_ty:?}"),
             }
         } else {
             // Convert the node
@@ -945,7 +942,7 @@ impl ConversionContext {
                         Some("fallthrough") | Some("__fallthrough__") => {
                             attributes.push(Attribute::Fallthrough)
                         }
-                        Some(str) => panic!("Unknown statement attribute: {}", str),
+                        Some(str) => panic!("Unknown statement attribute: {str}"),
                         None => panic!("Invalid statement attribute"),
                     };
 
@@ -1017,8 +1014,7 @@ impl ConversionContext {
                         .insert(CStmtId(new_id), label_name.clone())
                     {
                         panic!(
-                            "Duplicate label name with id {}. Old name: {}. New name: {}",
-                            new_id, old_label_name, label_name,
+                            "Duplicate label name with id {new_id}. Old name: {old_label_name}. New name: {label_name}",
                         );
                     }
 
@@ -1178,7 +1174,7 @@ impl ConversionContext {
                         8 => IntBase::Oct,
                         10 => IntBase::Dec,
                         16 => IntBase::Hex,
-                        _ => panic!("Invalid base: {}", base),
+                        _ => panic!("Invalid base: {base}"),
                     };
 
                     let ty_old = node.type_id.expect("Expected expression to have type");
@@ -1258,7 +1254,7 @@ impl ConversionContext {
                         "__imag" => UnOp::Imag,
                         "__extension__" => UnOp::Extension,
                         "co_await" => UnOp::Coawait,
-                        o => panic!("Unexpected operator: {}", o),
+                        o => panic!("Unexpected operator: {o}"),
                     };
 
                     let operand_old = node.children[0].expect("Expected operand");
@@ -1500,7 +1496,7 @@ impl ConversionContext {
                         "sizeof" => UnTypeOp::SizeOf,
                         "alignof" => UnTypeOp::AlignOf,
                         "preferredalignof" => UnTypeOp::PreferredAlignOf,
-                        str => panic!("Unsupported operation: {}", str),
+                        str => panic!("Unsupported operation: {str}"),
                     };
 
                     let arg_ty = from_value(node.extras[1].clone()).expect("expected type id");
@@ -1601,7 +1597,7 @@ impl ConversionContext {
                                     from_value(entry[1].clone()).expect("expected array start"),
                                     from_value(entry[2].clone()).expect("expected array end"),
                                 ),
-                                n => panic!("invalid designator tag: {}", n),
+                                n => panic!("invalid designator tag: {n}"),
                             }
                         })
                         .collect();
@@ -1921,8 +1917,7 @@ impl ConversionContext {
 
                     assert!(
                         has_static_duration || has_thread_duration || !is_externally_visible,
-                        "Variable cannot be extern without also being static or thread-local: {}",
-                        ident
+                        "Variable cannot be extern without also being static or thread-local: {ident}"
                     );
 
                     let initializer = node
@@ -2140,7 +2135,7 @@ impl ConversionContext {
                     self.add_decl(new_id, located(node, static_assert));
                 }
 
-                t => panic!("Could not translate node {:?} as type {}", t, expected_ty),
+                t => panic!("Could not translate node {t:?} as type {expected_ty}"),
             }
         }
     }

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -834,7 +834,7 @@ impl Index<CTypeId> for TypedAstContext {
 
     fn index(&self, index: CTypeId) -> &CType {
         match self.c_types.get(&index) {
-            None => panic!("Could not find {:?} in TypedAstContext", index),
+            None => panic!("Could not find {index:?} in TypedAstContext"),
             Some(ty) => ty,
         }
     }
@@ -866,7 +866,7 @@ impl Index<CDeclId> for TypedAstContext {
 
     fn index(&self, index: CDeclId) -> &CDecl {
         match self.c_decls.get(&index) {
-            None => panic!("Could not find {:?} in TypedAstContext", index),
+            None => panic!("Could not find {index:?} in TypedAstContext"),
             Some(ty) => ty,
         }
     }
@@ -877,7 +877,7 @@ impl Index<CStmtId> for TypedAstContext {
 
     fn index(&self, index: CStmtId) -> &CStmt {
         match self.c_stmts.get(&index) {
-            None => panic!("Could not find {:?} in TypedAstContext", index),
+            None => panic!("Could not find {index:?} in TypedAstContext"),
             Some(ty) => ty,
         }
     }

--- a/c2rust-transpile/src/cfg/loops.rs
+++ b/c2rust-transpile/src/cfg/loops.rs
@@ -133,7 +133,7 @@ impl LoopId {
     /// this to be usable as a loop label.
     pub fn pretty_print(&self) -> String {
         let &LoopId(loop_id) = self;
-        format!("l_{}", loop_id)
+        format!("l_{loop_id}")
     }
 }
 
@@ -243,7 +243,7 @@ impl<Lbl: Hash + Eq + Clone> LoopInfo<Lbl> {
         &self
             .loops
             .get(&id)
-            .unwrap_or_else(|| panic!("There is no loop with id {:?}", id))
+            .unwrap_or_else(|| panic!("There is no loop with id {id:?}"))
             .0
     }
 }

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -73,8 +73,8 @@ impl Label {
     pub fn pretty_print(&self) -> String {
         match self {
             Label::FromC(_, Some(s)) => format!("_{}", s.as_ref()),
-            Label::FromC(CStmtId(label_id), None) => format!("c_{}", label_id),
-            Label::Synthetic(syn_id) => format!("s_{}", syn_id),
+            Label::FromC(CStmtId(label_id), None) => format!("c_{label_id}"),
+            Label::Synthetic(syn_id) => format!("s_{syn_id}"),
         }
     }
 
@@ -343,7 +343,7 @@ impl<L: Serialize> Serialize for GenTerminator<L> {
                 ref cases,
             } => {
                 let mut cases_sane: Vec<(String, &L)> = vec![];
-                for &(ref p, ref l) in cases {
+                for (p, l) in cases {
                     let pat: String = pprust::pat_to_string(p);
                     cases_sane.push((pat, l));
                 }
@@ -1087,9 +1087,8 @@ impl DeclStmtStore {
 
     /// Extract the Rust statements for the full declaration and initializers. DEBUGGING ONLY.
     pub fn peek_decl_and_assign(&self, decl_id: CDeclId) -> TranslationResult<Vec<Stmt>> {
-        let &DeclStmtInfo {
-            ref decl_and_assign,
-            ..
+        let DeclStmtInfo {
+            decl_and_assign, ..
         } = self
             .store
             .get(&decl_id)
@@ -1172,7 +1171,7 @@ impl CfgBuilder {
             .insert(lbl.clone(), bb)
         {
             None => {}
-            Some(_) => panic!("Label {:?} cannot identify two basic blocks", lbl),
+            Some(_) => panic!("Label {lbl:?} cannot identify two basic blocks"),
         }
 
         if let Some((_, loop_vec)) = self.loops.last_mut() {
@@ -1209,7 +1208,7 @@ impl CfgBuilder {
     /// know the terminators of a block by visiting it.
     fn update_terminator(&mut self, lbl: Label, new_term: GenTerminator<Label>) {
         match self.last_per_stmt_mut().nodes.get_mut(&lbl) {
-            None => panic!("Cannot find label {:?} to update", lbl),
+            None => panic!("Cannot find label {lbl:?} to update"),
             Some(bb) => bb.terminator = new_term,
         }
     }
@@ -2057,7 +2056,7 @@ impl CfgBuilder {
 
         // Run relooper
         let mut stmts = translator.convert_cfg(
-            &format!("<substmt_{:?}>", stmt_id),
+            &format!("<substmt_{stmt_id:?}>"),
             graph,
             store,
             live_in,

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -568,10 +568,7 @@ impl Cfg<Label, StmtOrDecl> {
                 _ => None,
             })
         {
-            c_label_to_goto
-                .entry(target)
-                .or_insert(IndexSet::new())
-                .insert(x);
+            c_label_to_goto.entry(target).or_default().insert(x);
         }
 
         let mut cfg_builder = CfgBuilder::new(c_label_to_goto);
@@ -1723,7 +1720,7 @@ impl CfgBuilder {
                 self.last_per_stmt_mut()
                     .c_labels_used
                     .entry(label_id)
-                    .or_insert(IndexSet::new())
+                    .or_default()
                     .insert(stmt_id);
 
                 Ok(None)

--- a/c2rust-transpile/src/cfg/multiples.rs
+++ b/c2rust-transpile/src/cfg/multiples.rs
@@ -94,7 +94,7 @@ impl<Lbl: Hash + Ord + Clone> MultipleInfo<Lbl> {
         self.multiples = self
             .multiples
             .iter()
-            .filter_map(|(entries, &(ref join_lbl, ref arms))| {
+            .filter_map(|(entries, (join_lbl, arms))| {
                 let entries: BTreeSet<Lbl> = entries
                     .iter()
                     .map(|lbl| rewrites.get(lbl).unwrap_or(lbl).clone())
@@ -122,7 +122,7 @@ impl<Lbl: Hash + Ord + Clone> MultipleInfo<Lbl> {
 
     /// Add in information about a new multiple
     pub fn add_multiple(&mut self, join: Lbl, arms: Vec<(Lbl, IndexSet<Lbl>)>) {
-        let entry_set: BTreeSet<Lbl> = arms.iter().map(|&(ref l, _)| l.clone()).collect();
+        let entry_set: BTreeSet<Lbl> = arms.iter().map(|(l, _)| l.clone()).collect();
         let arm_map: IndexMap<Lbl, IndexSet<Lbl>> = arms.into_iter().collect();
 
         if arm_map.len() > 1 {

--- a/c2rust-transpile/src/cfg/relooper.rs
+++ b/c2rust-transpile/src/cfg/relooper.rs
@@ -154,10 +154,7 @@ impl RelooperState {
             let mut flipped_map: IndexMap<Label, IndexSet<Label>> = IndexMap::new();
             for (lbl, vals) in map {
                 for val in vals {
-                    flipped_map
-                        .entry(val)
-                        .or_insert(IndexSet::new())
-                        .insert(lbl.clone());
+                    flipped_map.entry(val).or_default().insert(lbl.clone());
                 }
             }
             flipped_map
@@ -289,7 +286,7 @@ impl RelooperState {
 
             let mut closure: IndexMap<V, IndexSet<V>> = IndexMap::new();
             for (f, t) in edges {
-                closure.entry(f).or_insert(IndexSet::new()).insert(t);
+                closure.entry(f).or_default().insert(t);
             }
 
             closure
@@ -433,7 +430,7 @@ impl RelooperState {
         for entry in &entries {
             reachable_from
                 .entry(entry.clone())
-                .or_insert(IndexSet::new())
+                .or_default()
                 .insert(entry.clone());
         }
 
@@ -577,10 +574,7 @@ fn simplify_structure<Stmt: Clone>(structures: Vec<Structure<Stmt>>) -> Vec<Stru
                             StructureLabel::ExitTo(lbl) => (lbl, &mut merged_exit),
                             _ => panic!("simplify_structure: Nested precondition violated"),
                         };
-                        merged
-                            .entry(lbl.clone())
-                            .or_insert(Default::default())
-                            .push(pat.clone());
+                        merged.entry(lbl.clone()).or_default().push(pat.clone());
                     }
 
                     // When converting these patterns back into a vector, we have to be careful to

--- a/c2rust-transpile/src/cfg/relooper.rs
+++ b/c2rust-transpile/src/cfg/relooper.rs
@@ -355,7 +355,7 @@ impl RelooperState {
             // Partition blocks into those belonging in or after the loop
             let (mut body_blocks, mut follow_blocks): (StructuredBlocks, StructuredBlocks) = blocks
                 .into_iter()
-                .partition(|&(ref lbl, _)| new_returns.contains(lbl) || entries.contains(lbl));
+                .partition(|(lbl, _)| new_returns.contains(lbl) || entries.contains(lbl));
             let mut follow_entries = out_edges(&body_blocks);
 
             // Try to match an existing loop (from the initial C)
@@ -439,7 +439,7 @@ impl RelooperState {
             reachable_from
                 .into_iter()
                 .map(|(lbl, reachable)| (lbl, &reachable & &entries.clone()))
-                .filter(|&(_, ref reachable)| reachable.len() == 1)
+                .filter(|(_, reachable)| reachable.len() == 1)
                 .collect(),
         );
 
@@ -558,66 +558,63 @@ fn simplify_structure<Stmt: Clone>(structures: Vec<Structure<Stmt>>) -> Vec<Stru
             } => {
                 // Here, we ensure that all labels in a terminator are mentioned only once in the
                 // terminator.
-                let terminator: GenTerminator<StructureLabel<Stmt>> = if let &Switch {
-                    ref expr,
-                    ref cases,
-                } = terminator
-                {
-                    // Here, we group patterns by the label they go to.
-                    type Merged = IndexMap<Label, Vec<Pat>>;
-                    let mut merged_goto: Merged = IndexMap::new();
-                    let mut merged_exit: Merged = IndexMap::new();
+                let terminator: GenTerminator<StructureLabel<Stmt>> =
+                    if let Switch { expr, cases } = terminator {
+                        // Here, we group patterns by the label they go to.
+                        type Merged = IndexMap<Label, Vec<Pat>>;
+                        let mut merged_goto: Merged = IndexMap::new();
+                        let mut merged_exit: Merged = IndexMap::new();
 
-                    for (pat, lbl) in cases {
-                        let (lbl, merged) = match lbl {
-                            StructureLabel::GoTo(lbl) => (lbl, &mut merged_goto),
-                            StructureLabel::ExitTo(lbl) => (lbl, &mut merged_exit),
-                            _ => panic!("simplify_structure: Nested precondition violated"),
-                        };
-                        merged.entry(lbl.clone()).or_default().push(pat.clone());
-                    }
+                        for (pat, lbl) in cases {
+                            let (lbl, merged) = match lbl {
+                                StructureLabel::GoTo(lbl) => (lbl, &mut merged_goto),
+                                StructureLabel::ExitTo(lbl) => (lbl, &mut merged_exit),
+                                _ => panic!("simplify_structure: Nested precondition violated"),
+                            };
+                            merged.entry(lbl.clone()).or_default().push(pat.clone());
+                        }
 
-                    // When converting these patterns back into a vector, we have to be careful to
-                    // preserve their initial order (so that the default pattern doesn't end up on
-                    // top).
-                    let mut cases_new = Vec::new();
-                    for (_, lbl) in cases.iter().rev() {
-                        use StructureLabel::*;
-                        match lbl {
-                            GoTo(lbl) => match merged_goto.swap_remove(lbl) {
-                                None => {}
-                                Some(mut pats) => {
-                                    let pat = if pats.len() == 1 {
-                                        pats.pop().unwrap()
-                                    } else {
-                                        mk().or_pat(pats)
-                                    };
-                                    cases_new.push((pat, GoTo(lbl.clone())))
-                                }
-                            },
-                            ExitTo(lbl) => match merged_exit.swap_remove(lbl) {
-                                None => {}
-                                Some(mut pats) => {
-                                    let pat = if pats.len() == 1 {
-                                        pats.pop().unwrap()
-                                    } else {
-                                        mk().or_pat(pats)
-                                    };
-                                    cases_new.push((pat, ExitTo(lbl.clone())))
-                                }
-                            },
-                            _ => panic!("simplify_structure: Nested precondition violated"),
-                        };
-                    }
-                    cases_new.reverse();
+                        // When converting these patterns back into a vector, we have to be careful to
+                        // preserve their initial order (so that the default pattern doesn't end up on
+                        // top).
+                        let mut cases_new = Vec::new();
+                        for (_, lbl) in cases.iter().rev() {
+                            use StructureLabel::*;
+                            match lbl {
+                                GoTo(lbl) => match merged_goto.swap_remove(lbl) {
+                                    None => {}
+                                    Some(mut pats) => {
+                                        let pat = if pats.len() == 1 {
+                                            pats.pop().unwrap()
+                                        } else {
+                                            mk().or_pat(pats)
+                                        };
+                                        cases_new.push((pat, GoTo(lbl.clone())))
+                                    }
+                                },
+                                ExitTo(lbl) => match merged_exit.swap_remove(lbl) {
+                                    None => {}
+                                    Some(mut pats) => {
+                                        let pat = if pats.len() == 1 {
+                                            pats.pop().unwrap()
+                                        } else {
+                                            mk().or_pat(pats)
+                                        };
+                                        cases_new.push((pat, ExitTo(lbl.clone())))
+                                    }
+                                },
+                                _ => panic!("simplify_structure: Nested precondition violated"),
+                            };
+                        }
+                        cases_new.reverse();
 
-                    Switch {
-                        expr: expr.clone(),
-                        cases: cases_new,
-                    }
-                } else {
-                    terminator.clone()
-                };
+                        Switch {
+                            expr: expr.clone(),
+                            cases: cases_new,
+                        }
+                    } else {
+                        terminator.clone()
+                    };
 
                 match acc_structures.pop() {
                     Some(Structure::Multiple {

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -287,7 +287,7 @@ fn structured_cfg_help<S: StructuredStatement<E = Box<Expr>, P = Pat, L = Label,
                         Switch { expr, cases } => {
                             let branched_cases = cases
                                 .iter()
-                                .map(|&(ref pat, ref slbl)| Ok((pat.clone(), branch(slbl)?)))
+                                .map(|(pat, slbl)| Ok((pat.clone(), branch(slbl)?)))
                                 .collect::<TranslationResult<_>>()?;
 
                             S::mk_match(expr.clone(), branched_cases)
@@ -605,7 +605,7 @@ impl StructureState {
                 let (body, body_span) = self.to_stmt(*body, comment_store);
 
                 // TODO: this is ugly but it needn't be. We are just pattern matching on particular ASTs.
-                if let Some(stmt @ &Stmt::Expr(ref expr)) = body.first() {
+                if let Some(stmt @ Stmt::Expr(expr)) = body.first() {
                     let stmt_span = stmt.span();
                     let span = if !stmt_span.is_dummy() {
                         stmt_span

--- a/c2rust-transpile/src/compile_cmds/mod.rs
+++ b/c2rust-transpile/src/compile_cmds/mod.rs
@@ -179,7 +179,7 @@ pub fn get_compile_commands(
     let v: Vec<Rc<CompileCmd>> = serde_json::from_reader(f)?;
 
     // apply the filter argument, if any
-    let v = if let &Some(ref re) = filter {
+    let v = if let Some(re) = filter {
         v.into_iter()
             .filter(|c| re.is_match(c.file.to_str().unwrap()))
             .collect::<Vec<Rc<CompileCmd>>>()

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -450,7 +450,7 @@ impl TypeConverter {
                 _ => panic!("Typedef decl did not point to a typedef"),
             },
 
-            ref kind => panic!("ctype parameter must be a function instead of {:?}", kind),
+            ref kind => panic!("ctype parameter must be a function instead of {kind:?}"),
         }
     }
 }

--- a/c2rust-transpile/src/diagnostics.rs
+++ b/c2rust-transpile/src/diagnostics.rs
@@ -43,7 +43,7 @@ pub fn init(mut enabled_warnings: HashSet<Diagnostic>, log_level: log::LevelFilt
             };
             let target = record.target();
             let warn_flag = Diagnostic::from_str(target)
-                .map(|_| format!(" [-W{}]", target))
+                .map(|_| format!(" [-W{target}]"))
                 .unwrap_or_default();
             out.finish(format_args!(
                 "\x1B[{}m{}:\x1B[0m {}{}",
@@ -143,11 +143,11 @@ impl Fail for TranslationError {
 impl Display for TranslationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(cause) = self.cause() {
-            writeln!(f, "{}", cause)?;
+            writeln!(f, "{cause}")?;
         }
         match self.inner.get_context() {
             TranslationErrorKind::Generic => {}
-            ref kind => writeln!(f, "{}", kind)?,
+            ref kind => writeln!(f, "{kind}")?,
         }
         for loc in &self.loc {
             writeln!(f, "{} {}", "-->".blue(), loc)?;

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -191,7 +191,7 @@ fn str_to_ident_checked(filename: &Option<String>, check_reserved: bool) -> Opti
     filename.as_ref().map(str_to_ident).map(|module| {
         // make sure the module name does not clash with keywords
         if check_reserved && RESERVED_NAMES.contains(&module.as_str()) {
-            format!("r#{}", module)
+            format!("r#{module}")
         } else {
             module
         }
@@ -470,11 +470,11 @@ fn transpile_single(
         Ok(cxt) => cxt,
     };
 
-    println!("Transpiling {}", file);
+    println!("Transpiling {file}");
 
     if tcfg.dump_untyped_context {
         println!("CBOR Clang AST");
-        println!("{:#?}", untyped_context);
+        println!("{untyped_context:#?}");
     }
 
     // Convert this into a typed AST
@@ -488,7 +488,7 @@ fn transpile_single(
 
     if tcfg.dump_typed_context {
         println!("Clang AST");
-        println!("{:#?}", typed_context);
+        println!("{typed_context:#?}");
     }
 
     if tcfg.pretty_typed_context {

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -381,7 +381,7 @@ fn get_extra_args_macos() -> Vec<String> {
         let usr_incl = Path::new("/usr/include");
         if !usr_incl.exists() {
             let output = process::Command::new("xcrun")
-                .args(&["--show-sdk-path"])
+                .args(["--show-sdk-path"])
                 .output()
                 .expect("failed to run `xcrun` subcommand");
             let mut sdk_path = String::from_utf8(output.stdout).unwrap();
@@ -416,7 +416,7 @@ fn reorganize_definitions(
     invoke_refactor(build_dir)?;
     // fix the formatting of the output of `c2rust-refactor`
     let status = process::Command::new("cargo")
-        .args(&["fmt"])
+        .args(["fmt"])
         .current_dir(build_dir)
         .status()?;
     if !status.success() {
@@ -556,7 +556,7 @@ fn get_output_path(
         // Create the parent directory if it doesn't exist
         let parent = output_path.parent().unwrap();
         if !parent.exists() {
-            fs::create_dir_all(&parent).unwrap_or_else(|_| {
+            fs::create_dir_all(parent).unwrap_or_else(|_| {
                 panic!("couldn't create source directory: {}", parent.display())
             });
         }

--- a/c2rust-transpile/src/renamer.rs
+++ b/c2rust-transpile/src/renamer.rs
@@ -90,7 +90,7 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
 
         for i in 0.. {
             if self.is_target_used(&target) {
-                target = format!("{}_{}", basename, i);
+                target = format!("{basename}_{i}");
             } else {
                 break;
             }
@@ -174,7 +174,7 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
     pub fn fresh(&mut self) -> String {
         let fresh = self.next_fresh;
         self.next_fresh += 1;
-        self.pick_name(&format!("fresh{}", fresh))
+        self.pick_name(&format!("fresh{fresh}"))
     }
 }
 

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -375,20 +375,20 @@ fn rewrite_reserved_reg_operands(
 
     for (n_moved, (idx, reg, mods)) in rewrite_idxs.into_iter().enumerate() {
         let operand = &mut operands[idx];
-        let name = format!("restmp{}", n_moved);
+        let name = format!("restmp{n_moved}");
         if let Some((_idx, _in_expr)) = operand.in_expr {
             let move_input = if att_syntax {
-                format!("mov %{}, {{{}:{}}}\n", reg, name, mods)
+                format!("mov %{reg}, {{{name}:{mods}}}\n")
             } else {
-                format!("mov {{{}:{}}}\n, {}", name, mods, reg)
+                format!("mov {{{name}:{mods}}}\n, {reg}")
             };
             prolog.push_str(&move_input);
         }
         if let Some((_idx, _out_expr)) = operand.out_expr {
             let move_output = if att_syntax {
-                format!("\nmov {{{}:{}}}, %{}", name, mods, reg)
+                format!("\nmov {{{name}:{mods}}}, %{reg}")
             } else {
-                format!("\nmov {}, {{{}:{}}}", reg, name, mods)
+                format!("\nmov {reg}, {{{name}:{mods}}}")
             };
             epilog.push_str(&move_output);
         }
@@ -687,13 +687,7 @@ impl<'c> Translation<'c> {
         let mut tokens: Vec<TokenTree> = vec![];
 
         let mut tied_operands = HashMap::new();
-        for (
-            input_idx,
-            &AsmOperand {
-                ref constraints, ..
-            },
-        ) in inputs.iter().enumerate()
-        {
+        for (input_idx, AsmOperand { constraints, .. }) in inputs.iter().enumerate() {
             let constraints_digits = constraints.trim_matches(|c: char| !c.is_ascii_digit());
             if let Ok(output_idx) = constraints_digits.parse::<usize>() {
                 let output_key = (output_idx, true);
@@ -780,7 +774,7 @@ impl<'c> Translation<'c> {
                     });
                 }
                 // Constraint could not be parsed, drop it
-                Err(e) => eprintln!("{}", e),
+                Err(e) => eprintln!("{e}"),
             }
         }
         // Add unmatched inputs
@@ -791,7 +785,7 @@ impl<'c> Translation<'c> {
             let (dir_spec, mem_only, parsed) = match parse_constraints(&input.constraints, arch) {
                 Ok(x) => x,
                 Err(e) => {
-                    eprintln!("{}", e);
+                    eprintln!("{e}");
                     continue;
                 }
             };
@@ -964,7 +958,7 @@ impl<'c> Translation<'c> {
             // We must drop clobbers of reserved registers, even though this
             // really means we're misinforming the compiler of what's been
             // overwritten. Warn verbosely.
-            let quoted = format!("\"{}\"", clobber);
+            let quoted = format!("\"{clobber}\"");
             if reg_is_reserved(&quoted, arch).is_some() {
                 warn!(
                     "Attempting to clobber reserved register ({}), dropping clobber! \

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -134,7 +134,7 @@ fn parse_constraints(
     }
 
     // Handle register names
-    let mut constraints = constraints.replace('{', "\"").replace('}', "\"");
+    let mut constraints = constraints.replace(['{', '}'], "\"");
 
     // Convert (simple) constraints to ones rustc understands
     match &*constraints {

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -361,7 +361,7 @@ impl<'c> Translation<'c> {
             } else if func_name.starts_with("atomic_and") {
                 (BinOp::BitAnd(Default::default()), false)
             } else {
-                panic!("Unexpected atomic intrinsic name: {}", func_name)
+                panic!("Unexpected atomic intrinsic name: {func_name}")
             };
 
             // Since the value of `arg1` is used twice, we need to copy

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -318,7 +318,7 @@ impl<'c> Translation<'c> {
         // Emit `atomic_cxchg(a0, a1, a2).idx`
         let atomic_cxchg = mk().abs_path_expr(vec!["core", "intrinsics", intrinsic_name]);
         let call = mk().call_expr(atomic_cxchg, vec![dst, old_val, src_val]);
-        let field_idx = if returns_val { 0 } else { 1 };
+        let field_idx = (!returns_val).into();
         let call_expr = mk().anon_field_expr(call, field_idx);
         self.convert_side_effects_expr(
             ctx,

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -679,7 +679,7 @@ impl<'c> Translation<'c> {
             } else {
                 Ok(WithStmts::new(
                     vec![mk().semi_stmt(mem_expr)],
-                    self.panic_or_err(&format!("__builtin_{} not used", name)),
+                    self.panic_or_err(&format!("__builtin_{name} not used")),
                 ))
             }
         })

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -17,8 +17,8 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<Box<Expr>> {
         let lit = match base {
             IntBase::Dec => mk().int_unsuffixed_lit(val.into()),
-            IntBase::Hex => mk().float_unsuffixed_lit(&format!("0x{:x}", val)),
-            IntBase::Oct => mk().float_unsuffixed_lit(&format!("0o{:o}", val)),
+            IntBase::Hex => mk().float_unsuffixed_lit(&format!("0x{val:x}")),
+            IntBase::Oct => mk().float_unsuffixed_lit(&format!("0o{val:o}")),
         };
 
         let target_ty = self.convert_type(ty.ctype)?;
@@ -30,7 +30,7 @@ impl<'c> Translation<'c> {
     pub fn enum_for_i64(&self, enum_type_id: CTypeId, value: i64) -> Box<Expr> {
         let def_id = match self.ast_context.resolve_type(enum_type_id).kind {
             CTypeKind::Enum(def_id) => def_id,
-            _ => panic!("{:?} does not point to an `enum` type", enum_type_id),
+            _ => panic!("{enum_type_id:?} does not point to an `enum` type"),
         };
 
         let (variants, underlying_type_id) = match self.ast_context[def_id].kind {
@@ -39,7 +39,7 @@ impl<'c> Translation<'c> {
                 integral_type,
                 ..
             } => (variants, integral_type),
-            _ => panic!("{:?} does not point to an `enum` declaration", def_id),
+            _ => panic!("{def_id:?} does not point to an `enum` declaration"),
         };
 
         for &variant_id in variants {
@@ -55,7 +55,7 @@ impl<'c> Translation<'c> {
                         return mk().path_expr(vec![name]);
                     }
                 }
-                _ => panic!("{:?} does not point to an enum variant", variant_id),
+                _ => panic!("{variant_id:?} does not point to an enum variant"),
             }
         }
 
@@ -125,7 +125,7 @@ impl<'c> Translation<'c> {
                     }
                     CTypeKind::Double => mk().lit_expr(mk().float_lit(&str, "f64")),
                     CTypeKind::Float => mk().lit_expr(mk().float_lit(&str, "f32")),
-                    ref k => panic!("Unsupported floating point literal type {:?}", k),
+                    ref k => panic!("Unsupported floating point literal type {k:?}"),
                 };
                 Ok(WithStmts::new_val(val))
             }

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -646,7 +646,7 @@ pub fn translate(
                 match t.convert_decl(ctx, decl_id) {
                     Err(e) => {
                         let k = &t.ast_context.get_decl(&decl_id).map(|x| &x.kind);
-                        let msg = format!("Skipping declaration {:?} due to error: {}", k, e);
+                        let msg = format!("Skipping declaration {k:?} due to error: {e}");
                         translate_failure(t.tcfg, &msg);
                     }
                     Ok(converted_decl) => {
@@ -726,13 +726,13 @@ pub fn translate(
                                     || {
                                         t.ast_context
                                             .display_loc(&decl.loc)
-                                            .map_or("Unknown".to_string(), |l| format!("at {}", l))
+                                            .map_or("Unknown".to_string(), |l| format!("at {l}"))
                                     },
                                     |name| name.clone(),
                                 );
-                                format!("Failed to translate {}: {}", decl_identifier, e)
+                                format!("Failed to translate {decl_identifier}: {e}")
                             }
-                            _ => format!("Failed to translate declaration: {}", e,),
+                            _ => format!("Failed to translate declaration: {e}",),
                         };
                         translate_failure(t.tcfg, &msg);
                     }
@@ -769,7 +769,7 @@ pub fn translate(
             match t.convert_main(main_id) {
                 Ok(item) => t.items.borrow_mut()[&t.main_file].add_item(item),
                 Err(e) => {
-                    let msg = format!("Failed to translate main: {}", e);
+                    let msg = format!("Failed to translate main: {e}");
                     translate_failure(t.tcfg, &msg)
                 }
             }
@@ -1027,7 +1027,7 @@ fn make_submodule(
         });
         module_builder.str_attr(
             vec!["c2rust", "header_src"],
-            format!("{}:{}", file_path_str, include_line_number),
+            format!("{file_path_str}:{include_line_number}"),
         )
     } else {
         module_builder
@@ -2305,10 +2305,7 @@ impl<'c> Translation<'c> {
                         .borrow_mut()
                         .insert(decl_id, var.as_str())
                         .unwrap_or_else(|| {
-                            panic!(
-                                "Failed to insert argument '{}' while converting '{}'",
-                                var, name
-                            )
+                            panic!("Failed to insert argument '{var}' while converting '{name}'")
                         });
 
                     mk().set_mutbl(mutbl).ident_pat(new_var)
@@ -2507,7 +2504,7 @@ impl<'c> Translation<'c> {
         if self.tcfg.dump_structures {
             eprintln!("Relooped structures:");
             for s in &relooped {
-                eprintln!("  {:#?}", s);
+                eprintln!("  {s:#?}");
             }
         }
 
@@ -2728,7 +2725,7 @@ impl<'c> Translation<'c> {
                     .renamer
                     .borrow_mut()
                     .insert(decl_id, ident)
-                    .unwrap_or_else(|| panic!("Failed to insert variable '{}'", ident));
+                    .unwrap_or_else(|| panic!("Failed to insert variable '{ident}'"));
 
                 if self.ast_context.is_va_list(typ.ctype) {
                     // translate `va_list` variables to `VaListImpl`s and omit the initializer.
@@ -3382,7 +3379,7 @@ impl<'c> Translation<'c> {
                 // need to cast it to fn() to ensure that it has a real address.
                 let mut set_unsafe = false;
                 if ctx.needs_address() {
-                    if let &CDeclKind::Function { ref parameters, .. } = decl {
+                    if let CDeclKind::Function { parameters, .. } = decl {
                         let ty = self.convert_type(qual_ty.ctype)?;
                         let actual_ty = self
                             .type_converter
@@ -3711,7 +3708,7 @@ impl<'c> Translation<'c> {
                             CTypeKind::ConstantArray(..) => None,
                             CTypeKind::IncompleteArray(..) => None,
                             CTypeKind::VariableArray(elt, _) => Some(elt),
-                            ref other => panic!("Unexpected array type {:?}", other),
+                            ref other => panic!("Unexpected array type {other:?}"),
                         };
 
                         let lhs = self.convert_expr(ctx.used(), arr)?;
@@ -4132,7 +4129,7 @@ impl<'c> Translation<'c> {
                 let n = substmt_ids.len();
                 let result_id = substmt_ids[n - 1];
 
-                let name = format!("<stmt-expr_{:?}>", compound_stmt_id);
+                let name = format!("<stmt-expr_{compound_stmt_id:?}>");
                 let lbl = cfg::Label::FromC(compound_stmt_id, None);
 
                 let mut stmts = match self.ast_context[result_id].kind {
@@ -4539,7 +4536,7 @@ impl<'c> Translation<'c> {
         // Extract the IDs of the `EnumConstant` decls underlying the enum.
         let variants = match self.ast_context.index(enum_decl).kind {
             CDeclKind::Enum { ref variants, .. } => variants,
-            _ => panic!("{:?} does not point to an `enum` declaration", enum_decl),
+            _ => panic!("{enum_decl:?} does not point to an `enum` declaration"),
         };
 
         match self.ast_context.index(expr).kind {
@@ -4549,7 +4546,7 @@ impl<'c> Translation<'c> {
             CExprKind::DeclRef(_, decl_id, _) if variants.contains(&decl_id) => {
                 return val.map(|x| match *unparen(&x) {
                     Expr::Cast(ExprCast { ref expr, .. }) => expr.clone(),
-                    _ => panic!("DeclRef {:?} of enum {:?} is not cast", expr, enum_decl),
+                    _ => panic!("DeclRef {expr:?} of enum {enum_decl:?} is not cast"),
                 });
             }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4867,9 +4867,7 @@ impl<'c> Translation<'c> {
             let attrs = item_attrs(&mut item).expect("no attrs field on unexpected item variant");
             add_src_loc_attr(attrs, &decl.loc.as_ref().map(|x| x.begin()));
             let mut item_stores = self.items.borrow_mut();
-            let items = item_stores
-                .entry(decl_file_id.unwrap())
-                .or_insert(ItemStore::new());
+            let items = item_stores.entry(decl_file_id.unwrap()).or_default();
 
             items.add_item(item);
         } else {
@@ -4888,9 +4886,7 @@ impl<'c> Translation<'c> {
                 .expect("no attrs field on unexpected foreign item variant");
             add_src_loc_attr(attrs, &decl.loc.as_ref().map(|x| x.begin()));
             let mut items = self.items.borrow_mut();
-            let mod_block_items = items
-                .entry(decl_file_id.unwrap())
-                .or_insert(ItemStore::new());
+            let mod_block_items = items.entry(decl_file_id.unwrap()).or_default();
 
             mod_block_items.add_foreign_item(item);
         } else {
@@ -4927,7 +4923,7 @@ impl<'c> Translation<'c> {
         self.items
             .borrow_mut()
             .entry(decl_file_id)
-            .or_insert(ItemStore::new())
+            .or_default()
             .add_use(module_path, ident_name);
     }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -451,8 +451,7 @@ fn clean_path(mod_names: &RefCell<IndexMap<String, PathBuf>>, path: Option<&path
             .unwrap()
             .to_str()
             .unwrap()
-            .replace('.', "_")
-            .replace('-', "_")
+            .replace(['.', '-'], "_")
     }
 
     let mut file_path: String = path.map_or("internal".to_string(), path_to_str);

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -32,7 +32,7 @@ impl From<c_ast::BinOp> for BinOp {
             c_ast::BinOp::And => BinOp::And(Default::default()),
             c_ast::BinOp::Or => BinOp::Or(Default::default()),
 
-            _ => panic!("C BinOp {:?} is not a valid Rust BinOp", op),
+            _ => panic!("C BinOp {op:?} is not a valid Rust BinOp"),
         }
     }
 }

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -224,7 +224,7 @@ impl<'a> Translation<'a> {
 
                         let bit_start = platform_bit_offset - start_bit;
                         let bit_end = bit_start + bitfield_width - 1;
-                        let bit_range = format!("{}..={}", bit_start, bit_end);
+                        let bit_range = format!("{bit_start}..={bit_end}");
 
                         attrs.push((field_name.clone(), ty, bit_range));
                     }
@@ -579,7 +579,7 @@ impl<'a> Translation<'a> {
 
                 // Now we must use the bitfield methods to initialize bitfields
                 for (field_name, val) in bitfield_inits {
-                    let field_name_setter = format!("set_{}", field_name);
+                    let field_name_setter = format!("set_{field_name}");
                     let struct_ident = mk().ident_expr("init");
                     is_unsafe |= val.is_unsafe();
                     let val = val
@@ -716,7 +716,7 @@ impl<'a> Translation<'a> {
                     .borrow()
                     .resolve_field_name(None, field_id)
                     .ok_or("Could not find bitfield name")?;
-                let setter_name = format!("set_{}", field_name);
+                let setter_name = format!("set_{field_name}");
                 let lhs_expr_read = mk().method_call_expr(lhs_expr.clone(), field_name, Vec::new());
                 // Allow the value of this assignment to be used as the RHS of other assignments
                 let val = lhs_expr_read.clone();

--- a/c2rust/src/main.rs
+++ b/c2rust/src/main.rs
@@ -88,7 +88,7 @@ impl SubCommand {
                 self.name
             )
         })?;
-        let status = Command::new(&path).args(args).status()?;
+        let status = Command::new(path).args(args).status()?;
         process::exit(status.code().unwrap_or(1));
     }
 }

--- a/dynamic_instrumentation/src/callbacks.rs
+++ b/dynamic_instrumentation/src/callbacks.rs
@@ -34,7 +34,7 @@ impl rustc_driver::Callbacks for MirTransformCallbacks {
         let parse = queries.parse().unwrap();
         let mut parse = parse.peek_mut();
         parse.items.push(P(Item {
-            attrs: Vec::new(),
+            attrs: Default::default(),
             id: NodeId::from_u32(0),
             span: DUMMY_SP,
             vis: Visibility {

--- a/dynamic_instrumentation/src/instrument.rs
+++ b/dynamic_instrumentation/src/instrument.rs
@@ -237,7 +237,7 @@ impl<'tcx> MutVisitor<'tcx> for RewriteAddressTakenLocals<'tcx> {
         // terminators with a destination to the address-taken local, or drop and replace
         // statements, put the address-taking statement in the first statement of the successor
         // block
-        for (bid, block) in body.basic_blocks().iter_enumerated().rev() {
+        for (bid, block) in body.basic_blocks.iter_enumerated().rev() {
             for (sid, statement) in block.statements.iter().enumerate().rev() {
                 if let StatementKind::Assign(stmt) = &statement.kind {
                     let (ref place, _) = **stmt;
@@ -408,7 +408,7 @@ impl<'tcx> Visitor<'tcx> for CollectInstrumentationPoints<'_, 'tcx> {
                 // TODO: this is a hack that places the store_addr_taken_fn
                 // after the instrumentation for taking the address of that local,
                 // which must be in place prior to this instrumentation.
-                let num_statements = self.body.basic_blocks()[location.block].statements.len();
+                let num_statements = self.body.basic_blocks[location.block].statements.len();
                 let store_addr_taken_loc = Location {
                     block: location.block,
                     // +1 to ensure `dest` is in scope
@@ -740,7 +740,7 @@ fn instrument_entry_fn<'tcx>(tcx: TyCtxt<'tcx>, hooks: Hooks, body: &mut Body<'t
 
     let mut return_blocks = vec![];
     let mut resume_blocks = vec![];
-    for (block, block_data) in body.basic_blocks().iter_enumerated() {
+    for (block, block_data) in body.basic_blocks.iter_enumerated() {
         match &block_data.terminator().kind {
             TerminatorKind::Return => {
                 return_blocks.push(block);

--- a/dynamic_instrumentation/src/instrument.rs
+++ b/dynamic_instrumentation/src/instrument.rs
@@ -688,10 +688,10 @@ fn mark_scopes_unsafe(scopes: &mut rustc_index::vec::IndexVec<SourceScope, Sourc
     }
 }
 
-fn instrument_body<'a, 'tcx>(
+fn instrument_body<'tcx>(
     state: &Instrumenter,
     tcx: TyCtxt<'tcx>,
-    body: &'a mut Body<'tcx>,
+    body: &mut Body<'tcx>,
     body_did: DefId,
 ) {
     let hooks = Hooks::new(tcx);

--- a/dynamic_instrumentation/src/into_operand.rs
+++ b/dynamic_instrumentation/src/into_operand.rs
@@ -1,6 +1,6 @@
 use rustc_middle::{
     mir::{Constant, ConstantKind, Local, Operand, Place},
-    ty::{self, ParamEnv, TyCtxt},
+    ty::{ParamEnv, TyCtxt},
 };
 use rustc_span::DUMMY_SP;
 
@@ -37,10 +37,6 @@ fn make_const(tcx: TyCtxt, idx: u32) -> Operand {
     Operand::Constant(Box::new(Constant {
         span: DUMMY_SP,
         user_ty: None,
-        literal: ConstantKind::Ty(ty::Const::from_bits(
-            tcx,
-            idx.into(),
-            ParamEnv::empty().and(tcx.types.u32),
-        )),
+        literal: ConstantKind::from_bits(tcx, idx.into(), ParamEnv::empty().and(tcx.types.u32)),
     }))
 }

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -117,7 +117,7 @@ fn exit_with_status(status: ExitStatus) {
 fn resolve_sysroot() -> anyhow::Result<PathBuf> {
     let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
     let output = Command::new(rustc)
-        .args(&["--print", "sysroot"])
+        .args(["--print", "sysroot"])
         .output()
         .context("could not invoke `rustc` to find rust sysroot")?;
     // trim, but `str::trim` doesn't exist on `[u8]`
@@ -496,14 +496,14 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
 
     if set_runtime {
         cargo.run(|cmd| {
-            cmd.args(&["add", "--optional", "c2rust-analysis-rt"]);
+            cmd.args(["add", "--optional", "c2rust-analysis-rt"]);
             if let Some(mut runtime) = runtime_path {
                 if manifest_dir.is_some() {
                     runtime = fs_err::canonicalize(runtime)?;
                 }
                 // Since it's a local path, we don't need the internet,
                 // and running it offline saves a slow index sync.
-                cmd.args(&["--offline", "--path"]).arg(runtime);
+                cmd.args(["--offline", "--path"]).arg(runtime);
             }
             if let Some(manifest_path) = manifest_path {
                 cmd.arg("--manifest-path").arg(manifest_path);

--- a/dynamic_instrumentation/src/point/apply.rs
+++ b/dynamic_instrumentation/src/point/apply.rs
@@ -104,10 +104,7 @@ impl<'tcx, 'a> InstrumentationApplier<'tcx, 'a> {
                     InstrumentationArg::Op(ArgKind::RawPtr(Operand::Copy(*place)))
                 }
             } else {
-                panic!(
-                    "Expected a call terminator in block to instrument, found: {:?}",
-                    call
-                );
+                panic!("Expected a call terminator in block to instrument, found: {call:?}");
             };
 
             // push return value to argument list

--- a/dynamic_instrumentation/src/point/build.rs
+++ b/dynamic_instrumentation/src/point/build.rs
@@ -172,7 +172,7 @@ impl<'tcx> InstrumentationBuilder<'_, 'tcx> {
     }
 
     fn debug_mir_to_string(&self, loc: Location) -> String {
-        let block = &self.body.basic_blocks()[loc.block];
+        let block = &self.body.basic_blocks[loc.block];
         if loc.statement_index != block.statements.len() {
             return format!("{:?}", block.statements[loc.statement_index]);
         }

--- a/dynamic_instrumentation/src/point/cast.rs
+++ b/dynamic_instrumentation/src/point/cast.rs
@@ -31,9 +31,7 @@ pub fn cast_ptr_to_usize<'tcx>(
         InstrumentationArg::Op(ArgKind::AddressUsize(_arg)) => {
             assert!(
                 arg_ty.is_integral() || arg_ty.is_unit(),
-                "{:?}: {:?} is not of integral or unit type",
-                arg,
-                arg_ty
+                "{arg:?}: {arg_ty:?} is not of integral or unit type"
             );
             return None;
         }
@@ -63,9 +61,7 @@ pub fn cast_ptr_to_usize<'tcx>(
         InstrumentationArg::Op(ArgKind::RawPtr(arg)) => {
             assert!(
                 arg_ty.is_unsafe_ptr(),
-                "{:?}: {:?} is not an unsafe ptr",
-                arg,
-                arg_ty
+                "{arg:?}: {arg_ty:?} is not an unsafe ptr"
             );
             arg.to_copy()
         }

--- a/dynamic_instrumentation/src/point/cast.rs
+++ b/dynamic_instrumentation/src/point/cast.rs
@@ -107,7 +107,7 @@ pub fn cast_ptr_to_usize<'tcx>(
             source_info: SourceInfo::outermost(DUMMY_SP),
             kind: StatementKind::Assign(Box::new((
                 casted_local.into(),
-                Rvalue::Cast(CastKind::Misc, ptr, thin_raw_ptr_ty),
+                Rvalue::Cast(CastKind::PtrToPtr, ptr, thin_raw_ptr_ty),
             ))),
         };
         new_stmts.push(cast_stmt);

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -317,7 +317,7 @@ mod tests {
 
         let mut cmd = Command::new("cargo");
         cmd.current_dir(repo_dir()?)
-            .args(&[
+            .args([
                 "run",
                 "--bin",
                 "c2rust-instrument",
@@ -329,11 +329,11 @@ mod tests {
                 "--metadata",
             ])
             .arg(&metadata_path)
-            .args(&["--runtime-path"])
+            .args(["--runtime-path"])
             .arg(&runtime_path)
-            .args(&["--", "run", "--manifest-path"])
+            .args(["--", "run", "--manifest-path"])
             .arg(&manifest_path)
-            .args(&["--profile", profile.name()])
+            .args(["--profile", profile.name()])
             .arg("--")
             .args(args)
             .env("METADATA_FILE", &metadata_path)
@@ -390,7 +390,7 @@ mod tests {
         init();
         let mut cmd = Command::new("cargo");
         cmd.current_dir(repo_dir()?.join("analysis/tests/misc"))
-            .args(&["miri", "run", "--features", "miri"])
+            .args(["miri", "run", "--features", "miri"])
             .env("MIRIFLAGS", "");
         let status = cmd.status()?;
         ensure!(status.success(), eyre!("{cmd:?} failed: {status}"));

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_tests_misc_pdg_snapshot_debug.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_tests_misc_pdg_snapshot_debug.snap
@@ -215,7 +215,7 @@ g {
 	n[18]: copy       n[1]  => _43 @ bb21[6]:  fn exercise_allocator;  _43 = _1;
 	n[19]: copy       n[18] => _42 @ bb21[7]:  fn exercise_allocator;  _42 = move _43 as *mut libc::c_void (Misc);
 	n[20]: copy       n[1]  => _4  @ bb0[1]:   fn reallocarray;        _4 = _1;
-	n[21]: copy       n[20] => _1  @ bb1[3]:   fn reallocarray;        _0 = const pointers::REALLOC(move _4, move _5);
+	n[21]: copy       n[20] => _1  @ bb1[3]:   fn reallocarray;        _0 = const _(move _4, move _5);
 	n[22]: free       n[19] => _41 @ bb22[2]:  fn exercise_allocator;  _41 = reallocarray(move _42, move _44, move _45);
 }
 nodes_that_need_write = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_tests_misc_pdg_snapshot_debug.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_tests_misc_pdg_snapshot_debug.snap
@@ -45,18 +45,18 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc   _    => _2  @ bb1[2]: fn simple;  _2 = malloc(move _3);
-	n[1]: copy    n[0] => _1  @ bb2[1]: fn simple;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy    n[0] => _1  @ bb2[1]: fn simple;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: copy    n[1] => _5  @ bb2[5]: fn simple;  _5 = _1;
 	n[3]: field.0 n[1] => _10 @ bb4[5]: fn simple;  _10 = &raw const ((*_1).0: i32);
 	n[4]: copy    n[2] => _24 @ bb5[5]: fn simple;  _24 = _5;
-	n[5]: copy    n[4] => _23 @ bb5[6]: fn simple;  _23 = move _24 as *mut libc::c_void (Misc);
+	n[5]: copy    n[4] => _23 @ bb5[6]: fn simple;  _23 = move _24 as *mut libc::c_void (PtrToPtr);
 	n[6]: free    n[5] => _22 @ bb5[8]: fn simple;  _22 = free(move _23);
 }
 nodes_that_need_write = []
 
 g {
 	n[0]:  alloc       _     => _7     @ bb3[2]:  fn simple;  _7 = malloc(move _8);
-	n[1]:  copy        n[0]  => _6     @ bb4[1]:  fn simple;  _6 = move _7 as *mut pointers::S (Misc);
+	n[1]:  copy        n[0]  => _6     @ bb4[1]:  fn simple;  _6 = move _7 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy        n[1]  => _11    @ bb4[8]:  fn simple;  _11 = _6;
 	n[3]:  copy        n[2]  => _1     @ bb4[9]:  fn simple;  _1 = move _11;
 	n[4]:  field.0     n[3]  => _      @ bb4[11]: fn simple;  ((*_1).0: i32) = const 10_i32;
@@ -88,7 +88,7 @@ g {
 	n[30]: copy        n[29] => _13    @ bb8[3]:  fn recur;   _13 = _2;
 	n[31]: copy        n[30] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _13);
 	n[32]: copy        n[31] => _8     @ bb1[2]:  fn recur;   _8 = _2;
-	n[33]: copy        n[32] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (Misc);
+	n[33]: copy        n[32] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (PtrToPtr);
 	n[34]: free        n[33] => _0     @ bb1[5]:  fn recur;   _0 = free(move _7);
 	n[35]: copy        n[31] => _14    @ bb9[4]:  fn recur;   _14 = _2;
 	n[36]: copy        n[31] => _14    @ bb9[4]:  fn recur;   _14 = _2;
@@ -103,13 +103,13 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn exercise_allocator;  _2 = malloc(move _3);
-	n[1]: copy       n[0] => _1  @ bb2[1]:  fn exercise_allocator;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1  @ bb2[1]:  fn exercise_allocator;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _   @ bb2[5]:  fn exercise_allocator;  ((*_1).0: i32) = const 10_i32;
 	n[3]: addr.store n[2] => _   @ bb2[5]:  fn exercise_allocator;  ((*_1).0: i32) = const 10_i32;
 	n[4]: field.0    n[1] => _10 @ bb2[18]: fn exercise_allocator;  _10 = ((*_1).0: i32);
 	n[5]: addr.load  n[4] => _   @ bb2[18]: fn exercise_allocator;  _10 = ((*_1).0: i32);
 	n[6]: copy       n[1] => _13 @ bb3[7]:  fn exercise_allocator;  _13 = _1;
-	n[7]: copy       n[6] => _12 @ bb3[8]:  fn exercise_allocator;  _12 = move _13 as *mut libc::c_void (Misc);
+	n[7]: copy       n[6] => _12 @ bb3[8]:  fn exercise_allocator;  _12 = move _13 as *mut libc::c_void (PtrToPtr);
 	n[8]: free       n[7] => _11 @ bb5[2]:  fn exercise_allocator;  _11 = realloc(move _12, move _14);
 }
 nodes_that_need_write = [3, 2, 1, 0]
@@ -118,84 +118,84 @@ g {
 	n[0]:  copy _     => _9  @ bb2[11]: fn exercise_allocator;       _9 = const b"%i\n\x00";
 	n[1]:  copy n[0]  => _8  @ bb2[12]: fn exercise_allocator;       _8 = &raw const (*_9);
 	n[2]:  copy n[1]  => _7  @ bb2[13]: fn exercise_allocator;       _7 = move _8 as *const u8 (Pointer(ArrayToPointer));
-	n[3]:  copy n[2]  => _6  @ bb2[15]: fn exercise_allocator;       _6 = move _7 as *const i8 (Misc);
+	n[3]:  copy n[2]  => _6  @ bb2[15]: fn exercise_allocator;       _6 = move _7 as *const i8 (PtrToPtr);
 	n[4]:  copy n[3]  => _1  @ bb0[0]:  fn printf;                   _5 = printf(move _6, move _10);
 	n[5]:  copy _     => _31 @ bb11[5]: fn exercise_allocator;       _31 = const b"%i\n\x00";
 	n[6]:  copy n[5]  => _30 @ bb11[6]: fn exercise_allocator;       _30 = &raw const (*_31);
 	n[7]:  copy n[6]  => _29 @ bb11[7]: fn exercise_allocator;       _29 = move _30 as *const u8 (Pointer(ArrayToPointer));
-	n[8]:  copy n[7]  => _28 @ bb11[9]: fn exercise_allocator;       _28 = move _29 as *const i8 (Misc);
+	n[8]:  copy n[7]  => _28 @ bb11[9]: fn exercise_allocator;       _28 = move _29 as *const i8 (PtrToPtr);
 	n[9]:  copy n[8]  => _1  @ bb0[0]:  fn printf;                   _27 = printf(move _28, move _32);
 	n[10]: copy _     => _31 @ bb11[5]: fn exercise_allocator;       _31 = const b"%i\n\x00";
 	n[11]: copy n[10] => _30 @ bb11[6]: fn exercise_allocator;       _30 = &raw const (*_31);
 	n[12]: copy n[11] => _29 @ bb11[7]: fn exercise_allocator;       _29 = move _30 as *const u8 (Pointer(ArrayToPointer));
-	n[13]: copy n[12] => _28 @ bb11[9]: fn exercise_allocator;       _28 = move _29 as *const i8 (Misc);
+	n[13]: copy n[12] => _28 @ bb11[9]: fn exercise_allocator;       _28 = move _29 as *const i8 (PtrToPtr);
 	n[14]: copy n[13] => _1  @ bb0[0]:  fn printf;                   _27 = printf(move _28, move _32);
 	n[15]: copy _     => _61 @ bb29[5]: fn exercise_allocator;       _61 = const b"%i\n\x00";
 	n[16]: copy n[15] => _60 @ bb29[6]: fn exercise_allocator;       _60 = &raw const (*_61);
 	n[17]: copy n[16] => _59 @ bb29[7]: fn exercise_allocator;       _59 = move _60 as *const u8 (Pointer(ArrayToPointer));
-	n[18]: copy n[17] => _58 @ bb29[9]: fn exercise_allocator;       _58 = move _59 as *const i8 (Misc);
+	n[18]: copy n[17] => _58 @ bb29[9]: fn exercise_allocator;       _58 = move _59 as *const i8 (PtrToPtr);
 	n[19]: copy n[18] => _1  @ bb0[0]:  fn printf;                   _57 = printf(move _58, move _62);
 	n[20]: copy _     => _61 @ bb29[5]: fn exercise_allocator;       _61 = const b"%i\n\x00";
 	n[21]: copy n[20] => _60 @ bb29[6]: fn exercise_allocator;       _60 = &raw const (*_61);
 	n[22]: copy n[21] => _59 @ bb29[7]: fn exercise_allocator;       _59 = move _60 as *const u8 (Pointer(ArrayToPointer));
-	n[23]: copy n[22] => _58 @ bb29[9]: fn exercise_allocator;       _58 = move _59 as *const i8 (Misc);
+	n[23]: copy n[22] => _58 @ bb29[9]: fn exercise_allocator;       _58 = move _59 as *const i8 (PtrToPtr);
 	n[24]: copy n[23] => _1  @ bb0[0]:  fn printf;                   _57 = printf(move _58, move _62);
 	n[25]: copy _     => _61 @ bb29[5]: fn exercise_allocator;       _61 = const b"%i\n\x00";
 	n[26]: copy n[25] => _60 @ bb29[6]: fn exercise_allocator;       _60 = &raw const (*_61);
 	n[27]: copy n[26] => _59 @ bb29[7]: fn exercise_allocator;       _59 = move _60 as *const u8 (Pointer(ArrayToPointer));
-	n[28]: copy n[27] => _58 @ bb29[9]: fn exercise_allocator;       _58 = move _59 as *const i8 (Misc);
+	n[28]: copy n[27] => _58 @ bb29[9]: fn exercise_allocator;       _58 = move _59 as *const i8 (PtrToPtr);
 	n[29]: copy n[28] => _1  @ bb0[0]:  fn printf;                   _57 = printf(move _58, move _62);
 	n[30]: copy _     => _94 @ bb49[5]: fn exercise_allocator;       _94 = const b"%i\n\x00";
 	n[31]: copy n[30] => _93 @ bb49[6]: fn exercise_allocator;       _93 = &raw const (*_94);
 	n[32]: copy n[31] => _92 @ bb49[7]: fn exercise_allocator;       _92 = move _93 as *const u8 (Pointer(ArrayToPointer));
-	n[33]: copy n[32] => _91 @ bb49[9]: fn exercise_allocator;       _91 = move _92 as *const i8 (Misc);
+	n[33]: copy n[32] => _91 @ bb49[9]: fn exercise_allocator;       _91 = move _92 as *const i8 (PtrToPtr);
 	n[34]: copy n[33] => _1  @ bb0[0]:  fn printf;                   _90 = printf(move _91, move _95);
 	n[35]: copy _     => _94 @ bb49[5]: fn exercise_allocator;       _94 = const b"%i\n\x00";
 	n[36]: copy n[35] => _93 @ bb49[6]: fn exercise_allocator;       _93 = &raw const (*_94);
 	n[37]: copy n[36] => _92 @ bb49[7]: fn exercise_allocator;       _92 = move _93 as *const u8 (Pointer(ArrayToPointer));
-	n[38]: copy n[37] => _91 @ bb49[9]: fn exercise_allocator;       _91 = move _92 as *const i8 (Misc);
+	n[38]: copy n[37] => _91 @ bb49[9]: fn exercise_allocator;       _91 = move _92 as *const i8 (PtrToPtr);
 	n[39]: copy n[38] => _1  @ bb0[0]:  fn printf;                   _90 = printf(move _91, move _95);
 	n[40]: copy _     => _94 @ bb49[5]: fn exercise_allocator;       _94 = const b"%i\n\x00";
 	n[41]: copy n[40] => _93 @ bb49[6]: fn exercise_allocator;       _93 = &raw const (*_94);
 	n[42]: copy n[41] => _92 @ bb49[7]: fn exercise_allocator;       _92 = move _93 as *const u8 (Pointer(ArrayToPointer));
-	n[43]: copy n[42] => _91 @ bb49[9]: fn exercise_allocator;       _91 = move _92 as *const i8 (Misc);
+	n[43]: copy n[42] => _91 @ bb49[9]: fn exercise_allocator;       _91 = move _92 as *const i8 (PtrToPtr);
 	n[44]: copy n[43] => _1  @ bb0[0]:  fn printf;                   _90 = printf(move _91, move _95);
 	n[45]: copy _     => _94 @ bb49[5]: fn exercise_allocator;       _94 = const b"%i\n\x00";
 	n[46]: copy n[45] => _93 @ bb49[6]: fn exercise_allocator;       _93 = &raw const (*_94);
 	n[47]: copy n[46] => _92 @ bb49[7]: fn exercise_allocator;       _92 = move _93 as *const u8 (Pointer(ArrayToPointer));
-	n[48]: copy n[47] => _91 @ bb49[9]: fn exercise_allocator;       _91 = move _92 as *const i8 (Misc);
+	n[48]: copy n[47] => _91 @ bb49[9]: fn exercise_allocator;       _91 = move _92 as *const i8 (PtrToPtr);
 	n[49]: copy n[48] => _1  @ bb0[0]:  fn printf;                   _90 = printf(move _91, move _95);
 	n[50]: copy _     => _9  @ bb2[11]: fn simple_analysis;          _9 = const b"%i\n\x00";
 	n[51]: copy n[50] => _8  @ bb2[12]: fn simple_analysis;          _8 = &raw const (*_9);
 	n[52]: copy n[51] => _7  @ bb2[13]: fn simple_analysis;          _7 = move _8 as *const u8 (Pointer(ArrayToPointer));
-	n[53]: copy n[52] => _6  @ bb2[15]: fn simple_analysis;          _6 = move _7 as *const i8 (Misc);
+	n[53]: copy n[52] => _6  @ bb2[15]: fn simple_analysis;          _6 = move _7 as *const i8 (PtrToPtr);
 	n[54]: copy n[53] => _1  @ bb0[0]:  fn printf;                   _5 = printf(move _6, move _10);
 	n[55]: copy _     => _6  @ bb0[5]:  fn analysis2_helper;         _6 = const b"%i\n\x00";
 	n[56]: copy n[55] => _5  @ bb0[6]:  fn analysis2_helper;         _5 = &raw const (*_6);
 	n[57]: copy n[56] => _4  @ bb0[7]:  fn analysis2_helper;         _4 = move _5 as *const u8 (Pointer(ArrayToPointer));
-	n[58]: copy n[57] => _3  @ bb0[9]:  fn analysis2_helper;         _3 = move _4 as *const i8 (Misc);
+	n[58]: copy n[57] => _3  @ bb0[9]:  fn analysis2_helper;         _3 = move _4 as *const i8 (PtrToPtr);
 	n[59]: copy n[58] => _1  @ bb0[0]:  fn printf;                   _2 = printf(move _3, move _7);
 	n[60]: copy _     => _9  @ bb2[11]: fn inter_function_analysis;  _9 = const b"%i\n\x00";
 	n[61]: copy n[60] => _8  @ bb2[12]: fn inter_function_analysis;  _8 = &raw const (*_9);
 	n[62]: copy n[61] => _7  @ bb2[13]: fn inter_function_analysis;  _7 = move _8 as *const u8 (Pointer(ArrayToPointer));
-	n[63]: copy n[62] => _6  @ bb2[15]: fn inter_function_analysis;  _6 = move _7 as *const i8 (Misc);
+	n[63]: copy n[62] => _6  @ bb2[15]: fn inter_function_analysis;  _6 = move _7 as *const i8 (PtrToPtr);
 	n[64]: copy n[63] => _1  @ bb0[0]:  fn printf;                   _5 = printf(move _6, move _10);
 	n[65]: copy _     => _11 @ bb2[18]: fn invalid;                  _11 = const b"%i\n\x00";
 	n[66]: copy n[65] => _10 @ bb2[19]: fn invalid;                  _10 = &raw const (*_11);
 	n[67]: copy n[66] => _9  @ bb2[20]: fn invalid;                  _9 = move _10 as *const u8 (Pointer(ArrayToPointer));
-	n[68]: copy n[67] => _8  @ bb2[22]: fn invalid;                  _8 = move _9 as *const i8 (Misc);
+	n[68]: copy n[67] => _8  @ bb2[22]: fn invalid;                  _8 = move _9 as *const i8 (PtrToPtr);
 	n[69]: copy n[68] => _1  @ bb0[0]:  fn printf;                   _7 = printf(move _8, move _12);
 	n[70]: copy _     => _17 @ bb3[9]:  fn invalid;                  _17 = const b"%i\n\x00";
 	n[71]: copy n[70] => _16 @ bb3[10]: fn invalid;                  _16 = &raw const (*_17);
 	n[72]: copy n[71] => _15 @ bb3[11]: fn invalid;                  _15 = move _16 as *const u8 (Pointer(ArrayToPointer));
-	n[73]: copy n[72] => _14 @ bb3[13]: fn invalid;                  _14 = move _15 as *const i8 (Misc);
+	n[73]: copy n[72] => _14 @ bb3[13]: fn invalid;                  _14 = move _15 as *const i8 (PtrToPtr);
 	n[74]: copy n[73] => _1  @ bb0[0]:  fn printf;                   _13 = printf(move _14, move _18);
 }
 nodes_that_need_write = []
 
 g {
 	n[0]:  alloc      _     => _11 @ bb5[2]:   fn exercise_allocator;  _11 = realloc(move _12, move _14);
-	n[1]:  copy       n[0]  => _1  @ bb6[2]:   fn exercise_allocator;  _1 = move _11 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0]  => _1  @ bb6[2]:   fn exercise_allocator;  _1 = move _11 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy       n[1]  => _19 @ bb6[6]:   fn exercise_allocator;  _19 = _1;
 	n[3]:  offset[0]  n[2]  => _18 @ bb6[7]:   fn exercise_allocator;  _18 = offset(move _19, const 0_isize);
 	n[4]:  field.0    n[3]  => _   @ bb7[1]:   fn exercise_allocator;  ((*_18).0: i32) = const 10_i32;
@@ -213,7 +213,7 @@ g {
 	n[16]: field.0    n[15] => _32 @ bb13[2]:  fn exercise_allocator;  _32 = ((*_33).0: i32);
 	n[17]: addr.load  n[16] => _   @ bb13[2]:  fn exercise_allocator;  _32 = ((*_33).0: i32);
 	n[18]: copy       n[1]  => _43 @ bb21[6]:  fn exercise_allocator;  _43 = _1;
-	n[19]: copy       n[18] => _42 @ bb21[7]:  fn exercise_allocator;  _42 = move _43 as *mut libc::c_void (Misc);
+	n[19]: copy       n[18] => _42 @ bb21[7]:  fn exercise_allocator;  _42 = move _43 as *mut libc::c_void (PtrToPtr);
 	n[20]: copy       n[1]  => _4  @ bb0[1]:   fn reallocarray;        _4 = _1;
 	n[21]: copy       n[20] => _1  @ bb1[3]:   fn reallocarray;        _0 = const _(move _4, move _5);
 	n[22]: free       n[19] => _41 @ bb22[2]:  fn exercise_allocator;  _41 = reallocarray(move _42, move _44, move _45);
@@ -222,7 +222,7 @@ nodes_that_need_write = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
 g {
 	n[0]:  alloc      _     => _41 @ bb22[2]:  fn exercise_allocator;  _41 = reallocarray(move _42, move _44, move _45);
-	n[1]:  copy       n[0]  => _1  @ bb23[3]:  fn exercise_allocator;  _1 = move _41 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0]  => _1  @ bb23[3]:  fn exercise_allocator;  _1 = move _41 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy       n[1]  => _48 @ bb23[7]:  fn exercise_allocator;  _48 = _1;
 	n[3]:  offset[0]  n[2]  => _47 @ bb23[8]:  fn exercise_allocator;  _47 = offset(move _48, const 0_isize);
 	n[4]:  field.0    n[3]  => _   @ bb24[1]:  fn exercise_allocator;  ((*_47).0: i32) = const 10_i32;
@@ -248,14 +248,14 @@ g {
 	n[24]: field.0    n[23] => _62 @ bb31[2]:  fn exercise_allocator;  _62 = ((*_63).0: i32);
 	n[25]: addr.load  n[24] => _   @ bb31[2]:  fn exercise_allocator;  _62 = ((*_63).0: i32);
 	n[26]: copy       n[1]  => _73 @ bb39[6]:  fn exercise_allocator;  _73 = _1;
-	n[27]: copy       n[26] => _72 @ bb39[7]:  fn exercise_allocator;  _72 = move _73 as *mut libc::c_void (Misc);
+	n[27]: copy       n[26] => _72 @ bb39[7]:  fn exercise_allocator;  _72 = move _73 as *mut libc::c_void (PtrToPtr);
 	n[28]: free       n[27] => _71 @ bb39[9]:  fn exercise_allocator;  _71 = free(move _72);
 }
 nodes_that_need_write = [13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
 g {
 	n[0]:  alloc      _     => _74  @ bb41[2]:  fn exercise_allocator;  _74 = calloc(move _75, move _76);
-	n[1]:  copy       n[0]  => _1   @ bb42[2]:  fn exercise_allocator;  _1 = move _74 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0]  => _1   @ bb42[2]:  fn exercise_allocator;  _1 = move _74 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy       n[1]  => _79  @ bb42[6]:  fn exercise_allocator;  _79 = _1;
 	n[3]:  offset[0]  n[2]  => _78  @ bb42[7]:  fn exercise_allocator;  _78 = offset(move _79, const 0_isize);
 	n[4]:  field.0    n[3]  => _    @ bb43[1]:  fn exercise_allocator;  ((*_78).0: i32) = const 10_i32;
@@ -289,27 +289,27 @@ g {
 	n[32]: field.0    n[31] => _95  @ bb51[2]:  fn exercise_allocator;  _95 = ((*_96).0: i32);
 	n[33]: addr.load  n[32] => _    @ bb51[2]:  fn exercise_allocator;  _95 = ((*_96).0: i32);
 	n[34]: copy       n[1]  => _106 @ bb59[6]:  fn exercise_allocator;  _106 = _1;
-	n[35]: copy       n[34] => _105 @ bb59[7]:  fn exercise_allocator;  _105 = move _106 as *mut libc::c_void (Misc);
+	n[35]: copy       n[34] => _105 @ bb59[7]:  fn exercise_allocator;  _105 = move _106 as *mut libc::c_void (PtrToPtr);
 	n[36]: free       n[35] => _104 @ bb59[9]:  fn exercise_allocator;  _104 = free(move _105);
 }
 nodes_that_need_write = [17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn simple_analysis;  _2 = malloc(move _3);
-	n[1]: copy       n[0] => _1  @ bb2[1]:  fn simple_analysis;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1  @ bb2[1]:  fn simple_analysis;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _   @ bb2[5]:  fn simple_analysis;  ((*_1).0: i32) = const 10_i32;
 	n[3]: addr.store n[2] => _   @ bb2[5]:  fn simple_analysis;  ((*_1).0: i32) = const 10_i32;
 	n[4]: field.0    n[1] => _10 @ bb2[18]: fn simple_analysis;  _10 = ((*_1).0: i32);
 	n[5]: addr.load  n[4] => _   @ bb2[18]: fn simple_analysis;  _10 = ((*_1).0: i32);
 	n[6]: copy       n[1] => _13 @ bb3[7]:  fn simple_analysis;  _13 = _1;
-	n[7]: copy       n[6] => _12 @ bb3[8]:  fn simple_analysis;  _12 = move _13 as *mut libc::c_void (Misc);
+	n[7]: copy       n[6] => _12 @ bb3[8]:  fn simple_analysis;  _12 = move _13 as *mut libc::c_void (PtrToPtr);
 	n[8]: free       n[7] => _11 @ bb3[10]: fn simple_analysis;  _11 = free(move _12);
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]:  alloc      _    => _2 @ bb1[2]:  fn analysis2;         _2 = malloc(move _3);
-	n[1]:  copy       n[0] => _1 @ bb2[1]:  fn analysis2;         _1 = move _2 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0] => _1 @ bb2[1]:  fn analysis2;         _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]:  field.0    n[1] => _  @ bb2[5]:  fn analysis2;         ((*_1).0: i32) = const 10_i32;
 	n[3]:  addr.store n[2] => _  @ bb2[5]:  fn analysis2;         ((*_1).0: i32) = const 10_i32;
 	n[4]:  copy       n[1] => _6 @ bb2[8]:  fn analysis2;         _6 = _1;
@@ -317,7 +317,7 @@ g {
 	n[6]:  field.0    n[5] => _7 @ bb0[12]: fn analysis2_helper;  _7 = ((*_1).0: i32);
 	n[7]:  addr.load  n[6] => _  @ bb0[12]: fn analysis2_helper;  _7 = ((*_1).0: i32);
 	n[8]:  copy       n[5] => _9 @ bb3[5]:  fn analysis2;         _9 = _1;
-	n[9]:  copy       n[8] => _8 @ bb3[6]:  fn analysis2;         _8 = move _9 as *mut libc::c_void (Misc);
+	n[9]:  copy       n[8] => _8 @ bb3[6]:  fn analysis2;         _8 = move _9 as *mut libc::c_void (PtrToPtr);
 	n[10]: free       n[9] => _7 @ bb3[8]:  fn analysis2;         _7 = free(move _8);
 }
 nodes_that_need_write = [3, 2, 1, 0]
@@ -325,33 +325,33 @@ nodes_that_need_write = [3, 2, 1, 0]
 g {
 	n[0]: alloc      _    => _0  @ bb0[2]:  fn malloc_wrapper;           _0 = malloc(move _3);
 	n[1]: copy       n[0] => _2  @ bb1[2]:  fn inter_function_analysis;  _2 = malloc_wrapper(move _3);
-	n[2]: copy       n[1] => _1  @ bb2[1]:  fn inter_function_analysis;  _1 = move _2 as *mut pointers::S (Misc);
+	n[2]: copy       n[1] => _1  @ bb2[1]:  fn inter_function_analysis;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[3]: field.0    n[2] => _   @ bb2[5]:  fn inter_function_analysis;  ((*_1).0: i32) = const 11_i32;
 	n[4]: addr.store n[3] => _   @ bb2[5]:  fn inter_function_analysis;  ((*_1).0: i32) = const 11_i32;
 	n[5]: field.0    n[2] => _10 @ bb2[18]: fn inter_function_analysis;  _10 = ((*_1).0: i32);
 	n[6]: addr.load  n[5] => _   @ bb2[18]: fn inter_function_analysis;  _10 = ((*_1).0: i32);
 	n[7]: copy       n[2] => _13 @ bb3[7]:  fn inter_function_analysis;  _13 = _1;
-	n[8]: copy       n[7] => _12 @ bb3[8]:  fn inter_function_analysis;  _12 = move _13 as *mut libc::c_void (Misc);
+	n[8]: copy       n[7] => _12 @ bb3[8]:  fn inter_function_analysis;  _12 = move _13 as *mut libc::c_void (PtrToPtr);
 	n[9]: free       n[8] => _11 @ bb3[10]: fn inter_function_analysis;  _11 = free(move _12);
 }
 nodes_that_need_write = [4, 3, 2, 1, 0]
 
 g {
 	n[0]: alloc       _    => _2   @ bb1[2]: fn no_owner;  _2 = malloc(move _3);
-	n[1]: value.store n[0] => _5.* @ bb2[3]: fn no_owner;  (*_5) = move _2 as *mut pointers::S (Misc);
+	n[1]: value.store n[0] => _5.* @ bb2[3]: fn no_owner;  (*_5) = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: value.load  _    => _12  @ bb6[6]: fn main_0;    _12 = (*_13);
-	n[3]: copy        n[2] => _11  @ bb6[7]: fn main_0;    _11 = move _12 as *mut libc::c_void (Misc);
+	n[3]: copy        n[2] => _11  @ bb6[7]: fn main_0;    _11 = move _12 as *mut libc::c_void (PtrToPtr);
 	n[4]: free        n[3] => _10  @ bb6[9]: fn main_0;    _10 = free(move _11);
 }
 nodes_that_need_write = []
 
 g {
 	n[0]:  copy       _     => _5  @ bb2[2]:  fn no_owner;  _5 = const {alloc8: *mut *mut pointers::S};
-	n[1]:  addr.store n[0]  => _   @ bb2[3]:  fn no_owner;  (*_5) = move _2 as *mut pointers::S (Misc);
+	n[1]:  addr.store n[0]  => _   @ bb2[3]:  fn no_owner;  (*_5) = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy       _     => _13 @ bb6[5]:  fn main_0;    _13 = const {alloc8: *mut *mut pointers::S};
 	n[3]:  addr.load  n[2]  => _   @ bb6[6]:  fn main_0;    _12 = (*_13);
 	n[4]:  copy       _     => _5  @ bb2[2]:  fn no_owner;  _5 = const {alloc8: *mut *mut pointers::S};
-	n[5]:  addr.store n[4]  => _   @ bb2[3]:  fn no_owner;  (*_5) = move _2 as *mut pointers::S (Misc);
+	n[5]:  addr.store n[4]  => _   @ bb2[3]:  fn no_owner;  (*_5) = move _2 as *mut pointers::S (PtrToPtr);
 	n[6]:  copy       _     => _12 @ bb3[4]:  fn no_owner;  _12 = const {alloc8: *mut *mut pointers::S};
 	n[7]:  addr.load  n[6]  => _   @ bb3[5]:  fn no_owner;  _11 = (*_12);
 	n[8]:  copy       _     => _6  @ bb2[9]:  fn invalid;   _6 = const {alloc8: *mut *mut pointers::S};
@@ -366,16 +366,16 @@ nodes_that_need_write = [14, 13, 9, 8, 5, 4, 1, 0]
 
 g {
 	n[0]: alloc       _    => _2   @ bb1[2]: fn no_owner;  _2 = malloc(move _3);
-	n[1]: value.store n[0] => _5.* @ bb2[3]: fn no_owner;  (*_5) = move _2 as *mut pointers::S (Misc);
+	n[1]: value.store n[0] => _5.* @ bb2[3]: fn no_owner;  (*_5) = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: value.load  _    => _11  @ bb3[5]: fn no_owner;  _11 = (*_12);
-	n[3]: copy        n[2] => _10  @ bb3[6]: fn no_owner;  _10 = move _11 as *mut libc::c_void (Misc);
+	n[3]: copy        n[2] => _10  @ bb3[6]: fn no_owner;  _10 = move _11 as *mut libc::c_void (PtrToPtr);
 	n[4]: free        n[3] => _9   @ bb3[8]: fn no_owner;  _9 = free(move _10);
 }
 nodes_that_need_write = []
 
 g {
 	n[0]:  alloc       _    => _2   @ bb1[2]:  fn invalid;  _2 = malloc(move _3);
-	n[1]:  copy        n[0] => _1   @ bb2[1]:  fn invalid;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]:  copy        n[0] => _1   @ bb2[1]:  fn invalid;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]:  field.0     n[1] => _    @ bb2[5]:  fn invalid;  ((*_1).0: i32) = const 10_i32;
 	n[3]:  addr.store  n[2] => _    @ bb2[5]:  fn invalid;  ((*_1).0: i32) = const 10_i32;
 	n[4]:  copy        n[1] => _5   @ bb2[7]:  fn invalid;  _5 = _1;
@@ -383,7 +383,7 @@ g {
 	n[6]:  field.0     n[1] => _12  @ bb2[25]: fn invalid;  _12 = ((*_1).0: i32);
 	n[7]:  addr.load   n[6] => _    @ bb2[25]: fn invalid;  _12 = ((*_1).0: i32);
 	n[8]:  copy        n[1] => _23  @ bb4[12]: fn invalid;  _23 = _1;
-	n[9]:  copy        n[8] => _22  @ bb4[13]: fn invalid;  _22 = move _23 as *mut libc::c_void (Misc);
+	n[9]:  copy        n[8] => _22  @ bb4[13]: fn invalid;  _22 = move _23 as *mut libc::c_void (PtrToPtr);
 	n[10]: free        n[9] => _21  @ bb4[15]: fn invalid;  _21 = free(move _22);
 }
 nodes_that_need_write = [3, 2, 1, 0]
@@ -409,9 +409,9 @@ nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn simple1;  _2 = malloc(move _3);
-	n[1]: copy       n[0] => _1  @ bb2[1]:  fn simple1;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1  @ bb2[1]:  fn simple1;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: copy       n[1] => _8  @ bb2[8]:  fn simple1;  _8 = _1;
-	n[3]: copy       n[2] => _7  @ bb2[9]:  fn simple1;  _7 = move _8 as *mut libc::c_void (Misc);
+	n[3]: copy       n[2] => _7  @ bb2[9]:  fn simple1;  _7 = move _8 as *mut libc::c_void (PtrToPtr);
 	n[4]: free       n[3] => _6  @ bb3[2]:  fn simple1;  _6 = realloc(move _7, move _9);
 	n[5]: copy       n[1] => _16 @ bb4[21]: fn simple1;  _16 = _1;
 	n[6]: ptr_to_int n[5] => _   @ bb4[22]: fn simple1;  _15 = move _16 as usize (PointerExposeAddress);
@@ -420,7 +420,7 @@ nodes_that_need_write = []
 
 g {
 	n[0]:  alloc      _    => _6  @ bb3[2]:  fn simple1;  _6 = realloc(move _7, move _9);
-	n[1]:  copy       n[0] => _5  @ bb4[2]:  fn simple1;  _5 = move _6 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0] => _5  @ bb4[2]:  fn simple1;  _5 = move _6 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy       n[1] => _11 @ bb4[6]:  fn simple1;  _11 = _5;
 	n[3]:  field.0    n[2] => _   @ bb4[8]:  fn simple1;  ((*_11).0: i32) = const 10_i32;
 	n[4]:  addr.store n[3] => _   @ bb4[8]:  fn simple1;  ((*_11).0: i32) = const 10_i32;
@@ -428,7 +428,7 @@ g {
 	n[6]:  copy       n[2] => _13 @ bb4[13]: fn simple1;  _13 = _11;
 	n[7]:  int_to_ptr _    => _17 @ bb4[28]: fn simple1;  _17 = move _18 as *const libc::c_void (PointerFromExposedAddress);
 	n[8]:  copy       n[1] => _21 @ bb4[34]: fn simple1;  _21 = _5;
-	n[9]:  copy       n[8] => _20 @ bb4[35]: fn simple1;  _20 = move _21 as *mut libc::c_void (Misc);
+	n[9]:  copy       n[8] => _20 @ bb4[35]: fn simple1;  _20 = move _21 as *mut libc::c_void (PtrToPtr);
 	n[10]: free       n[9] => _19 @ bb4[37]: fn simple1;  _19 = free(move _20);
 }
 nodes_that_need_write = [4, 3, 2, 1, 0]
@@ -442,7 +442,7 @@ nodes_that_need_write = [1, 0]
 
 g {
 	n[0]:  alloc       _     => _2     @ bb1[2]:  fn lighttpd_test;       _2 = malloc(move _3);
-	n[1]:  copy        n[0]  => _1     @ bb2[1]:  fn lighttpd_test;       _1 = move _2 as *mut *mut pointers::fdnode_st (Misc);
+	n[1]:  copy        n[0]  => _1     @ bb2[1]:  fn lighttpd_test;       _1 = move _2 as *mut *mut pointers::fdnode_st (PtrToPtr);
 	n[2]:  copy        n[1]  => _9     @ bb4[5]:  fn lighttpd_test;       _9 = _1;
 	n[3]:  value.store n[2]  => _5.*.0 @ bb4[6]:  fn lighttpd_test;       ((*_5).0: *mut *mut pointers::fdnode_st) = move _9;
 	n[4]:  value.load  _     => _8     @ bb0[2]:  fn fdevent_register;    _8 = ((*_1).0: *mut *mut pointers::fdnode_st);
@@ -458,14 +458,14 @@ g {
 	n[14]: copy        n[13] => _17    @ bb8[3]:  fn fdevent_unregister;  _17 = &mut (*_18);
 	n[15]: addr.store  n[14] => _      @ bb8[4]:  fn fdevent_unregister;  (*_17) = const 0_usize as *mut pointers::fdnode_st (PointerFromExposedAddress);
 	n[16]: copy        n[1]  => _20    @ bb6[6]:  fn lighttpd_test;       _20 = _1;
-	n[17]: copy        n[16] => _19    @ bb6[7]:  fn lighttpd_test;       _19 = move _20 as *mut libc::c_void (Misc);
+	n[17]: copy        n[16] => _19    @ bb6[7]:  fn lighttpd_test;       _19 = move _20 as *mut libc::c_void (PtrToPtr);
 	n[18]: free        n[17] => _18    @ bb6[9]:  fn lighttpd_test;       _18 = free(move _19);
 }
 nodes_that_need_write = [15, 14, 13, 12, 7, 6, 5, 4]
 
 g {
 	n[0]:  alloc      _     => _6  @ bb3[2]:  fn lighttpd_test;                  _6 = malloc(move _7);
-	n[1]:  copy       n[0]  => _5  @ bb4[1]:  fn lighttpd_test;                  _5 = move _6 as *mut pointers::fdevents (Misc);
+	n[1]:  copy       n[0]  => _5  @ bb4[1]:  fn lighttpd_test;                  _5 = move _6 as *mut pointers::fdevents (PtrToPtr);
 	n[2]:  field.0    n[1]  => _   @ bb4[6]:  fn lighttpd_test;                  ((*_5).0: *mut *mut pointers::fdnode_st) = move _9;
 	n[3]:  addr.store n[2]  => _   @ bb4[6]:  fn lighttpd_test;                  ((*_5).0: *mut *mut pointers::fdnode_st) = move _9;
 	n[4]:  copy       n[1]  => _12 @ bb4[10]: fn lighttpd_test;                  _12 = _5;
@@ -484,7 +484,7 @@ g {
 	n[17]: field.0    n[14] => _19 @ bb7[4]:  fn fdevent_unregister;             _19 = ((*_1).0: *mut *mut pointers::fdnode_st);
 	n[18]: addr.load  n[17] => _   @ bb7[4]:  fn fdevent_unregister;             _19 = ((*_1).0: *mut *mut pointers::fdnode_st);
 	n[19]: copy       n[15] => _23 @ bb7[5]:  fn lighttpd_test;                  _23 = _5;
-	n[20]: copy       n[19] => _22 @ bb7[6]:  fn lighttpd_test;                  _22 = move _23 as *mut libc::c_void (Misc);
+	n[20]: copy       n[19] => _22 @ bb7[6]:  fn lighttpd_test;                  _22 = move _23 as *mut libc::c_void (PtrToPtr);
 	n[21]: free       n[20] => _21 @ bb7[8]:  fn lighttpd_test;                  _21 = free(move _22);
 }
 nodes_that_need_write = [3, 2, 1, 0]
@@ -508,13 +508,13 @@ nodes_that_need_write = [1, 0]
 
 g {
 	n[0]:  alloc       _     => _5      @ bb1[2]:  fn connection_accepted;  _5 = malloc(move _6);
-	n[1]:  copy        n[0]  => _4      @ bb2[1]:  fn connection_accepted;  _4 = move _5 as *mut pointers::connection (Misc);
+	n[1]:  copy        n[0]  => _4      @ bb2[1]:  fn connection_accepted;  _4 = move _5 as *mut pointers::connection (PtrToPtr);
 	n[2]:  field.0     n[1]  => _       @ bb2[6]:  fn connection_accepted;  ((*_4).0: i32) = move _8;
 	n[3]:  addr.store  n[2]  => _       @ bb2[6]:  fn connection_accepted;  ((*_4).0: i32) = move _8;
 	n[4]:  field.0     n[1]  => _11     @ bb2[12]: fn connection_accepted;  _11 = ((*_4).0: i32);
 	n[5]:  addr.load   n[4]  => _       @ bb2[12]: fn connection_accepted;  _11 = ((*_4).0: i32);
 	n[6]:  copy        n[1]  => _15     @ bb2[20]: fn connection_accepted;  _15 = _4;
-	n[7]:  copy        n[6]  => _14     @ bb2[21]: fn connection_accepted;  _14 = move _15 as *mut libc::c_void (Misc);
+	n[7]:  copy        n[6]  => _14     @ bb2[21]: fn connection_accepted;  _14 = move _15 as *mut libc::c_void (PtrToPtr);
 	n[8]:  copy        n[7]  => _4      @ bb0[0]:  fn fdevent_register;     _9 = fdevent_register(move _10, move _11, move _12, move _14);
 	n[9]:  copy        n[8]  => _15     @ bb2[15]: fn fdevent_register;     _15 = _4;
 	n[10]: value.store n[9]  => _12.*.1 @ bb2[16]: fn fdevent_register;     ((*_12).1: *mut libc::c_void) = move _15;
@@ -529,14 +529,14 @@ g {
 	n[19]: field.0     n[16] => _8      @ bb1[7]:  fn connection_close;     _8 = ((*_2).0: i32);
 	n[20]: addr.load   n[19] => _       @ bb1[7]:  fn connection_close;     _8 = ((*_2).0: i32);
 	n[21]: copy        n[16] => _11     @ bb2[6]:  fn connection_close;     _11 = _2;
-	n[22]: copy        n[21] => _10     @ bb2[7]:  fn connection_close;     _10 = move _11 as *mut libc::c_void (Misc);
+	n[22]: copy        n[21] => _10     @ bb2[7]:  fn connection_close;     _10 = move _11 as *mut libc::c_void (PtrToPtr);
 	n[23]: free        n[22] => _9      @ bb2[9]:  fn connection_close;     _9 = free(move _10);
 }
 nodes_that_need_write = [12, 11, 3, 2, 1, 0]
 
 g {
 	n[0]:  alloc       _     => _3     @ bb1[2]:  fn fdnode_init;                    _3 = calloc(move _4, move _6);
-	n[1]:  copy        n[0]  => _2     @ bb2[2]:  fn fdnode_init;                    _2 = move _3 as *mut pointers::fdnode_st (Misc);
+	n[1]:  copy        n[0]  => _2     @ bb2[2]:  fn fdnode_init;                    _2 = move _3 as *mut pointers::fdnode_st (PtrToPtr);
 	n[2]:  copy        n[1]  => _10    @ bb2[9]:  fn fdnode_init;                    _10 = _2;
 	n[3]:  copy        n[2]  => _1     @ bb0[0]:  fn is_null;                        _9 = is_null(move _10);
 	n[4]:  copy        n[1]  => _0     @ bb9[2]:  fn fdnode_init;                    _0 = _2;
@@ -570,7 +570,7 @@ g {
 	n[32]: copy        n[29] => _23    @ bb8[7]:  fn fdevent_unregister;             _23 = _3;
 	n[33]: copy        n[32] => _1     @ bb0[0]:  fn fdnode_free;                    _22 = fdnode_free(move _23);
 	n[34]: copy        n[33] => _4     @ bb0[3]:  fn fdnode_free;                    _4 = _1;
-	n[35]: copy        n[34] => _3     @ bb0[4]:  fn fdnode_free;                    _3 = move _4 as *mut libc::c_void (Misc);
+	n[35]: copy        n[34] => _3     @ bb0[4]:  fn fdnode_free;                    _3 = move _4 as *mut libc::c_void (PtrToPtr);
 	n[36]: free        n[35] => _2     @ bb0[6]:  fn fdnode_free;                    _2 = free(move _3);
 }
 nodes_that_need_write = [17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7]
@@ -584,9 +584,9 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc _    => _2 @ bb1[2]:  fn test_malloc_free_cast;  _2 = malloc(move _3);
-	n[1]: copy  n[0] => _1 @ bb2[1]:  fn test_malloc_free_cast;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy  n[0] => _1 @ bb2[1]:  fn test_malloc_free_cast;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: copy  n[1] => _7 @ bb2[7]:  fn test_malloc_free_cast;  _7 = _1;
-	n[3]: copy  n[2] => _6 @ bb2[8]:  fn test_malloc_free_cast;  _6 = move _7 as *mut libc::c_void (Misc);
+	n[3]: copy  n[2] => _6 @ bb2[8]:  fn test_malloc_free_cast;  _6 = move _7 as *mut libc::c_void (PtrToPtr);
 	n[4]: free  n[3] => _5 @ bb2[10]: fn test_malloc_free_cast;  _5 = free(move _6);
 }
 nodes_that_need_write = []
@@ -691,10 +691,10 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc     _    => _2 @ bb1[2]:  fn test_load_addr;  _2 = calloc(const 1_u64, move _3);
-	n[1]: copy      n[0] => _1 @ bb2[1]:  fn test_load_addr;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy      n[0] => _1 @ bb2[1]:  fn test_load_addr;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: addr.load n[1] => _  @ bb2[5]:  fn test_load_addr;  _5 = (*_1);
 	n[3]: copy      n[1] => _8 @ bb2[10]: fn test_load_addr;  _8 = _1;
-	n[4]: copy      n[3] => _7 @ bb2[11]: fn test_load_addr;  _7 = move _8 as *mut libc::c_void (Misc);
+	n[4]: copy      n[3] => _7 @ bb2[11]: fn test_load_addr;  _7 = move _8 as *mut libc::c_void (PtrToPtr);
 	n[5]: free      n[4] => _6 @ bb2[13]: fn test_load_addr;  _6 = free(move _7);
 }
 nodes_that_need_write = []
@@ -718,42 +718,42 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc      _    => _2 @ bb1[2]:  fn test_store_addr;  _2 = malloc(move _3);
-	n[1]: copy       n[0] => _1 @ bb2[1]:  fn test_store_addr;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1 @ bb2[1]:  fn test_store_addr;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _  @ bb2[4]:  fn test_store_addr;  ((*_1).0: i32) = const 10_i32;
 	n[3]: addr.store n[2] => _  @ bb2[4]:  fn test_store_addr;  ((*_1).0: i32) = const 10_i32;
 	n[4]: copy       n[1] => _7 @ bb2[8]:  fn test_store_addr;  _7 = _1;
-	n[5]: copy       n[4] => _6 @ bb2[9]:  fn test_store_addr;  _6 = move _7 as *mut libc::c_void (Misc);
+	n[5]: copy       n[4] => _6 @ bb2[9]:  fn test_store_addr;  _6 = move _7 as *mut libc::c_void (PtrToPtr);
 	n[6]: free       n[5] => _5 @ bb2[11]: fn test_store_addr;  _5 = free(move _6);
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn test_load_other_store_self;  _2 = malloc(move _3);
-	n[1]: copy       n[0] => _1  @ bb2[1]:  fn test_load_other_store_self;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1  @ bb2[1]:  fn test_load_other_store_self;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _   @ bb4[4]:  fn test_load_other_store_self;  ((*_1).0: i32) = const 10_i32;
 	n[3]: addr.store n[2] => _   @ bb4[4]:  fn test_load_other_store_self;  ((*_1).0: i32) = const 10_i32;
 	n[4]: field.0    n[1] => _9  @ bb4[6]:  fn test_load_other_store_self;  _9 = ((*_1).0: i32);
 	n[5]: addr.load  n[4] => _   @ bb4[6]:  fn test_load_other_store_self;  _9 = ((*_1).0: i32);
 	n[6]: copy       n[1] => _12 @ bb4[12]: fn test_load_other_store_self;  _12 = _1;
-	n[7]: copy       n[6] => _11 @ bb4[13]: fn test_load_other_store_self;  _11 = move _12 as *mut libc::c_void (Misc);
+	n[7]: copy       n[6] => _11 @ bb4[13]: fn test_load_other_store_self;  _11 = move _12 as *mut libc::c_void (PtrToPtr);
 	n[8]: free       n[7] => _10 @ bb4[15]: fn test_load_other_store_self;  _10 = free(move _11);
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc      _    => _6  @ bb3[2]: fn test_load_other_store_self;  _6 = malloc(move _7);
-	n[1]: copy       n[0] => _5  @ bb4[1]: fn test_load_other_store_self;  _5 = move _6 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _5  @ bb4[1]: fn test_load_other_store_self;  _5 = move _6 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _   @ bb4[7]: fn test_load_other_store_self;  ((*_5).0: i32) = move _9;
 	n[3]: addr.store n[2] => _   @ bb4[7]: fn test_load_other_store_self;  ((*_5).0: i32) = move _9;
 	n[4]: copy       n[1] => _15 @ bb5[5]: fn test_load_other_store_self;  _15 = _5;
-	n[5]: copy       n[4] => _14 @ bb5[6]: fn test_load_other_store_self;  _14 = move _15 as *mut libc::c_void (Misc);
+	n[5]: copy       n[4] => _14 @ bb5[6]: fn test_load_other_store_self;  _14 = move _15 as *mut libc::c_void (PtrToPtr);
 	n[6]: free       n[5] => _13 @ bb5[8]: fn test_load_other_store_self;  _13 = free(move _14);
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]:  alloc      _    => _2 @ bb1[2]:  fn test_load_self_store_self;  _2 = calloc(move _3, move _4);
-	n[1]:  copy       n[0] => _1 @ bb2[2]:  fn test_load_self_store_self;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0] => _1 @ bb2[2]:  fn test_load_self_store_self;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]:  field.3    n[1] => _  @ bb2[6]:  fn test_load_self_store_self;  _6 = (((*_1).3: pointers::T).3: i32);
 	n[3]:  field.3    n[2] => _6 @ bb2[6]:  fn test_load_self_store_self;  _6 = (((*_1).3: pointers::T).3: i32);
 	n[4]:  addr.load  n[3] => _  @ bb2[6]:  fn test_load_self_store_self;  _6 = (((*_1).3: pointers::T).3: i32);
@@ -761,20 +761,20 @@ g {
 	n[6]:  field.3    n[5] => _  @ bb2[7]:  fn test_load_self_store_self;  (((*_1).3: pointers::T).3: i32) = move _6;
 	n[7]:  addr.store n[6] => _  @ bb2[7]:  fn test_load_self_store_self;  (((*_1).3: pointers::T).3: i32) = move _6;
 	n[8]:  copy       n[1] => _9 @ bb2[12]: fn test_load_self_store_self;  _9 = _1;
-	n[9]:  copy       n[8] => _8 @ bb2[13]: fn test_load_self_store_self;  _8 = move _9 as *mut libc::c_void (Misc);
+	n[9]:  copy       n[8] => _8 @ bb2[13]: fn test_load_self_store_self;  _8 = move _9 as *mut libc::c_void (PtrToPtr);
 	n[10]: free       n[9] => _7 @ bb2[15]: fn test_load_self_store_self;  _7 = free(move _8);
 }
 nodes_that_need_write = [7, 6, 5, 1, 0]
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn test_load_self_store_self_inter;  _2 = calloc(move _3, move _4);
-	n[1]: copy       n[0] => _1  @ bb2[2]:  fn test_load_self_store_self_inter;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1  @ bb2[2]:  fn test_load_self_store_self_inter;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _6  @ bb2[6]:  fn test_load_self_store_self_inter;  _6 = ((*_1).0: i32);
 	n[3]: addr.load  n[2] => _   @ bb2[6]:  fn test_load_self_store_self_inter;  _6 = ((*_1).0: i32);
 	n[4]: field.0    n[1] => _   @ bb2[10]: fn test_load_self_store_self_inter;  ((*_1).0: i32) = move _7;
 	n[5]: addr.store n[4] => _   @ bb2[10]: fn test_load_self_store_self_inter;  ((*_1).0: i32) = move _7;
 	n[6]: copy       n[1] => _10 @ bb2[15]: fn test_load_self_store_self_inter;  _10 = _1;
-	n[7]: copy       n[6] => _9  @ bb2[16]: fn test_load_self_store_self_inter;  _9 = move _10 as *mut libc::c_void (Misc);
+	n[7]: copy       n[6] => _9  @ bb2[16]: fn test_load_self_store_self_inter;  _9 = move _10 as *mut libc::c_void (PtrToPtr);
 	n[8]: free       n[7] => _8  @ bb2[18]: fn test_load_self_store_self_inter;  _8 = free(move _9);
 }
 nodes_that_need_write = [5, 4, 1, 0]
@@ -824,7 +824,7 @@ nodes_that_need_write = [3, 2, 0]
 
 g {
 	n[0]:  alloc       _    => _2     @ bb1[2]:  fn test_store_value_field;  _2 = malloc(move _3);
-	n[1]:  copy        n[0] => _1     @ bb2[1]:  fn test_store_value_field;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]:  copy        n[0] => _1     @ bb2[1]:  fn test_store_value_field;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy        n[1] => _9     @ bb4[5]:  fn test_store_value_field;  _9 = _1;
 	n[3]:  value.store n[2] => _5.*.2 @ bb4[6]:  fn test_store_value_field;  ((*_5).2: *const pointers::S) = move _9 as *const pointers::S (Pointer(MutToConstPointer));
 	n[4]:  value.load  _    => _10    @ bb4[9]:  fn test_store_value_field;  _10 = ((*_5).2: *const pointers::S);
@@ -832,20 +832,20 @@ g {
 	n[6]:  addr.store  n[5] => _      @ bb4[10]: fn test_store_value_field;  ((*_1).2: *const pointers::S) = move _10;
 	n[7]:  value.store n[4] => _1.*.2 @ bb4[10]: fn test_store_value_field;  ((*_1).2: *const pointers::S) = move _10;
 	n[8]:  copy        n[1] => _16    @ bb5[5]:  fn test_store_value_field;  _16 = _1;
-	n[9]:  copy        n[8] => _15    @ bb5[6]:  fn test_store_value_field;  _15 = move _16 as *mut libc::c_void (Misc);
+	n[9]:  copy        n[8] => _15    @ bb5[6]:  fn test_store_value_field;  _15 = move _16 as *mut libc::c_void (PtrToPtr);
 	n[10]: free        n[9] => _14    @ bb5[8]:  fn test_store_value_field;  _14 = free(move _15);
 }
 nodes_that_need_write = [6, 5, 1, 0]
 
 g {
 	n[0]: alloc      _    => _6  @ bb3[2]:  fn test_store_value_field;  _6 = malloc(move _7);
-	n[1]: copy       n[0] => _5  @ bb4[1]:  fn test_store_value_field;  _5 = move _6 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _5  @ bb4[1]:  fn test_store_value_field;  _5 = move _6 as *mut pointers::S (PtrToPtr);
 	n[2]: field.2    n[1] => _   @ bb4[6]:  fn test_store_value_field;  ((*_5).2: *const pointers::S) = move _9 as *const pointers::S (Pointer(MutToConstPointer));
 	n[3]: addr.store n[2] => _   @ bb4[6]:  fn test_store_value_field;  ((*_5).2: *const pointers::S) = move _9 as *const pointers::S (Pointer(MutToConstPointer));
 	n[4]: field.2    n[1] => _10 @ bb4[9]:  fn test_store_value_field;  _10 = ((*_5).2: *const pointers::S);
 	n[5]: addr.load  n[4] => _   @ bb4[9]:  fn test_store_value_field;  _10 = ((*_5).2: *const pointers::S);
 	n[6]: copy       n[1] => _13 @ bb4[15]: fn test_store_value_field;  _13 = _5;
-	n[7]: copy       n[6] => _12 @ bb4[16]: fn test_store_value_field;  _12 = move _13 as *mut libc::c_void (Misc);
+	n[7]: copy       n[6] => _12 @ bb4[16]: fn test_store_value_field;  _12 = move _13 as *mut libc::c_void (PtrToPtr);
 	n[8]: free       n[7] => _11 @ bb4[18]: fn test_store_value_field;  _11 = free(move _12);
 }
 nodes_that_need_write = [3, 2, 1, 0]

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_tests_misc_pdg_snapshot_release.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_tests_misc_pdg_snapshot_release.snap
@@ -45,18 +45,18 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc   _    => _2  @ bb1[2]: fn simple;  _2 = malloc(move _3);
-	n[1]: copy    n[0] => _1  @ bb2[1]: fn simple;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy    n[0] => _1  @ bb2[1]: fn simple;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: copy    n[1] => _5  @ bb2[5]: fn simple;  _5 = _1;
 	n[3]: field.0 n[1] => _10 @ bb4[5]: fn simple;  _10 = &raw const ((*_1).0: i32);
 	n[4]: copy    n[2] => _24 @ bb5[5]: fn simple;  _24 = _5;
-	n[5]: copy    n[4] => _23 @ bb5[6]: fn simple;  _23 = move _24 as *mut libc::c_void (Misc);
+	n[5]: copy    n[4] => _23 @ bb5[6]: fn simple;  _23 = move _24 as *mut libc::c_void (PtrToPtr);
 	n[6]: free    n[5] => _22 @ bb5[8]: fn simple;  _22 = free(move _23);
 }
 nodes_that_need_write = []
 
 g {
 	n[0]:  alloc       _     => _7     @ bb3[2]:  fn simple;  _7 = malloc(move _8);
-	n[1]:  copy        n[0]  => _6     @ bb4[1]:  fn simple;  _6 = move _7 as *mut pointers::S (Misc);
+	n[1]:  copy        n[0]  => _6     @ bb4[1]:  fn simple;  _6 = move _7 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy        n[1]  => _11    @ bb4[8]:  fn simple;  _11 = _6;
 	n[3]:  copy        n[2]  => _1     @ bb4[9]:  fn simple;  _1 = move _11;
 	n[4]:  field.0     n[3]  => _      @ bb4[11]: fn simple;  ((*_1).0: i32) = const 10_i32;
@@ -88,7 +88,7 @@ g {
 	n[30]: copy        n[29] => _12    @ bb7[9]:  fn recur;   _12 = _2;
 	n[31]: copy        n[30] => _2     @ bb0[0]:  fn recur;   _9 = recur(move _10, move _12);
 	n[32]: copy        n[31] => _8     @ bb1[2]:  fn recur;   _8 = _2;
-	n[33]: copy        n[32] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (Misc);
+	n[33]: copy        n[32] => _7     @ bb1[3]:  fn recur;   _7 = move _8 as *mut libc::c_void (PtrToPtr);
 	n[34]: free        n[33] => _0     @ bb1[5]:  fn recur;   _0 = free(move _7);
 	n[35]: copy        n[31] => _13    @ bb8[4]:  fn recur;   _13 = _2;
 	n[36]: copy        n[31] => _13    @ bb8[4]:  fn recur;   _13 = _2;
@@ -103,13 +103,13 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn exercise_allocator;  _2 = malloc(move _3);
-	n[1]: copy       n[0] => _1  @ bb2[1]:  fn exercise_allocator;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1  @ bb2[1]:  fn exercise_allocator;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _   @ bb2[5]:  fn exercise_allocator;  ((*_1).0: i32) = const 10_i32;
 	n[3]: addr.store n[2] => _   @ bb2[5]:  fn exercise_allocator;  ((*_1).0: i32) = const 10_i32;
 	n[4]: field.0    n[1] => _10 @ bb2[18]: fn exercise_allocator;  _10 = ((*_1).0: i32);
 	n[5]: addr.load  n[4] => _   @ bb2[18]: fn exercise_allocator;  _10 = ((*_1).0: i32);
 	n[6]: copy       n[1] => _13 @ bb3[7]:  fn exercise_allocator;  _13 = _1;
-	n[7]: copy       n[6] => _12 @ bb3[8]:  fn exercise_allocator;  _12 = move _13 as *mut libc::c_void (Misc);
+	n[7]: copy       n[6] => _12 @ bb3[8]:  fn exercise_allocator;  _12 = move _13 as *mut libc::c_void (PtrToPtr);
 	n[8]: free       n[7] => _11 @ bb5[2]:  fn exercise_allocator;  _11 = realloc(move _12, move _14);
 }
 nodes_that_need_write = [3, 2, 1, 0]
@@ -118,84 +118,84 @@ g {
 	n[0]:  copy _     => _9  @ bb2[11]: fn exercise_allocator;       _9 = const b"%i\n\x00";
 	n[1]:  copy n[0]  => _8  @ bb2[12]: fn exercise_allocator;       _8 = &raw const (*_9);
 	n[2]:  copy n[1]  => _7  @ bb2[13]: fn exercise_allocator;       _7 = move _8 as *const u8 (Pointer(ArrayToPointer));
-	n[3]:  copy n[2]  => _6  @ bb2[15]: fn exercise_allocator;       _6 = move _7 as *const i8 (Misc);
+	n[3]:  copy n[2]  => _6  @ bb2[15]: fn exercise_allocator;       _6 = move _7 as *const i8 (PtrToPtr);
 	n[4]:  copy n[3]  => _1  @ bb0[0]:  fn printf;                   _5 = printf(move _6, move _10);
 	n[5]:  copy _     => _31 @ bb11[5]: fn exercise_allocator;       _31 = const b"%i\n\x00";
 	n[6]:  copy n[5]  => _30 @ bb11[6]: fn exercise_allocator;       _30 = &raw const (*_31);
 	n[7]:  copy n[6]  => _29 @ bb11[7]: fn exercise_allocator;       _29 = move _30 as *const u8 (Pointer(ArrayToPointer));
-	n[8]:  copy n[7]  => _28 @ bb11[9]: fn exercise_allocator;       _28 = move _29 as *const i8 (Misc);
+	n[8]:  copy n[7]  => _28 @ bb11[9]: fn exercise_allocator;       _28 = move _29 as *const i8 (PtrToPtr);
 	n[9]:  copy n[8]  => _1  @ bb0[0]:  fn printf;                   _27 = printf(move _28, move _32);
 	n[10]: copy _     => _31 @ bb11[5]: fn exercise_allocator;       _31 = const b"%i\n\x00";
 	n[11]: copy n[10] => _30 @ bb11[6]: fn exercise_allocator;       _30 = &raw const (*_31);
 	n[12]: copy n[11] => _29 @ bb11[7]: fn exercise_allocator;       _29 = move _30 as *const u8 (Pointer(ArrayToPointer));
-	n[13]: copy n[12] => _28 @ bb11[9]: fn exercise_allocator;       _28 = move _29 as *const i8 (Misc);
+	n[13]: copy n[12] => _28 @ bb11[9]: fn exercise_allocator;       _28 = move _29 as *const i8 (PtrToPtr);
 	n[14]: copy n[13] => _1  @ bb0[0]:  fn printf;                   _27 = printf(move _28, move _32);
 	n[15]: copy _     => _60 @ bb28[5]: fn exercise_allocator;       _60 = const b"%i\n\x00";
 	n[16]: copy n[15] => _59 @ bb28[6]: fn exercise_allocator;       _59 = &raw const (*_60);
 	n[17]: copy n[16] => _58 @ bb28[7]: fn exercise_allocator;       _58 = move _59 as *const u8 (Pointer(ArrayToPointer));
-	n[18]: copy n[17] => _57 @ bb28[9]: fn exercise_allocator;       _57 = move _58 as *const i8 (Misc);
+	n[18]: copy n[17] => _57 @ bb28[9]: fn exercise_allocator;       _57 = move _58 as *const i8 (PtrToPtr);
 	n[19]: copy n[18] => _1  @ bb0[0]:  fn printf;                   _56 = printf(move _57, move _61);
 	n[20]: copy _     => _60 @ bb28[5]: fn exercise_allocator;       _60 = const b"%i\n\x00";
 	n[21]: copy n[20] => _59 @ bb28[6]: fn exercise_allocator;       _59 = &raw const (*_60);
 	n[22]: copy n[21] => _58 @ bb28[7]: fn exercise_allocator;       _58 = move _59 as *const u8 (Pointer(ArrayToPointer));
-	n[23]: copy n[22] => _57 @ bb28[9]: fn exercise_allocator;       _57 = move _58 as *const i8 (Misc);
+	n[23]: copy n[22] => _57 @ bb28[9]: fn exercise_allocator;       _57 = move _58 as *const i8 (PtrToPtr);
 	n[24]: copy n[23] => _1  @ bb0[0]:  fn printf;                   _56 = printf(move _57, move _61);
 	n[25]: copy _     => _60 @ bb28[5]: fn exercise_allocator;       _60 = const b"%i\n\x00";
 	n[26]: copy n[25] => _59 @ bb28[6]: fn exercise_allocator;       _59 = &raw const (*_60);
 	n[27]: copy n[26] => _58 @ bb28[7]: fn exercise_allocator;       _58 = move _59 as *const u8 (Pointer(ArrayToPointer));
-	n[28]: copy n[27] => _57 @ bb28[9]: fn exercise_allocator;       _57 = move _58 as *const i8 (Misc);
+	n[28]: copy n[27] => _57 @ bb28[9]: fn exercise_allocator;       _57 = move _58 as *const i8 (PtrToPtr);
 	n[29]: copy n[28] => _1  @ bb0[0]:  fn printf;                   _56 = printf(move _57, move _61);
 	n[30]: copy _     => _92 @ bb47[5]: fn exercise_allocator;       _92 = const b"%i\n\x00";
 	n[31]: copy n[30] => _91 @ bb47[6]: fn exercise_allocator;       _91 = &raw const (*_92);
 	n[32]: copy n[31] => _90 @ bb47[7]: fn exercise_allocator;       _90 = move _91 as *const u8 (Pointer(ArrayToPointer));
-	n[33]: copy n[32] => _89 @ bb47[9]: fn exercise_allocator;       _89 = move _90 as *const i8 (Misc);
+	n[33]: copy n[32] => _89 @ bb47[9]: fn exercise_allocator;       _89 = move _90 as *const i8 (PtrToPtr);
 	n[34]: copy n[33] => _1  @ bb0[0]:  fn printf;                   _88 = printf(move _89, move _93);
 	n[35]: copy _     => _92 @ bb47[5]: fn exercise_allocator;       _92 = const b"%i\n\x00";
 	n[36]: copy n[35] => _91 @ bb47[6]: fn exercise_allocator;       _91 = &raw const (*_92);
 	n[37]: copy n[36] => _90 @ bb47[7]: fn exercise_allocator;       _90 = move _91 as *const u8 (Pointer(ArrayToPointer));
-	n[38]: copy n[37] => _89 @ bb47[9]: fn exercise_allocator;       _89 = move _90 as *const i8 (Misc);
+	n[38]: copy n[37] => _89 @ bb47[9]: fn exercise_allocator;       _89 = move _90 as *const i8 (PtrToPtr);
 	n[39]: copy n[38] => _1  @ bb0[0]:  fn printf;                   _88 = printf(move _89, move _93);
 	n[40]: copy _     => _92 @ bb47[5]: fn exercise_allocator;       _92 = const b"%i\n\x00";
 	n[41]: copy n[40] => _91 @ bb47[6]: fn exercise_allocator;       _91 = &raw const (*_92);
 	n[42]: copy n[41] => _90 @ bb47[7]: fn exercise_allocator;       _90 = move _91 as *const u8 (Pointer(ArrayToPointer));
-	n[43]: copy n[42] => _89 @ bb47[9]: fn exercise_allocator;       _89 = move _90 as *const i8 (Misc);
+	n[43]: copy n[42] => _89 @ bb47[9]: fn exercise_allocator;       _89 = move _90 as *const i8 (PtrToPtr);
 	n[44]: copy n[43] => _1  @ bb0[0]:  fn printf;                   _88 = printf(move _89, move _93);
 	n[45]: copy _     => _92 @ bb47[5]: fn exercise_allocator;       _92 = const b"%i\n\x00";
 	n[46]: copy n[45] => _91 @ bb47[6]: fn exercise_allocator;       _91 = &raw const (*_92);
 	n[47]: copy n[46] => _90 @ bb47[7]: fn exercise_allocator;       _90 = move _91 as *const u8 (Pointer(ArrayToPointer));
-	n[48]: copy n[47] => _89 @ bb47[9]: fn exercise_allocator;       _89 = move _90 as *const i8 (Misc);
+	n[48]: copy n[47] => _89 @ bb47[9]: fn exercise_allocator;       _89 = move _90 as *const i8 (PtrToPtr);
 	n[49]: copy n[48] => _1  @ bb0[0]:  fn printf;                   _88 = printf(move _89, move _93);
 	n[50]: copy _     => _9  @ bb2[11]: fn simple_analysis;          _9 = const b"%i\n\x00";
 	n[51]: copy n[50] => _8  @ bb2[12]: fn simple_analysis;          _8 = &raw const (*_9);
 	n[52]: copy n[51] => _7  @ bb2[13]: fn simple_analysis;          _7 = move _8 as *const u8 (Pointer(ArrayToPointer));
-	n[53]: copy n[52] => _6  @ bb2[15]: fn simple_analysis;          _6 = move _7 as *const i8 (Misc);
+	n[53]: copy n[52] => _6  @ bb2[15]: fn simple_analysis;          _6 = move _7 as *const i8 (PtrToPtr);
 	n[54]: copy n[53] => _1  @ bb0[0]:  fn printf;                   _5 = printf(move _6, move _10);
 	n[55]: copy _     => _6  @ bb0[5]:  fn analysis2_helper;         _6 = const b"%i\n\x00";
 	n[56]: copy n[55] => _5  @ bb0[6]:  fn analysis2_helper;         _5 = &raw const (*_6);
 	n[57]: copy n[56] => _4  @ bb0[7]:  fn analysis2_helper;         _4 = move _5 as *const u8 (Pointer(ArrayToPointer));
-	n[58]: copy n[57] => _3  @ bb0[9]:  fn analysis2_helper;         _3 = move _4 as *const i8 (Misc);
+	n[58]: copy n[57] => _3  @ bb0[9]:  fn analysis2_helper;         _3 = move _4 as *const i8 (PtrToPtr);
 	n[59]: copy n[58] => _1  @ bb0[0]:  fn printf;                   _2 = printf(move _3, move _7);
 	n[60]: copy _     => _9  @ bb2[11]: fn inter_function_analysis;  _9 = const b"%i\n\x00";
 	n[61]: copy n[60] => _8  @ bb2[12]: fn inter_function_analysis;  _8 = &raw const (*_9);
 	n[62]: copy n[61] => _7  @ bb2[13]: fn inter_function_analysis;  _7 = move _8 as *const u8 (Pointer(ArrayToPointer));
-	n[63]: copy n[62] => _6  @ bb2[15]: fn inter_function_analysis;  _6 = move _7 as *const i8 (Misc);
+	n[63]: copy n[62] => _6  @ bb2[15]: fn inter_function_analysis;  _6 = move _7 as *const i8 (PtrToPtr);
 	n[64]: copy n[63] => _1  @ bb0[0]:  fn printf;                   _5 = printf(move _6, move _10);
 	n[65]: copy _     => _11 @ bb2[18]: fn invalid;                  _11 = const b"%i\n\x00";
 	n[66]: copy n[65] => _10 @ bb2[19]: fn invalid;                  _10 = &raw const (*_11);
 	n[67]: copy n[66] => _9  @ bb2[20]: fn invalid;                  _9 = move _10 as *const u8 (Pointer(ArrayToPointer));
-	n[68]: copy n[67] => _8  @ bb2[22]: fn invalid;                  _8 = move _9 as *const i8 (Misc);
+	n[68]: copy n[67] => _8  @ bb2[22]: fn invalid;                  _8 = move _9 as *const i8 (PtrToPtr);
 	n[69]: copy n[68] => _1  @ bb0[0]:  fn printf;                   _7 = printf(move _8, move _12);
 	n[70]: copy _     => _17 @ bb3[9]:  fn invalid;                  _17 = const b"%i\n\x00";
 	n[71]: copy n[70] => _16 @ bb3[10]: fn invalid;                  _16 = &raw const (*_17);
 	n[72]: copy n[71] => _15 @ bb3[11]: fn invalid;                  _15 = move _16 as *const u8 (Pointer(ArrayToPointer));
-	n[73]: copy n[72] => _14 @ bb3[13]: fn invalid;                  _14 = move _15 as *const i8 (Misc);
+	n[73]: copy n[72] => _14 @ bb3[13]: fn invalid;                  _14 = move _15 as *const i8 (PtrToPtr);
 	n[74]: copy n[73] => _1  @ bb0[0]:  fn printf;                   _13 = printf(move _14, move _18);
 }
 nodes_that_need_write = []
 
 g {
 	n[0]:  alloc      _     => _11 @ bb5[2]:   fn exercise_allocator;  _11 = realloc(move _12, move _14);
-	n[1]:  copy       n[0]  => _1  @ bb6[2]:   fn exercise_allocator;  _1 = move _11 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0]  => _1  @ bb6[2]:   fn exercise_allocator;  _1 = move _11 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy       n[1]  => _19 @ bb6[6]:   fn exercise_allocator;  _19 = _1;
 	n[3]:  offset[0]  n[2]  => _18 @ bb6[7]:   fn exercise_allocator;  _18 = offset(move _19, const 0_isize);
 	n[4]:  field.0    n[3]  => _   @ bb7[1]:   fn exercise_allocator;  ((*_18).0: i32) = const 10_i32;
@@ -213,7 +213,7 @@ g {
 	n[16]: field.0    n[15] => _32 @ bb13[2]:  fn exercise_allocator;  _32 = ((*_33).0: i32);
 	n[17]: addr.load  n[16] => _   @ bb13[2]:  fn exercise_allocator;  _32 = ((*_33).0: i32);
 	n[18]: copy       n[1]  => _42 @ bb20[6]:  fn exercise_allocator;  _42 = _1;
-	n[19]: copy       n[18] => _41 @ bb20[7]:  fn exercise_allocator;  _41 = move _42 as *mut libc::c_void (Misc);
+	n[19]: copy       n[18] => _41 @ bb20[7]:  fn exercise_allocator;  _41 = move _42 as *mut libc::c_void (PtrToPtr);
 	n[20]: copy       n[1]  => _4  @ bb0[1]:   fn reallocarray;        _4 = _1;
 	n[21]: copy       n[20] => _1  @ bb0[10]:  fn reallocarray;        _0 = const _(move _4, move _5);
 	n[22]: free       n[19] => _40 @ bb21[2]:  fn exercise_allocator;  _40 = reallocarray(move _41, move _43, move _44);
@@ -222,7 +222,7 @@ nodes_that_need_write = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
 g {
 	n[0]:  alloc      _     => _40 @ bb21[2]:  fn exercise_allocator;  _40 = reallocarray(move _41, move _43, move _44);
-	n[1]:  copy       n[0]  => _1  @ bb22[3]:  fn exercise_allocator;  _1 = move _40 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0]  => _1  @ bb22[3]:  fn exercise_allocator;  _1 = move _40 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy       n[1]  => _47 @ bb22[7]:  fn exercise_allocator;  _47 = _1;
 	n[3]:  offset[0]  n[2]  => _46 @ bb22[8]:  fn exercise_allocator;  _46 = offset(move _47, const 0_isize);
 	n[4]:  field.0    n[3]  => _   @ bb23[1]:  fn exercise_allocator;  ((*_46).0: i32) = const 10_i32;
@@ -248,14 +248,14 @@ g {
 	n[24]: field.0    n[23] => _61 @ bb30[2]:  fn exercise_allocator;  _61 = ((*_62).0: i32);
 	n[25]: addr.load  n[24] => _   @ bb30[2]:  fn exercise_allocator;  _61 = ((*_62).0: i32);
 	n[26]: copy       n[1]  => _71 @ bb37[6]:  fn exercise_allocator;  _71 = _1;
-	n[27]: copy       n[26] => _70 @ bb37[7]:  fn exercise_allocator;  _70 = move _71 as *mut libc::c_void (Misc);
+	n[27]: copy       n[26] => _70 @ bb37[7]:  fn exercise_allocator;  _70 = move _71 as *mut libc::c_void (PtrToPtr);
 	n[28]: free       n[27] => _69 @ bb37[9]:  fn exercise_allocator;  _69 = free(move _70);
 }
 nodes_that_need_write = [13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
 g {
 	n[0]:  alloc      _     => _72  @ bb39[2]:  fn exercise_allocator;  _72 = calloc(move _73, move _74);
-	n[1]:  copy       n[0]  => _1   @ bb40[2]:  fn exercise_allocator;  _1 = move _72 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0]  => _1   @ bb40[2]:  fn exercise_allocator;  _1 = move _72 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy       n[1]  => _77  @ bb40[6]:  fn exercise_allocator;  _77 = _1;
 	n[3]:  offset[0]  n[2]  => _76  @ bb40[7]:  fn exercise_allocator;  _76 = offset(move _77, const 0_isize);
 	n[4]:  field.0    n[3]  => _    @ bb41[1]:  fn exercise_allocator;  ((*_76).0: i32) = const 10_i32;
@@ -289,27 +289,27 @@ g {
 	n[32]: field.0    n[31] => _93  @ bb49[2]:  fn exercise_allocator;  _93 = ((*_94).0: i32);
 	n[33]: addr.load  n[32] => _    @ bb49[2]:  fn exercise_allocator;  _93 = ((*_94).0: i32);
 	n[34]: copy       n[1]  => _103 @ bb56[6]:  fn exercise_allocator;  _103 = _1;
-	n[35]: copy       n[34] => _102 @ bb56[7]:  fn exercise_allocator;  _102 = move _103 as *mut libc::c_void (Misc);
+	n[35]: copy       n[34] => _102 @ bb56[7]:  fn exercise_allocator;  _102 = move _103 as *mut libc::c_void (PtrToPtr);
 	n[36]: free       n[35] => _101 @ bb56[9]:  fn exercise_allocator;  _101 = free(move _102);
 }
 nodes_that_need_write = [17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn simple_analysis;  _2 = malloc(move _3);
-	n[1]: copy       n[0] => _1  @ bb2[1]:  fn simple_analysis;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1  @ bb2[1]:  fn simple_analysis;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _   @ bb2[5]:  fn simple_analysis;  ((*_1).0: i32) = const 10_i32;
 	n[3]: addr.store n[2] => _   @ bb2[5]:  fn simple_analysis;  ((*_1).0: i32) = const 10_i32;
 	n[4]: field.0    n[1] => _10 @ bb2[18]: fn simple_analysis;  _10 = ((*_1).0: i32);
 	n[5]: addr.load  n[4] => _   @ bb2[18]: fn simple_analysis;  _10 = ((*_1).0: i32);
 	n[6]: copy       n[1] => _13 @ bb3[7]:  fn simple_analysis;  _13 = _1;
-	n[7]: copy       n[6] => _12 @ bb3[8]:  fn simple_analysis;  _12 = move _13 as *mut libc::c_void (Misc);
+	n[7]: copy       n[6] => _12 @ bb3[8]:  fn simple_analysis;  _12 = move _13 as *mut libc::c_void (PtrToPtr);
 	n[8]: free       n[7] => _11 @ bb3[10]: fn simple_analysis;  _11 = free(move _12);
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]:  alloc      _    => _2 @ bb1[2]:  fn analysis2;         _2 = malloc(move _3);
-	n[1]:  copy       n[0] => _1 @ bb2[1]:  fn analysis2;         _1 = move _2 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0] => _1 @ bb2[1]:  fn analysis2;         _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]:  field.0    n[1] => _  @ bb2[5]:  fn analysis2;         ((*_1).0: i32) = const 10_i32;
 	n[3]:  addr.store n[2] => _  @ bb2[5]:  fn analysis2;         ((*_1).0: i32) = const 10_i32;
 	n[4]:  copy       n[1] => _6 @ bb2[8]:  fn analysis2;         _6 = _1;
@@ -317,7 +317,7 @@ g {
 	n[6]:  field.0    n[5] => _7 @ bb0[12]: fn analysis2_helper;  _7 = ((*_1).0: i32);
 	n[7]:  addr.load  n[6] => _  @ bb0[12]: fn analysis2_helper;  _7 = ((*_1).0: i32);
 	n[8]:  copy       n[5] => _9 @ bb3[5]:  fn analysis2;         _9 = _1;
-	n[9]:  copy       n[8] => _8 @ bb3[6]:  fn analysis2;         _8 = move _9 as *mut libc::c_void (Misc);
+	n[9]:  copy       n[8] => _8 @ bb3[6]:  fn analysis2;         _8 = move _9 as *mut libc::c_void (PtrToPtr);
 	n[10]: free       n[9] => _7 @ bb3[8]:  fn analysis2;         _7 = free(move _8);
 }
 nodes_that_need_write = [3, 2, 1, 0]
@@ -325,33 +325,33 @@ nodes_that_need_write = [3, 2, 1, 0]
 g {
 	n[0]: alloc      _    => _0  @ bb0[2]:  fn malloc_wrapper;           _0 = malloc(move _3);
 	n[1]: copy       n[0] => _2  @ bb1[2]:  fn inter_function_analysis;  _2 = malloc_wrapper(move _3);
-	n[2]: copy       n[1] => _1  @ bb2[1]:  fn inter_function_analysis;  _1 = move _2 as *mut pointers::S (Misc);
+	n[2]: copy       n[1] => _1  @ bb2[1]:  fn inter_function_analysis;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[3]: field.0    n[2] => _   @ bb2[5]:  fn inter_function_analysis;  ((*_1).0: i32) = const 11_i32;
 	n[4]: addr.store n[3] => _   @ bb2[5]:  fn inter_function_analysis;  ((*_1).0: i32) = const 11_i32;
 	n[5]: field.0    n[2] => _10 @ bb2[18]: fn inter_function_analysis;  _10 = ((*_1).0: i32);
 	n[6]: addr.load  n[5] => _   @ bb2[18]: fn inter_function_analysis;  _10 = ((*_1).0: i32);
 	n[7]: copy       n[2] => _13 @ bb3[7]:  fn inter_function_analysis;  _13 = _1;
-	n[8]: copy       n[7] => _12 @ bb3[8]:  fn inter_function_analysis;  _12 = move _13 as *mut libc::c_void (Misc);
+	n[8]: copy       n[7] => _12 @ bb3[8]:  fn inter_function_analysis;  _12 = move _13 as *mut libc::c_void (PtrToPtr);
 	n[9]: free       n[8] => _11 @ bb3[10]: fn inter_function_analysis;  _11 = free(move _12);
 }
 nodes_that_need_write = [4, 3, 2, 1, 0]
 
 g {
 	n[0]: alloc       _    => _2   @ bb1[2]: fn no_owner;  _2 = malloc(move _3);
-	n[1]: value.store n[0] => _5.* @ bb2[3]: fn no_owner;  (*_5) = move _2 as *mut pointers::S (Misc);
+	n[1]: value.store n[0] => _5.* @ bb2[3]: fn no_owner;  (*_5) = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: value.load  _    => _12  @ bb6[6]: fn main_0;    _12 = (*_13);
-	n[3]: copy        n[2] => _11  @ bb6[7]: fn main_0;    _11 = move _12 as *mut libc::c_void (Misc);
+	n[3]: copy        n[2] => _11  @ bb6[7]: fn main_0;    _11 = move _12 as *mut libc::c_void (PtrToPtr);
 	n[4]: free        n[3] => _10  @ bb6[9]: fn main_0;    _10 = free(move _11);
 }
 nodes_that_need_write = []
 
 g {
 	n[0]:  copy       _     => _5  @ bb2[2]:  fn no_owner;  _5 = const {alloc8: *mut *mut pointers::S};
-	n[1]:  addr.store n[0]  => _   @ bb2[3]:  fn no_owner;  (*_5) = move _2 as *mut pointers::S (Misc);
+	n[1]:  addr.store n[0]  => _   @ bb2[3]:  fn no_owner;  (*_5) = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy       _     => _13 @ bb6[5]:  fn main_0;    _13 = const {alloc8: *mut *mut pointers::S};
 	n[3]:  addr.load  n[2]  => _   @ bb6[6]:  fn main_0;    _12 = (*_13);
 	n[4]:  copy       _     => _5  @ bb2[2]:  fn no_owner;  _5 = const {alloc8: *mut *mut pointers::S};
-	n[5]:  addr.store n[4]  => _   @ bb2[3]:  fn no_owner;  (*_5) = move _2 as *mut pointers::S (Misc);
+	n[5]:  addr.store n[4]  => _   @ bb2[3]:  fn no_owner;  (*_5) = move _2 as *mut pointers::S (PtrToPtr);
 	n[6]:  copy       _     => _12 @ bb3[4]:  fn no_owner;  _12 = const {alloc8: *mut *mut pointers::S};
 	n[7]:  addr.load  n[6]  => _   @ bb3[5]:  fn no_owner;  _11 = (*_12);
 	n[8]:  copy       _     => _6  @ bb2[9]:  fn invalid;   _6 = const {alloc8: *mut *mut pointers::S};
@@ -366,16 +366,16 @@ nodes_that_need_write = [14, 13, 9, 8, 5, 4, 1, 0]
 
 g {
 	n[0]: alloc       _    => _2   @ bb1[2]: fn no_owner;  _2 = malloc(move _3);
-	n[1]: value.store n[0] => _5.* @ bb2[3]: fn no_owner;  (*_5) = move _2 as *mut pointers::S (Misc);
+	n[1]: value.store n[0] => _5.* @ bb2[3]: fn no_owner;  (*_5) = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: value.load  _    => _11  @ bb3[5]: fn no_owner;  _11 = (*_12);
-	n[3]: copy        n[2] => _10  @ bb3[6]: fn no_owner;  _10 = move _11 as *mut libc::c_void (Misc);
+	n[3]: copy        n[2] => _10  @ bb3[6]: fn no_owner;  _10 = move _11 as *mut libc::c_void (PtrToPtr);
 	n[4]: free        n[3] => _9   @ bb3[8]: fn no_owner;  _9 = free(move _10);
 }
 nodes_that_need_write = []
 
 g {
 	n[0]:  alloc       _    => _2   @ bb1[2]:  fn invalid;  _2 = malloc(move _3);
-	n[1]:  copy        n[0] => _1   @ bb2[1]:  fn invalid;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]:  copy        n[0] => _1   @ bb2[1]:  fn invalid;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]:  field.0     n[1] => _    @ bb2[5]:  fn invalid;  ((*_1).0: i32) = const 10_i32;
 	n[3]:  addr.store  n[2] => _    @ bb2[5]:  fn invalid;  ((*_1).0: i32) = const 10_i32;
 	n[4]:  copy        n[1] => _5   @ bb2[7]:  fn invalid;  _5 = _1;
@@ -383,7 +383,7 @@ g {
 	n[6]:  field.0     n[1] => _12  @ bb2[25]: fn invalid;  _12 = ((*_1).0: i32);
 	n[7]:  addr.load   n[6] => _    @ bb2[25]: fn invalid;  _12 = ((*_1).0: i32);
 	n[8]:  copy        n[1] => _23  @ bb4[12]: fn invalid;  _23 = _1;
-	n[9]:  copy        n[8] => _22  @ bb4[13]: fn invalid;  _22 = move _23 as *mut libc::c_void (Misc);
+	n[9]:  copy        n[8] => _22  @ bb4[13]: fn invalid;  _22 = move _23 as *mut libc::c_void (PtrToPtr);
 	n[10]: free        n[9] => _21  @ bb4[15]: fn invalid;  _21 = free(move _22);
 }
 nodes_that_need_write = [3, 2, 1, 0]
@@ -409,9 +409,9 @@ nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn simple1;  _2 = malloc(move _3);
-	n[1]: copy       n[0] => _1  @ bb2[1]:  fn simple1;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1  @ bb2[1]:  fn simple1;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: copy       n[1] => _8  @ bb2[8]:  fn simple1;  _8 = _1;
-	n[3]: copy       n[2] => _7  @ bb2[9]:  fn simple1;  _7 = move _8 as *mut libc::c_void (Misc);
+	n[3]: copy       n[2] => _7  @ bb2[9]:  fn simple1;  _7 = move _8 as *mut libc::c_void (PtrToPtr);
 	n[4]: free       n[3] => _6  @ bb3[2]:  fn simple1;  _6 = realloc(move _7, move _9);
 	n[5]: copy       n[1] => _16 @ bb4[21]: fn simple1;  _16 = _1;
 	n[6]: ptr_to_int n[5] => _   @ bb4[22]: fn simple1;  _15 = move _16 as usize (PointerExposeAddress);
@@ -420,7 +420,7 @@ nodes_that_need_write = []
 
 g {
 	n[0]:  alloc      _    => _6  @ bb3[2]:  fn simple1;  _6 = realloc(move _7, move _9);
-	n[1]:  copy       n[0] => _5  @ bb4[2]:  fn simple1;  _5 = move _6 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0] => _5  @ bb4[2]:  fn simple1;  _5 = move _6 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy       n[1] => _11 @ bb4[6]:  fn simple1;  _11 = _5;
 	n[3]:  field.0    n[2] => _   @ bb4[8]:  fn simple1;  ((*_11).0: i32) = const 10_i32;
 	n[4]:  addr.store n[3] => _   @ bb4[8]:  fn simple1;  ((*_11).0: i32) = const 10_i32;
@@ -428,7 +428,7 @@ g {
 	n[6]:  copy       n[2] => _13 @ bb4[13]: fn simple1;  _13 = _11;
 	n[7]:  int_to_ptr _    => _17 @ bb4[28]: fn simple1;  _17 = move _18 as *const libc::c_void (PointerFromExposedAddress);
 	n[8]:  copy       n[1] => _21 @ bb4[34]: fn simple1;  _21 = _5;
-	n[9]:  copy       n[8] => _20 @ bb4[35]: fn simple1;  _20 = move _21 as *mut libc::c_void (Misc);
+	n[9]:  copy       n[8] => _20 @ bb4[35]: fn simple1;  _20 = move _21 as *mut libc::c_void (PtrToPtr);
 	n[10]: free       n[9] => _19 @ bb4[37]: fn simple1;  _19 = free(move _20);
 }
 nodes_that_need_write = [4, 3, 2, 1, 0]
@@ -442,7 +442,7 @@ nodes_that_need_write = [1, 0]
 
 g {
 	n[0]:  alloc       _     => _2     @ bb1[2]:  fn lighttpd_test;       _2 = malloc(move _3);
-	n[1]:  copy        n[0]  => _1     @ bb2[1]:  fn lighttpd_test;       _1 = move _2 as *mut *mut pointers::fdnode_st (Misc);
+	n[1]:  copy        n[0]  => _1     @ bb2[1]:  fn lighttpd_test;       _1 = move _2 as *mut *mut pointers::fdnode_st (PtrToPtr);
 	n[2]:  copy        n[1]  => _9     @ bb4[5]:  fn lighttpd_test;       _9 = _1;
 	n[3]:  value.store n[2]  => _5.*.0 @ bb4[6]:  fn lighttpd_test;       ((*_5).0: *mut *mut pointers::fdnode_st) = move _9;
 	n[4]:  value.load  _     => _8     @ bb0[2]:  fn fdevent_register;    _8 = ((*_1).0: *mut *mut pointers::fdnode_st);
@@ -458,14 +458,14 @@ g {
 	n[14]: copy        n[13] => _17    @ bb8[3]:  fn fdevent_unregister;  _17 = &mut (*_18);
 	n[15]: addr.store  n[14] => _      @ bb8[4]:  fn fdevent_unregister;  (*_17) = const 0_usize as *mut pointers::fdnode_st (PointerFromExposedAddress);
 	n[16]: copy        n[1]  => _20    @ bb6[6]:  fn lighttpd_test;       _20 = _1;
-	n[17]: copy        n[16] => _19    @ bb6[7]:  fn lighttpd_test;       _19 = move _20 as *mut libc::c_void (Misc);
+	n[17]: copy        n[16] => _19    @ bb6[7]:  fn lighttpd_test;       _19 = move _20 as *mut libc::c_void (PtrToPtr);
 	n[18]: free        n[17] => _18    @ bb6[9]:  fn lighttpd_test;       _18 = free(move _19);
 }
 nodes_that_need_write = [15, 14, 13, 12, 7, 6, 5, 4]
 
 g {
 	n[0]:  alloc      _     => _6  @ bb3[2]:  fn lighttpd_test;                  _6 = malloc(move _7);
-	n[1]:  copy       n[0]  => _5  @ bb4[1]:  fn lighttpd_test;                  _5 = move _6 as *mut pointers::fdevents (Misc);
+	n[1]:  copy       n[0]  => _5  @ bb4[1]:  fn lighttpd_test;                  _5 = move _6 as *mut pointers::fdevents (PtrToPtr);
 	n[2]:  field.0    n[1]  => _   @ bb4[6]:  fn lighttpd_test;                  ((*_5).0: *mut *mut pointers::fdnode_st) = move _9;
 	n[3]:  addr.store n[2]  => _   @ bb4[6]:  fn lighttpd_test;                  ((*_5).0: *mut *mut pointers::fdnode_st) = move _9;
 	n[4]:  copy       n[1]  => _12 @ bb4[10]: fn lighttpd_test;                  _12 = _5;
@@ -484,7 +484,7 @@ g {
 	n[17]: field.0    n[14] => _19 @ bb7[4]:  fn fdevent_unregister;             _19 = ((*_1).0: *mut *mut pointers::fdnode_st);
 	n[18]: addr.load  n[17] => _   @ bb7[4]:  fn fdevent_unregister;             _19 = ((*_1).0: *mut *mut pointers::fdnode_st);
 	n[19]: copy       n[15] => _23 @ bb7[5]:  fn lighttpd_test;                  _23 = _5;
-	n[20]: copy       n[19] => _22 @ bb7[6]:  fn lighttpd_test;                  _22 = move _23 as *mut libc::c_void (Misc);
+	n[20]: copy       n[19] => _22 @ bb7[6]:  fn lighttpd_test;                  _22 = move _23 as *mut libc::c_void (PtrToPtr);
 	n[21]: free       n[20] => _21 @ bb7[8]:  fn lighttpd_test;                  _21 = free(move _22);
 }
 nodes_that_need_write = [3, 2, 1, 0]
@@ -508,13 +508,13 @@ nodes_that_need_write = [1, 0]
 
 g {
 	n[0]:  alloc       _     => _5      @ bb1[2]:  fn connection_accepted;  _5 = malloc(move _6);
-	n[1]:  copy        n[0]  => _4      @ bb2[1]:  fn connection_accepted;  _4 = move _5 as *mut pointers::connection (Misc);
+	n[1]:  copy        n[0]  => _4      @ bb2[1]:  fn connection_accepted;  _4 = move _5 as *mut pointers::connection (PtrToPtr);
 	n[2]:  field.0     n[1]  => _       @ bb2[6]:  fn connection_accepted;  ((*_4).0: i32) = move _8;
 	n[3]:  addr.store  n[2]  => _       @ bb2[6]:  fn connection_accepted;  ((*_4).0: i32) = move _8;
 	n[4]:  field.0     n[1]  => _11     @ bb2[12]: fn connection_accepted;  _11 = ((*_4).0: i32);
 	n[5]:  addr.load   n[4]  => _       @ bb2[12]: fn connection_accepted;  _11 = ((*_4).0: i32);
 	n[6]:  copy        n[1]  => _15     @ bb2[20]: fn connection_accepted;  _15 = _4;
-	n[7]:  copy        n[6]  => _14     @ bb2[21]: fn connection_accepted;  _14 = move _15 as *mut libc::c_void (Misc);
+	n[7]:  copy        n[6]  => _14     @ bb2[21]: fn connection_accepted;  _14 = move _15 as *mut libc::c_void (PtrToPtr);
 	n[8]:  copy        n[7]  => _4      @ bb0[0]:  fn fdevent_register;     _9 = fdevent_register(move _10, move _11, move _12, move _14);
 	n[9]:  copy        n[8]  => _15     @ bb2[15]: fn fdevent_register;     _15 = _4;
 	n[10]: value.store n[9]  => _12.*.1 @ bb2[16]: fn fdevent_register;     ((*_12).1: *mut libc::c_void) = move _15;
@@ -529,14 +529,14 @@ g {
 	n[19]: field.0     n[16] => _8      @ bb1[7]:  fn connection_close;     _8 = ((*_2).0: i32);
 	n[20]: addr.load   n[19] => _       @ bb1[7]:  fn connection_close;     _8 = ((*_2).0: i32);
 	n[21]: copy        n[16] => _11     @ bb2[6]:  fn connection_close;     _11 = _2;
-	n[22]: copy        n[21] => _10     @ bb2[7]:  fn connection_close;     _10 = move _11 as *mut libc::c_void (Misc);
+	n[22]: copy        n[21] => _10     @ bb2[7]:  fn connection_close;     _10 = move _11 as *mut libc::c_void (PtrToPtr);
 	n[23]: free        n[22] => _9      @ bb2[9]:  fn connection_close;     _9 = free(move _10);
 }
 nodes_that_need_write = [12, 11, 3, 2, 1, 0]
 
 g {
 	n[0]:  alloc       _     => _3     @ bb1[2]:  fn fdnode_init;                    _3 = calloc(move _4, move _6);
-	n[1]:  copy        n[0]  => _2     @ bb2[2]:  fn fdnode_init;                    _2 = move _3 as *mut pointers::fdnode_st (Misc);
+	n[1]:  copy        n[0]  => _2     @ bb2[2]:  fn fdnode_init;                    _2 = move _3 as *mut pointers::fdnode_st (PtrToPtr);
 	n[2]:  copy        n[1]  => _10    @ bb2[9]:  fn fdnode_init;                    _10 = _2;
 	n[3]:  copy        n[2]  => _1     @ bb0[0]:  fn is_null;                        _9 = is_null(move _10);
 	n[4]:  copy        n[1]  => _0     @ bb9[2]:  fn fdnode_init;                    _0 = _2;
@@ -570,7 +570,7 @@ g {
 	n[32]: copy        n[29] => _23    @ bb8[7]:  fn fdevent_unregister;             _23 = _3;
 	n[33]: copy        n[32] => _1     @ bb0[0]:  fn fdnode_free;                    _22 = fdnode_free(move _23);
 	n[34]: copy        n[33] => _4     @ bb0[3]:  fn fdnode_free;                    _4 = _1;
-	n[35]: copy        n[34] => _3     @ bb0[4]:  fn fdnode_free;                    _3 = move _4 as *mut libc::c_void (Misc);
+	n[35]: copy        n[34] => _3     @ bb0[4]:  fn fdnode_free;                    _3 = move _4 as *mut libc::c_void (PtrToPtr);
 	n[36]: free        n[35] => _2     @ bb0[6]:  fn fdnode_free;                    _2 = free(move _3);
 }
 nodes_that_need_write = [17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7]
@@ -584,9 +584,9 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc _    => _2 @ bb1[2]:  fn test_malloc_free_cast;  _2 = malloc(move _3);
-	n[1]: copy  n[0] => _1 @ bb2[1]:  fn test_malloc_free_cast;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy  n[0] => _1 @ bb2[1]:  fn test_malloc_free_cast;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: copy  n[1] => _7 @ bb2[7]:  fn test_malloc_free_cast;  _7 = _1;
-	n[3]: copy  n[2] => _6 @ bb2[8]:  fn test_malloc_free_cast;  _6 = move _7 as *mut libc::c_void (Misc);
+	n[3]: copy  n[2] => _6 @ bb2[8]:  fn test_malloc_free_cast;  _6 = move _7 as *mut libc::c_void (PtrToPtr);
 	n[4]: free  n[3] => _5 @ bb2[10]: fn test_malloc_free_cast;  _5 = free(move _6);
 }
 nodes_that_need_write = []
@@ -691,10 +691,10 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc     _    => _2 @ bb1[2]:  fn test_load_addr;  _2 = calloc(const 1_u64, move _3);
-	n[1]: copy      n[0] => _1 @ bb2[1]:  fn test_load_addr;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy      n[0] => _1 @ bb2[1]:  fn test_load_addr;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: addr.load n[1] => _  @ bb2[5]:  fn test_load_addr;  _5 = (*_1);
 	n[3]: copy      n[1] => _8 @ bb2[10]: fn test_load_addr;  _8 = _1;
-	n[4]: copy      n[3] => _7 @ bb2[11]: fn test_load_addr;  _7 = move _8 as *mut libc::c_void (Misc);
+	n[4]: copy      n[3] => _7 @ bb2[11]: fn test_load_addr;  _7 = move _8 as *mut libc::c_void (PtrToPtr);
 	n[5]: free      n[4] => _6 @ bb2[13]: fn test_load_addr;  _6 = free(move _7);
 }
 nodes_that_need_write = []
@@ -718,42 +718,42 @@ nodes_that_need_write = []
 
 g {
 	n[0]: alloc      _    => _2 @ bb1[2]:  fn test_store_addr;  _2 = malloc(move _3);
-	n[1]: copy       n[0] => _1 @ bb2[1]:  fn test_store_addr;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1 @ bb2[1]:  fn test_store_addr;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _  @ bb2[4]:  fn test_store_addr;  ((*_1).0: i32) = const 10_i32;
 	n[3]: addr.store n[2] => _  @ bb2[4]:  fn test_store_addr;  ((*_1).0: i32) = const 10_i32;
 	n[4]: copy       n[1] => _7 @ bb2[8]:  fn test_store_addr;  _7 = _1;
-	n[5]: copy       n[4] => _6 @ bb2[9]:  fn test_store_addr;  _6 = move _7 as *mut libc::c_void (Misc);
+	n[5]: copy       n[4] => _6 @ bb2[9]:  fn test_store_addr;  _6 = move _7 as *mut libc::c_void (PtrToPtr);
 	n[6]: free       n[5] => _5 @ bb2[11]: fn test_store_addr;  _5 = free(move _6);
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn test_load_other_store_self;  _2 = malloc(move _3);
-	n[1]: copy       n[0] => _1  @ bb2[1]:  fn test_load_other_store_self;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1  @ bb2[1]:  fn test_load_other_store_self;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _   @ bb4[4]:  fn test_load_other_store_self;  ((*_1).0: i32) = const 10_i32;
 	n[3]: addr.store n[2] => _   @ bb4[4]:  fn test_load_other_store_self;  ((*_1).0: i32) = const 10_i32;
 	n[4]: field.0    n[1] => _9  @ bb4[6]:  fn test_load_other_store_self;  _9 = ((*_1).0: i32);
 	n[5]: addr.load  n[4] => _   @ bb4[6]:  fn test_load_other_store_self;  _9 = ((*_1).0: i32);
 	n[6]: copy       n[1] => _12 @ bb4[12]: fn test_load_other_store_self;  _12 = _1;
-	n[7]: copy       n[6] => _11 @ bb4[13]: fn test_load_other_store_self;  _11 = move _12 as *mut libc::c_void (Misc);
+	n[7]: copy       n[6] => _11 @ bb4[13]: fn test_load_other_store_self;  _11 = move _12 as *mut libc::c_void (PtrToPtr);
 	n[8]: free       n[7] => _10 @ bb4[15]: fn test_load_other_store_self;  _10 = free(move _11);
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]: alloc      _    => _6  @ bb3[2]: fn test_load_other_store_self;  _6 = malloc(move _7);
-	n[1]: copy       n[0] => _5  @ bb4[1]: fn test_load_other_store_self;  _5 = move _6 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _5  @ bb4[1]: fn test_load_other_store_self;  _5 = move _6 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _   @ bb4[7]: fn test_load_other_store_self;  ((*_5).0: i32) = move _9;
 	n[3]: addr.store n[2] => _   @ bb4[7]: fn test_load_other_store_self;  ((*_5).0: i32) = move _9;
 	n[4]: copy       n[1] => _15 @ bb5[5]: fn test_load_other_store_self;  _15 = _5;
-	n[5]: copy       n[4] => _14 @ bb5[6]: fn test_load_other_store_self;  _14 = move _15 as *mut libc::c_void (Misc);
+	n[5]: copy       n[4] => _14 @ bb5[6]: fn test_load_other_store_self;  _14 = move _15 as *mut libc::c_void (PtrToPtr);
 	n[6]: free       n[5] => _13 @ bb5[8]: fn test_load_other_store_self;  _13 = free(move _14);
 }
 nodes_that_need_write = [3, 2, 1, 0]
 
 g {
 	n[0]:  alloc      _    => _2 @ bb1[2]:  fn test_load_self_store_self;  _2 = calloc(move _3, move _4);
-	n[1]:  copy       n[0] => _1 @ bb2[2]:  fn test_load_self_store_self;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]:  copy       n[0] => _1 @ bb2[2]:  fn test_load_self_store_self;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]:  field.3    n[1] => _  @ bb2[6]:  fn test_load_self_store_self;  _6 = (((*_1).3: pointers::T).3: i32);
 	n[3]:  field.3    n[2] => _6 @ bb2[6]:  fn test_load_self_store_self;  _6 = (((*_1).3: pointers::T).3: i32);
 	n[4]:  addr.load  n[3] => _  @ bb2[6]:  fn test_load_self_store_self;  _6 = (((*_1).3: pointers::T).3: i32);
@@ -761,20 +761,20 @@ g {
 	n[6]:  field.3    n[5] => _  @ bb2[7]:  fn test_load_self_store_self;  (((*_1).3: pointers::T).3: i32) = move _6;
 	n[7]:  addr.store n[6] => _  @ bb2[7]:  fn test_load_self_store_self;  (((*_1).3: pointers::T).3: i32) = move _6;
 	n[8]:  copy       n[1] => _9 @ bb2[12]: fn test_load_self_store_self;  _9 = _1;
-	n[9]:  copy       n[8] => _8 @ bb2[13]: fn test_load_self_store_self;  _8 = move _9 as *mut libc::c_void (Misc);
+	n[9]:  copy       n[8] => _8 @ bb2[13]: fn test_load_self_store_self;  _8 = move _9 as *mut libc::c_void (PtrToPtr);
 	n[10]: free       n[9] => _7 @ bb2[15]: fn test_load_self_store_self;  _7 = free(move _8);
 }
 nodes_that_need_write = [7, 6, 5, 1, 0]
 
 g {
 	n[0]: alloc      _    => _2  @ bb1[2]:  fn test_load_self_store_self_inter;  _2 = calloc(move _3, move _4);
-	n[1]: copy       n[0] => _1  @ bb2[2]:  fn test_load_self_store_self_inter;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _1  @ bb2[2]:  fn test_load_self_store_self_inter;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]: field.0    n[1] => _6  @ bb2[6]:  fn test_load_self_store_self_inter;  _6 = ((*_1).0: i32);
 	n[3]: addr.load  n[2] => _   @ bb2[6]:  fn test_load_self_store_self_inter;  _6 = ((*_1).0: i32);
 	n[4]: field.0    n[1] => _   @ bb2[10]: fn test_load_self_store_self_inter;  ((*_1).0: i32) = move _7;
 	n[5]: addr.store n[4] => _   @ bb2[10]: fn test_load_self_store_self_inter;  ((*_1).0: i32) = move _7;
 	n[6]: copy       n[1] => _10 @ bb2[15]: fn test_load_self_store_self_inter;  _10 = _1;
-	n[7]: copy       n[6] => _9  @ bb2[16]: fn test_load_self_store_self_inter;  _9 = move _10 as *mut libc::c_void (Misc);
+	n[7]: copy       n[6] => _9  @ bb2[16]: fn test_load_self_store_self_inter;  _9 = move _10 as *mut libc::c_void (PtrToPtr);
 	n[8]: free       n[7] => _8  @ bb2[18]: fn test_load_self_store_self_inter;  _8 = free(move _9);
 }
 nodes_that_need_write = [5, 4, 1, 0]
@@ -824,7 +824,7 @@ nodes_that_need_write = [3, 2, 0]
 
 g {
 	n[0]:  alloc       _    => _2     @ bb1[2]:  fn test_store_value_field;  _2 = malloc(move _3);
-	n[1]:  copy        n[0] => _1     @ bb2[1]:  fn test_store_value_field;  _1 = move _2 as *mut pointers::S (Misc);
+	n[1]:  copy        n[0] => _1     @ bb2[1]:  fn test_store_value_field;  _1 = move _2 as *mut pointers::S (PtrToPtr);
 	n[2]:  copy        n[1] => _9     @ bb4[5]:  fn test_store_value_field;  _9 = _1;
 	n[3]:  value.store n[2] => _5.*.2 @ bb4[6]:  fn test_store_value_field;  ((*_5).2: *const pointers::S) = move _9 as *const pointers::S (Pointer(MutToConstPointer));
 	n[4]:  value.load  _    => _10    @ bb4[9]:  fn test_store_value_field;  _10 = ((*_5).2: *const pointers::S);
@@ -832,20 +832,20 @@ g {
 	n[6]:  addr.store  n[5] => _      @ bb4[10]: fn test_store_value_field;  ((*_1).2: *const pointers::S) = move _10;
 	n[7]:  value.store n[4] => _1.*.2 @ bb4[10]: fn test_store_value_field;  ((*_1).2: *const pointers::S) = move _10;
 	n[8]:  copy        n[1] => _16    @ bb5[5]:  fn test_store_value_field;  _16 = _1;
-	n[9]:  copy        n[8] => _15    @ bb5[6]:  fn test_store_value_field;  _15 = move _16 as *mut libc::c_void (Misc);
+	n[9]:  copy        n[8] => _15    @ bb5[6]:  fn test_store_value_field;  _15 = move _16 as *mut libc::c_void (PtrToPtr);
 	n[10]: free        n[9] => _14    @ bb5[8]:  fn test_store_value_field;  _14 = free(move _15);
 }
 nodes_that_need_write = [6, 5, 1, 0]
 
 g {
 	n[0]: alloc      _    => _6  @ bb3[2]:  fn test_store_value_field;  _6 = malloc(move _7);
-	n[1]: copy       n[0] => _5  @ bb4[1]:  fn test_store_value_field;  _5 = move _6 as *mut pointers::S (Misc);
+	n[1]: copy       n[0] => _5  @ bb4[1]:  fn test_store_value_field;  _5 = move _6 as *mut pointers::S (PtrToPtr);
 	n[2]: field.2    n[1] => _   @ bb4[6]:  fn test_store_value_field;  ((*_5).2: *const pointers::S) = move _9 as *const pointers::S (Pointer(MutToConstPointer));
 	n[3]: addr.store n[2] => _   @ bb4[6]:  fn test_store_value_field;  ((*_5).2: *const pointers::S) = move _9 as *const pointers::S (Pointer(MutToConstPointer));
 	n[4]: field.2    n[1] => _10 @ bb4[9]:  fn test_store_value_field;  _10 = ((*_5).2: *const pointers::S);
 	n[5]: addr.load  n[4] => _   @ bb4[9]:  fn test_store_value_field;  _10 = ((*_5).2: *const pointers::S);
 	n[6]: copy       n[1] => _13 @ bb4[15]: fn test_store_value_field;  _13 = _5;
-	n[7]: copy       n[6] => _12 @ bb4[16]: fn test_store_value_field;  _12 = move _13 as *mut libc::c_void (Misc);
+	n[7]: copy       n[6] => _12 @ bb4[16]: fn test_store_value_field;  _12 = move _13 as *mut libc::c_void (PtrToPtr);
 	n[8]: free       n[7] => _11 @ bb4[18]: fn test_store_value_field;  _11 = free(move _12);
 }
 nodes_that_need_write = [3, 2, 1, 0]

--- a/pdg/src/snapshots/c2rust_pdg__tests__analysis_tests_misc_pdg_snapshot_release.snap
+++ b/pdg/src/snapshots/c2rust_pdg__tests__analysis_tests_misc_pdg_snapshot_release.snap
@@ -215,7 +215,7 @@ g {
 	n[18]: copy       n[1]  => _42 @ bb20[6]:  fn exercise_allocator;  _42 = _1;
 	n[19]: copy       n[18] => _41 @ bb20[7]:  fn exercise_allocator;  _41 = move _42 as *mut libc::c_void (Misc);
 	n[20]: copy       n[1]  => _4  @ bb0[1]:   fn reallocarray;        _4 = _1;
-	n[21]: copy       n[20] => _1  @ bb0[10]:  fn reallocarray;        _0 = const pointers::REALLOC(move _4, move _5);
+	n[21]: copy       n[20] => _1  @ bb0[10]:  fn reallocarray;        _0 = const _(move _4, move _5);
 	n[22]: free       n[19] => _40 @ bb21[2]:  fn exercise_allocator;  _40 = reallocarray(move _41, move _43, move _44);
 }
 nodes_that_need_write = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]

--- a/pdg/src/util.rs
+++ b/pdg/src/util.rs
@@ -12,7 +12,7 @@ pub struct ShortOption<T>(pub Option<T>);
 impl<T: Display> Display for ShortOption<T> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self.0 {
-            Some(this) => write!(f, "{}", this),
+            Some(this) => write!(f, "{this}"),
             None => write!(f, "_"),
         }
     }
@@ -21,7 +21,7 @@ impl<T: Display> Display for ShortOption<T> {
 impl<T: Debug> Debug for ShortOption<T> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match &self.0 {
-            Some(this) => write!(f, "{:?}", this),
+            Some(this) => write!(f, "{this:?}"),
             None => write!(f, "_"),
         }
     }
@@ -94,7 +94,7 @@ impl<T> Duplicates<T> {
                     _ => format!("({count}x) {duplicate}"),
                 })
                 .join(", ");
-            writeln!(f, "\t{}", duplicates)?;
+            writeln!(f, "\t{duplicates}")?;
         }
         write!(f, "and {} more...", num_remaining(self.len()))?;
         Ok(())
@@ -120,7 +120,7 @@ impl<T: Debug + Eq + Hash> Duplicates<T> {
         if self.is_empty() {
             return;
         }
-        panic!("unexpected duplicates: {:?}", self);
+        panic!("unexpected duplicates: {self:?}");
     }
 }
 
@@ -131,7 +131,7 @@ impl<T: Display + Eq + Hash> Duplicates<T> {
         if self.is_empty() {
             return;
         }
-        panic!("unexpected duplicates: {}", self);
+        panic!("unexpected duplicates: {self}");
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-08-29"
+channel = "nightly-2022-08-30"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-09-17"
+channel = "nightly-2022-09-19"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-10-08"
+channel = "nightly-2022-10-09"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-10-09"
+channel = "nightly-2022-12-06"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-08-30"
+channel = "nightly-2022-09-08"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-09-19"
+channel = "nightly-2022-09-21"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-08-08"
+channel = "nightly-2022-08-22"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-08-22"
+channel = "nightly-2022-08-23"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-08-23"
+channel = "nightly-2022-08-29"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-09-08"
+channel = "nightly-2022-09-17"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-09-21"
+channel = "nightly-2022-10-08"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]


### PR DESCRIPTION
This incrementally updates our `rustc` version to `nightly-2022-12-06` from `nightly-2022-08-08`.

I stopped there as the next nightly causes a panic in `c2rust-analyze` whose fix will probably be a bit more involved.

This helps us get closer back to the latest nightly so we don't stay too far behind, which makes updating later much harder.  

And as a result, the published [`rustc` nightly docs](https://doc.rust-lang.org/nightly/nightly-rustc/) become increasingly accurate as we near the latest nightly.  Docs are only published for the latest nightly, not the old versions we're using, and `rustup doc` doesn't seem to contain them anywhere (it contains the `rustc` book docs, but not the `rustdoc` docs of `rustc`'s code itself).  Docs could be built directly from [rust-lang/rust](https://github.com/rust-lang/rust), but that's a major pain as the build system is not trivial.

The changes should be a lot easier to see/review by commit rather than all at once.

The commits of meaningful changes are:
* 74f703fcc7a865cc27f83539eaa2a5afaff84a6a
* de457a95064d93b9c6e5448e777fc938121103ee
* 4a740ab2f3db148e11e5a5ae92fecf2c5f6669e7
* 76be3078892d5d3fd7c076568d447339070c265d
* 674d0e20458ca26b3d32bdb9e3e4bdc37bc29ae8
* 7fd06e33496b8e3817eb37a61f80e68042ab8b30

Of these, really only these are significant changes/fixes:
* 4a740ab2f3db148e11e5a5ae92fecf2c5f6669e7