### PR TITLE
(`c2rust-analyze`) Split `Callee::Other` into `Callee::{Local, Unknown}Def` and include `fn` ptrs in `Callee::UnknownDef`

### DIFF
--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -369,27 +369,27 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 let callee = util::ty_callee(*self.ltcx, func_ty);
                 eprintln!("callee = {callee:?}");
                 match callee {
-                    Some(Callee::PtrOffset { .. }) => {
+                    Callee::Trivial => {}
+                    Callee::PtrOffset { .. } => {
                         // We handle this like a pointer assignment.
                         let pl_lty = self.visit_place(destination);
                         assert!(args.len() == 2);
                         let rv_lty = self.visit_operand(&args[0]);
                         self.do_assign(pl_lty, rv_lty);
                     }
-                    Some(Callee::SliceAsPtr { .. }) => {
+                    Callee::SliceAsPtr { .. } => {
                         // TODO: handle this like a cast
                     }
-                    Some(Callee::Trivial) => {}
-                    Some(Callee::Other { .. }) => {
+                    Callee::Other { .. } => {
                         // TODO
                     }
-                    Some(Callee::Malloc) => {
+                    Callee::Malloc => {
                         // TODO
                     }
-                    Some(Callee::Calloc) => {
+                    Callee::Calloc => {
                         // TODO
                     }
-                    Some(Callee::Realloc) => {
+                    Callee::Realloc => {
                         // We handle this like a pointer assignment.
                         let pl_lty = self.visit_place(destination);
                         let rv_lty = assert_matches!(&args[..], [p, _] => {
@@ -398,18 +398,17 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
                         self.do_assign(pl_lty, rv_lty);
                     }
-                    Some(Callee::Free) => {
+                    Callee::Free => {
                         let _pl_lty = self.visit_place(destination);
                         let _rv_lty = assert_matches!(&args[..], [p] => {
                             self.visit_operand(p)
                         });
                     }
-                    Some(Callee::IsNull) => {
+                    Callee::IsNull => {
                         let _rv_lty = assert_matches!(&args[..], [p] => {
                             self.visit_operand(p)
                         });
                     }
-                    None => {}
                 }
             }
             // TODO(spernsteiner): handle other `TerminatorKind`s

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -1,7 +1,7 @@
 use crate::borrowck::atoms::{AllFacts, AtomMaps, Loan, Origin, Path, Point, SubPoint};
 use crate::borrowck::{LTy, LTyCtxt, Label, OriginParam};
 use crate::context::PermissionSet;
-use crate::util::{self, Callee};
+use crate::util::{self, ty_callee, Callee};
 use crate::AdtMetadataTable;
 use assert_matches::assert_matches;
 use indexmap::IndexMap;
@@ -366,7 +366,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 ..
             } => {
                 let func_ty = func.ty(self.local_decls, *self.ltcx);
-                let callee = util::ty_callee(*self.ltcx, func_ty);
+                let callee = ty_callee(*self.ltcx, func_ty);
                 eprintln!("callee = {callee:?}");
                 match callee {
                     Callee::Trivial => {}

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -370,6 +370,12 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 eprintln!("callee = {callee:?}");
                 match callee {
                     Callee::Trivial => {}
+                    Callee::UnknownDef { .. } => {
+                        // TODO
+                    }
+                    Callee::Normal { .. } => {
+                        // TODO
+                    }
                     Callee::PtrOffset { .. } => {
                         // We handle this like a pointer assignment.
                         let pl_lty = self.visit_place(destination);
@@ -379,9 +385,6 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     }
                     Callee::SliceAsPtr { .. } => {
                         // TODO: handle this like a cast
-                    }
-                    Callee::Other { .. } => {
-                        // TODO
                     }
                     Callee::Malloc => {
                         // TODO

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -373,7 +373,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     Callee::UnknownDef { .. } => {
                         // TODO
                     }
-                    Callee::Normal { .. } => {
+                    Callee::LocalDef { .. } => {
                         // TODO
                     }
                     Callee::PtrOffset { .. } => {

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -278,7 +278,9 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 let callee = util::ty_callee(tcx, func_ty);
                 eprintln!("callee = {callee:?}");
                 match callee {
-                    Some(Callee::PtrOffset { .. }) => {
+                    Callee::Trivial => {}
+
+                    Callee::PtrOffset { .. } => {
                         // We handle this like a pointer assignment.
                         self.visit_place(destination, Mutability::Mut);
                         let pl_lty = self.acx.type_of(destination);
@@ -290,7 +292,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         self.constraints.add_all_perms(rv_lty.label, perms);
                     }
 
-                    Some(Callee::SliceAsPtr { elem_ty, .. }) => {
+                    Callee::SliceAsPtr { elem_ty, .. } => {
                         // We handle this like an assignment, but with some adjustments due to the
                         // difference in input and output types.
                         self.visit_place(destination, Mutability::Mut);
@@ -314,16 +316,14 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         self.do_assign_pointer_ids(pl_lty.label, rv_lty.label);
                     }
 
-                    Some(Callee::Trivial) => {}
-
-                    Some(Callee::Malloc) => {
+                    Callee::Malloc => {
                         self.visit_place(destination, Mutability::Mut);
                     }
 
-                    Some(Callee::Calloc) => {
+                    Callee::Calloc => {
                         self.visit_place(destination, Mutability::Mut);
                     }
-                    Some(Callee::Realloc) => {
+                    Callee::Realloc => {
                         self.visit_place(destination, Mutability::Mut);
                         let pl_lty = self.acx.type_of(destination);
                         assert!(args.len() == 2);
@@ -337,7 +337,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         // unify inner-most pointer types
                         self.do_equivalence_nested(pl_lty, rv_lty);
                     }
-                    Some(Callee::Free) => {
+                    Callee::Free => {
                         self.visit_place(destination, Mutability::Mut);
                         assert!(args.len() == 1);
                         self.visit_operand(&args[0]);
@@ -347,16 +347,14 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         self.constraints.add_all_perms(rv_lty.label, perms);
                     }
 
-                    Some(Callee::IsNull) => {
+                    Callee::IsNull => {
                         assert!(args.len() == 1);
                         self.visit_operand(&args[0]);
                     }
 
-                    Some(Callee::Other { def_id, substs }) => {
+                    Callee::Other { def_id, substs } => {
                         self.visit_call_other(def_id, substs, args, destination);
                     }
-
-                    None => {}
                 }
             }
             // TODO(spernsteiner): handle other `TerminatorKind`s

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -1,6 +1,6 @@
 use super::DataflowConstraints;
 use crate::context::{AnalysisCtxt, LTy, PermissionSet, PointerId};
-use crate::util::{self, describe_rvalue, Callee, RvalueDesc};
+use crate::util::{describe_rvalue, ty_callee, Callee, RvalueDesc};
 use assert_matches::assert_matches;
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir::{
@@ -275,7 +275,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 ..
             } => {
                 let func_ty = func.ty(self.mir, tcx);
-                let callee = util::ty_callee(tcx, func_ty);
+                let callee = ty_callee(tcx, func_ty);
                 eprintln!("callee = {callee:?}");
                 match callee {
                     Callee::Trivial => {}

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -283,8 +283,8 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         todo!("visit Callee::{callee:?}");
                     }
 
-                    Callee::Normal { def_id, substs } => {
-                        self.visit_normal_call(def_id, substs, args, destination);
+                    Callee::LocalDef { def_id, substs } => {
+                        self.visit_local_call(def_id, substs, args, destination);
                     }
 
                     Callee::PtrOffset { .. } => {
@@ -365,7 +365,11 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         }
     }
 
-    fn visit_normal_call(
+    /// Visit a local call, where local means
+    /// local to the current crate with a static, known definition.
+    ///
+    /// See [`Callee::LocalDef`].
+    fn visit_local_call(
         &mut self,
         def_id: DefId,
         substs: SubstsRef<'tcx>,
@@ -373,7 +377,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         dest: Place<'tcx>,
     ) {
         let sig = self.acx.gacx.fn_sigs.get(&def_id)
-            .unwrap_or_else(|| panic!("Callee::Normal LFnSig not found (unknown calls should've been Callee::UnknownDef): {def_id:?}"));
+            .unwrap_or_else(|| panic!("Callee::LocalDef LFnSig not found (unknown calls should've been Callee::UnknownDef): {def_id:?}"));
         if substs.non_erasable_generics().next().is_some() {
             todo!("call to generic function {def_id:?} {substs:?}");
         }

--- a/c2rust-analyze/src/expr_rewrite.rs
+++ b/c2rust-analyze/src/expr_rewrite.rs
@@ -172,19 +172,17 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 let func_ty = func.ty(self.mir, tcx);
                 let pl_ty = self.acx.type_of(destination);
 
-                if let Some(callee) = util::ty_callee(tcx, func_ty) {
-                    // Special cases for particular functions.
-                    match callee {
-                        Callee::PtrOffset { .. } => {
-                            self.visit_ptr_offset(&args[0], pl_ty);
-                            return;
-                        }
-                        Callee::SliceAsPtr { .. } => {
-                            self.visit_slice_as_ptr(&args[0], pl_ty);
-                            return;
-                        }
-                        _ => {}
+                // Special cases for particular functions.
+                match util::ty_callee(tcx, func_ty) {
+                    Callee::PtrOffset { .. } => {
+                        self.visit_ptr_offset(&args[0], pl_ty);
+                        return;
                     }
+                    Callee::SliceAsPtr { .. } => {
+                        self.visit_slice_as_ptr(&args[0], pl_ty);
+                        return;
+                    }
+                    _ => {}
                 }
 
                 // General case: cast `args` to match the signature of `func`.

--- a/c2rust-analyze/src/expr_rewrite.rs
+++ b/c2rust-analyze/src/expr_rewrite.rs
@@ -1,7 +1,7 @@
 use crate::context::{AnalysisCtxt, Assignment, FlagSet, LTy, PermissionSet, PointerId};
 use crate::pointer_id::PointerTable;
 use crate::type_desc::{self, Ownership, Quantity};
-use crate::util::{self, Callee};
+use crate::util::{ty_callee, Callee};
 use rustc_middle::mir::{
     BasicBlock, Body, Location, Operand, Place, Rvalue, Statement, StatementKind, Terminator,
     TerminatorKind,
@@ -173,7 +173,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 let pl_ty = self.acx.type_of(destination);
 
                 // Special cases for particular functions.
-                match util::ty_callee(tcx, func_ty) {
+                match ty_callee(tcx, func_ty) {
                     Callee::PtrOffset { .. } => {
                         self.visit_ptr_offset(&args[0], pl_ty);
                         return;

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -787,7 +787,7 @@ fn for_each_callee(tcx: TyCtxt, ldid: LocalDefId, f: impl FnMut(LocalDefId)) {
         fn visit_operand(&mut self, operand: &Operand<'tcx>, _location: Location) {
             let ty = operand.ty(self.mir, self.tcx);
             let def_id = match util::ty_callee(self.tcx, ty) {
-                Callee::Other { def_id, .. } => def_id,
+                Callee::Normal { def_id, .. } => def_id,
                 _ => return,
             };
             let ldid = match def_id.as_local() {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -787,7 +787,7 @@ fn for_each_callee(tcx: TyCtxt, ldid: LocalDefId, f: impl FnMut(LocalDefId)) {
         fn visit_operand(&mut self, operand: &Operand<'tcx>, _location: Location) {
             let ty = operand.ty(self.mir, self.tcx);
             let def_id = match util::ty_callee(self.tcx, ty) {
-                Some(Callee::Other { def_id, .. }) => def_id,
+                Callee::Other { def_id, .. } => def_id,
                 _ => return,
             };
             let ldid = match def_id.as_local() {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -787,7 +787,7 @@ fn for_each_callee(tcx: TyCtxt, ldid: LocalDefId, f: impl FnMut(LocalDefId)) {
         fn visit_operand(&mut self, operand: &Operand<'tcx>, _location: Location) {
             let ty = operand.ty(self.mir, self.tcx);
             let def_id = match util::ty_callee(self.tcx, ty) {
-                Callee::Normal { def_id, .. } => def_id,
+                Callee::LocalDef { def_id, .. } => def_id,
                 _ => return,
             };
             let ldid = match def_id.as_local() {

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -110,13 +110,13 @@ pub enum Callee<'tcx> {
     /// and we definitely can't rewrite them at all.
     UnknownDef { ty: Ty<'tcx> },
 
-    /// A "normal" function that:
-    /// * is statically-known
+    /// A function that:
     /// * is in the current, local crate
+    /// * is statically-known
+    /// * has an accessible definition
     /// * is non-trivial
     /// * is non-builtin
-    /// * has an accessible definition
-    Normal {
+    LocalDef {
         def_id: DefId,
         substs: SubstsRef<'tcx>,
     },
@@ -171,7 +171,7 @@ pub fn ty_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Callee<'tcx> {
             } else if !did.is_local() || tcx.def_kind(tcx.parent(did)) == DefKind::ForeignMod {
                 Callee::UnknownDef { ty }
             } else {
-                Callee::Normal {
+                Callee::LocalDef {
                     def_id: did,
                     substs,
                 }

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -180,7 +180,7 @@ pub fn ty_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Callee<'tcx> {
                 Callee::UnknownDef { ty }
             }
         }
-        _ => Callee::Trivial,
+        _ => Callee::UnknownDef { ty },
     }
 }
 

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -5,7 +5,7 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::mir::{
     Field, Local, Mutability, Operand, PlaceElem, PlaceRef, ProjectionElem, Rvalue,
 };
-use rustc_middle::ty::{AdtDef, DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy};
+use rustc_middle::ty::{self, AdtDef, DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy};
 use std::fmt::Debug;
 
 #[derive(Debug)]
@@ -91,6 +91,31 @@ pub enum Callee<'tcx> {
     /// [`Trivial`]: Self::Trivial
     Trivial,
 
+    /// A function whose definition is not known.
+    ///
+    /// This could be for multiple reasons.
+    ///
+    /// A function could be `extern`, so there is no source for it.
+    /// Sometimes the actual definition could be linked with a `use` (the ideal solution),
+    /// but sometimes it's completely external and thus completely unknown,
+    /// as it may be dynamically linked.
+    ///
+    /// It could also be a function pointer,
+    /// for which there could be multiple definitions.
+    /// While possible definitions could be statically determined as an optimization,
+    /// this provides a safe fallback.
+    UnknownDef { ty: Ty<'tcx> },
+
+    /// A "normal" function that:
+    /// * is statically-known
+    /// * is non-trivial
+    /// * is non-builtin
+    /// * has a definition
+    Normal {
+        def_id: DefId,
+        substs: SubstsRef<'tcx>,
+    },
+
     /// `<*mut T>::offset` or `<*const T>::offset`.
     PtrOffset {
         pointee_ty: Ty<'tcx>,
@@ -123,36 +148,43 @@ pub enum Callee<'tcx> {
 
     /// core::ptr::is_null
     IsNull,
-
-    /// Some other statically-known function, including functions defined in the current crate.
-    Other {
-        def_id: DefId,
-        substs: SubstsRef<'tcx>,
-    },
 }
 
 pub fn ty_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Callee<'tcx> {
-    let (did, substs) = match *ty.kind() {
-        TyKind::FnDef(did, substs) => (did, substs),
-        _ => return Callee::Trivial,
+    let is_trivial = || {
+        let is_trivial = ty.fn_sig(tcx).is_trivial(tcx);
+        eprintln!("{ty:?} is trivial: {is_trivial}");
+        is_trivial
     };
 
-    if let Some(callee) = builtin_callee(tcx, ty, did) {
-        return callee;
-    }
-    Callee::Other {
-        def_id: did,
-        substs,
+    match *ty.kind() {
+        ty::FnDef(did, substs) => {
+            if is_trivial() {
+                return Callee::Trivial;
+            }
+            if let Some(callee) = builtin_callee(tcx, did) {
+                return callee;
+            }
+            if tcx.def_kind(tcx.parent(did)) == DefKind::ForeignMod {
+                return Callee::UnknownDef { ty };
+            }
+            Callee::Normal {
+                def_id: did,
+                substs,
+            }
+        }
+        ty::FnPtr(..) => {
+            if is_trivial() {
+                Callee::Trivial
+            } else {
+                Callee::UnknownDef { ty }
+            }
+        }
+        _ => Callee::Trivial,
     }
 }
 
-fn builtin_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, did: DefId) -> Option<Callee<'tcx>> {
-    let is_trivial = ty.fn_sig(tcx).is_trivial(tcx);
-    eprintln!("{ty:?} is trivial: {is_trivial}");
-    if is_trivial {
-        return Some(Callee::Trivial);
-    }
-
+fn builtin_callee(tcx: TyCtxt, did: DefId) -> Option<Callee> {
     let name = tcx.item_name(did);
 
     match name.as_str() {

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -160,17 +160,16 @@ pub fn ty_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Callee<'tcx> {
     match *ty.kind() {
         ty::FnDef(did, substs) => {
             if is_trivial() {
-                return Callee::Trivial;
-            }
-            if let Some(callee) = builtin_callee(tcx, did) {
-                return callee;
-            }
-            if tcx.def_kind(tcx.parent(did)) == DefKind::ForeignMod {
-                return Callee::UnknownDef { ty };
-            }
-            Callee::Normal {
-                def_id: did,
-                substs,
+                Callee::Trivial
+            } else if let Some(callee) = builtin_callee(tcx, did) {
+                callee
+            } else if tcx.def_kind(tcx.parent(did)) == DefKind::ForeignMod {
+                Callee::UnknownDef { ty }
+            } else {
+                Callee::Normal {
+                    def_id: did,
+                    substs,
+                }
             }
         }
         ty::FnPtr(..) => {


### PR DESCRIPTION
Split `Callee::Other` into `Callee::{Local, Unknown}Def` and include `fn` ptrs in `Callee::UnknownDef`.

Currently, `Callee::Other` is as it sounds, just any other function that is not first recognized to be `Trivial` or a builtin.  The docs for `Callee::Other` say it is statically known, but `extern` functions with statically unknown definitions are still included, and these currently panic when we look up `LFnSig` in `visit_call_other`.

Also, calls to `fn` ptrs are completely unsupported, but `lighttpd` does have a lot of them.

This tightens `Callee::Other` into what it says it is, `Callee::LocalDef`, which is a statically-known function with a known definition in the current (local) crate (functions in other crates don't have an accessible definition).

On the other hand, `Callee::UnknownDef` is added for cases where the function's definition is not known, and is meant to be treated as a potential fallback for any function call. This includes `extern` functions, whose definition may be completely unknown and dynamically linked.

And it also includes `fn` ptrs who may have multiple definitions.  It may be possible to statically determine the set of function definitions it could be, but not always, and doing so would be an optimization over this fallback.

Plus, it also includes normal Rust functions from other crates, as their definitions aren't available.  The vast majority of these should be safe (like from `std`), and so with the expanded `Callee::Trivial` definition, most of them should be handled already.

Also, since we can now handle `FnPtr`s, we also consider them for triviality checking.


This PR also folds `None::<Callee>` into `Callee::UnknownDef`, as it should error.  Previously nothing was done for `None`, which was incorrect.