### PR TITLE
(`c2rust-analyze`) Clarify some points in `PermissionSet` docs

### DIFF
--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -26,6 +26,10 @@ bitflags! {
     /// as opposed to something like `ALIASED` (a pointer capability),
     /// as removing [`UNIQUE`] (`&mut`) allows more values to be taken on (`&`).
     ///
+    /// Currently, we assume that all pointers are valid
+    /// (see [the `std::ptr` safety docs](https://doc.rust-lang.org/std/ptr/index.html#safety)).
+    /// We do not yet (here) consider null, unaligned, or cast-from-integer pointers.
+    ///
     /// [`UNIQUE`]: Self::UNIQUE
     #[derive(Default)]
     pub struct PermissionSet: u16 {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -29,23 +29,29 @@ bitflags! {
     pub struct PermissionSet: u16 {
         /// The value(s) accessible through this pointer can be read.
         const READ = 0x0001;
+
         /// The value(s) accessible through this pointer can be written.
         const WRITE = 0x0002;
+
         /// This pointer is unique: using an alias not derived from this
         /// pointer invalidates this pointer, after which it is not valid to use.
         const UNIQUE = 0x0004;
+
         /// This pointer is linear-typed.  Copying a `LINEAR` pointer to another `LINEAR` location
         /// moves the pointer and invalidates the source of the copy.  (However, a
         /// copy-and-downcast to a non-`LINEAR` location is a borrow, which does not invalidate the
         /// source pointer.)
         const LINEAR = 0x0008;
+
         /// This pointer can be offset in the positive direction.
         ///
         /// Offsetting the pointer in an unknown direction requires both `OFFSET_ADD` and
         /// `OFFSET_SUB`.  Offsetting by zero requires neither `OFFSET_ADD` nor `OFFSET_SUB`.
         const OFFSET_ADD = 0x0010;
+
         /// This pointer can be offset in the negative direction.
         const OFFSET_SUB = 0x0020;
+
         /// This pointer can be freed.
         const FREE = 0x0040;
     }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -25,6 +25,8 @@ bitflags! {
     /// That's why, for example [`UNIQUE`] is named as such,
     /// as opposed to something like `ALIASED` (a pointer capability),
     /// as removing [`UNIQUE`] (`&mut`) allows more values to be taken on (`&`).
+    ///
+    /// [`UNIQUE`]: Self::UNIQUE
     #[derive(Default)]
     pub struct PermissionSet: u16 {
         /// The value(s) accessible through this pointer can be read.


### PR DESCRIPTION
This clarifies and elaborates on some points in the `PermissionSet` docs.

These were things that I found confusing working through the semantics of other PRs, so I just wanted to confirm that I'm understanding them correctly now and in preparation for other PRs like #818.