### PR TITLE
(`c2rust-analyze`) Skip `Trivial` function calls.

### DIFF
--- a/analysis/tests/lighttpd-minimal/src/main.rs
+++ b/analysis/tests/lighttpd-minimal/src/main.rs
@@ -1220,7 +1220,7 @@ unsafe extern "C" fn connections_get_new_connection(
     mut con: *mut connection,
 ) -> *mut connection {
     // let mut con: *mut connection = 0 as *mut connection;
-    // (*srv).lim_conns = ((*srv).lim_conns).wrapping_sub(1);
+    (*srv).lim_conns = ((*srv).lim_conns).wrapping_sub(1);
     if !((*srv).conns_pool).is_null() {
         con = (*srv).conns_pool;
         (*srv).conns_pool = (*con).next;
@@ -1283,7 +1283,7 @@ unsafe extern "C" fn connection_del(mut srv: *mut server, mut con: *mut connecti
     (*con).prev = con; // 0 as *mut connection;
     (*con).next = (*srv).conns_pool;
     (*srv).conns_pool = con;
-    // (*srv).lim_conns = ((*srv).lim_conns).wrapping_add(1);
+    (*srv).lim_conns = ((*srv).lim_conns).wrapping_add(1);
 }
 
 unsafe extern "C" fn connection_close(mut con: *mut connection) {
@@ -1302,9 +1302,9 @@ unsafe extern "C" fn connection_close(mut con: *mut connection) {
     fdevent_fdnode_event_del((*srv).ev, (*con).fdn);
     fdevent_unregister((*srv).ev, (*con).fd);
     // (*con).fdn = 0 as *mut fdnode;
-    // if 0 as libc::c_int == close((*con).fd) {
-    //     (*srv).cur_fds -= 1;
-    // } else {
+    if 0 as libc::c_int == close((*con).fd) {
+        (*srv).cur_fds -= 1;
+    } else {
     //     log_perror(
     //         (*r).conf.errh,
     //         b"src/connections.c\0" as *const u8 as *const libc::c_char,
@@ -1312,7 +1312,7 @@ unsafe extern "C" fn connection_close(mut con: *mut connection) {
     //         b"(warning) close: %d\0" as *const u8 as *const libc::c_char,
     //         (*con).fd,
     //     );
-    // }
+    }
     if (*r).conf.log_state_handling != 0 {
         // log_error(
         //     (*r).conf.errh,

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(control_flow_enum)]
 #![feature(rustc_private)]
 extern crate either;
 extern crate rustc_arena;

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -51,6 +51,7 @@ mod equiv;
 mod expr_rewrite;
 mod labeled_ty;
 mod pointer_id;
+mod trivial;
 mod type_desc;
 mod util;
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(control_flow_enum)]
 #![feature(rustc_private)]
 extern crate either;
 extern crate rustc_arena;

--- a/c2rust-analyze/src/trivial.rs
+++ b/c2rust-analyze/src/trivial.rs
@@ -1,0 +1,146 @@
+use rustc_middle::ty::{self, Binder, EarlyBinder, FnSig, GenSig, Subst, Ty, TyCtxt};
+
+pub trait IsTrivial<'tcx> {
+    /// Something [`is_trivial`] if it has no effect on pointer permissions,
+    /// and thus requires no special handling.
+    /// That is, it must contain no raw pointers.
+    ///
+    /// See [`Trivial`] for more info.
+    ///
+    /// [`is_trivial`]: Self::is_trivial
+    /// [`Trivial`]: crate::util::Callee::Trivial
+    fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool;
+}
+
+impl<'tcx, T: IsTrivial<'tcx>> IsTrivial<'tcx> for &T {
+    fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool {
+        (*self).is_trivial(tcx)
+    }
+}
+
+fn are_all_trivial<'tcx, T, I>(tcx: TyCtxt<'tcx>, ts: I) -> bool
+where
+    I: IntoIterator<Item = T>,
+    T: IsTrivial<'tcx>,
+{
+    ts.into_iter().all(|t| t.is_trivial(tcx))
+}
+
+impl<'tcx> IsTrivial<'tcx> for Binder<'tcx, FnSig<'tcx>> {
+    /// A [`Binder`]`<`[`FnSig`]`>` [`is_trivial`] if
+    /// the [`FnSig`] without the [`Binder`] is trivial.
+    ///
+    /// Lifetimes do not affect [`Trivial`]ity,
+    /// so we can ignore higher-kinded lifetimes from the [`Binder`].
+    ///
+    /// [`is_trivial`]: IsTrivial::is_trivial
+    /// [`Trivial`]: crate::util::Callee::Trivial
+    fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool {
+        // We don't care about higher-kinded lifetimes here, as we don't care about lifetimes at all.
+        self.skip_binder().is_trivial(tcx)
+    }
+}
+
+impl<'tcx> IsTrivial<'tcx> for FnSig<'tcx> {
+    /// A [`FnSig`] [`is_trivial`] if
+    /// all of its argument and return types are [`Trivial`].
+    ///
+    /// [`is_trivial`]: IsTrivial::is_trivial
+    /// [`Trivial`]: crate::util::Callee::Trivial
+    fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool {
+        are_all_trivial(tcx, self.inputs_and_output)
+    }
+}
+
+impl<'tcx> IsTrivial<'tcx> for Ty<'tcx> {
+    /// A [`Ty`] [`is_trivial`] if
+    /// it is not a (raw) pointer and contains no (raw) pointers.
+    ///
+    /// [`is_trivial`]: IsTrivial::is_trivial
+    fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool {
+        let not_sure_yet = |is_trivial: bool| {
+            let kind = self.kind();
+            eprintln!("assuming non-trivial for now as a safe backup (guessed {is_trivial:?}): ty.kind() = {kind:?}, ty = {self:?}");
+            false
+        };
+
+        match *self.kind() {
+            ty::RawPtr(..) => false, // raw pointers are never trivial, can break out early
+
+            ty::Bool | ty::Char | ty::Str | ty::Int(..) | ty::Uint(..) | ty::Float(..) => true, // primitive types are trivial
+
+            ty::Never => true,
+
+            ty::Foreign(..) => false, // no introspection into a foreign, extern type, but as it's extern, it likely contains raw pointers
+
+            // delegate to the inner type
+            ty::Ref(_, ty, _) | ty::Slice(ty) | ty::Array(ty, _) => ty.is_trivial(tcx),
+
+            // delegate to all inner types
+            ty::Tuple(tys) => are_all_trivial(tcx, tys),
+            ty::Adt(adt_def, substs) => {
+                are_all_trivial(tcx, adt_def.all_fields().map(|field| field.ty(tcx, substs)))
+            }
+
+            // don't know, as `dyn Trait` could be anything
+            ty::Dynamic(trait_ty, _reg) => {
+                eprintln!("unsure how to check `dyn Trait` for accessible pointers, so assuming non-trivial: ty = {self:?}, trait_ty = {trait_ty:?}");
+                false
+            }
+
+            // For the below [`TyKind`]s, we're not yet certain about their triviality,
+            // so they use `not_sure_yet` to return `false` as a safe backup,
+            // along with printing a message about this assumption,
+            // which includes a potential guess.
+            // This allows us to keep the potentially correct code for these,
+            // even if we haven't verified yet if they're implemented correctly.
+
+            // function ptrs/defs carry no data, so they should be trivial
+            // but for now, assume they're non-trivial as a safe backup
+            ty::FnPtr(..) | ty::FnDef(..) => not_sure_yet(true),
+
+            // the function part of the closure should be trivial,
+            // so just check the enclosed type (upvars) for triviality,
+            // but for now, assume they're non-trivial as a safe backup
+            ty::Closure(_, substs) => {
+                not_sure_yet(substs.as_closure().tupled_upvars_ty().is_trivial(tcx))
+            }
+
+            // similar to closures, check all possible types created by the generator
+            ty::Generator(_, substs, _) => not_sure_yet({
+                let generator = substs.as_generator();
+                let GenSig {
+                    resume_ty,
+                    yield_ty,
+                    return_ty,
+                } = generator.sig();
+                are_all_trivial(
+                    tcx,
+                    [
+                        generator.tupled_upvars_ty(),
+                        resume_ty,
+                        yield_ty,
+                        return_ty,
+                        generator.witness(),
+                    ],
+                )
+            }),
+
+            // try to get the actual type and delegate to it
+            ty::Opaque(did, substs) => not_sure_yet(
+                EarlyBinder(tcx.type_of(did))
+                    .subst(tcx, substs)
+                    .is_trivial(tcx),
+            ),
+
+            // not sure how to handle yet, and may never come up anyways
+            ty::GeneratorWitness(..)
+            | ty::Projection(..)
+            | ty::Error(_)
+            | ty::Infer(_)
+            | ty::Placeholder(..)
+            | ty::Bound(..)
+            | ty::Param(..) => not_sure_yet(false),
+        }
+    }
+}

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -345,7 +345,8 @@ impl<'tcx> IsTrivial<'tcx> for Ty<'tcx> {
     /// [`is_trivial`]: IsTrivial::is_trivial
     fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool {
         let not_sure_yet = |is_trivial: bool| {
-            eprintln!("assuming non-trivial for now as a safe backup (guessed {is_trivial:?}): ty = {self:?}");
+            let kind = self.kind();
+            eprintln!("assuming non-trivial for now as a safe backup (guessed {is_trivial:?}): ty.kind() = {kind:?}, ty = {self:?}");
             false
         };
 

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -1,14 +1,11 @@
 use crate::labeled_ty::LabeledTy;
+use crate::trivial::IsTrivial;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir::{
     Field, Local, Mutability, Operand, PlaceElem, PlaceRef, ProjectionElem, Rvalue,
 };
-use rustc_middle::ty::GenSig;
-use rustc_middle::ty::{
-    self, subst::Subst, AdtDef, Binder, DefIdTree, EarlyBinder, FnSig, SubstsRef, Ty, TyCtxt,
-    TyKind, UintTy,
-};
+use rustc_middle::ty::{AdtDef, DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy};
 use std::fmt::Debug;
 
 #[derive(Debug)]
@@ -252,151 +249,6 @@ fn builtin_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, did: DefId) -> Option<C
         _ => {
             eprintln!("name: {name:?}");
             None
-        }
-    }
-}
-
-trait IsTrivial<'tcx> {
-    /// Something [`is_trivial`] if it has no effect on pointer permissions,
-    /// and thus requires no special handling.
-    /// That is, it must contain no raw pointers.
-    ///
-    /// See [`Trivial`] for more info.
-    ///
-    /// [`is_trivial`]: Self::is_trivial
-    /// [`Trivial`]: Callee::Trivial
-    fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool;
-}
-
-impl<'tcx, T: IsTrivial<'tcx>> IsTrivial<'tcx> for &T {
-    fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool {
-        (*self).is_trivial(tcx)
-    }
-}
-
-fn are_all_trivial<'tcx, T, I>(tcx: TyCtxt<'tcx>, ts: I) -> bool
-where
-    I: IntoIterator<Item = T>,
-    T: IsTrivial<'tcx>,
-{
-    ts.into_iter().all(|t| t.is_trivial(tcx))
-}
-
-impl<'tcx> IsTrivial<'tcx> for Binder<'tcx, FnSig<'tcx>> {
-    /// A [`Binder`]`<`[`FnSig`]`>` [`is_trivial`] if
-    /// the [`FnSig`] without the [`Binder`] is trivial.
-    ///
-    /// Lifetimes do not affect [`Trivial`]ity,
-    /// so we can ignore higher-kinded lifetimes from the [`Binder`].
-    ///
-    /// [`is_trivial`]: IsTrivial::is_trivial
-    /// [`Trivial`]: Callee::Trivial
-    fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool {
-        // We don't care about higher-kinded lifetimes here, as we don't care about lifetimes at all.
-        self.skip_binder().is_trivial(tcx)
-    }
-}
-
-impl<'tcx> IsTrivial<'tcx> for FnSig<'tcx> {
-    /// A [`FnSig`] [`is_trivial`] if
-    /// all of its argument and return types are [`Trivial`].
-    ///
-    /// [`is_trivial`]: IsTrivial::is_trivial
-    /// [`Trivial`]: Callee::Trivial
-    fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool {
-        are_all_trivial(tcx, self.inputs_and_output)
-    }
-}
-
-impl<'tcx> IsTrivial<'tcx> for Ty<'tcx> {
-    /// A [`Ty`] [`is_trivial`] if
-    /// it is not a (raw) pointer and contains no (raw) pointers.
-    ///
-    /// [`is_trivial`]: IsTrivial::is_trivial
-    fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool {
-        let not_sure_yet = |is_trivial: bool| {
-            let kind = self.kind();
-            eprintln!("assuming non-trivial for now as a safe backup (guessed {is_trivial:?}): ty.kind() = {kind:?}, ty = {self:?}");
-            false
-        };
-
-        match *self.kind() {
-            ty::RawPtr(..) => false, // raw pointers are never trivial, can break out early
-
-            ty::Bool | ty::Char | ty::Str | ty::Int(..) | ty::Uint(..) | ty::Float(..) => true, // primitive types are trivial
-
-            ty::Never => true,
-
-            ty::Foreign(..) => false, // no introspection into a foreign, extern type, but as it's extern, it likely contains raw pointers
-
-            // delegate to the inner type
-            ty::Ref(_, ty, _) | ty::Slice(ty) | ty::Array(ty, _) => ty.is_trivial(tcx),
-
-            // delegate to all inner types
-            ty::Tuple(tys) => are_all_trivial(tcx, tys),
-            ty::Adt(adt_def, substs) => {
-                are_all_trivial(tcx, adt_def.all_fields().map(|field| field.ty(tcx, substs)))
-            }
-
-            // don't know, as `dyn Trait` could be anything
-            ty::Dynamic(trait_ty, _reg) => {
-                eprintln!("unsure how to check `dyn Trait` for accessible pointers, so assuming non-trivial: ty = {self:?}, trait_ty = {trait_ty:?}");
-                false
-            }
-
-            // For the below [`TyKind`]s, we're not yet certain about their triviality,
-            // so they use `not_sure_yet` to return `false` as a safe backup,
-            // along with printing a message about this assumption,
-            // which includes a potential guess.
-            // This allows us to keep the potentially correct code for these,
-            // even if we haven't verified yet if they're implemented correctly.
-
-            // function ptrs/defs carry no data, so they should be trivial
-            // but for now, assume they're non-trivial as a safe backup
-            ty::FnPtr(..) | ty::FnDef(..) => not_sure_yet(true),
-
-            // the function part of the closure should be trivial,
-            // so just check the enclosed type (upvars) for triviality,
-            // but for now, assume they're non-trivial as a safe backup
-            ty::Closure(_, substs) => {
-                not_sure_yet(substs.as_closure().tupled_upvars_ty().is_trivial(tcx))
-            }
-
-            // similar to closures, check all possible types created by the generator
-            ty::Generator(_, substs, _) => not_sure_yet({
-                let generator = substs.as_generator();
-                let GenSig {
-                    resume_ty,
-                    yield_ty,
-                    return_ty,
-                } = generator.sig();
-                are_all_trivial(
-                    tcx,
-                    [
-                        generator.tupled_upvars_ty(),
-                        resume_ty,
-                        yield_ty,
-                        return_ty,
-                        generator.witness(),
-                    ],
-                )
-            }),
-
-            // try to get the actual type and delegate to it
-            ty::Opaque(did, substs) => not_sure_yet(
-                EarlyBinder(tcx.type_of(did))
-                    .subst(tcx, substs)
-                    .is_trivial(tcx),
-            ),
-
-            // not sure how to handle yet, and may never come up anyways
-            ty::GeneratorWitness(..)
-            | ty::Projection(..)
-            | ty::Error(_)
-            | ty::Infer(_)
-            | ty::Placeholder(..)
-            | ty::Bound(..)
-            | ty::Param(..) => not_sure_yet(false),
         }
     }
 }

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -204,36 +204,6 @@ fn builtin_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, did: DefId) -> Option<C
             })
         }
 
