### PR TITLE
(`c2rust-analyze/tests`) Add tests for string literals and casts

### DIFF
--- a/c2rust-analyze/tests/analyze.rs
+++ b/c2rust-analyze/tests/analyze.rs
@@ -4,15 +4,15 @@ pub mod common;
 
 #[test]
 fn string_literals() {
-    Analyze::new().run("tests/analyze/string_literals.rs");
+    Analyze::resolve().run("tests/analyze/string_literals.rs");
 }
 
 #[test]
 fn string_casts() {
-    Analyze::new().run("tests/analyze/string_casts.rs");
+    Analyze::resolve().run("tests/analyze/string_casts.rs");
 }
 
 #[test]
 fn lighttpd_minimal() {
-    Analyze::new().run("../analysis/tests/lighttpd-minimal/src/main.rs");
+    Analyze::resolve().run("../analysis/tests/lighttpd-minimal/src/main.rs");
 }

--- a/c2rust-analyze/tests/analyze.rs
+++ b/c2rust-analyze/tests/analyze.rs
@@ -3,6 +3,16 @@ use common::Analyze;
 pub mod common;
 
 #[test]
+fn string_literals() {
+    Analyze::new().run("tests/analyze/string_literals.rs");
+}
+
+#[test]
+fn string_casts() {
+    Analyze::new().run("tests/analyze/string_casts.rs");
+}
+
+#[test]
 fn lighttpd_minimal() {
     Analyze::new().run("../analysis/tests/lighttpd-minimal/src/main.rs");
 }

--- a/c2rust-analyze/tests/analyze.rs
+++ b/c2rust-analyze/tests/analyze.rs
@@ -3,6 +3,6 @@ use common::Analyze;
 pub mod common;
 
 #[test]
-fn test_lighttpd_minimal() {
+fn lighttpd_minimal() {
     Analyze::new().run("../analysis/tests/lighttpd-minimal/src/main.rs");
 }

--- a/c2rust-analyze/tests/analyze/string_casts.rs
+++ b/c2rust-analyze/tests/analyze/string_casts.rs
@@ -1,0 +1,9 @@
+#[cfg(any())]
+fn cast_only(s: *const u8) {
+    s as *const core::ffi::c_char;
+}
+
+#[cfg(any())]
+fn cast_from_literal() {
+    b"" as *const u8 as *const core::ffi::c_char;
+}

--- a/c2rust-analyze/tests/analyze/string_literals.rs
+++ b/c2rust-analyze/tests/analyze/string_literals.rs
@@ -1,0 +1,9 @@
+#[cfg(any())]
+fn str() {
+    "";
+}
+
+#[cfg(any())]
+fn bstr() {
+    b"";
+}

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -6,7 +6,7 @@ use common::{Analyze, FileCheck};
 
 #[test]
 fn filecheck() {
-    let analyze = Analyze::new();
+    let analyze = Analyze::resolve();
     let file_check = FileCheck::resolve();
 
     for entry in fs::read_dir("tests/filecheck").unwrap() {


### PR DESCRIPTION
Add tests for string literals and casts.

They are currently unsupported:
- #833
- #837

so for now the tests are skipped over with `#[cfg(any())]`.  Once those issues are fixed, these tests will be turned back on, but it's easier to start with the tests existing.

These tests just check if `c2rust-analyze` doesn't crash on them, similar to the existing `lighttpd-minimal` test.  For the `FileCheck` tests, `FileCheck` requires at least one `CHECK:` command, which we don't want.  Thus, I've renamed `lighttpd.rs` to `analyze.rs` and it'll be for `c2rust-analyze`-only tests, as opposed to `filecheck.rs` for `c2rust-analyze` + `FileCheck` tests.

Furthermore, running `cargo` concurrently (due to multiple tests) for `c2rust-analyze` crashes in macOS CI, so now the `c2rust-analyze` binary is found to run directly, rather than going through `cargo` again.

Skipping going through `cargo` makes the tests run much faster, but more importantly, prevents them from competing for the `target/` lock, which caused issues in CI on macOS sometimes.  It's also a bit simpler now, not needing to go through `cargo`.