### PR TITLE
(`c2rust-analyze`) `log::error!` rather than `todo!` on `Callee::UnknownDef` to test skipping it

### DIFF
--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -280,7 +280,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 match callee {
                     Callee::Trivial => {}
                     Callee::UnknownDef { .. } => {
-                        todo!("visit Callee::{callee:?}");
+                        log::error!("TODO: visit Callee::{callee:?}");
                     }
 
                     Callee::LocalDef { def_id, substs } => {


### PR DESCRIPTION
Fixes
* #842

`log::error!` rather than `todo!` on `Callee::UnknownDef`.

This allows us to test what happens when these `UnknownDef` calls are not crashed on by setting `RUST_LOG_PANIC=off` (see #854) to disable the normal panic on `log::error!`.

This is incorrect, but will allow us to avoid crashing on a lot more code and see what other issues there may be.