### PR TITLE
(`c2rust-analyze/tests`) Allow `c2rust analyze` test files to contain `//! directive`s like `//! allow_crash`

### DIFF
--- a/c2rust-analyze/tests/common/mod.rs
+++ b/c2rust-analyze/tests/common/mod.rs
@@ -23,7 +23,7 @@ impl Analyze {
         let manifest_path = dir.join("Cargo.toml");
         let rs_path = dir.join(rs_path); // allow relative paths, or override with an absolute path
 
-        let _directives = fs::read_to_string(&rs_path)
+        let directives = fs::read_to_string(&rs_path)
             .unwrap()
             .split('\n')
             .flat_map(|line| {
@@ -57,7 +57,7 @@ impl Analyze {
             .stdout(output_stdout)
             .stderr(output_stderr);
         let status = cmd.status().unwrap();
-        if !status.success() {
+        if !status.success() && !directives.contains("allow_crash") {
             let message = format!(
                 "c2rust-analyze failed with status {status}:\n> {cmd:?} > {output_path:?} 2>&1\n"
             );

--- a/c2rust-analyze/tests/common/mod.rs
+++ b/c2rust-analyze/tests/common/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     env,
     fs::{self, File},
     path::{Path, PathBuf},
@@ -21,6 +22,20 @@ impl Analyze {
 
         let manifest_path = dir.join("Cargo.toml");
         let rs_path = dir.join(rs_path); // allow relative paths, or override with an absolute path
+
+        let _directives = fs::read_to_string(&rs_path)
+            .unwrap()
+            .split('\n')
+            .flat_map(|line| {
+                line.trim()
+                    .strip_prefix("//!")
+                    .unwrap_or_default()
+                    .split(',')
+                    .map(|directive| directive.trim())
+            })
+            .map(String::from)
+            .collect::<HashSet<_>>();
+
         let output_path = {
             let mut file_name = rs_path.file_name().unwrap().to_owned();
             file_name.push(".analysis.txt");


### PR DESCRIPTION
This allows `c2rust analyze` test files to contain `//! directive`s similar to those in `tests/` for `c2rust transpile`.

This also adds one directive, the `//! allow_crash` directive, which allows `c2rust analyze` to crash (which it often does).
  This allows for `FileCheck` to still run on the output, which may already contain the necessary output before the crash.

Note that this is (formerly) needed to have tests for `IsTrivial` (#817) (which are ready to be added once this merges) as they crash on `type_of Aggregate` (#736), and it'll probably be useful for other things as well, just like it is for the `c2rust transpile` tests under `tests/`.