-        "abort" | "exit" => {
-            // `std::process::abort` and `std::process::exit`
-            let path = tcx.def_path(did);
-            if tcx.crate_name(path.krate).as_str() != "std" {
-                return None;
-            }
-            if path.data.len() != 2 {
-                return None;
-            }
-            if path.data[0].to_string() != "process" {
-                return None;
-            }
-            Some(Callee::Trivial)
-        }
-
-        "size_of" => {
-            // `core::mem::size_of`
-            let path = tcx.def_path(did);
-            if tcx.crate_name(path.krate).as_str() != "core" {
-                return None;
-            }
-            if path.data.len() != 2 {
-                return None;
-            }
-            if path.data[0].to_string() != "mem" {
-                return None;
-            }
-            Some(Callee::Trivial)
-        }
-
         "malloc" | "c2rust_test_typed_malloc" => {
             if matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod) {
                 return Some(Callee::Malloc);

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -150,7 +150,9 @@ pub fn ty_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Callee<'tcx>> 
 }
 
 fn builtin_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, did: DefId) -> Option<Callee<'tcx>> {
-    if ty.fn_sig(tcx).is_trivial(tcx) {
+    let is_trivial = ty.fn_sig(tcx).is_trivial(tcx);
+    eprintln!("{ty:?} is trivial: {is_trivial}");
+    if is_trivial {
         return Some(Callee::Trivial);
     }
 

--- a/c2rust-analyze/tests/filecheck/trivial.rs
+++ b/c2rust-analyze/tests/filecheck/trivial.rs
@@ -1,7 +1,6 @@
 use std::cell::{Cell, RefCell};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicPtr};
