### PR TITLE
Feat.cast.loc

### DIFF
--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -442,7 +442,7 @@ pub fn visit_body<'tcx>(
             };
             tc.current_location = loc;
 
-            if !c_void_casts.should_skip_stmt(&loc) {
+            if !c_void_casts.should_skip_stmt(loc) {
                 tc.visit_statement(stmt);
             }
         }

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -331,10 +331,6 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     }
 
     pub fn visit_statement(&mut self, stmt: &Statement<'tcx>) {
-        if self.c_void_casts.should_skip_stmt(stmt) {
-            return;
-        }
-
         // TODO(spernsteiner): other `StatementKind`s will be handled in the future
         #[allow(clippy::single_match)]
         match stmt.kind {
@@ -440,17 +436,21 @@ pub fn visit_body<'tcx>(
         c_void_casts,
     };
 
-    for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
+    for (block, bb_data) in mir.basic_blocks().iter_enumerated() {
         for (idx, stmt) in bb_data.statements.iter().enumerate() {
-            tc.current_location = Location {
-                block: bb,
+            let loc = Location {
+                block,
                 statement_index: idx,
             };
-            tc.visit_statement(stmt);
+            tc.current_location = loc;
+
+            if !c_void_casts.should_skip_stmt(&loc) {
+                tc.visit_statement(stmt);
+            }
         }
 
         tc.current_location = Location {
-            block: bb,
+            block,
             statement_index: bb_data.statements.len(),
         };
         tc.visit_terminator(bb_data.terminator());

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -26,7 +26,6 @@ struct TypeChecker<'tcx, 'a> {
     local_decls: &'a IndexVec<Local, LocalDecl<'tcx>>,
     current_location: Location,
     adt_metadata: &'a AdtMetadataTable<'tcx>,
-    c_void_casts: &'a CVoidCasts<'tcx>,
 }
 
 impl<'tcx> TypeChecker<'tcx, '_> {
@@ -433,7 +432,6 @@ pub fn visit_body<'tcx>(
         local_decls: &mir.local_decls,
         current_location: Location::START,
         adt_metadata,
-        c_void_casts,
     };
 
     for (block, bb_data) in mir.basic_blocks().iter_enumerated() {

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -138,7 +138,7 @@ impl<'tcx> Borrow<Place<'tcx>> for CVoidPtr<'tcx> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 /// A cast to/from a [`*c_void`](core::ffi::c_void) to/from a properly typed pointer.
 pub struct CVoidCast<'tcx> {
     /// The [`*c_void`](core::ffi::c_void) side of the cast.
@@ -163,7 +163,7 @@ pub struct CVoidCast<'tcx> {
 /// like [`CVoidCasts`], but in a single direction, meaning it represents either
 /// [`CVoidCastDirection::From`] or [`CVoidCastDirection::To`].
 #[derive(Default, Clone, Debug)]
-pub struct CVoidCastsUniDirectional<'tcx>(HashMap<Location, (CVoidPtr<'tcx>, Place<'tcx>)>);
+pub struct CVoidCastsUniDirectional<'tcx>(HashMap<Location, CVoidCast<'tcx>>);
 
 impl<'tcx> CVoidCastsUniDirectional<'tcx> {
     pub fn contains(&self, loc: &Location) -> bool {
@@ -183,16 +183,16 @@ impl<'tcx> CVoidCastsUniDirectional<'tcx> {
         *self
             .0
             .get(loc)
-            .map(|(void, subst)| {
-                assert!(void.place == place);
-                subst
+            .map(|cast| {
+                assert!(cast.c_void_ptr.place == place);
+                &cast.other_ptr
             })
             .unwrap_or(&place)
     }
 
     pub fn insert(&mut self, loc: Location, cast: CVoidCast<'tcx>) {
         assert!(!self.contains(&loc));
-        self.0.insert(loc, (cast.c_void_ptr, cast.other_ptr));
+        self.0.insert(loc, cast);
     }
 }
 

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -437,20 +437,25 @@ impl<'tcx> CVoidCasts<'tcx> {
                     To => Self::find_last_cast(&bb_data.statements, c_void_ptr),
                 };
                 if let Some((statement_index, cast)) = cast {
-                    let loc = Location {
-                        statement_index,
-                        block: match direction {
-                            To => BasicBlock::from_usize(block),
-                            From => target.unwrap(),
+                    self.insert_cast(
+                        Location {
+                            statement_index,
+                            block: match direction {
+                                To => BasicBlock::from_usize(block),
+                                From => target.unwrap(),
+                            },
                         },
-                    };
-                    self.insert_cast(loc, direction, cast.clone());
-
-                    let loc = Location {
-                        statement_index: bb_data.statements.len(),
-                        block: BasicBlock::from_usize(block),
-                    };
-                    self.insert_call(loc, direction, cast);
+                        direction,
+                        cast.clone(),
+                    );
+                    self.insert_call(
+                        Location {
+                            statement_index: bb_data.statements.len(),
+                            block: BasicBlock::from_usize(block),
+                        },
+                        direction,
+                        cast,
+                    );
                 }
             }
         }

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -311,8 +311,8 @@ impl<'tcx> CVoidCasts<'tcx> {
 
         let local = p.local;
 
-        if let StatementKind::Assign(asgn) = stmt.kind.clone() {
-            let (lhs, rv) = *asgn;
+        if let StatementKind::Assign(assign) = stmt.kind.clone() {
+            let (lhs, rv) = *assign;
             if lhs.local == local {
                 return true;
             }

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -189,11 +189,13 @@ impl<'tcx> CVoidCastsUniDirectional<'tcx> {
             .unwrap_or(&place)
     }
 
+    /// Tracks the [Location] of the use of a casted pointer in a [TerminatorKind::Call]
     pub fn insert_call(&mut self, loc: Location, cast: CVoidCast<'tcx>) {
         assert!(!self.calls.contains_key(&loc));
         self.calls.insert(loc, cast);
     }
 
+    /// Tracks the [Location] of void pointer [Rvalue::Cast]
     pub fn insert_cast(&mut self, loc: Location, cast: CVoidCast<'tcx>) {
         assert!(!self.casts.contains_key(&loc));
         self.casts.insert(loc, cast);

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -180,7 +180,7 @@ impl<'tcx> CVoidCastsUniDirectional<'tcx> {
         loc: &Location,
         place: Place<'tcx>,
     ) -> Place<'tcx> {
-        *self.0.get(loc).map(|(void, subst)| subst).unwrap_or(&place)
+        *self.0.get(loc).map(|(_void, subst)| subst).unwrap_or(&place)
     }
 
     pub fn insert(&mut self, loc: Location, cast: CVoidCast<'tcx>) {
@@ -284,9 +284,6 @@ impl<'tcx> CVoidCasts<'tcx> {
     /// [`From`]: CVoidCastDirection::From
     /// [`To`]: CVoidCastDirection::To
     pub fn should_skip_stmt(&self, loc: &Location) -> bool {
-        eprintln!("{loc:?}");
-        eprintln!("to: {:?}", self.to);
-        eprintln!("from: {:?}", self.from);
         self.to.contains(loc) || self.from.contains(loc)
     }
 

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use rustc_middle::{
     mir::{
-        BasicBlock, BasicBlockData, Body, LocalDecls, Location, Place, Rvalue, Statement,
-        StatementKind, Terminator, TerminatorKind,
+        BasicBlock, Body, LocalDecls, Location, Place, Rvalue, Statement, StatementKind,
+        Terminator, TerminatorKind,
     },
     ty::{TyCtxt, TyKind},
 };
@@ -333,18 +333,12 @@ impl<'tcx> CVoidCasts<'tcx> {
 
     fn find_first_cast_succ_block<F: FnMut(&Statement<'tcx>) -> Option<CVoidCast<'tcx>>>(
         mut get_cast: F,
-        target: Option<BasicBlock>,
-        body: &Body<'tcx>,
+        statements: &[Statement<'tcx>],
     ) -> Option<(usize, CVoidCast<'tcx>)> {
         // For [`CVoidCastDirection::From`], we only count
         // a cast from `*c_void` to an arbitrary type in the subsequent block,
         // searching forward.
-        let successor_block_id = target.unwrap();
-        for (sidx, stmt) in body.basic_blocks()[successor_block_id]
-            .statements
-            .iter()
-            .enumerate()
-        {
+        for (sidx, stmt) in statements.iter().enumerate() {
             if let StatementKind::StorageDead(_) = stmt.kind {
                 continue;
             }
@@ -360,13 +354,13 @@ impl<'tcx> CVoidCasts<'tcx> {
 
     fn find_last_cast_curr_block<F: FnMut(&Statement<'tcx>) -> Option<CVoidCast<'tcx>>>(
         mut get_cast: F,
-        bb_data: &BasicBlockData<'tcx>,
+        statements: &[Statement<'tcx>],
         place: &Place<'tcx>,
     ) -> Option<(usize, CVoidCast<'tcx>)> {
         // For [`CVoidCastDirection::From`], we only count
         // a cast to `*c_void` from an arbitrary type in the same block,
         // searching backwards.
-        for (sidx, stmt) in bb_data.statements.iter().enumerate().rev() {
+        for (sidx, stmt) in statements.iter().enumerate().rev() {
             let cast = get_cast(stmt);
             if let Some(cast) = cast {
                 return Some((sidx, cast));
@@ -424,8 +418,15 @@ impl<'tcx> CVoidCasts<'tcx> {
                 let get_cast =
                     |stmt: &Statement<'tcx>| c_void_ptr.get_cast_from_stmt(direction, stmt);
                 let cast = match direction {
-                    From => Self::find_first_cast_succ_block(get_cast, target, body),
-                    To => Self::find_last_cast_curr_block(get_cast, bb_data, &c_void_ptr_place),
+                    From => Self::find_first_cast_succ_block(
+                        get_cast,
+                        &body.basic_blocks()[target.unwrap()].statements,
+                    ),
+                    To => Self::find_last_cast_curr_block(
+                        get_cast,
+                        &bb_data.statements,
+                        &c_void_ptr_place,
+                    ),
                 };
                 if let Some((statement_index, cast)) = cast {
                     let loc = Location {

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -188,6 +188,7 @@ impl<'tcx> CVoidCastsUniDirectional<'tcx> {
     }
 
     pub fn insert(&mut self, loc: Location, cast: CVoidCast<'tcx>) {
+        assert!(!self.contains(&loc));
         self.0.insert(loc, (cast.c_void_ptr, cast.other_ptr));
     }
 }

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -183,7 +183,10 @@ impl<'tcx> CVoidCastsUniDirectional<'tcx> {
         *self
             .0
             .get(loc)
-            .map(|(_void, subst)| subst)
+            .map(|(void, subst)| {
+                assert!(void.place == place);
+                subst
+            })
             .unwrap_or(&place)
     }
 

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -11,7 +11,7 @@ use rustc_middle::{
 
 use assert_matches::assert_matches;
 
-use crate::util::{get_assign_sides, get_cast_place, ty_callee, Callee};
+use crate::util::{get_assign_sides, get_cast_place, terminator_location, ty_callee, Callee};
 
 /// The direction of a [`*c_void`](core::ffi::c_void) cast.
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -462,10 +462,7 @@ impl<'tcx> CVoidCasts<'tcx> {
                         cast.clone(),
                     );
                     self.insert_call(
-                        Location {
-                            statement_index: bb_data.statements.len(),
-                            block: BasicBlock::from_usize(block),
-                        },
+                        terminator_location(BasicBlock::from_usize(block), bb_data),
                         direction,
                         cast,
                     );

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -354,8 +354,12 @@ impl<'tcx> CVoidCasts<'tcx> {
         false
     }
 
-    /// Search for the first cast from a void pointer
-    /// in a sequence of [Statement]s
+    /// Search for the first [Rvalue::Cast] from a void pointer
+    /// in a sequence of [Statement]s. We expect that the
+    /// cast is the first non-[StatementKind::StorageDead]
+    /// statement in the block, a special case for
+    /// [Terminator]s whose destination is casted from a
+    /// void pointer to some other pointer type.
     fn find_first_cast(
         statements: &[Statement<'tcx>],
         c_void_ptr: CVoidPtr<'tcx>,

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -276,12 +276,12 @@ impl<'tcx> CVoidCasts<'tcx> {
     }
 
     /// See [`CVoidCastsUniDirectional::insert_cast`].
-    fn insert_cast(&mut self, loc: Location, direction: CVoidCastDirection, cast: CVoidCast<'tcx>) {
+    fn insert_cast(&mut self, direction: CVoidCastDirection, loc: Location, cast: CVoidCast<'tcx>) {
         self.direction_mut(direction).insert_cast(loc, cast)
     }
 
     /// See [`CVoidCastsUniDirectional::insert_call`].
-    fn insert_call(&mut self, loc: Location, direction: CVoidCastDirection, cast: CVoidCast<'tcx>) {
+    fn insert_call(&mut self, direction: CVoidCastDirection, loc: Location, cast: CVoidCast<'tcx>) {
         self.direction_mut(direction).insert_call(loc, cast)
     }
 
@@ -451,6 +451,7 @@ impl<'tcx> CVoidCasts<'tcx> {
                 };
                 if let Some((statement_index, cast)) = cast {
                     self.insert_cast(
+                        direction,
                         Location {
                             statement_index,
                             block: match direction {
@@ -458,12 +459,11 @@ impl<'tcx> CVoidCasts<'tcx> {
                                 From => target.unwrap(),
                             },
                         },
-                        direction,
                         cast.clone(),
                     );
                     self.insert_call(
-                        terminator_location(BasicBlock::from_usize(block), bb_data),
                         direction,
+                        terminator_location(BasicBlock::from_usize(block), bb_data),
                         cast,
                     );
                 }

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -311,8 +311,8 @@ impl<'tcx> CVoidCasts<'tcx> {
 
         let local = p.local;
 
-        if let StatementKind::Assign(assign) = stmt.kind.clone() {
-            let (lhs, rv) = *assign;
+        if let StatementKind::Assign(assign) = &stmt.kind {
+            let (lhs, rv) = &**assign;
             if lhs.local == local {
                 return true;
             }
@@ -321,18 +321,19 @@ impl<'tcx> CVoidCasts<'tcx> {
             let rv_place = match rv {
                 Use(op) => op.place(),
                 Repeat(op, _) => op.place(),
-                Ref(_, _, p) => Some(p),
+                Ref(_, _, p) => Some(*p),
                 ThreadLocalRef(..) => None,
-                AddressOf(_, p) => Some(p),
-                Len(p) => Some(p),
+                AddressOf(_, p) => Some(*p),
+                Len(p) => Some(*p),
                 Cast(_, op, _) => op.place(),
                 BinaryOp(..) => None,
                 CheckedBinaryOp(..) => None,
                 NullaryOp(..) => None,
                 UnaryOp(_, op) => op.place(),
-                Discriminant(p) => Some(p),
+                Discriminant(p) => Some(*p),
                 Aggregate(..) => None,
                 ShallowInitBox(op, _) => op.place(),
+                CopyForDeref(..) => None,
             };
 
             if let Some(rv_local) = rv_place.map(|p| p.local) {

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -176,12 +176,12 @@ impl<'tcx> CVoidCastsUniDirectional<'tcx> {
     /// Otherwise, the same `place` is returned, as no adjustments are necessary.
     pub fn get_adjusted_place_or_default_to(
         &self,
-        loc: &Location,
+        loc: Location,
         place: Place<'tcx>,
     ) -> Place<'tcx> {
         *self
             .calls
-            .get(loc)
+            .get(&loc)
             .map(|cast| {
                 assert!(cast.c_void_ptr.place == place);
                 &cast.other_ptr
@@ -265,7 +265,7 @@ impl<'tcx> CVoidCasts<'tcx> {
     /// See [`CVoidCastsUniDirectional::get_adjusted_place_or_default_to`].
     pub fn get_adjusted_place_or_default_to(
         &self,
-        loc: &Location,
+        loc: Location,
         direction: CVoidCastDirection,
         place: Place<'tcx>,
     ) -> Place<'tcx> {
@@ -300,8 +300,8 @@ impl<'tcx> CVoidCasts<'tcx> {
     /// [`Cast`]: rustc_middle::mir::Rvalue::Cast
     /// [`From`]: CVoidCastDirection::From
     /// [`To`]: CVoidCastDirection::To
-    pub fn should_skip_stmt(&self, loc: &Location) -> bool {
-        self.to.casts.contains_key(loc) || self.from.casts.contains_key(loc)
+    pub fn should_skip_stmt(&self, loc: Location) -> bool {
+        self.to.casts.contains_key(&loc) || self.from.casts.contains_key(&loc)
     }
 
     fn is_place_local_modified(p: &Place, stmt: &Statement) -> bool {

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -366,16 +366,15 @@ impl<'tcx> CVoidCasts<'tcx> {
         // For [`CVoidCastDirection::From`], we only count
         // a cast to `*c_void` from an arbitrary type in the same block,
         // searching backwards.
-        let mut casts = vec![];
-        for (sidx, stmt) in bb_data.statements.iter().enumerate() {
+        for (sidx, stmt) in bb_data.statements.iter().enumerate().rev() {
             let cast = get_cast(stmt);
             if let Some(cast) = cast {
-                casts.push((sidx, cast))
+                return Some((sidx, cast));
             } else if Self::is_place_local_modified(place, stmt) {
                 return None;
             }
         }
-        casts.last().cloned()
+        None
     }
 
     /// Insert all applicable [`*c_void`] casts

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -183,7 +183,7 @@ impl<'tcx> CVoidCastsUniDirectional<'tcx> {
             .calls
             .get(&loc)
             .map(|cast| {
-                assert!(cast.c_void_ptr.place == place);
+                assert_eq!(cast.c_void_ptr.place, place);
                 &cast.other_ptr
             })
             .unwrap_or(&place)

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -350,18 +350,16 @@ impl<'tcx> CVoidCasts<'tcx> {
         statements: &[Statement<'tcx>],
         c_void_ptr: CVoidPtr<'tcx>,
     ) -> Option<(usize, CVoidCast<'tcx>)> {
-        for (sidx, stmt) in statements.iter().enumerate() {
-            if let StatementKind::StorageDead(_) = stmt.kind {
-                continue;
-            }
-            if let Some(cast) = c_void_ptr.get_cast_from_stmt(CVoidCastDirection::From, stmt) {
-                return Some((sidx, cast));
-            } else {
-                break;
-            }
-        }
-
-        None
+        statements
+            .iter()
+            .enumerate()
+            .skip_while(|(_, stmt)| matches!(stmt.kind, StatementKind::StorageDead(_)))
+            .find_map(|(i, stmt)| {
+                Some((
+                    i,
+                    c_void_ptr.get_cast_from_stmt(CVoidCastDirection::From, stmt)?,
+                ))
+            })
     }
 
     /// Search for the last cast to a void pointer in a sequence of

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -420,11 +420,11 @@ impl<'tcx> CVoidCasts<'tcx> {
                 .copied()
             {
                 use CVoidCastDirection::*;
-                let c_void_ptr_place = match direction {
+                let c_void_ptr = match direction {
                     From => destination,
                     To => args[0].place().unwrap(),
                 };
-                let c_void_ptr = CVoidPtr::checked(c_void_ptr_place, &body.local_decls, tcx);
+                let c_void_ptr = CVoidPtr::checked(c_void_ptr, &body.local_decls, tcx);
                 let cast = match direction {
                     // For [`CVoidCastDirection::From`], we only count
                     // a cast from `*c_void` to an arbitrary type in the subsequent block,

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -180,7 +180,11 @@ impl<'tcx> CVoidCastsUniDirectional<'tcx> {
         loc: &Location,
         place: Place<'tcx>,
     ) -> Place<'tcx> {
-        *self.0.get(loc).map(|(_void, subst)| subst).unwrap_or(&place)
+        *self
+            .0
+            .get(loc)
+            .map(|(_void, subst)| subst)
+            .unwrap_or(&place)
     }
 
     pub fn insert(&mut self, loc: Location, cast: CVoidCast<'tcx>) {

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -2,7 +2,10 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 
 use rustc_middle::{
-    mir::{BasicBlock, Body, LocalDecls, Location, Place, Statement, Terminator, TerminatorKind, StatementKind},
+    mir::{
+        BasicBlock, Body, LocalDecls, Location, Place, Statement, StatementKind, Terminator,
+        TerminatorKind,
+    },
     ty::{TyCtxt, TyKind},
 };
 
@@ -359,8 +362,9 @@ impl<'tcx> CVoidCasts<'tcx> {
                     To => args[0].place().unwrap(),
                 };
                 let c_void_ptr = CVoidPtr::checked(c_void_ptr, &body.local_decls, tcx);
-                let get_cast =
-                    move |(idx, stmt): (usize, &Statement<'tcx>) | (idx, c_void_ptr.get_cast_from_stmt(direction, stmt));
+                let get_cast = move |(idx, stmt): (usize, &Statement<'tcx>)| {
+                    (idx, c_void_ptr.get_cast_from_stmt(direction, stmt))
+                };
                 let cast = match direction {
                     From => find_first_cast_succ_block(get_cast),
                     To => find_last_cast_curr_block(get_cast),

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -306,7 +306,15 @@ impl<'tcx> CVoidCasts<'tcx> {
         self.to.casts.contains_key(&loc) || self.from.casts.contains_key(&loc)
     }
 
-    fn is_place_local_modified(p: &Place, stmt: &Statement) -> bool {
+    /// Checking whether a statement could modify a particular Place is
+    /// nontrivial (particularly if the Place involves Deref projections),
+    /// but currently rustc always uses a temporary for the LHS of the
+    /// cast in the desired free(ptr as *mut c_void) pattern, so I think we
+    /// can conservatively treat the Place as unmodified only if (1) it's
+    /// just a Local, with no projections, and (2) that local isn't
+    /// mentioned in the LHS or RHS of any statements between the cast and
+    /// the call.
+    fn is_place_modified_by_statement(p: &Place, stmt: &Statement) -> bool {
         if !p.projection.is_empty() {
             return false;
         }
@@ -374,7 +382,7 @@ impl<'tcx> CVoidCasts<'tcx> {
             let cast = c_void_ptr.get_cast_from_stmt(CVoidCastDirection::To, stmt);
             if let Some(cast) = cast {
                 return Some((sidx, cast));
-            } else if Self::is_place_local_modified(&c_void_ptr.place, stmt) {
+            } else if Self::is_place_modified_by_statement(&c_void_ptr.place, stmt) {
                 return None;
             }
         }

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -163,13 +163,12 @@ pub struct CVoidCast<'tcx> {
 /// like [`CVoidCasts`], but in a single direction, meaning it represents either
 /// [`CVoidCastDirection::From`] or [`CVoidCastDirection::To`].
 #[derive(Default, Clone, Debug)]
-pub struct CVoidCastsUniDirectional<'tcx>(HashMap<Location, CVoidCast<'tcx>>);
+pub struct CVoidCastsUniDirectional<'tcx> {
+    calls: HashMap<Location, CVoidCast<'tcx>>,
+    casts: HashMap<Location, CVoidCast<'tcx>>,
+}
 
 impl<'tcx> CVoidCastsUniDirectional<'tcx> {
-    pub fn contains(&self, loc: &Location) -> bool {
-        self.0.contains_key(loc)
-    }
-
     /// Get the adjusted [`Place`], skipping over [`*c_void`](core::ffi::c_void) intermediaries.
     ///
     /// That is, if `place` is a [`CVoidPtr`] in this map of [`CVoidCast`]s,
@@ -181,7 +180,7 @@ impl<'tcx> CVoidCastsUniDirectional<'tcx> {
         place: Place<'tcx>,
     ) -> Place<'tcx> {
         *self
-            .0
+            .calls
             .get(loc)
             .map(|cast| {
                 assert!(cast.c_void_ptr.place == place);
@@ -190,9 +189,14 @@ impl<'tcx> CVoidCastsUniDirectional<'tcx> {
             .unwrap_or(&place)
     }
 
-    pub fn insert(&mut self, loc: Location, cast: CVoidCast<'tcx>) {
-        assert!(!self.contains(&loc));
-        self.0.insert(loc, cast);
+    pub fn insert_call(&mut self, loc: Location, cast: CVoidCast<'tcx>) {
+        assert!(!self.calls.contains_key(&loc));
+        self.calls.insert(loc, cast);
+    }
+
+    pub fn insert_cast(&mut self, loc: Location, cast: CVoidCast<'tcx>) {
+        assert!(!self.casts.contains_key(&loc));
+        self.casts.insert(loc, cast);
     }
 }
 
@@ -270,8 +274,13 @@ impl<'tcx> CVoidCasts<'tcx> {
     }
 
     /// See [`CVoidCastsUniDirectional::insert`].
-    fn insert(&mut self, loc: Location, direction: CVoidCastDirection, cast: CVoidCast<'tcx>) {
-        self.direction_mut(direction).insert(loc, cast)
+    fn insert_cast(&mut self, loc: Location, direction: CVoidCastDirection, cast: CVoidCast<'tcx>) {
+        self.direction_mut(direction).insert_cast(loc, cast)
+    }
+
+    /// See [`CVoidCastsUniDirectional::insert`].
+    fn insert_call(&mut self, loc: Location, direction: CVoidCastDirection, cast: CVoidCast<'tcx>) {
+        self.direction_mut(direction).insert_call(loc, cast)
     }
 
     /// Determine if this [`Statement`] should be skipped
@@ -292,7 +301,7 @@ impl<'tcx> CVoidCasts<'tcx> {
     /// [`From`]: CVoidCastDirection::From
     /// [`To`]: CVoidCastDirection::To
     pub fn should_skip_stmt(&self, loc: &Location) -> bool {
-        self.to.contains(loc) || self.from.contains(loc)
+        self.to.casts.contains_key(loc) || self.from.casts.contains_key(loc)
     }
 
     fn is_place_local_modified(p: &Place, stmt: &Statement) -> bool {
@@ -433,13 +442,13 @@ impl<'tcx> CVoidCasts<'tcx> {
                             From => target.unwrap(),
                         },
                     };
-                    self.insert(loc, direction, cast.clone());
+                    self.insert_cast(loc, direction, cast.clone());
 
                     let loc = Location {
                         statement_index: bb_data.statements.len(),
                         block: BasicBlock::from_usize(block),
                     };
-                    self.insert(loc, direction, cast);
+                    self.insert_call(loc, direction, cast);
                 }
             }
         }

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -378,6 +378,9 @@ impl<'tcx> CVoidCasts<'tcx> {
         statements: &[Statement<'tcx>],
         c_void_ptr: CVoidPtr<'tcx>,
     ) -> Option<(usize, CVoidCast<'tcx>)> {
+        // Get the last cast in the current block, and ensure that the destination
+        // of that cast remains unmodified between the cast and the call in which
+        // the destination place is used.
         for (sidx, stmt) in statements.iter().enumerate().rev() {
             let cast = c_void_ptr.get_cast_from_stmt(CVoidCastDirection::To, stmt);
             if let Some(cast) = cast {

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use rustc_middle::{
     mir::{
-        BasicBlock, Body, LocalDecls, Location, Place, Rvalue, Statement, StatementKind,
-        Terminator, TerminatorKind,
+        Body, LocalDecls, Location, Place, Rvalue, Statement, StatementKind, Terminator,
+        TerminatorKind,
     },
     ty::{TyCtxt, TyKind},
 };
@@ -409,7 +409,7 @@ impl<'tcx> CVoidCasts<'tcx> {
     ///
     /// [`*c_void`]: core::ffi::c_void
     fn insert_all_from_body(&mut self, body: &Body<'tcx>, tcx: TyCtxt<'tcx>) {
-        for (block, bb_data) in body.basic_blocks().iter().enumerate() {
+        for (block, bb_data) in body.basic_blocks().iter_enumerated() {
             let term: &Terminator = match &bb_data.terminator {
                 Some(term) => term,
                 None => continue,
@@ -455,17 +455,13 @@ impl<'tcx> CVoidCasts<'tcx> {
                         Location {
                             statement_index,
                             block: match direction {
-                                To => BasicBlock::from_usize(block),
+                                To => block,
                                 From => target.unwrap(),
                             },
                         },
                         cast.clone(),
                     );
-                    self.insert_call(
-                        direction,
-                        terminator_location(BasicBlock::from_usize(block), bb_data),
-                        cast,
-                    );
+                    self.insert_call(direction, terminator_location(block, bb_data), cast);
                 }
             }
         }

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -335,9 +335,9 @@ impl<'tcx> CVoidCasts<'tcx> {
         false
     }
 
-    fn find_first_cast_succ_block<F: FnMut(&Statement<'tcx>) -> Option<CVoidCast<'tcx>>>(
-        mut get_cast: F,
+    fn find_first_cast_succ_block(
         statements: &[Statement<'tcx>],
+        c_void_ptr: CVoidPtr<'tcx>,
     ) -> Option<(usize, CVoidCast<'tcx>)> {
         // For [`CVoidCastDirection::From`], we only count
         // a cast from `*c_void` to an arbitrary type in the subsequent block,
@@ -346,7 +346,7 @@ impl<'tcx> CVoidCasts<'tcx> {
             if let StatementKind::StorageDead(_) = stmt.kind {
                 continue;
             }
-            if let Some(cast) = get_cast(stmt) {
+            if let Some(cast) = c_void_ptr.get_cast_from_stmt(CVoidCastDirection::From, stmt) {
                 return Some((sidx, cast));
             } else {
                 break;
@@ -356,19 +356,18 @@ impl<'tcx> CVoidCasts<'tcx> {
         None
     }
 
-    fn find_last_cast_curr_block<F: FnMut(&Statement<'tcx>) -> Option<CVoidCast<'tcx>>>(
-        mut get_cast: F,
+    fn find_last_cast_curr_block(
         statements: &[Statement<'tcx>],
-        place: &Place<'tcx>,
+        c_void_ptr: CVoidPtr<'tcx>,
     ) -> Option<(usize, CVoidCast<'tcx>)> {
         // For [`CVoidCastDirection::From`], we only count
         // a cast to `*c_void` from an arbitrary type in the same block,
         // searching backwards.
         for (sidx, stmt) in statements.iter().enumerate().rev() {
-            let cast = get_cast(stmt);
+            let cast = c_void_ptr.get_cast_from_stmt(CVoidCastDirection::To, stmt);
             if let Some(cast) = cast {
                 return Some((sidx, cast));
-            } else if Self::is_place_local_modified(place, stmt) {
+            } else if Self::is_place_local_modified(&c_void_ptr.place, stmt) {
                 return None;
             }
         }
@@ -419,18 +418,12 @@ impl<'tcx> CVoidCasts<'tcx> {
                     To => args[0].place().unwrap(),
                 };
                 let c_void_ptr = CVoidPtr::checked(c_void_ptr_place, &body.local_decls, tcx);
-                let get_cast =
-                    |stmt: &Statement<'tcx>| c_void_ptr.get_cast_from_stmt(direction, stmt);
                 let cast = match direction {
                     From => Self::find_first_cast_succ_block(
-                        get_cast,
                         &body.basic_blocks()[target.unwrap()].statements,
+                        c_void_ptr,
                     ),
-                    To => Self::find_last_cast_curr_block(
-                        get_cast,
-                        &bb_data.statements,
-                        &c_void_ptr_place,
-                    ),
+                    To => Self::find_last_cast_curr_block(&bb_data.statements, c_void_ptr),
                 };
                 if let Some((statement_index, cast)) = cast {
                     let loc = Location {

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -322,18 +322,17 @@ impl<'tcx> CVoidCasts<'tcx> {
                 Use(op) => op.place(),
                 Repeat(op, _) => op.place(),
                 Ref(_, _, p) => Some(p),
-                // ThreadLocalRef
+                ThreadLocalRef(..) => None,
                 AddressOf(_, p) => Some(p),
                 Len(p) => Some(p),
                 Cast(_, op, _) => op.place(),
-                // BinaryOp
-                // CheckedBinaryOp
-                // NullaryOp
+                BinaryOp(..) => None,
+                CheckedBinaryOp(..) => None,
+                NullaryOp(..) => None,
                 UnaryOp(_, op) => op.place(),
                 Discriminant(p) => Some(p),
-                // Aggregate
+                Aggregate(..) => None,
                 ShallowInitBox(op, _) => op.place(),
-                _ => None,
             };
 
             if let Some(rv_local) = rv_place.map(|p| p.local) {

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -224,7 +224,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     pub fn visit_statement(&mut self, stmt: &Statement<'tcx>, loc: Location) {
         eprintln!("visit_statement({:?})", stmt);
 
-        if self.acx.c_void_casts.should_skip_stmt(&loc) {
+        if self.acx.c_void_casts.should_skip_stmt(loc) {
             return;
         }
 
@@ -301,7 +301,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
                     Some(Callee::Malloc | Callee::Calloc) => {
                         let out_ptr = self.acx.c_void_casts.get_adjusted_place_or_default_to(
-                            &loc,
+                            loc,
                             CVoidCastDirection::From,
                             destination,
                         );
@@ -309,13 +309,13 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     }
                     Some(Callee::Realloc) => {
                         let out_ptr = self.acx.c_void_casts.get_adjusted_place_or_default_to(
-                            &loc,
+                            loc,
                             CVoidCastDirection::From,
                             destination,
                         );
                         let in_ptr = args[0].place().unwrap();
                         let in_ptr = self.acx.c_void_casts.get_adjusted_place_or_default_to(
-                            &loc,
+                            loc,
                             CVoidCastDirection::To,
                             in_ptr,
                         );
@@ -335,7 +335,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     Some(Callee::Free) => {
                         let in_ptr = args[0].place().unwrap();
                         let in_ptr = self.acx.c_void_casts.get_adjusted_place_or_default_to(
-                            &loc,
+                            loc,
                             CVoidCastDirection::To,
                             in_ptr,
                         );

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -224,7 +224,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     pub fn visit_statement(&mut self, stmt: &Statement<'tcx>, loc: Location) {
         eprintln!("visit_statement({:?})", stmt);
 
-        if self.acx.c_void_casts.should_skip_stmt(stmt) {
+        if self.acx.c_void_casts.should_skip_stmt(&loc) {
             return;
         }
 
@@ -245,7 +245,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         }
     }
 
-    pub fn visit_terminator(&mut self, term: &Terminator<'tcx>) {
+    pub fn visit_terminator(&mut self, term: &Terminator<'tcx>, loc: Location) {
         eprintln!("visit_terminator({:?})", term.kind);
         let tcx = self.acx.tcx();
         // TODO(spernsteiner): other `TerminatorKind`s will be handled in the future
@@ -301,6 +301,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
                     Some(Callee::Malloc | Callee::Calloc) => {
                         let out_ptr = self.acx.c_void_casts.get_adjusted_place_or_default_to(
+                            &loc,
                             CVoidCastDirection::From,
                             destination,
                         );
@@ -308,14 +309,16 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     }
                     Some(Callee::Realloc) => {
                         let out_ptr = self.acx.c_void_casts.get_adjusted_place_or_default_to(
+                            &loc,
                             CVoidCastDirection::From,
                             destination,
                         );
                         let in_ptr = args[0].place().unwrap();
-                        let in_ptr = self
-                            .acx
-                            .c_void_casts
-                            .get_adjusted_place_or_default_to(CVoidCastDirection::To, in_ptr);
+                        let in_ptr = self.acx.c_void_casts.get_adjusted_place_or_default_to(
+                            &loc,
+                            CVoidCastDirection::To,
+                            in_ptr,
+                        );
                         self.visit_place(out_ptr, Mutability::Mut);
                         let pl_lty = self.acx.type_of(out_ptr);
                         assert!(args.len() == 2);
@@ -331,10 +334,11 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     }
                     Some(Callee::Free) => {
                         let in_ptr = args[0].place().unwrap();
-                        let in_ptr = self
-                            .acx
-                            .c_void_casts
-                            .get_adjusted_place_or_default_to(CVoidCastDirection::To, in_ptr);
+                        let in_ptr = self.acx.c_void_casts.get_adjusted_place_or_default_to(
+                            &loc,
+                            CVoidCastDirection::To,
+                            in_ptr,
+                        );
                         self.visit_place(destination, Mutability::Mut);
                         assert!(args.len() == 1);
 
@@ -411,7 +415,13 @@ pub fn visit<'tcx>(
                 },
             );
         }
-        tc.visit_terminator(bb_data.terminator());
+        tc.visit_terminator(
+            bb_data.terminator(),
+            Location {
+                statement_index: bb_data.statements.len(),
+                block: bb,
+            },
+        );
     }
 
     (tc.constraints, tc.equiv_constraints)

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -4,8 +4,8 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_middle::{
     mir::{
-        Field, Local, Mutability, Operand, Place, PlaceElem, PlaceRef, ProjectionElem, Rvalue,
-        Statement, StatementKind,
+        BasicBlock, BasicBlockData, Field, Local, Location, Mutability, Operand, Place, PlaceElem,
+        PlaceRef, ProjectionElem, Rvalue, Statement, StatementKind,
     },
     ty::{AdtDef, DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy},
 };
@@ -315,6 +315,13 @@ pub fn get_cast_place<'tcx>(rv: &Rvalue<'tcx>) -> Option<Place<'tcx>> {
     match rv {
         Rvalue::Cast(_, op, _) => op.place(),
         _ => None,
+    }
+}
+
+pub fn terminator_location(block: BasicBlock, block_data: &BasicBlockData) -> Location {
+    Location {
+        block,
+        statement_index: block_data.statements.len(),
     }
 }
 


### PR DESCRIPTION
Separating some improvements for #788, namely
- keying casts by `Location`
- expecting casts from void to be the first statement in the destination block of an allocation call
- ensuring that the argument to `free` is not modified between its cast and its use