### PR TITLE
(`c2rust-analyze`) Separate the two `*c_void` cast directions

### DIFF
--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -369,4 +369,10 @@ impl<'tcx> CVoidCasts<'tcx> {
             }
         }
     }
+
+    pub fn new(mir: &Body<'tcx>, tcx: TyCtxt<'tcx>) -> Self {
+        let mut this = Self::default();
+        this.insert_all_from_mir(mir, tcx);
+        this
+    }
 }

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -1,0 +1,372 @@
+use std::borrow::Borrow;
+use std::collections::HashMap;
+
+use rustc_middle::{
+    mir::{Body, LocalDecls, Place, Rvalue, Statement, StatementKind, Terminator, TerminatorKind},
+    ty::{TyCtxt, TyKind},
+};
+
+use assert_matches::assert_matches;
+
+use crate::util::{ty_callee, Callee};
+
+/// The direction of a [`*c_void`](core::ffi::c_void) cast.
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum CVoidCastDirection {
+    /// From [`*c_void`](core::ffi::c_void) to another pointer type.
+    ///
+    /// This is used immediately after allocating,
+    /// after both [`Callee::Malloc`], [`Callee::Calloc`], and [`Callee::Realloc`].
+    From,
+
+    /// To [`*c_void`](core::ffi::c_void) from another pointer type.
+    ///
+    /// This is used immediately before freeing,
+    /// before both [`Callee::Free`] and [`Callee::Realloc`].
+    To,
+}
+
+impl CVoidCastDirection {
+    /// For applicable [`Callee`]s that take or return [`*c_void`](core::ffi::c_void),
+    /// return the [`CVoidCastDirection`]s that they use for casts.
+    ///
+    /// That is, these [`Callee`]s are [`CVoidCastDirection::From`]:
+    /// * [`Callee::Malloc`]
+    /// * [`Callee::Calloc`]
+    /// * [`Callee::Realloc`]
+    ///
+    /// And these [`Callee`]s are [`CVoidCastDirection::To`]:
+    /// * [`Callee::Free`]
+    /// * [`Callee::Realloc`]
+    pub fn from_callee(callee: Option<Callee>) -> &'static [Self] {
+        let callee = match callee {
+            None => return &[],
+            Some(it) => it,
+        };
+        use CVoidCastDirection::*;
+        use Callee::*;
+        match callee {
+            Malloc | Calloc => &[From][..],
+            Realloc => &[To, From][..],
+            Free => &[To][..],
+            _ => &[],
+        }
+    }
+}
+
+/// The [`Place`] of a [`*c_void`].
+///
+/// It is checked to be a [`*c_void`] upon construction.
+///
+/// [`*c_void`]: core::ffi::c_void
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+pub struct CVoidPtr<'tcx> {
+    place: Place<'tcx>,
+}
+
+impl<'tcx> CVoidPtr<'tcx> {
+    /// Check if a [`Place`] is really a [`*c_void`](core::ffi::c_void)
+    /// by checking its [`TyCtxt::def_path`] and [`TyCtxt::item_name`].
+    ///
+    /// This panics on failure.
+    pub fn checked(place: Place<'tcx>, local_decls: &LocalDecls<'tcx>, tcx: TyCtxt<'tcx>) -> Self {
+        let deref_ty = place
+            .ty(local_decls, tcx)
+            .ty
+            .builtin_deref(true)
+            .unwrap()
+            .ty
+            .kind();
+        assert_matches!(deref_ty, TyKind::Adt(adt, _) => {
+            assert_eq!(tcx.def_path(adt.did()).data[0].to_string(), "ffi");
+            assert_eq!(tcx.item_name(adt.did()).as_str(), "c_void");
+        });
+        Self { place }
+    }
+
+    /// Check another [`Place`] for being a [`*c_void`](core::ffi::c_void)
+    /// by comparing it to ourself, which is already checked.
+    ///
+    /// If the [`Place`] is the same [`CVoidPtr`], return it as [`Ok`];
+    /// otherwise, return the same [`Place`] as [`Err`].
+    pub fn checked_by_eq(&self, place: Place<'tcx>) -> Result<Self, Place<'tcx>> {
+        if self.place == place {
+            Ok(Self { place })
+        } else {
+            Err(place)
+        }
+    }
+}
+
+fn get_cast_place<'tcx>(rv: &Rvalue<'tcx>) -> Option<Place<'tcx>> {
+    match rv {
+        Rvalue::Cast(_, op, _) => op.place(),
+        _ => None,
+    }
+}
+
+fn get_assign_sides<'tcx, 'a>(
+    stmt: &'a Statement<'tcx>,
+) -> Option<(Place<'tcx>, &'a Rvalue<'tcx>)> {
+    let (pl, ref rv) = match &stmt.kind {
+        StatementKind::Assign(it) => Some(&**it),
+        _ => None,
+    }?;
+    Some((*pl, rv))
+}
+
+impl<'tcx> CVoidPtr<'tcx> {
+    /// Try to get the appropriate [`CVoidCast`]
+    /// from this [`Statement`] in the given [`CVoidCastDirection`].
+    ///
+    /// For the [`From`] direction, the [`*c_void`] is on the rhs.\
+    /// For the [`To`] direction, the [`*c_void`] is on the lhs.
+    ///
+    /// [`*c_void`]: core::ffi::c_void
+    /// [`From`]: CVoidCastDirection::From
+    /// [`To`]: CVoidCastDirection::To
+    pub fn get_cast_from_stmt(
+        &self,
+        direction: CVoidCastDirection,
+        stmt: &Statement<'tcx>,
+    ) -> Option<CVoidCast<'tcx>> {
+        let (lhs, rv) = get_assign_sides(stmt)?;
+        let rhs = get_cast_place(rv)?;
+
+        use CVoidCastDirection::*;
+        let cast = match direction {
+            From => CVoidCast {
+                c_void_ptr: self.checked_by_eq(rhs).ok()?,
+                other_ptr: lhs,
+            },
+            To => CVoidCast {
+                c_void_ptr: self.checked_by_eq(lhs).ok()?,
+                other_ptr: rhs,
+            },
+        };
+        Some(cast)
+    }
+}
+
+impl<'tcx> Borrow<Place<'tcx>> for CVoidPtr<'tcx> {
+    fn borrow(&self) -> &Place<'tcx> {
+        &self.place
+    }
+}
+
+/// A cast to/from a [`*c_void`](core::ffi::c_void) to/from a properly typed pointer.
+pub struct CVoidCast<'tcx> {
+    /// The [`*c_void`](core::ffi::c_void) side of the cast.
+    ///
+    /// It can be either the [`From`] or [`To`] side.
+    ///
+    /// [`From`]: CVoidCastDirection::From
+    /// [`To`]: CVoidCastDirection::To
+    c_void_ptr: CVoidPtr<'tcx>,
+
+    /// The non-[`*c_void`](core::ffi::c_void), properly typed pointer side of the cast.
+    ///
+    /// It can be either the [`From`] or [`To`] side.
+    ///
+    /// [`From`]: CVoidCastDirection::From
+    /// [`To`]: CVoidCastDirection::To
+    other_ptr: Place<'tcx>,
+}
+
+/// A mapping from [`*c_void`](core::ffi::c_void)s ([`CVoidPtr`]s)
+/// to their properly typed pointers,
+/// like [`CVoidCasts`], but in a single direction, meaning it represents either
+/// [`CVoidCastDirection::From`] or [`CVoidCastDirection::To`].
+#[derive(Default)]
+pub struct CVoidCastsUniDirectional<'tcx>(HashMap<CVoidPtr<'tcx>, Place<'tcx>>);
+
+impl<'tcx> CVoidCastsUniDirectional<'tcx> {
+    pub fn contains(&self, place: Place<'tcx>) -> bool {
+        self.0.contains_key(&place)
+    }
+
+    /// Get the adjusted [`Place`], skipping over [`*c_void`](core::ffi::c_void) intermediaries.
+    ///
+    /// That is, if `place` is a [`CVoidPtr`] in this map of [`CVoidCast`]s,
+    /// then the [`Place`] of its other, property-typed pointer is returned.
+    /// Otherwise, the same `place` is returned, as no adjustments are necessary.
+    pub fn get_adjusted_place(&self, place: Place<'tcx>) -> Place<'tcx> {
+        *self.0.get(&place).unwrap_or(&place)
+    }
+
+    pub fn insert(&mut self, cast: CVoidCast<'tcx>) {
+        self.0.insert(cast.c_void_ptr, cast.other_ptr);
+    }
+}
+
+/// A mapping from [`*c_void`](core::ffi::c_void)s ([`CVoidPtr`]s)
+/// to their properly typed pointers.
+///
+/// For example, in
+///
+/// ```mir
+/// _1 = malloc(...);
+/// _2 = _1 as *mut T;
+/// ```
+///
+/// this would map `_1` => `_2`.
+///
+/// And in
+///
+/// ```mir
+/// _1 = ...;
+/// _2 = _1 as *mut c_void;
+/// free(_2);
+/// ```
+///
+/// this would map `_2` to `_1`.
+///
+/// This is in order to map them back,
+/// skipping over the `*c_void`,
+/// thus yielding (for the two above examples),
+///
+/// ```mir
+/// _2 = malloc(...);
+/// ```
+///
+/// and
+///
+/// ```mir
+/// _1 = ...;
+/// free(_1);
+/// ```
+#[derive(Default)]
+pub struct CVoidCasts<'tcx> {
+    from: CVoidCastsUniDirectional<'tcx>,
+    to: CVoidCastsUniDirectional<'tcx>,
+}
+
+impl<'tcx> CVoidCasts<'tcx> {
+    pub fn direction(&self, direction: CVoidCastDirection) -> &CVoidCastsUniDirectional<'tcx> {
+        use CVoidCastDirection::*;
+        match direction {
+            From => &self.from,
+            To => &self.to,
+        }
+    }
+
+    pub fn direction_mut(
+        &mut self,
+        direction: CVoidCastDirection,
+    ) -> &mut CVoidCastsUniDirectional<'tcx> {
+        use CVoidCastDirection::*;
+        match direction {
+            From => &mut self.from,
+            To => &mut self.to,
+        }
+    }
+
+    /// See [`CVoidCastsUniDirectional::get_adjusted_place`].
+    pub fn get_adjusted_place(
+        &self,
+        direction: CVoidCastDirection,
+        place: Place<'tcx>,
+    ) -> Place<'tcx> {
+        self.direction(direction).get_adjusted_place(place)
+    }
+
+    /// See [`CVoidCastsUniDirectional::insert`].
+    pub fn insert(&mut self, direction: CVoidCastDirection, cast: CVoidCast<'tcx>) {
+        self.direction_mut(direction).insert(cast)
+    }
+
+    /// Determine if this [`Statement`] should be skipped
+    /// because it contains a [`CVoidCast`] that is in this [`CVoidCasts`],
+    /// as it will be handled in a way that effectively elides the cast.
+    ///
+    /// That is, if this [`Statement`] is an [`Assign`],
+    /// then it will be skipped if:
+    ///
+    /// * the lhs [`Place`] of the [`Assign`] is a [`CVoidPtr`] in the [`To`] direction,
+    ///     as in the [`To`] direction, the [`CVoidPtr`] is on the lhs.
+    ///
+    /// * the rhs [`Place`] of the [`Rvalue::Cast`] of the [`Assign`] is a [`CVoidPtr`] in the [`From`] direction,
+    ///     as in the [`From`] direction, the [`CVoidPtr`] is on the rhs.
+    ///
+    /// [`Assign`]: StatementKind::Assign
+    /// [`From`]: CVoidCastDirection::From
+    /// [`To`]: CVoidCastDirection::To
+    pub fn should_skip_stmt(&self, stmt: &Statement<'tcx>) -> bool {
+        || -> Option<bool> {
+            let (lhs, rv) = get_assign_sides(stmt)?;
+            let skip = self.to.contains(lhs) || self.from.contains(get_cast_place(rv)?);
+            Some(skip)
+        }()
+        .unwrap_or_default()
+    }
+
+    /// Insert all applicable [`*c_void`] casts
+    /// from the `mir` [`Body`] into this [`CVoidCasts`].
+    ///
+    /// That is, find all calls to:
+    ///
+    /// * `malloc`
+    /// * `calloc`
+    /// * `realloc`
+    /// * `free`
+    ///
+    /// and insert their casts to and from [`*c_void`].
+    ///
+    /// [`*c_void`]: core::ffi::c_void
+    pub fn insert_all_from_mir(&mut self, mir: &Body<'tcx>, tcx: TyCtxt<'tcx>) {
+        for bb_data in mir.basic_blocks().iter() {
+            if let Some(term) = &bb_data.terminator {
+                let term: &Terminator = term;
+                if let TerminatorKind::Call {
+                    ref func,
+                    ref args,
+                    destination,
+                    target,
+                    ..
+                } = term.kind
+                {
+                    let func_ty = func.ty(&mir.local_decls, tcx);
+
+                    // For [`CVoidCastDirection::From`], we only count
+                    // a cast from `*c_void` to an arbitrary type in the subsequent block,
+                    // searching forward.
+                    let find_first_cast_succ_block = |get_cast| {
+                        let successor_block_id = target.unwrap();
+                        mir.basic_blocks()[successor_block_id]
+                            .statements
+                            .iter()
+                            .find_map(get_cast)
+                    };
+
+                    // For [`CVoidCastDirection::From`], we only count
+                    // a cast to `*c_void` from an arbitrary type in the same block,
+                    // searching backwards.
+                    let find_last_cast_curr_block =
+                        |get_cast| bb_data.statements.iter().rev().find_map(get_cast);
+
+                    for direction in CVoidCastDirection::from_callee(ty_callee(tcx, func_ty))
+                        .iter()
+                        .copied()
+                    {
+                        use CVoidCastDirection::*;
+                        let c_void_ptr = match direction {
+                            From => destination,
+                            To => args[0].place().unwrap(),
+                        };
+                        let c_void_ptr = CVoidPtr::checked(c_void_ptr, &mir.local_decls, tcx);
+                        let get_cast = move |stmt: &Statement<'tcx>| {
+                            c_void_ptr.get_cast_from_stmt(direction, stmt)
+                        };
+                        let cast = match direction {
+                            From => find_first_cast_succ_block(get_cast),
+                            To => find_last_cast_curr_block(get_cast),
+                        };
+                        if let Some(cast) = cast {
+                            self.insert(direction, cast);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -171,7 +171,7 @@ impl<'tcx> CVoidCastsUniDirectional<'tcx> {
     /// That is, if `place` is a [`CVoidPtr`] in this map of [`CVoidCast`]s,
     /// then the [`Place`] of its other, property-typed pointer is returned.
     /// Otherwise, the same `place` is returned, as no adjustments are necessary.
-    pub fn get_adjusted_place(&self, place: Place<'tcx>) -> Place<'tcx> {
+    pub fn get_adjusted_place_or_default_to(&self, place: Place<'tcx>) -> Place<'tcx> {
         *self.0.get(&place).unwrap_or(&place)
     }
 
@@ -242,13 +242,14 @@ impl<'tcx> CVoidCasts<'tcx> {
         }
     }
 
-    /// See [`CVoidCastsUniDirectional::get_adjusted_place`].
-    pub fn get_adjusted_place(
+    /// See [`CVoidCastsUniDirectional::get_adjusted_place_or_default_to`].
+    pub fn get_adjusted_place_or_default_to(
         &self,
         direction: CVoidCastDirection,
         place: Place<'tcx>,
     ) -> Place<'tcx> {
-        self.direction(direction).get_adjusted_place(place)
+        self.direction(direction)
+            .get_adjusted_place_or_default_to(place)
     }
 
     /// See [`CVoidCastsUniDirectional::insert`].

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -2,13 +2,13 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 
 use rustc_middle::{
-    mir::{Body, LocalDecls, Place, Rvalue, Statement, StatementKind, Terminator, TerminatorKind},
+    mir::{Body, LocalDecls, Place, Statement, Terminator, TerminatorKind},
     ty::{TyCtxt, TyKind},
 };
 
 use assert_matches::assert_matches;
 
-use crate::util::{ty_callee, Callee};
+use crate::util::{get_assign_sides, get_cast_place, ty_callee, Callee};
 
 /// The direction of a [`*c_void`](core::ffi::c_void) cast.
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -96,26 +96,7 @@ impl<'tcx> CVoidPtr<'tcx> {
             Err(place)
         }
     }
-}
 
-fn get_cast_place<'tcx>(rv: &Rvalue<'tcx>) -> Option<Place<'tcx>> {
-    match rv {
-        Rvalue::Cast(_, op, _) => op.place(),
-        _ => None,
-    }
-}
-
-fn get_assign_sides<'tcx, 'a>(
-    stmt: &'a Statement<'tcx>,
-) -> Option<(Place<'tcx>, &'a Rvalue<'tcx>)> {
-    let (pl, ref rv) = match &stmt.kind {
-        StatementKind::Assign(it) => Some(&**it),
-        _ => None,
-    }?;
-    Some((*pl, rv))
-}
-
-impl<'tcx> CVoidPtr<'tcx> {
     /// Try to get the appropriate [`CVoidCast`]
     /// from this [`Statement`] in the given [`CVoidCastDirection`].
     ///
@@ -285,10 +266,11 @@ impl<'tcx> CVoidCasts<'tcx> {
     /// * the lhs [`Place`] of the [`Assign`] is a [`CVoidPtr`] in the [`To`] direction,
     ///     as in the [`To`] direction, the [`CVoidPtr`] is on the lhs.
     ///
-    /// * the rhs [`Place`] of the [`Rvalue::Cast`] of the [`Assign`] is a [`CVoidPtr`] in the [`From`] direction,
+    /// * the rhs [`Place`] of the [`Cast`] of the [`Assign`] is a [`CVoidPtr`] in the [`From`] direction,
     ///     as in the [`From`] direction, the [`CVoidPtr`] is on the rhs.
     ///
-    /// [`Assign`]: StatementKind::Assign
+    /// [`Assign`]: rustc_middle::mir::StatementKind::Assign
+    /// [`Cast`]: rustc_middle::mir::Rvalue::Cast
     /// [`From`]: CVoidCastDirection::From
     /// [`To`]: CVoidCastDirection::To
     pub fn should_skip_stmt(&self, stmt: &Statement<'tcx>) -> bool {

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -274,12 +274,15 @@ impl<'tcx> CVoidCasts<'tcx> {
     /// [`From`]: CVoidCastDirection::From
     /// [`To`]: CVoidCastDirection::To
     pub fn should_skip_stmt(&self, stmt: &Statement<'tcx>) -> bool {
-        || -> Option<bool> {
-            let (lhs, rv) = get_assign_sides(stmt)?;
-            let skip = self.to.contains(lhs) || self.from.contains(get_cast_place(rv)?);
-            Some(skip)
-        }()
-        .unwrap_or_default()
+        let (lhs, rv) = match get_assign_sides(stmt) {
+            None => return false,
+            Some(it) => it,
+        };
+        self.to.contains(lhs)
+            || self.from.contains(match get_cast_place(rv) {
+                None => return false,
+                Some(it) => it,
+            })
     }
 
     /// Insert all applicable [`*c_void`] casts

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -1,9 +1,10 @@
+use crate::c_void_casts::CVoidCasts;
 use crate::labeled_ty::{LabeledTy, LabeledTyCtxt};
 use crate::pointer_id::{
     GlobalPointerTable, LocalPointerTable, NextGlobalPointerId, NextLocalPointerId, PointerTable,
     PointerTableMut,
 };
-use crate::util::{self, describe_rvalue, CVoidCasts, RvalueDesc};
+use crate::util::{self, describe_rvalue, RvalueDesc};
 use crate::AssignPointerIds;
 use bitflags::bitflags;
 use rustc_hir::def_id::DefId;

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -182,11 +182,12 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         gacx: &'a mut GlobalAnalysisCtxt<'tcx>,
         mir: &'a Body<'tcx>,
     ) -> AnalysisCtxt<'a, 'tcx> {
+        let tcx = gacx.tcx;
         AnalysisCtxt {
             gacx,
             local_decls: &mir.local_decls,
             local_tys: IndexVec::new(),
-            c_void_casts: CVoidCasts::default(),
+            c_void_casts: CVoidCasts::new(mir, tcx),
             addr_of_local: IndexVec::new(),
             rvalue_tys: HashMap::new(),
             next_ptr_id: NextLocalPointerId::new(),

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -300,22 +300,22 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     Some(Callee::Trivial) => {}
 
                     Some(Callee::Malloc | Callee::Calloc) => {
-                        let out_ptr = self
-                            .acx
-                            .c_void_casts
-                            .get_adjusted_place(CVoidCastDirection::From, destination);
+                        let out_ptr = self.acx.c_void_casts.get_adjusted_place_or_default_to(
+                            CVoidCastDirection::From,
+                            destination,
+                        );
                         self.visit_place(out_ptr, Mutability::Mut);
                     }
                     Some(Callee::Realloc) => {
-                        let out_ptr = self
-                            .acx
-                            .c_void_casts
-                            .get_adjusted_place(CVoidCastDirection::From, destination);
+                        let out_ptr = self.acx.c_void_casts.get_adjusted_place_or_default_to(
+                            CVoidCastDirection::From,
+                            destination,
+                        );
                         let in_ptr = args[0].place().unwrap();
                         let in_ptr = self
                             .acx
                             .c_void_casts
-                            .get_adjusted_place(CVoidCastDirection::To, in_ptr);
+                            .get_adjusted_place_or_default_to(CVoidCastDirection::To, in_ptr);
                         self.visit_place(out_ptr, Mutability::Mut);
                         let pl_lty = self.acx.type_of(out_ptr);
                         assert!(args.len() == 2);
@@ -334,7 +334,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         let in_ptr = self
                             .acx
                             .c_void_casts
-                            .get_adjusted_place(CVoidCastDirection::To, in_ptr);
+                            .get_adjusted_place_or_default_to(CVoidCastDirection::To, in_ptr);
                         self.visit_place(destination, Mutability::Mut);
                         assert!(args.len() == 1);
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -450,8 +450,6 @@ fn run(tcx: TyCtxt) {
             assert_eq!(local, l);
         }
 
-        acx.c_void_casts.insert_all_from_mir(&mir, tcx);
-
         for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
             for (i, stmt) in bb_data.statements.iter().enumerate() {
                 let (_, rv) = match &stmt.kind {

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -260,28 +260,28 @@ fn builtin_callee<'tcx>(
             Some(Callee::Trivial)
         }
 
-        "malloc" | "c2rust_test_typed_malloc" => {
+        "malloc" => {
             if matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod) {
                 return Some(Callee::Malloc);
             }
             None
         }
 
-        "calloc" | "c2rust_test_typed_calloc" => {
+        "calloc" => {
             if matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod) {
                 return Some(Callee::Calloc);
             }
             None
         }
 
-        "realloc" | "c2rust_test_typed_realloc" => {
+        "realloc" => {
             if matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod) {
                 return Some(Callee::Realloc);
             }
             None
         }
 
-        "free" | "c2rust_test_typed_free" => {
+        "free" => {
             if matches!(tcx.def_kind(tcx.parent(did)), DefKind::ForeignMod) {
                 return Some(Callee::Free);
             }

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -3,7 +3,10 @@ use std::fmt::Debug;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_middle::{
-    mir::{Field, Local, Mutability, Operand, PlaceElem, PlaceRef, ProjectionElem, Rvalue},
+    mir::{
+        Field, Local, Mutability, Operand, Place, PlaceElem, PlaceRef, ProjectionElem, Rvalue,
+        Statement, StatementKind,
+    },
     ty::{AdtDef, DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy},
 };
 
@@ -306,4 +309,21 @@ pub fn lty_project<'tcx, L: Debug>(
         ProjectionElem::Subslice { .. } => todo!("type_of Subslice"),
         ProjectionElem::Downcast(..) => todo!("type_of Downcast"),
     }
+}
+
+pub fn get_cast_place<'tcx>(rv: &Rvalue<'tcx>) -> Option<Place<'tcx>> {
+    match rv {
+        Rvalue::Cast(_, op, _) => op.place(),
+        _ => None,
+    }
+}
+
+pub fn get_assign_sides<'tcx, 'a>(
+    stmt: &'a Statement<'tcx>,
+) -> Option<(Place<'tcx>, &'a Rvalue<'tcx>)> {
+    let (pl, ref rv) = match &stmt.kind {
+        StatementKind::Assign(it) => Some(&**it),
+        _ => None,
+    }?;
+    Some((*pl, rv))
 }

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -1,43 +1,13 @@
-use crate::labeled_ty::LabeledTy;
-use rustc_hir::def::DefKind;
-use rustc_hir::def_id::DefId;
-use rustc_middle::mir::{
-    Field, Local, Mutability, Operand, Place, PlaceElem, PlaceRef, ProjectionElem, Rvalue,
-};
-use rustc_middle::ty::{AdtDef, DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy};
-use std::collections::HashMap;
 use std::fmt::Debug;
 
-/// A mapping for substituting [`Place`]s adhering to the
-/// following pattern
-///
-/// ```mir
-/// _1 = malloc(...);
-/// _2 = _1 as *mut T;
-/// ```
-///
-/// where `_1` is [`*c_void`](core::ffi::c_void).
-///
-/// In this case, `_1` would be mapped to `_2`, which is indicative
-/// of the amended statement:
-///
-/// ```mir
-/// _2 = malloc(...);
-/// ```
-#[derive(Default)]
-pub struct CVoidCasts<'tcx>(pub HashMap<Place<'tcx>, Place<'tcx>>);
+use rustc_hir::def::DefKind;
+use rustc_hir::def_id::DefId;
+use rustc_middle::{
+    mir::{Field, Local, Mutability, Operand, PlaceElem, PlaceRef, ProjectionElem, Rvalue},
+    ty::{AdtDef, DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy},
+};
 
-impl<'tcx> CVoidCasts<'tcx> {
-    /// Checks if the casted-to or casted-from value is a [`*c_void`](core::ffi::c_void).
-    pub fn contains(&self, lhs: &Place<'tcx>, rv: &Rvalue<'tcx>) -> bool {
-        matches!(rv, Rvalue::Cast(_, Operand::Copy(p) | Operand::Move(p), _) if self.0.contains_key(p))
-            || self.0.contains_key(lhs)
-    }
-
-    pub fn get_or_default_to(&self, p: &Place<'tcx>) -> Place<'tcx> {
-        *self.0.get(p).unwrap_or(p)
-    }
-}
+use crate::labeled_ty::LabeledTy;
 
 #[derive(Debug)]
 pub enum RvalueDesc<'tcx> {

--- a/c2rust-analyze/tests/filecheck/alloc.rs
+++ b/c2rust-analyze/tests/filecheck/alloc.rs
@@ -18,16 +18,9 @@ use std::mem;
 pub type size_t = libc::c_ulong;
 
 extern "C" {
-    fn c2rust_test_typed_malloc(_: libc::c_ulong) -> *mut i32;
-    fn c2rust_test_typed_realloc(_: *mut i32, _: libc::c_ulong) -> *mut i32;
-    fn c2rust_test_typed_free(__ptr: *mut i32);
-    fn c2rust_test_typed_calloc(_: libc::c_ulong, _: libc::c_ulong) -> *mut i32;
-}
-
-extern "C" {
     fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
     fn realloc(_: *mut libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
-    fn free(__ptr: *mut libc::c_void);
+    fn free(_: *mut libc::c_void);
     fn calloc(_: libc::c_ulong, _: libc::c_ulong) -> *mut libc::c_void;
 }
 


### PR DESCRIPTION
This is a rework of #788 that properly separates the two `*c_void` cast directions.

In #788, these are conflated.  I'm not exactly sure if this can lead to a bug (the `Place`s in the map are not necessary unique), but the point is, the conflation makes it harder to understand and reason about, so it is harder to tell if there is one or not.  It may be correct due to details of our particular analysis and how MIR works, but then you have to understand all the details to know if it's correct or not, and it's a lot more brittle to future changes.

By separating the `From` and `To` directions here, it IMO makes it much easier to understand.  It allows the logic to be more easily separated, such as in
* `CVoidCastDirection::from_callee`
* `CVoidPtr::checked`
* `CVoidPtr::get_cast_from_stmt`
* `CVoidCasts::should_skip_stmt`

Separating the logic also allows each part to be more documented, which IMO makes it a lot easier to readon about and understand.

It also separates the `*c_void` casts code into its own module.