### PR TITLE
[WIP] Remove  #![feature(label_break_value)]  (fix #731)

### DIFF
--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -216,7 +216,7 @@ fn run_polonius<'tcx>(
     //pretty::write_mir_fn(tcx, mir, &mut |_, _| Ok(()), &mut std::io::stdout()).unwrap();
 
     // Populate `cfg_edge`
-    for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
+    for (bb, bb_data) in mir.basic_blocks.iter_enumerated() {
         eprintln!("{:?}:", bb);
 
         for idx in 0..bb_data.statements.len() {

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -531,7 +531,7 @@ pub fn visit_body<'tcx>(
         adt_metadata,
     };
 
-    for (block, bb_data) in mir.basic_blocks().iter_enumerated() {
+    for (block, bb_data) in mir.basic_blocks.iter_enumerated() {
         for (idx, stmt) in bb_data.statements.iter().enumerate() {
             let loc = Location {
                 block,

--- a/c2rust-analyze/src/c_void_casts.rs
+++ b/c2rust-analyze/src/c_void_casts.rs
@@ -402,7 +402,7 @@ impl<'tcx> CVoidCasts<'tcx> {
     ///
     /// [`*c_void`]: core::ffi::c_void
     fn insert_all_from_body(&mut self, body: &Body<'tcx>, tcx: TyCtxt<'tcx>) {
-        for (block, bb_data) in body.basic_blocks().iter_enumerated() {
+        for (block, bb_data) in body.basic_blocks.iter_enumerated() {
             let term: &Terminator = match &bb_data.terminator {
                 Some(term) => term,
                 None => continue,
@@ -436,7 +436,7 @@ impl<'tcx> CVoidCasts<'tcx> {
                     // a cast from `*c_void` to an arbitrary type in the subsequent block,
                     // searching forward.
                     From => Self::find_first_cast(
-                        &body.basic_blocks()[target.unwrap()].statements,
+                        &body.basic_blocks[target.unwrap()].statements,
                         c_void_ptr,
                     ),
                     // For [`CVoidCastDirection::To`], we only count

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -457,7 +457,7 @@ pub fn visit<'tcx>(
         equiv_constraints: Vec::new(),
     };
 
-    for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
+    for (bb, bb_data) in mir.basic_blocks.iter_enumerated() {
         for (i, stmt) in bb_data.statements.iter().enumerate() {
             tc.visit_statement(
                 stmt,

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -454,7 +454,7 @@ fn run(tcx: TyCtxt) {
             assert_eq!(local, l);
         }
 
-        for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
+        for (bb, bb_data) in mir.basic_blocks.iter_enumerated() {
             for (i, stmt) in bb_data.statements.iter().enumerate() {
                 let (_, rv) = match &stmt.kind {
                     StatementKind::Assign(x) => *x.clone(),

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -137,7 +137,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             StatementKind::Retag(..) => {}
             StatementKind::AscribeUserType(..) => {}
             StatementKind::Coverage(..) => {}
-            StatementKind::CopyNonOverlapping(..) => todo!("statement {:?}", stmt),
+            StatementKind::Intrinsic(..) => todo!("statement {:?}", stmt),
             StatementKind::Nop => {}
         }
     }
@@ -386,7 +386,7 @@ pub fn gen_mir_rewrites<'tcx>(
 
     let mut v = ExprRewriteVisitor::new(acx, asn, &mut out, mir);
 
-    for (bb_id, bb) in mir.basic_blocks().iter_enumerated() {
+    for (bb_id, bb) in mir.basic_blocks.iter_enumerated() {
         for (i, stmt) in bb.statements.iter().enumerate() {
             let loc = Location {
                 block: bb_id,

--- a/c2rust-analyze/src/trivial.rs
+++ b/c2rust-analyze/src/trivial.rs
@@ -1,4 +1,4 @@
-use rustc_middle::ty::{self, Binder, EarlyBinder, FnSig, GenSig, Subst, Ty, TyCtxt};
+use rustc_middle::ty::{self, Binder, EarlyBinder, FnSig, GenSig, Ty, TyCtxt};
 
 pub trait IsTrivial<'tcx> {
     /// Something [`is_trivial`] if it has no effect on pointer permissions,
@@ -83,7 +83,7 @@ impl<'tcx> IsTrivial<'tcx> for Ty<'tcx> {
             }
 
             // don't know, as `dyn Trait` could be anything
-            ty::Dynamic(trait_ty, _reg) => {
+            ty::Dynamic(trait_ty, _reg, _) => {
                 eprintln!("unsure how to check `dyn Trait` for accessible pointers, so assuming non-trivial: ty = {self:?}, trait_ty = {trait_ty:?}");
                 false
             }

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -314,6 +314,7 @@ pub fn lty_project<'tcx, L: Debug>(
         }
         ProjectionElem::Subslice { .. } => todo!("type_of Subslice"),
         ProjectionElem::Downcast(..) => todo!("type_of Downcast"),
+        ProjectionElem::OpaqueCast(..) => todo!("type of OpaqueCast"),
     }
 }
 

--- a/c2rust-analyze/tests/filecheck/alloc.rs
+++ b/c2rust-analyze/tests/filecheck/alloc.rs
@@ -1,5 +1,4 @@
 #![feature(extern_types)]
-#![feature(label_break_value)]
 #![feature(rustc_private)]
 #![feature(c_variadic)]
 #![allow(non_upper_case_globals)]

--- a/c2rust-refactor/src/lib.rs
+++ b/c2rust-refactor/src/lib.rs
@@ -5,7 +5,6 @@
     box_patterns,
     generator_trait,
     drain_filter,
-    label_break_value,
 )]
 #![cfg_attr(feature = "profile", feature(proc_macro_hygiene))]
 

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -2072,7 +2072,6 @@ impl CfgBuilder {
             || !IncCleanup::new(in_tail, brk_lbl.clone()).remove_tail_expr(&mut stmts);
 
         if has_fallthrough && need_block && use_brk_lbl {
-            translator.use_feature("label_break_value");
             let block_body = mk().block(stmts);
             let block: Box<Expr> = mk().labelled_block_expr(block_body, brk_lbl.pretty_print());
             stmts = vec![mk().expr_stmt(block)]

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4108,9 +4108,7 @@ impl<'c> Translation<'c> {
 
                             return Ok(WithStmts::new(stmts, val));
                         }
-                        _ => {
-                            stmts.push(stmt)
-                        }
+                        _ => stmts.push(stmt),
                     }
                 }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4109,7 +4109,6 @@ impl<'c> Translation<'c> {
                             return Ok(WithStmts::new(stmts, val));
                         }
                         _ => {
-                            self.use_feature("label_break_value");
                             stmts.push(stmt)
                         }
                     }

--- a/dynamic_instrumentation/src/callbacks.rs
+++ b/dynamic_instrumentation/src/callbacks.rs
@@ -3,6 +3,7 @@ use rustc_ast::ast::{Item, ItemKind, Visibility, VisibilityKind};
 use rustc_ast::node_id::NodeId;
 use rustc_ast::ptr::P;
 use rustc_const_eval::transform::validate::Validator;
+use rustc_data_structures::thin_vec::ThinVec;
 use rustc_driver::Compilation;
 use rustc_interface::interface::Compiler;
 use rustc_interface::Queries;
@@ -34,7 +35,7 @@ impl rustc_driver::Callbacks for MirTransformCallbacks {
         let parse = queries.parse().unwrap();
         let mut parse = parse.peek_mut();
         parse.items.push(P(Item {
-            attrs: Vec::new(),
+            attrs: ThinVec::new(),
             id: NodeId::from_u32(0),
             span: DUMMY_SP,
             vis: Visibility {

--- a/dynamic_instrumentation/src/callbacks.rs
+++ b/dynamic_instrumentation/src/callbacks.rs
@@ -14,8 +14,8 @@ use rustc_span::def_id::LocalDefId;
 use rustc_span::symbol::Ident;
 use rustc_span::DUMMY_SP;
 
-use thin_vec::ThinVec;
 use crate::instrument::Instrumenter;
+use thin_vec::ThinVec;
 
 pub static INSTRUMENTER: Lazy<Instrumenter> = Lazy::new(Instrumenter::new);
 

--- a/dynamic_instrumentation/src/callbacks.rs
+++ b/dynamic_instrumentation/src/callbacks.rs
@@ -3,7 +3,6 @@ use rustc_ast::ast::{Item, ItemKind, Visibility, VisibilityKind};
 use rustc_ast::node_id::NodeId;
 use rustc_ast::ptr::P;
 use rustc_const_eval::transform::validate::Validator;
-use rustc_data_structures::thin_vec::ThinVec;
 use rustc_driver::Compilation;
 use rustc_interface::interface::Compiler;
 use rustc_interface::Queries;
@@ -15,6 +14,7 @@ use rustc_span::def_id::LocalDefId;
 use rustc_span::symbol::Ident;
 use rustc_span::DUMMY_SP;
 
+use thin_vec::ThinVec;
 use crate::instrument::Instrumenter;
 
 pub static INSTRUMENTER: Lazy<Instrumenter> = Lazy::new(Instrumenter::new);

--- a/dynamic_instrumentation/src/instrument.rs
+++ b/dynamic_instrumentation/src/instrument.rs
@@ -237,7 +237,7 @@ impl<'tcx> MutVisitor<'tcx> for RewriteAddressTakenLocals<'tcx> {
         // terminators with a destination to the address-taken local, or drop and replace
         // statements, put the address-taking statement in the first statement of the successor
         // block
-        for (bid, block) in body.basic_blocks().iter_enumerated().rev() {
+        for (bid, block) in body.basic_blocks.iter_enumerated().rev() {
             for (sid, statement) in block.statements.iter().enumerate().rev() {
                 if let StatementKind::Assign(stmt) = &statement.kind {
                     let (ref place, _) = **stmt;
@@ -408,7 +408,7 @@ impl<'tcx> Visitor<'tcx> for CollectInstrumentationPoints<'_, 'tcx> {
                 // TODO: this is a hack that places the store_addr_taken_fn
                 // after the instrumentation for taking the address of that local,
                 // which must be in place prior to this instrumentation.
-                let num_statements = self.body.basic_blocks()[location.block].statements.len();
+                let num_statements = self.body.basic_blocks[location.block].statements.len();
                 let store_addr_taken_loc = Location {
                     block: location.block,
                     // +1 to ensure `dest` is in scope
@@ -740,7 +740,7 @@ fn instrument_entry_fn<'tcx>(tcx: TyCtxt<'tcx>, hooks: Hooks, body: &mut Body<'t
 
     let mut return_blocks = vec![];
     let mut resume_blocks = vec![];
-    for (block, block_data) in body.basic_blocks().iter_enumerated() {
+    for (block, block_data) in body.basic_blocks.iter_enumerated() {
         match &block_data.terminator().kind {
             TerminatorKind::Return => {
                 return_blocks.push(block);

--- a/dynamic_instrumentation/src/main.rs
+++ b/dynamic_instrumentation/src/main.rs
@@ -10,6 +10,7 @@ extern crate rustc_mir_build;
 extern crate rustc_mir_transform;
 extern crate rustc_session;
 extern crate rustc_span;
+extern crate thin_vec;
 
 mod arg;
 mod callbacks;

--- a/dynamic_instrumentation/src/point/build.rs
+++ b/dynamic_instrumentation/src/point/build.rs
@@ -172,7 +172,7 @@ impl<'tcx> InstrumentationBuilder<'_, 'tcx> {
     }
 
     fn debug_mir_to_string(&self, loc: Location) -> String {
-        let block = &self.body.basic_blocks()[loc.block];
+        let block = &self.body.basic_blocks[loc.block];
         if loc.statement_index != block.statements.len() {
             return format!("{:?}", block.statements[loc.statement_index]);
         }

--- a/dynamic_instrumentation/src/point/cast.rs
+++ b/dynamic_instrumentation/src/point/cast.rs
@@ -107,7 +107,7 @@ pub fn cast_ptr_to_usize<'tcx>(
             source_info: SourceInfo::outermost(DUMMY_SP),
             kind: StatementKind::Assign(Box::new((
                 casted_local.into(),
-                Rvalue::Cast(CastKind::Misc, ptr, thin_raw_ptr_ty),
+                Rvalue::Cast(CastKind::PtrToPtr, ptr, thin_raw_ptr_ty),
             ))),
         };
         new_stmts.push(cast_stmt);

--- a/examples/robotfindskitten/repo/rust/rust-toolchain.toml
+++ b/examples/robotfindskitten/repo/rust/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-08-25"
+channel = "nightly-2022-10-25"

--- a/examples/robotfindskitten/repo/rust/rust-toolchain.toml
+++ b/examples/robotfindskitten/repo/rust/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-02-14"
+channel = "nightly-2022-08-25"

--- a/examples/tinycc/translate.py
+++ b/examples/tinycc/translate.py
@@ -35,7 +35,6 @@ RUST_SRC_DIR = os.path.join(RUST_ROOT_DIR, "src")
 MAIN_RS = os.path.join(RUST_SRC_DIR, "main.rs")
 # TODO(kkysen) shouldn't need `extern crate`
 MAIN_MODS = """\
-#![feature(label_break_value)]
 extern crate libc;
 pub mod i386_asm;
 pub mod libtcc;

--- a/examples/tmux/translate.py
+++ b/examples/tmux/translate.py
@@ -56,7 +56,6 @@ FILES_NEEDING_TRAILING_UNDERSCORE = [
 ]
 # TODO(kkysen) shouldn't need `extern crate`
 MAIN_MODS = """\
-#![feature(label_break_value)]
 #![allow(unused_imports)]
 extern crate libc;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-08-08"
+channel = "nightly-2022-08-25"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-08-25"
+channel = "nightly-2022-09-25"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-09-25"
+channel = "nightly-2022-10-25"
 components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]

--- a/tests/gotos/src/test_translation_only.rs
+++ b/tests/gotos/src/test_translation_only.rs
@@ -1,5 +1,3 @@
-//! feature_label_break_value
-
 use crate::jump_into_loop::rust_jump_into_loop;
 use crate::label_break_trigger::rust_triggers_label_break;
 


### PR DESCRIPTION
remove `#![feature(label_break_value)]` from generated rust source file.
rust-toolchain is updated to `nightly-2022-10-25`
