### PR TITLE
(`c2rust-analyze`) Support `Repeat` array initializers with no pointers

### DIFF
--- a/analysis/tests/lighttpd-minimal/src/main.rs
+++ b/analysis/tests/lighttpd-minimal/src/main.rs
@@ -1369,6 +1369,22 @@ pub unsafe extern "C" fn lighttpd_test() {
     free(fdes /* TODO: handle cast as *mut libc::c_void */);
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn buffer_append_int(mut b: *mut buffer, mut val: intmax_t) {
+    let mut buf: [libc::c_char; 22] = [0; 22];
+    // let str: *const libc::c_char = itostr(buf.as_mut_ptr(), val);
+    // buffer_append_string_len(
+    //     b,
+    //     str,
+    //     buf
+    //         .as_mut_ptr()
+    //         .offset(
+    //             ::std::mem::size_of::<[libc::c_char; 22]>() as libc::c_ulong as isize,
+    //         )
+    //         .offset_from(str) as libc::c_long as size_t,
+    // );
+}
+
 fn main() {
     unsafe {
         lighttpd_test();

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -299,6 +299,15 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
             Rvalue::UnaryOp(_, ref op) => self.visit_operand(op),
 
+            Rvalue::Repeat(ref op, _) => {
+                if op.ty(self.local_decls, self.tcx).is_any_ptr() {
+                    todo!("Repeat types over pointers not yet implemented");
+                }
+                let ty = rv.ty(self.local_decls, *self.ltcx);
+                // TODO: create fresh origins for all pointers in `ty`, and generate subset
+                // relations between the regions of the array and the regions of its elements
+                self.ltcx.label(ty, &mut |_ty| Label::default())
+            }
             ref rv => panic!("unsupported rvalue {:?}", rv),
         }
     }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -115,6 +115,18 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 assert_matches!(lty.args, [elem_lty] => {
                     // Pseudo-assign from the operand to the element type of the array.
                     let op_lty = self.acx.type_of(op);
+                    /*
+                        TODO: This is the right thing to do here, though currently
+                        it's a no-op because type_of_rvalue (whose result is passed
+                        into this function as lty) constructs its result using
+                        type_of(op), so elem_lty and op_lty will always be identical.
+                        Eventually we'll want to change this so the Rvalue::Repeat gets
+                        its own LTy with its own PointerIds, similar to the handling of
+                        array aggregates. This would let us detect the need for a
+                        cast on the operand of the repeat (we can't cast [&[u32]; 3]
+                        to [&u32; 3], but we could cast the operand from &[u32] to
+                        &u32 before doing the repeat, e.g. let x = [&my_slice[0]; 3];).
+                    */
                     self.do_assign(elem_lty, op_lty);
                 });
             }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -109,7 +109,14 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
         match *rv {
             Rvalue::Use(ref op) => self.visit_operand(op),
-            Rvalue::Repeat(..) => todo!("visit_rvalue Repeat"),
+            Rvalue::Repeat(ref op, _) => {
+                assert!(matches!(lty.kind(), TyKind::Array(..)));
+                assert_eq!(lty.args.len(), 1);
+                let elem_lty = lty.args[0];
+                // Pseudo-assign from the operand to the element type of the array.
+                let op_lty = self.acx.type_of(op);
+                self.do_assign(elem_lty, op_lty);
+            }
             Rvalue::Ref(..) => {
                 unreachable!("Rvalue::Ref should be handled by describe_rvalue instead")
             }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -111,7 +111,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         match *rv {
             Rvalue::Use(ref op) => self.visit_operand(op),
             Rvalue::Repeat(ref op, _) => {
-                assert!(matches!(lty.kind(), TyKind::Array(..)));
+                assert!(lty.ty.is_array());
                 assert_matches!(lty.args, [elem_lty] => {
                     // Pseudo-assign from the operand to the element type of the array.
                     let op_lty = self.acx.type_of(op);

--- a/c2rust-analyze/tests/filecheck/aggregate1.rs
+++ b/c2rust-analyze/tests/filecheck/aggregate1.rs
@@ -14,3 +14,8 @@ pub unsafe fn aggregate1_array1(p: *mut i32) {
     let arr = [p];
     *arr[0] = 1;
 }
+
+pub unsafe fn repeat() {
+    let x = 22;
+    let _buf: [u32; 22] = [x; 22];
+}


### PR DESCRIPTION
`Repeat` initialization shows up a bunch in `lighttpd` code, e.g.

```rust
...
let mut x: [uint32_t; 16] = [0; 16];
...
```

As far as I can tell, though, no `Repeat` initialization in `lighttpd` includes arrays of pointer types. So, this PR minimally adds support for `Repeat` initialization for non-pointer types