### PR TITLE
(`c2rust-analyze/tests`) Save `c2rust-analyze` output during tests and print them if it crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ marks.*.json
 
 # Outputs of `c2rust-analyze`
 inspect/
+*.analysis.txt

--- a/c2rust-analyze/tests/common/mod.rs
+++ b/c2rust-analyze/tests/common/mod.rs
@@ -1,0 +1,97 @@
+use std::{
+    env,
+    fs::{self, File},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use c2rust_build_paths::find_llvm_config;
+
+#[derive(Default)]
+pub struct Analyze;
+
+impl Analyze {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn run_(&self, rs_path: &Path) -> PathBuf {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let lib_dir = Path::new(env!("C2RUST_TARGET_LIB_DIR"));
+
+        let manifest_path = dir.join("Cargo.toml");
+        let rs_path = dir.join(rs_path); // allow relative paths, or override with an absolute path
+        let output_path = {
+            let mut file_name = rs_path.file_name().unwrap().to_owned();
+            file_name.push(".analysis.txt");
+            rs_path.with_file_name(file_name)
+        };
+        let output_stdout = File::create(&output_path).unwrap();
+        let output_stderr = File::try_clone(&output_stdout).unwrap();
+
+        let mut cmd = Command::new("cargo");
+        cmd.arg("run")
+            .arg("--manifest-path")
+            .arg(&manifest_path)
+            .arg("--")
+            .arg(&rs_path)
+            .arg("-L")
+            .arg(lib_dir)
+            .arg("--crate-type")
+            .arg("rlib")
+            .stdout(output_stdout)
+            .stderr(output_stderr);
+        let status = cmd.status().unwrap();
+        if !status.success() {
+            let message = format!(
+                "c2rust-analyze failed with status {status}:\n> {cmd:?} > {output_path:?} 2>&1\n"
+            );
+            let output = fs::read_to_string(&output_path).unwrap();
+            panic!("\n{message}\n{output}\n{message}");
+        }
+        output_path
+    }
+
+    pub fn run(&self, rs_path: impl AsRef<Path>) -> PathBuf {
+        self.run_(rs_path.as_ref())
+    }
+}
+
+pub struct FileCheck {
+    path: PathBuf,
+}
+
+impl FileCheck {
+    pub fn resolve() -> Self {
+        let path = env::var_os("FILECHECK")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                let llvm_config = find_llvm_config().expect("llvm-config not found");
+                let output = Command::new(llvm_config)
+                    .args(&["--bindir"])
+                    .output()
+                    .ok()
+                    .filter(|output| output.status.success())
+                    .expect("llvm-config error");
+                let bin_dir =
+                    PathBuf::from(String::from_utf8(output.stdout).unwrap().trim().to_owned());
+                bin_dir.join("FileCheck")
+            });
+        Self { path }
+    }
+
+    fn run_(&self, path: &Path, input: &Path) {
+        let mut cmd = Command::new(&self.path);
+        let input_file = File::open(input).unwrap();
+        cmd.arg(path).stdin(input_file);
+        let status = cmd.status().unwrap();
+        assert!(
+            status.success(),
+            "\nFileCheck failed with status {status}:\n> {cmd:?} > {input:?}\n",
+        );
+    }
+
+    pub fn run(&self, path: impl AsRef<Path>, input: impl AsRef<Path>) {
+        self.run_(path.as_ref(), input.as_ref())
+    }
+}

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -1,30 +1,13 @@
-use c2rust_build_paths::find_llvm_config;
-use std::env;
+pub mod common;
+
 use std::fs;
