### PR TITLE
Handle two argument libc builtin functions properly

### DIFF
--- a/tests/builtins/src/mem_x_fns.c
+++ b/tests/builtins/src/mem_x_fns.c
@@ -7,6 +7,10 @@ void mem_x(const char src[4], char dest[4]) {
     __builtin_memcmp(dest, src, strlen(src)+1);
     __builtin_memmove(dest, src, strlen(src)+1);
     __builtin_memset(dest, 'a', 2);
+    __builtin_strcspn(dest, "a");
+    __builtin_strchr(dest, 'a');
+    __builtin_strndup(dest, 4);
+    __builtin_strdup(dest);
 }
 
 void* assume_aligned(void* ptr) {


### PR DESCRIPTION
This fixes #857 by passing through 2 argument libc builtin functions.
Tested on builtin_strrchr.
