### PR TITLE
(`c2rust-analyze/tests`) Define `FileCheck` tests statically, rather than searching for them dynamically

### DIFF
--- a/c2rust-analyze/tests/analyze.rs
+++ b/c2rust-analyze/tests/analyze.rs
@@ -1,20 +1,34 @@
-use common::Analyze;
-
 pub mod common;
 
-#[test]
-fn string_literals() {
-    Analyze::resolve().run("tests/analyze/string_literals.rs");
+use std::path::PathBuf;
+
+use common::Analyze;
+
+fn test(file_name: &str) {
+    let analyze = Analyze::resolve();
+    let path = ["tests", "analyze", file_name].iter().collect::<PathBuf>();
+    analyze.run(&path);
 }
 
-#[test]
-fn string_casts() {
-    Analyze::resolve().run("tests/analyze/string_casts.rs");
+macro_rules! define_test {
+    ($name:ident) => {
+        #[test]
+        fn $name() {
+            test(concat!(stringify!($name), ".rs"));
+        }
+    };
 }
 
-#[test]
-fn macros() {
-    Analyze::resolve().run("tests/analyze/macros.rs");
+macro_rules! define_tests {
+    ($($name:ident,)*) => {
+        $(define_test! { $name })*
+    }
+}
+
+define_tests! {
+    string_literals,
+    string_casts,
+    macros,
 }
 
 #[test]

--- a/c2rust-analyze/tests/analyze.rs
+++ b/c2rust-analyze/tests/analyze.rs
@@ -2,7 +2,12 @@ pub mod common;
 
 use std::path::PathBuf;
 
-use common::Analyze;
+use crate::common::{check_for_missing_tests_for, Analyze};
+
+#[test]
+fn check_for_missing_tests() {
+    check_for_missing_tests_for(file!());
+}
 
 fn test(file_name: &str) {
     let analyze = Analyze::resolve();

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -1,30 +1,49 @@
 pub mod common;
 
-use std::fs;
+use std::path::PathBuf;
 
 use common::{Analyze, FileCheck};
 
-#[test]
-fn filecheck() {
+fn test(file_name: &str) {
     let analyze = Analyze::resolve();
     let file_check = FileCheck::resolve();
+    let path = ["tests", "filecheck", file_name]
+        .iter()
+        .collect::<PathBuf>();
+    let output_path = analyze.run(&path);
+    file_check.run(&path, &output_path);
+}
 
-    for entry in fs::read_dir("tests/filecheck").unwrap() {
-        let entry = entry.unwrap();
-
-        if !entry.file_type().unwrap().is_file() {
-            continue;
+macro_rules! define_test {
+    ($name:ident) => {
+        #[test]
+        fn $name() {
+            test(concat!(stringify!($name), ".rs"));
         }
+    };
+}
 
-        let name = entry.file_name();
-        let name = name.to_str().unwrap();
-        if name.starts_with('.') || !name.ends_with(".rs") {
-            continue;
-        }
-
-        eprintln!("{:?}", entry.path());
-
-        let output_path = analyze.run(entry.path());
-        file_check.run(entry.path(), &output_path);
+macro_rules! define_tests {
+    ($($name:ident,)*) => {
+        $(define_test! { $name })*
     }
+}
+
+define_tests! {
+    aggregate1,
+    alias1,
+    alias2,
+    alias3,
+    alloc,
+    as_ptr,
+    call1,
+    cast,
+    clone1,
+    extern_fn1,
+    fields,
+    insertion_sort,
+    offset1,
+    offset2,
+    ptrptr1,
+    trivial,
 }

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -2,7 +2,12 @@ pub mod common;
 
 use std::path::PathBuf;
 
-use common::{Analyze, FileCheck};
+use crate::common::{check_for_missing_tests_for, Analyze, FileCheck};
+
+#[test]
+fn check_for_missing_tests() {
+    check_for_missing_tests_for(file!());
+}
 
 fn test(file_name: &str) {
     let analyze = Analyze::resolve();

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -35,6 +35,7 @@ macro_rules! define_tests {
 }
 
 define_tests! {
+    addr_of,
     aggregate1,
     alias1,
     alias2,
@@ -43,12 +44,18 @@ define_tests! {
     as_ptr,
     call1,
     cast,
+    cell,
     clone1,
     extern_fn1,
     fields,
+    field_temp,
     insertion_sort,
+    insertion_sort_driver,
+    insertion_sort_rewrites,
     offset1,
     offset2,
     ptrptr1,
+    statics,
     trivial,
+    type_annotation_rewrite,
 }


### PR DESCRIPTION
Define `FileCheck` tests statically, rather than searching for them dynamically.

This has a few major advantages:

- You can run a single test if you want. This is really useful when you're developing and testing one test, and you have no need to run the other tests yet, which are just slower and add to extra output.

- The tests are automatically parallelized, which makes them take ~0.5s vs. ~2s, 4x faster.

- You can add some custom logic for one particular test, for example, if it crashes, or you want to skip it for now as it's a WIP.

The macros `define_test!` and `define_tests!` are added here as a convenience for quickly and succinctly defining all the tests, but they don't have to be used for, e.x. a custom test.

I've also now added `check_for_missing_tests` tests than ensure we don't have test files that aren't being tested by a `#[test] fn`.