### PR TITLE
Don't attempt to evaluate constant values that don't exist

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -585,6 +585,8 @@ class TranslateASTVisitor final
             Expr::EvalResult eval_result;
 #endif // CLANG_VERSION_MAJOR
             bool hasValue = E->EvaluateAsInt(eval_result, *Context);
+            if (!hasValue)
+              return false;
 #if CLANG_VERSION_MAJOR < 8
             constant = eval_result;
 #else


### PR DESCRIPTION
ASTExporter attempts to convert constant int expressions to actual int values through evaluation.

However, even when evaluation fails, it still attempts to convert the result into an APint, leading to an assertion in APInt (due to trying to convert a none value to APInt).

Fixed by respecting the result of evaluation and exiting if it says no evaluated value was produced.