### PR TITLE
(`c2rust-analyze`) Get span of macro expansion callsites to avoid crashing on macro invocations

### DIFF
--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -706,7 +706,11 @@ fn describe_local(tcx: TyCtxt, decl: &LocalDecl) -> String {
 }
 
 fn describe_span(tcx: TyCtxt, span: Span) -> String {
-    let s = tcx.sess.source_map().span_to_snippet(span).unwrap();
+    let s = tcx
+        .sess
+        .source_map()
+        .span_to_snippet(span.source_callsite())
+        .unwrap();
     let s = {
         let mut s2 = String::new();
         for word in s.split_ascii_whitespace() {

--- a/c2rust-analyze/tests/analyze.rs
+++ b/c2rust-analyze/tests/analyze.rs
@@ -13,6 +13,11 @@ fn string_casts() {
 }
 
 #[test]
+fn macros() {
+    Analyze::resolve().run("tests/analyze/macros.rs");
+}
+
+#[test]
 fn lighttpd_minimal() {
     Analyze::resolve().run("../analysis/tests/lighttpd-minimal/src/main.rs");
 }

--- a/c2rust-analyze/tests/analyze/macros.rs
+++ b/c2rust-analyze/tests/analyze/macros.rs
@@ -1,0 +1,5 @@
+fn main() {
+    // Just make sure this doesn't crash (see #862).
+    let x = 1;
+    let _ = std::ptr::addr_of!(x);
+}


### PR DESCRIPTION
Fixes #862.

We need to get the span of macro expansion callsites to avoid crashing on macro invocations.  I used `addr_of!` to test instead of the `vec!` from #862 since `vec!` expands to `std::vec::from_elem`, which isn't yet supported as a `Callee::UnknownDef`.