-use std::os::unix::io::{AsRawFd, FromRawFd};
-use std::path::PathBuf;
-use std::process::{Command, Stdio};
+
+use common::{Analyze, FileCheck};
 
 #[test]
 fn filecheck() {
-    let lib_dir = env!("C2RUST_TARGET_LIB_DIR");
-    let lib_dir = &lib_dir;
-
-    let filecheck_bin = env::var_os("FILECHECK")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            let llvm_config = find_llvm_config().expect("llvm-config not found");
-            let output = Command::new(llvm_config)
-                .args(&["--bindir"])
-                .output()
-                .ok()
-                .filter(|output| output.status.success())
-                .expect("llvm-config error");
-            let bindir = PathBuf::from(String::from_utf8(output.stdout).unwrap().trim().to_owned());
-            bindir.join("FileCheck")
-        });
-
-    eprintln!("detected FILECHECK={}", filecheck_bin.display());
+    let analyze = Analyze::new();
+    let file_check = FileCheck::resolve();
 
     for entry in fs::read_dir("tests/filecheck").unwrap() {
         let entry = entry.unwrap();
@@ -41,39 +24,7 @@ fn filecheck() {
 
         eprintln!("{:?}", entry.path());
 
-        let mut filecheck_cmd = Command::new(&filecheck_bin);
-        filecheck_cmd.arg(entry.path()).stdin(Stdio::piped());
-        let mut filecheck = filecheck_cmd.spawn().unwrap();
-        let pipe_fd = filecheck.stdin.as_ref().unwrap().as_raw_fd();
-        let mut analyze_cmd = Command::new("cargo");
-        analyze_cmd
-            .arg("run")
-            .arg("--manifest-path")
-            .arg(format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR")))
-            .arg("--")
-            .arg(entry.path())
-            .arg("-L")
-            .arg(lib_dir)
-            .arg("--crate-type")
-            .arg("rlib")
-            .stdout(unsafe { Stdio::from_raw_fd(pipe_fd) })
-            .stderr(unsafe { Stdio::from_raw_fd(pipe_fd) });
-        let mut analyze = analyze_cmd.spawn().unwrap();
-
-        let filecheck_status = filecheck.wait().unwrap();
-        assert!(
-            filecheck_status.success(),
-            "{:?}: FileCheck failed with status {:?}",
-            entry.path(),
-            filecheck_status,
-        );
-
-        let analyze_status = analyze.wait().unwrap();
-        assert!(
-            analyze_status.success(),
-            "{:?}: c2rust-analyze failed with status {:?}",
-            entry.path(),
-            analyze_status,
-        );
+        let output_path = analyze.run(entry.path());
+        file_check.run(entry.path(), &output_path);
     }
 }

--- a/c2rust-analyze/tests/lighttpd.rs
+++ b/c2rust-analyze/tests/lighttpd.rs
@@ -1,24 +1,8 @@
-use std::process::Command;
+use common::Analyze;
+
+pub mod common;
 
 #[test]
 fn test_lighttpd_minimal() {
-    let dir = env!("CARGO_MANIFEST_DIR");
-    let lib_dir = env!("C2RUST_TARGET_LIB_DIR");
-    let mut cmd = Command::new("cargo");
-    let path = "analysis/tests/lighttpd-minimal/src/main.rs";
-    cmd.arg("run")
-        .arg("--manifest-path")
-        .arg(format!("{dir}/Cargo.toml"))
-        .arg("--")
-        .arg(format!("{dir}/../{path}"))
-        .arg("-L")
-        .arg(lib_dir)
-        .arg("--crate-type")
-        .arg("rlib");
-    let output = cmd.output().unwrap();
-    let status = output.status;
-    assert!(
-        status.success(),
-        "{path:?}: c2rust-analyze failed with status {status:?}",
-    );
+    Analyze::new().run("../analysis/tests/lighttpd-minimal/src/main.rs");
 }


### PR DESCRIPTION
Save `c2rust-analyze` output during tests and print them if it crashes.

Previously, for `filecheck.rs`, we piped directly to `FileCheck` and asserted on `status.success()`. And for `lighttpd.rs`, we just asserted on `status.success()`. But when `c2rust-analyze` crashed, which happens often, we just got the exit code, but no error messages.

So now we always save the `c2rust-analyze` output to `{input}.analysis.txt` and print it in case it crashes, as well as the status and the command just ran (so it can easily be run independently).

By saving it to a file, this also has the benefit of avoiding the `unsafe` used to duplicate the pipe to `FileCheck`.

This also moves most of the code in `mod common`, which is shared among integration tests, as otherwise there'd be a lot of useless duplication.