-use std::sync::{Mutex, RwLock};
 
 fn f4<A, B, C, D>(_a: A, _b: B, _c: C, _d: D) {}
 
@@ -53,9 +52,6 @@ fn main() {
         f!(Cell<()>); // CHECK: fn(std::cell::Cell<()>) {main::f} is trivial: true
         f!(RefCell<()>); // CHECK: fn(std::cell::RefCell<()>) {main::f} is trivial: true
         f!(AtomicBool); // CHECK: fn(std::sync::atomic::AtomicBool) {main::f} is trivial: true
-
-        f!(Mutex<()>); // CHECK: fn(std::sync::Mutex<()>) {main::f} is trivial: true
-        f!(RwLock<()>); // CHECK: fn(std::sync::RwLock<()>) {main::f} is trivial: true
 
         f!(Trivial); // CHECK: for<'r> fn(Trivial<'r>) {main::f} is trivial: true
 

--- a/c2rust-analyze/tests/filecheck/trivial.rs
+++ b/c2rust-analyze/tests/filecheck/trivial.rs
@@ -2,7 +2,7 @@ use std::cell::{Cell, RefCell};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicPtr};
 
-fn f4<A, B, C, D>(_a: A, _b: B, _c: C, _d: D) {}
+pub fn f4<A, B, C, D>(_a: A, _b: B, _c: C, _d: D) {}
 
 /// Check a type for triviality.
 ///
