### PR TITLE
(`c2rust-analyze`) Add `PermissionSet::NON_NULL` with precise docs

### DIFF
--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -41,6 +41,70 @@ bitflags! {
         const OFFSET_SUB = 0x0020;
         /// This pointer can be freed.
         const FREE = 0x0040;
+
+        /// This pointer is non-null.
+        ///
+        /// [`NON_NULL`] is set (or not) when the pointer is created,
+        /// and it flows forward along dataflow edges.
+        ///
+        /// The permission is [`NON_NULL`] rather than `NULL` because we allow dropping permissions in any assignment.
+        /// This means removing a permission from a pointer's [`PermissionSet`]
+        /// must allow the pointer to take on more values, not restrict it to fewer values.
+        ///
+        /// The following should be set to [`NON_NULL`]:
+        /// * the results of [`Rvalue::Ref`] and [`Rvalue::AddressOf`]
+        /// * a dereferent (i.e. [`READ`]` | `[`WRITE`]), as otherwise this would be UB
+        /// * the argument or result of a known function like [`_.offset`] where it is UB to pass it an invalid (null) pointer
+        ///
+        /// The following should not be set to [`NON_NULL`]:
+        /// * [`core::ptr::null`]
+        /// * [`core::ptr::null_mut`]
+        /// * [`core::ptr::from_exposed_addr`] with the constant `0`
+        /// * `0 as * {const,mut} _`, a cast from the constant `0` to a pointer type
+        /// * anything else
+        ///
+        /// Non-zero but invalid pointers, such as those produced by:
+        /// * [`core::ptr::invalid`]
+        /// * [`core::ptr::invalid_mut`]
+        /// * [`NonNull::dangling`]
+        /// * [`core::ptr::from_exposed_addr`]
+        /// * int-to-ptr casts though `as` or [`core::mem::transmute`]
+        ///
+        /// will not be [`NON_NULL`] but also will not be either [`READ`]` | `[`WRITE`],
+        /// which allows us to distinguish them.
+        ///
+        /// If a pointer is neither [`READ`] nor [`WRITE`], then it is invalid,
+        /// and thus will remain a pointer after rewriting.
+        ///
+        /// The rest below is for valid pointers ([`READ`]` | `[`WRITE`]):
+        ///
+        /// [`NON_NULL`] pointers will become references, e.x. `&T`.\
+        /// Non-[`NON_NULL`] pointers will become [`Option<&T>`].
+        ///
+        /// Casts/transitions from [`NON_NULL`] to non-[`NON_NULL`] will become [`Some(_)`].\
+        /// Casts/transitions from non-[`NON_NULL`] to [`NON_NULL`] will become [`_.unwrap()`].
+        ///
+        /// [`_.is_null()`] on a [`NON_NULL`] pointer will become [`false`].\
+        /// [`_.is_null()`] on a non-[`NON_NULL`] pointer will become [`_.is_some()`].
+        ///
+        /// Constant null pointers, like those produced by:
+        /// * [`core::ptr::null`]
+        /// * [`core::ptr::null_mut`]
+        /// * [`core::ptr::from_exposed_addr`] with the constant `0`
+        /// * `0 as * {const,mut} _`, a cast from the constant `0` to a pointer type
+        ///
+        /// will become [`None`].
+        ///
+        /// [`NON_NULL`]: Self::NON_NULL
+        /// [`READ`]: Self::READ
+        /// [`WRITE`]: Self::WRITE
+        /// [`_.offset`]: core::ptr::offset
+        /// [`NonNull::dangling`]: core::ptr::NonNull::dangling
+        /// [`Some(_)`]: Some
+        /// [`_.unwrap()`]: Option::unwrap
+        /// [`_.is_null()`]: core::ptr::is_null
+        /// [`_.is_some()`]: Option::is_some
+        const NON_NULL = 0x0080;
     }
 }
 


### PR DESCRIPTION
- Fixes the first step of #816.

This adds `PermissionSet::NON_NULL` and precise docs explaining its meaning and intended usage, but doesn't contain any actual implementation or use of `NON_NULL`.