### PR TITLE
(`c2rust-analyze`) Add `is_null_const` for use in #864

### DIFF
--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -2,6 +2,7 @@
 extern crate either;
 extern crate rustc_arena;
 extern crate rustc_ast;
+extern crate rustc_const_eval;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_hir;

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -1,10 +1,11 @@
 use crate::labeled_ty::LabeledTy;
 use crate::trivial::IsTrivial;
+use rustc_const_eval::interpret::Scalar;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir::{
-    BasicBlock, BasicBlockData, Field, Local, Location, Mutability, Operand, Place, PlaceElem,
-    PlaceRef, ProjectionElem, Rvalue, Statement, StatementKind,
+    BasicBlock, BasicBlockData, Constant, Field, Local, Location, Mutability, Operand, Place,
+    PlaceElem, PlaceRef, ProjectionElem, Rvalue, Statement, StatementKind,
 };
 use rustc_middle::ty::{self, AdtDef, DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy};
 use std::fmt::Debug;
@@ -338,4 +339,13 @@ pub fn get_assign_sides<'tcx, 'a>(
         _ => None,
     }?;
     Some((*pl, rv))
+}
+
+/// Check if a [`Constant`] is an integer constant that can be casted to a null pointer.
+#[allow(dead_code)] // Will be used soon in #864.
+pub fn is_null_const(constant: Constant) -> bool {
+    match constant.literal.try_to_scalar() {
+        Some(Scalar::Int(i)) => i.is_null(),
+        _ => false,
+    }
 }


### PR DESCRIPTION
Add `is_null_const` for use in #864.

I'm not sure the null constant/literal check in b2986b1d0e24b3d7023543f83ca12253bf479318 in #864 is quite accurate.  The `.try` methods called there are coercive and I don't think we want them to be (they coerce pointers to int).  This way also uses `ScalarInt::is_null`, which seems to be designed for what we want.  This also factors out the function, which I think is useful.