### PR TITLE
Support C11 atomics required by dav1d

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -281,6 +281,8 @@ class TypeEncoder final : public TypeVisitor<TypeEncoder> {
 
     void VisitVariableArrayType(const VariableArrayType *T);
 
+    void VisitAtomicType(const AtomicType *AT);
+
     void VisitIncompleteArrayType(const IncompleteArrayType *T) {
         auto t = T->getElementType();
         auto qt = encodeQualType(t);
@@ -2533,15 +2535,17 @@ void TypeEncoder::VisitVariableArrayType(const VariableArrayType *T) {
 
     VisitQualType(t);
 }
-//
-//void TypeEncoder::VisitAtomicType(const AtomicType *AT) {
-//    std::string msg =
-//            "C11 Atomic types are not supported. Aborting.";
-////    auto horse = AT->get
-////    astEncoder->printError(msg, AT);
-//    AT->getValueType()->dump();
-//    abort();
-//}
+
+void TypeEncoder::VisitAtomicType(const AtomicType *AT) {
+  auto t = AT->getValueType();
+  auto qt = encodeQualType(t);
+
+  encodeType(AT, TagAtomicType, [qt](CborEncoder *local) {
+      cbor_encode_uint(local, qt);
+  });
+
+  VisitQualType(t);
+}
 
 class TranslateConsumer : public clang::ASTConsumer {
     Outputs *outputs;

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -1967,10 +1967,6 @@ class TranslateASTVisitor final
         // Use the type from the definition in case the extern was an incomplete
         // type
         auto T = def->getType();
-        if (isa<AtomicType>(T)) {
-            printC11AtomicError(def);
-            abort();
-        }
 
         auto loc = is_defn ? def->getLocation() : VD->getLocation();
 
@@ -2055,10 +2051,6 @@ class TranslateASTVisitor final
         auto byteSize = 0;
 
         auto t = D->getTypeForDecl();
-        if (isa<AtomicType>(t)) {
-            printC11AtomicError(D);
-            abort();
-        }
 
         auto loc = D->getLocation();
         std::vector<void *> childIds;
@@ -2133,10 +2125,6 @@ class TranslateASTVisitor final
         // exit early via code like `if (!D->isCompleteDefinition()) return true;`.
 
         auto t = D->getTypeForDecl();
-        if (isa<AtomicType>(t)) {
-            printC11AtomicError(D);
-            abort();
-        }
 
         std::vector<void *> childIds;
         for (auto x : D->enumerators()) {
@@ -2196,10 +2184,6 @@ class TranslateASTVisitor final
 
         std::vector<void *> childIds;
         auto t = D->getType();
-        if (isa<AtomicType>(t)) {
-            printC11AtomicError(D);
-            abort();
-        }
 
         auto record = D->getParent();
         const ASTRecordLayout &layout =
@@ -2443,11 +2427,6 @@ class TranslateASTVisitor final
         DiagBuilder.AddString(Message);
         DiagBuilder.AddSourceRange(
             CharSourceRange::getCharRange(E->getSourceRange()));
-    }
-
-    void printC11AtomicError(Decl *D) {
-        std::string msg = "C11 Atomics are not supported. Aborting.";
-        printError(msg, D);
     }
 
     void printError(std::string Message, Decl *D) {

--- a/c2rust-ast-exporter/src/ast_tags.hpp
+++ b/c2rust-ast-exporter/src/ast_tags.hpp
@@ -149,6 +149,7 @@ enum TypeTag {
     TagSveBoolx4,
 
     TagFloat128,
+    TagAtomicType,
 };
 
 enum StringTypeTag {

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -162,6 +162,8 @@ fn parse_cast_kind(kind: &str) -> CastKind {
         "BuiltinFnToFnPtr" => CastKind::BuiltinFnToFnPtr,
         "ConstCast" => CastKind::ConstCast,
         "VectorSplat" => CastKind::VectorSplat,
+        "AtomicToNonAtomic" => CastKind::AtomicToNonAtomic,
+        "NonAtomicToAtomic" => CastKind::NonAtomicToAtomic,
         k => panic!("Unsupported implicit cast: {}", k),
     }
 }
@@ -831,8 +833,11 @@ impl ConversionContext {
                 }
 
                 TypeTag::TagAtomicType => {
-                    // Next step in atomics implementation: Transfer to a CTypeKind
-                    panic!("C11 Atomics are not implemented in C2Rust yet.");
+                    let qt = from_value(ty_node.extras[0].clone()).expect("Inner type not found");
+                    let qt_new = self.visit_qualified_type(qt);
+                    let atomic_ty = CTypeKind::Atomic(qt_new);
+                    self.add_type(new_id, not_located(atomic_ty));
+                    self.processed_nodes.insert(new_id, OTHER_TYPE);
                 }
 
                 t => panic!(
@@ -1775,6 +1780,11 @@ impl ConversionContext {
 
                     let typ = node.type_id.expect("Expected expression to have type");
                     let typ = self.visit_qualified_type(typ);
+
+                    // Perhaps as an optimization since atomic_init has no order,
+                    // clang stores val1 in the position otherwise used for order
+                    let is_atomic = name == "__c11_atomic_init" || name == "__opencl_atomic_init";
+                    let val1 = if is_atomic { Some(order) } else { val1 };
 
                     let e = CExprKind::Atomic {
                         typ,

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -830,6 +830,11 @@ impl ConversionContext {
                     self.processed_nodes.insert(new_id, OTHER_TYPE);
                 }
 
+                TypeTag::TagAtomicType => {
+                    // Next step in atomics implementation: Transfer to a CTypeKind
+                    panic!("C11 Atomics are not implemented in C2Rust yet.");
+                }
+
                 t => panic!(
                     "Type conversion not implemented for {:?} expecting {:?}",
                     t, expected_ty

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -833,9 +833,9 @@ impl ConversionContext {
                 }
 
                 TypeTag::TagAtomicType => {
-                    let qt = from_value(ty_node.extras[0].clone()).expect("Inner type not found");
-                    let qt_new = self.visit_qualified_type(qt);
-                    let atomic_ty = CTypeKind::Atomic(qt_new);
+                    let qty = from_value(ty_node.extras[0].clone()).expect("Inner type not found");
+                    let qty_new = self.visit_qualified_type(qty);
+                    let atomic_ty = CTypeKind::Atomic(qty_new);
                     self.add_type(new_id, not_located(atomic_ty));
                     self.processed_nodes.insert(new_id, OTHER_TYPE);
                 }

--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -293,7 +293,8 @@ fn immediate_type_children(kind: &CTypeKind) -> Vec<SomeId> {
         | Reference(qtype)
         | Attributed(qtype, _)
         | BlockPointer(qtype)
-        | Vector(qtype, _) => {
+        | Vector(qtype, _)
+        | Atomic(qtype) => {
             intos![qtype.ctype]
         }
 

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1225,6 +1225,8 @@ pub enum CastKind {
     BuiltinFnToFnPtr,
     ConstCast,
     VectorSplat,
+    AtomicToNonAtomic,
+    NonAtomicToAtomic,
 }
 
 /// Represents a unary operator in C (6.5.3 Unary operators) and GNU C extensions
@@ -1689,6 +1691,8 @@ pub enum CTypeKind {
     UnhandledSveType,
 
     Float128,
+    // Atomic types (6.7.2.4)
+    Atomic(CQualTypeId),
 }
 
 impl CTypeKind {

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -382,6 +382,7 @@ impl TypeConverter {
             }
 
             CTypeKind::Attributed(ty, _) => self.convert(ctxt, ty.ctype),
+            CTypeKind::Atomic(ty) => self.convert(ctxt, ty.ctype),
 
             // ANSI/ISO C-style function
             CTypeKind::Function(ret, ref params, is_var, is_noreturn, true) => {

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -208,9 +208,6 @@ impl<'c> Translation<'c> {
             | "__atomic_compare_exchange_n"
             | "__c11_atomic_compare_exchange_strong"
             | "__c11_atomic_compare_exchange_weak" => {
-                // TODO(perl): __c11_atomic_compare_exchange_strong does not
-                // seem to produce correct code. It produces a deref operation
-                // on the `src` argument to atomic_cxchg_seqcst_seqcst.
                 let expected =
                     val1.expect("__atomic_compare_exchange must have a expected argument");
                 let desired = val2.expect("__atomic_compare_exchange must have a desired argument");

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -16,6 +16,19 @@ impl<'c> Translation<'c> {
         let memorder = &self.ast_context[expr];
         let i = match memorder.kind {
             CExprKind::Literal(_, CLiteral::Integer(i, _)) => Some(i),
+            CExprKind::DeclRef(_, decl_id, LRValue::RValue) => {
+                let decl = self.ast_context.get_decl(&decl_id).unwrap();
+                match decl.kind {
+                    CDeclKind::EnumConstant { name: _, value: v } => match v {
+                        ConstIntExpr::I(i) => {
+                            assert!(0 <= i);
+                            Some(i as u64)
+                        }
+                        ConstIntExpr::U(u) => Some(u),
+                    },
+                    _ => unimplemented!(),
+                }
+            }
             _ => None,
         }?;
         use Ordering::*;
@@ -76,7 +89,7 @@ impl<'c> Translation<'c> {
         }
 
         match name {
-            "__atomic_load" | "__atomic_load_n" => ptr.and_then(|ptr| {
+            "__atomic_load" | "__atomic_load_n" | "__c11_atomic_load" => ptr.and_then(|ptr| {
                 let intrinsic_name = format!("atomic_load_{}", order_name(static_order(order)));
 
                 self.use_feature("core_intrinsics");
@@ -105,7 +118,7 @@ impl<'c> Translation<'c> {
                 }
             }),
 
-            "__atomic_store" | "__atomic_store_n" => {
+            "__atomic_store" | "__atomic_store_n" | "__c11_atomic_store" => {
                 let val = val1.expect("__atomic_store must have a val argument");
                 ptr.and_then(|ptr| {
                     val.and_then(|val| {
@@ -131,7 +144,25 @@ impl<'c> Translation<'c> {
                 })
             }
 
-            "__atomic_exchange" | "__atomic_exchange_n" => {
+            // NOTE: there is no corresponding __atomic_init builtin in clang
+            "__c11_atomic_init" => {
+                let val = val1.expect(&format!("__atomic_init must have a val argument"));
+                ptr.and_then(|ptr| {
+                    val.and_then(|val| {
+                        let assignment = mk().assign_expr(
+                            mk().unary_expr(UnOp::Deref(Default::default()), ptr),
+                            val,
+                        );
+                        self.convert_side_effects_expr(
+                            ctx,
+                            WithStmts::new_val(assignment),
+                            "Builtin is not supposed to be used",
+                        )
+                    })
+                })
+            }
+
+            "__atomic_exchange" | "__atomic_exchange_n" | "__c11_atomic_exchange" => {
                 let val = val1.expect("__atomic_store must have a val argument");
                 ptr.and_then(|ptr| {
                     val.and_then(|val| {
@@ -176,10 +207,23 @@ impl<'c> Translation<'c> {
                 })
             }
 
-            "__atomic_compare_exchange" | "__atomic_compare_exchange_n" => {
+            "__atomic_compare_exchange"
+            | "__atomic_compare_exchange_n"
+            | "__c11_atomic_compare_exchange_strong"
+            | "__c11_atomic_compare_exchange_weak" => {
+                // TODO(perl): __c11_atomic_compare_exchange_strong does not
+                // seem to produce correct code. It produces a deref operation
+                // on the `src` argument to atomic_cxchg_seqcst_seqcst.
                 let expected =
                     val1.expect("__atomic_compare_exchange must have a expected argument");
                 let desired = val2.expect("__atomic_compare_exchange must have a desired argument");
+                // Some C11 atomic operations encode the weak property in the name
+                let weak = match (name, weak) {
+                    ("__c11_atomic_compare_exchange_strong", None) => Some(false),
+                    ("__c11_atomic_compare_exchange_weak", None) => Some(true),
+                    _ => weak,
+                };
+
                 ptr.and_then(|ptr| {
                     expected.and_then(|expected| {
                         desired.and_then(|desired| {
@@ -216,10 +260,11 @@ impl<'c> Translation<'c> {
                             self.use_feature("core_intrinsics");
                             let expected =
                                 mk().unary_expr(UnOp::Deref(Default::default()), expected);
-                            let desired = if name == "__atomic_compare_exchange_n" {
-                                desired
-                            } else {
-                                mk().unary_expr(UnOp::Deref(Default::default()), desired)
+                            let desired = match name {
+                                "__atomic_compare_exchange_n"
+                                | "__c11_atomic_compare_exchange_strong"
+                                | "__c11_atomic_compare_exchange_weak" => desired,
+                                _ => mk().unary_expr(UnOp::Deref(Default::default()), desired),
                             };
 
                             let atomic_cxchg =
@@ -258,7 +303,13 @@ impl<'c> Translation<'c> {
             | "__atomic_fetch_and"
             | "__atomic_fetch_xor"
             | "__atomic_fetch_or"
-            | "__atomic_fetch_nand" => {
+            | "__atomic_fetch_nand"
+            | "__c11_atomic_fetch_add"
+            | "__c11_atomic_fetch_sub"
+            | "__c11_atomic_fetch_and"
+            | "__c11_atomic_fetch_xor"
+            | "__c11_atomic_fetch_or"
+            | "__c11_atomic_fetch_nand" => {
                 let intrinsic_name = if name.contains("_add") {
                     "atomic_xadd"
                 } else if name.contains("_sub") {
@@ -276,7 +327,8 @@ impl<'c> Translation<'c> {
                 let intrinsic_suffix = order_name(static_order(order));
                 let intrinsic_name = format!("{intrinsic_name}_{intrinsic_suffix}");
 
-                let fetch_first = name.starts_with("__atomic_fetch");
+                let fetch_first =
+                    name.starts_with("__atomic_fetch") || name.starts_with("__c11_atomic_fetch");
                 let val = val1.expect("__atomic arithmetic operations must have a val argument");
                 ptr.and_then(|ptr| {
                     val.and_then(|val| {
@@ -285,7 +337,7 @@ impl<'c> Translation<'c> {
                 })
             }
 
-            _ => unimplemented!("atomic not implemented"),
+            _ => unimplemented!("atomic not implemented: {}", name),
         }
     }
 

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -20,10 +20,7 @@ impl<'c> Translation<'c> {
                 let decl = self.ast_context.get_decl(&decl_id).unwrap();
                 match decl.kind {
                     CDeclKind::EnumConstant { name: _, value: v } => match v {
-                        ConstIntExpr::I(i) => {
-                            assert!(0 <= i);
-                            Some(i as u64)
-                        }
+                        ConstIntExpr::I(i) => Some(i.try_into().unwrap()),
                         ConstIntExpr::U(u) => Some(u),
                     },
                     _ => unimplemented!(),
@@ -146,7 +143,7 @@ impl<'c> Translation<'c> {
 
             // NOTE: there is no corresponding __atomic_init builtin in clang
             "__c11_atomic_init" => {
-                let val = val1.expect(&format!("__atomic_init must have a val argument"));
+                let val = val1.expect("__atomic_init must have a val argument");
                 ptr.and_then(|ptr| {
                     val.and_then(|val| {
                         let assignment = mk().assign_expr(

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4426,6 +4426,8 @@ impl<'c> Translation<'c> {
             CastKind::VectorSplat => Err(TranslationError::generic(
                 "TODO vector splat casts not supported",
             )),
+
+            CastKind::AtomicToNonAtomic | CastKind::NonAtomicToAtomic => Ok(val),
         }
     }
 
@@ -4935,7 +4937,7 @@ impl<'c> Translation<'c> {
             Vector(..) => {
                 // Handled in `import_simd_typedef`
             }
-            TypeOfExpr(_) | BuiltinFn => {}
+            TypeOfExpr(_) | BuiltinFn | Atomic(..) => {}
             UnhandledSveType => {
                 // TODO: handle SVE types
             }

--- a/c2rust-transpile/tests/snapshots/atomics.c
+++ b/c2rust-transpile/tests/snapshots/atomics.c
@@ -1,0 +1,22 @@
+#include <stdatomic.h>
+
+_Atomic(int) c11_atomics(_Atomic(int) x) {
+    __c11_atomic_init(&x, 0);
+    __c11_atomic_store(&x, 1, __ATOMIC_SEQ_CST);
+    __c11_atomic_load(&x, __ATOMIC_SEQ_CST);
+    __c11_atomic_fetch_add(&x, 2, __ATOMIC_SEQ_CST);
+    __c11_atomic_fetch_sub(&x, 1, __ATOMIC_SEQ_CST);
+    __c11_atomic_fetch_and(&x, 0xF, __ATOMIC_SEQ_CST);
+    __c11_atomic_fetch_or(&x, 0x10, __ATOMIC_SEQ_CST);
+    __c11_atomic_fetch_nand(&x, 0xFF, __ATOMIC_SEQ_CST);
+    __c11_atomic_exchange(&x, 42, __ATOMIC_SEQ_CST);
+
+    int expected = 42;
+    int desired = 100;
+    __c11_atomic_compare_exchange_strong(&x, &expected, desired, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    expected = 100;
+    desired = 200;
+    __c11_atomic_compare_exchange_weak(&x, &expected, desired, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+
+    return x;
+}

--- a/c2rust-transpile/tests/snapshots/atomics.rs
+++ b/c2rust-transpile/tests/snapshots/atomics.rs
@@ -1,0 +1,41 @@
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![feature(core_intrinsics)]
+#[no_mangle]
+pub unsafe extern "C" fn c11_atomics(mut x: std::ffi::c_int) -> std::ffi::c_int {
+    *&mut x = 0 as std::ffi::c_int;
+    ::core::intrinsics::atomic_store_seqcst(&mut x, 1 as std::ffi::c_int);
+    ::core::intrinsics::atomic_load_seqcst(&mut x);
+    ::core::intrinsics::atomic_xadd_seqcst(&mut x, 2 as std::ffi::c_int);
+    ::core::intrinsics::atomic_xsub_seqcst(&mut x, 1 as std::ffi::c_int);
+    ::core::intrinsics::atomic_and_seqcst(&mut x, 0xf as std::ffi::c_int);
+    ::core::intrinsics::atomic_or_seqcst(&mut x, 0x10 as std::ffi::c_int);
+    ::core::intrinsics::atomic_nand_seqcst(&mut x, 0xff as std::ffi::c_int);
+    ::core::intrinsics::atomic_xchg_seqcst(&mut x, 42 as std::ffi::c_int);
+    let mut expected: std::ffi::c_int = 42 as std::ffi::c_int;
+    let mut desired: std::ffi::c_int = 100 as std::ffi::c_int;
+    let fresh0 = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
+        &mut x,
+        *&mut expected,
+        desired,
+    );
+    *&mut expected = fresh0.0;
+    fresh0.1;
+    expected = 100 as std::ffi::c_int;
+    desired = 200 as std::ffi::c_int;
+    let fresh1 = ::core::intrinsics::atomic_cxchgweak_seqcst_seqcst(
+        &mut x,
+        *&mut expected,
+        desired,
+    );
+    *&mut expected = fresh1.0;
+    fresh1.1;
+    return x;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.snap
@@ -1,0 +1,46 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/atomics.rs
+input_file: c2rust-transpile/tests/snapshots/atomics.c
+---
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![feature(core_intrinsics)]
+#[no_mangle]
+pub unsafe extern "C" fn c11_atomics(mut x: std::ffi::c_int) -> std::ffi::c_int {
+    *&mut x = 0 as std::ffi::c_int;
+    ::core::intrinsics::atomic_store_seqcst(&mut x, 1 as std::ffi::c_int);
+    ::core::intrinsics::atomic_load_seqcst(&mut x);
+    ::core::intrinsics::atomic_xadd_seqcst(&mut x, 2 as std::ffi::c_int);
+    ::core::intrinsics::atomic_xsub_seqcst(&mut x, 1 as std::ffi::c_int);
+    ::core::intrinsics::atomic_and_seqcst(&mut x, 0xf as std::ffi::c_int);
+    ::core::intrinsics::atomic_or_seqcst(&mut x, 0x10 as std::ffi::c_int);
+    ::core::intrinsics::atomic_nand_seqcst(&mut x, 0xff as std::ffi::c_int);
+    ::core::intrinsics::atomic_xchg_seqcst(&mut x, 42 as std::ffi::c_int);
+    let mut expected: std::ffi::c_int = 42 as std::ffi::c_int;
+    let mut desired: std::ffi::c_int = 100 as std::ffi::c_int;
+    let fresh0 = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
+        &mut x,
+        *&mut expected,
+        desired,
+    );
+    *&mut expected = fresh0.0;
+    fresh0.1;
+    expected = 100 as std::ffi::c_int;
+    desired = 200 as std::ffi::c_int;
+    let fresh1 = ::core::intrinsics::atomic_cxchgweak_seqcst_seqcst(
+        &mut x,
+        *&mut expected,
+        desired,
+    );
+    *&mut expected = fresh1.0;
+    fresh1.1;
+    return x;
+}


### PR DESCRIPTION
* Fixes #293.
* Supercedes #302.

Useful documentation/context:

- https://en.cppreference.com/w/c/atomic/atomic_compare_exchange.html
- https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html
- https://clang.llvm.org/docs/LanguageExtensions.html#c11-atomic-builtins