### PR TITLE
Revert "Fixed all `clippy::too_many_arguments` warnings by adding `st…

### DIFF
--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -19,7 +19,6 @@ use crate::c_ast::iterators::{DFExpr, SomeId};
 use crate::c_ast::CLabelId;
 use crate::diagnostics::TranslationResult;
 use crate::rust_ast::SpanExt;
-use crate::translator::assembly::ConvertAsmArgs;
 use c2rust_ast_printer::pprust;
 use proc_macro2::Span;
 use std::collections::hash_map::DefaultHasher;
@@ -1950,14 +1949,12 @@ impl CfgBuilder {
             } => {
                 wip.extend(translator.convert_asm(
                     ctx,
-                    ConvertAsmArgs {
-                        span: Span::call_site(),
-                        is_volatile,
-                        asm,
-                        inputs,
-                        outputs,
-                        clobbers,
-                    },
+                    Span::call_site(),
+                    is_volatile,
+                    asm,
+                    inputs,
+                    outputs,
+                    clobbers,
                 )?);
                 Ok(Some(wip))
             }

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 mod diagnostics;
 
 pub mod build_files;

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -629,17 +629,6 @@ fn rewrite_asm<F: Fn(&str) -> bool, M: Fn(usize) -> usize>(
     Ok(out)
 }
 
-/// Args for [`Translation::convert_asm`](Translation::convert_asm).
-#[allow(missing_docs)]
-pub struct ConvertAsmArgs<'a> {
-    pub span: Span,
-    pub is_volatile: bool,
-    pub asm: &'a str,
-    pub inputs: &'a [AsmOperand],
-    pub outputs: &'a [AsmOperand],
-    pub clobbers: &'a [String],
-}
-
 impl<'c> Translation<'c> {
     /// Convert an inline-assembly statement into one or more Rust statements.
     /// If inline assembly translation is not enabled this will result in an
@@ -651,16 +640,13 @@ impl<'c> Translation<'c> {
     pub fn convert_asm(
         &self,
         ctx: ExprContext,
-        args: ConvertAsmArgs,
+        span: Span,
+        is_volatile: bool,
+        asm: &str,
+        inputs: &[AsmOperand],
+        outputs: &[AsmOperand],
+        clobbers: &[String],
     ) -> TranslationResult<Vec<Stmt>> {
-        let ConvertAsmArgs {
-            span,
-            is_volatile,
-            asm,
-            inputs,
-            outputs,
-            clobbers,
-        } = args;
         if !self.tcfg.translate_asm {
             return Err(TranslationError::generic(
                 "Inline assembly translation not enabled.",

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -3,17 +3,6 @@ use crate::format_translation_err;
 use super::*;
 use std::sync::atomic::Ordering;
 
-/// Args for [`Translation::convert_atomic`].
-pub struct ConvertAtomicArgs<'a> {
-    pub name: &'a str,
-    pub ptr_id: CExprId,
-    pub order_id: CExprId,
-    pub val1_id: Option<CExprId>,
-    pub order_fail_id: Option<CExprId>,
-    pub val2_id: Option<CExprId>,
-    pub weak_id: Option<CExprId>,
-}
-
 impl<'c> Translation<'c> {
     fn convert_constant_bool(&self, expr: CExprId) -> Option<bool> {
         let val = self.ast_context.resolve_expr(expr).1;
@@ -45,18 +34,14 @@ impl<'c> Translation<'c> {
     pub fn convert_atomic(
         &self,
         ctx: ExprContext,
-        args: ConvertAtomicArgs,
+        name: &str,
+        ptr_id: CExprId,
+        order_id: CExprId,
+        val1_id: Option<CExprId>,
+        order_fail_id: Option<CExprId>,
+        val2_id: Option<CExprId>,
+        weak_id: Option<CExprId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let ConvertAtomicArgs {
-            name,
-            ptr_id,
-            order_id,
-            val1_id,
-            order_fail_id,
-            val2_id,
-            weak_id,
-        } = args;
-
         let ptr = self.convert_expr(ctx.used(), ptr_id)?;
         let order = self.convert_memordering(order_id);
         let val1 = val1_id


### PR DESCRIPTION
…ruct *Args` types, which let you name all the arguments."

This reverts commit 833c6d3c79de308d602e10e8a4b458a482a74026.