@@ -26,21 +26,19 @@ macro_rules! f {
     }};
 }
 
-#[allow(dead_code)]
-struct Trivial<'a> {
-    a: u32,
-    b: &'a str,
-    c: Result<&'a Path, &'static str>,
+pub struct Trivial<'a> {
+    pub a: u32,
+    pub b: &'a str,
+    pub c: Result<&'a Path, &'static str>,
 }
 
-#[allow(dead_code)]
-struct NonTrivial {
-    a: *mut i32,
+pub struct NonTrivial {
+    pub a: *mut i32,
 }
 
 enum Never {}
 
-fn main() {
+pub fn main() {
     {
         // trivial
 

--- a/c2rust-analyze/tests/filecheck/trivial.rs
+++ b/c2rust-analyze/tests/filecheck/trivial.rs
@@ -36,6 +36,14 @@ pub struct NonTrivial {
     pub a: *mut i32,
 }
 
+pub struct RecursiveWithPtr {
+    pub a: *const RecursiveWithPtr,
+}
+
+pub struct RecursiveWithRef {
+    pub a: &'static RecursiveWithRef,
+}
+
 enum Never {}
 
 pub fn main() {
@@ -62,6 +70,11 @@ pub fn main() {
 
         f!(Trivial); // CHECK: for<'r> fn(Trivial<'r>) {main::f} is trivial: true
 
+        // TODO(kkysen) Test self-referential/recursive types through references (see #834).
+        // Since transpiled types shouldn't have references, only pointers,
+        // this shouldn't be an issue for a while until we get to partially-refactored code.
+        // f!(RecursiveWithRef); // COM: CHECK: fn(RecursiveWithRef) {main::f} is trivial: false
+
         f!(Never); // CHECK: fn(Never) {main::f} is trivial: true
     }
 
@@ -81,7 +94,7 @@ pub fn main() {
         f!(*mut i32); // CHECK: fn(*mut i32) {main::f} is trivial: false
 
         f!(NonTrivial); // CHECK: fn(NonTrivial) {main::f} is trivial: false
-    }
 
-    // TODO(kkysen) test self-referential types
+        f!(RecursiveWithPtr); // CHECK: fn(RecursiveWithPtr) {main::f} is trivial: false
+    }
 }

--- a/c2rust-analyze/tests/filecheck/trivial.rs
+++ b/c2rust-analyze/tests/filecheck/trivial.rs
@@ -4,8 +4,17 @@ use std::sync::atomic::{AtomicBool, AtomicPtr};
 
 fn f4<A, B, C, D>(_a: A, _b: B, _c: C, _d: D) {}
 
-// TODO(kkysen) generic calls are not monomorphized in time
-// and thus cannot yet be evaluated for triviality (or default to false)
+/// Check a type for triviality.
+///
+/// There are a lot of restrictions here.
+/// Generics are not supported.
+/// And more importantly, aggregate initialization is not supported (#736),
+/// so we can't create most types, including even simple ones like `None` and `()`.
+/// And we need to make a function call to test triviality,
+/// so we define a local function with the type already as an argument,
+/// and then call itself recursively to create the function call.
+/// The function is never actually called, so infinite recursion doesn't happen,
+/// though `rustc` still complains, so we put it in a dead branch.
 macro_rules! f {
     ($t:ty) => {{
         #[allow(unused)]

--- a/c2rust-analyze/tests/filecheck/trivial.rs
+++ b/c2rust-analyze/tests/filecheck/trivial.rs
@@ -1,0 +1,78 @@
+//! allow_crash
+
+use std::cell::{Cell, RefCell};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicPtr};
+use std::sync::{Mutex, RwLock};
+
+fn f<T>(_t: T) {}
+
+fn f4<A, B, C, D>(_a: A, _b: B, _c: C, _d: D) {}
+
+#[allow(dead_code)]
+struct Trivial<'a> {
+    a: u32,
+    b: &'a str,
+    c: Result<&'a Path, &'static str>,
+}
+
+#[allow(dead_code)]
+struct NonTrivial {
+    a: *mut i32,
+}
+
+fn main() {
+    {
+        // trivial
+
+        f(()); // CHECK: fn(()) {f::<()>} is trivial: true
+        f(1); // CHECK: fn(i32) {f::<i32>} is trivial: true
+        f(2usize); // CHECK: fn(usize) {f::<usize>} is trivial: true
+        f(3.14); // CHECK: fn(f64) {f::<f64>} is trivial: true
+        f(""); // CHECK: fn(&str) {f::<&str>} is trivial: true
+        f(("", 1)); // CHECK: fn((&str, i32)) {f::<(&str, i32)>} is trivial: true
+
+        f([0usize; 0]); // CHECK: fn([usize; 0]) {f::<[usize; 0]>} is trivial: true
+        f(['a', 'b', 'c']); // CHECK: fn([char; 3]) {f::<[char; 3]>} is trivial: true
+        f(b"abc"); // CHECK: fn(&[u8; 3]) {f::<&[u8; 3]>} is trivial: true
+
+        f4((), 1, "", [b""; 4]); // CHECK: fn((), i32, &str, [&[u8; 0]; 4]) {f4::<(), i32, &str, [&[u8; 0]; 4]>} is trivial: true
+        f(Some("")); // CHECK: fn(std::option::Option<&str>) {f::<std::option::Option<&str>>} is trivial: true
+        Path::new(""); // CHECK: for<'r> fn(&'r str) -> &'r std::path::Path {std::path::Path::new::<str>} is trivial: true
+        Cell::new(0); // CHECK: fn(i32) -> std::cell::Cell<i32> {std::cell::Cell::<i32>::new} is trivial: true
+        RefCell::new(0); // CHECK: fn(i32) -> std::cell::RefCell<i32> {std::cell::RefCell::<i32>::new} is trivial: true
+        let _ = AtomicBool::new(true); // CHECK: fn(bool) -> std::sync::atomic::AtomicBool {std::sync::atomic::AtomicBool::new} is trivial: true
+        
+        Mutex::new(0); // CHECK: fn(i32) -> std::sync::Mutex<i32> {std::sync::Mutex::<i32>::new} is trivial: true
+        RwLock::new(0); // CHECK: fn(i32) -> std::sync::RwLock<i32> {std::sync::RwLock::<i32>::new} is trivial: true
+
+        // custom structs
+        // can't use normal initialization b/c we don't have aggregate initialization support yet,
+        // but we just need the type, so we can use None::<T>
+        f(None::<Trivial>); // CHECK: fn(std::option::Option<Trivial>) {f::<std::option::Option<Trivial>>} is trivial: true
+    }
+
+    {
+        // non-trivial
+
+        // std smart pointers and containers, while safe, have internal pointers,
+        // so currently they're non trivial
+        // see #820
+        let _ = Vec::<&str>::new(); // CHECK: fn() -> std::vec::Vec<&str> {std::vec::Vec::<&str>::new} is trivial: false
+        let _ = Box::new(0); // CHECK: fn(i32) -> std::boxed::Box<i32> {std::boxed::Box::<i32>::new} is trivial: false
+        let _ = PathBuf::from(""); // CHECK: fn(&str) -> std::path::PathBuf {<std::path::PathBuf as std::convert::From<&str>>::from} is trivial: false
+        f(None::<AtomicPtr<i32>>); // CHECK: fn(std::option::Option<std::sync::atomic::AtomicPtr<i32>>) {f::<std::option::Option<std::sync::atomic::AtomicPtr<i32>>>} is trivial: false
+
+        f(Some(b"" as *const u8)); // CHECK: fn(std::option::Option<*const u8>) {f::<std::option::Option<*const u8>>} is trivial: false
+
+        // custom structs
+        // can't use normal initialization b/c we don't have aggregate initialization support yet,
+        // but we just need the type, so we can use None::<T>
+        f(None::<NonTrivial>); // CHECK: fn(std::option::Option<NonTrivial>) {f::<std::option::Option<NonTrivial>>} is trivial: false
+    }
+
+    // TODO test self-referential types
+
+    #[allow(unreachable_code)]
+    f(panic!()); // CHECK: fn(&str) -> ! {std::rt::begin_panic::<&str>} is trivial: true
+}

--- a/c2rust-analyze/tests/filecheck/trivial.rs
+++ b/c2rust-analyze/tests/filecheck/trivial.rs
@@ -73,7 +73,7 @@ pub fn main() {
         // TODO(kkysen) Test self-referential/recursive types through references (see #834).
         // Since transpiled types shouldn't have references, only pointers,
         // this shouldn't be an issue for a while until we get to partially-refactored code.
-        // f!(RecursiveWithRef); // COM: CHECK: fn(RecursiveWithRef) {main::f} is trivial: false
+        // f!(RecursiveWithRef);
 
         f!(Never); // CHECK: fn(Never) {main::f} is trivial: true
     }


### PR DESCRIPTION
- Fixes #794.
- Fixes #785.

As per #807, this skips analysis of `Trivial` function calls, i.e. function calls that have no effect on pointer permissions in their caller, which means their argument and return types have no pointers within them.

This is done by defining a `trait IsTrivial` implemented for `FnSig`, `Ty`, etc.  `Ty` is the important one, and for `Ty`, we determine triviality this way:
* `RawPtr` is non-trivial
* primitive types are trivial
* `Never` is trivial
* `Foreign`, `Dynamic` are pessimistically non-trivial, as it's impossible to determine
    * of these, `Foreign` is likely non-trivial, and `Dynamic` is likely trivial
* `Ref` delegates to its inner type
* `Slice`, `Array`, `Tuple`, `Adt` all delegate to all of their inner types
* other types are pessimistically considered non-trivial as we're not sure how to handle them yet
    * these print a warning that they're not known yet, and for some, a guess is made:
        * `Opaque` tries to un-`Opaque` its type
        * `FnPtr`, `FnDef` are trivial, as they have contain no data
        * `Closure` delegates to its closure type (upvars)
        * `Generator` delegates to its inner types (upvars, resume, return, and yield types, and the witness)

As it's not currently needed yet, caching/supporting self-referential (through references) types (#834) and safe `std` types being `Trivial` (#820) are put off until later.