### PR TITLE
c2rust-analyze: initial implementation of error recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ name = "c2rust-analyze"
 version = "0.18.0"
 dependencies = [
  "assert_matches",
+ "backtrace",
  "bitflags",
  "c2rust-build-paths",
  "clap 4.2.7",

--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -19,6 +19,7 @@ assert_matches = "1.5.0"
 indexmap = "1.9.2"
 env_logger = "0.10.0"
 log = "0.4.17"
+backtrace = "0.3.67"
 
 [build-dependencies]
 c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.18.0" }

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -2,6 +2,7 @@ use crate::borrowck::atoms::{AllFacts, AtomMaps, Loan, Origin, Path, Point, SubP
 use crate::borrowck::{construct_adt_origins, LTy, LTyCtxt, Label, OriginParam};
 use crate::c_void_casts::CVoidCasts;
 use crate::context::PermissionSet;
+use crate::panic_detail;
 use crate::util::{self, ty_callee, Callee};
 use crate::AdtMetadataTable;
 use assert_matches::assert_matches;
@@ -429,6 +430,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     }
 
     pub fn visit_statement(&mut self, stmt: &Statement<'tcx>) {
+        let _g = panic_detail::set_current_span(stmt.source_info.span);
         // TODO(spernsteiner): other `StatementKind`s will be handled in the future
         #[allow(clippy::single_match)]
         match stmt.kind {
@@ -445,6 +447,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
     pub fn visit_terminator(&mut self, term: &Terminator<'tcx>) {
         eprintln!("borrowck: visit_terminator({:?})", term.kind);
+        let _g = panic_detail::set_current_span(term.source_info.span);
         // TODO(spernsteiner): other `TerminatorKind`s will be handled in the future
         #[allow(clippy::single_match)]
         match term.kind {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -277,8 +277,8 @@ pub struct GlobalAnalysisCtxt<'tcx> {
     pub fn_callers: HashMap<DefId, Vec<DefId>>,
 
     pub fn_sigs: HashMap<DefId, LFnSig<'tcx>>,
-    /// `DefId`s of functions where analysis failed, and a `String` explaining the reason for each
-    /// failure.
+    /// `DefId`s of functions where analysis failed, and a [`PanicDetail`] explaining the reason
+    /// for each failure.
     pub fns_failed: HashMap<DefId, PanicDetail>,
 
     pub field_ltys: HashMap<DefId, LTy<'tcx>>,

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -26,7 +26,7 @@ use rustc_middle::ty::{
 };
 use rustc_type_ir::RegionKind::{ReEarlyBound, ReStatic};
 use std::collections::HashMap;
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::ops::Index;
 
 bitflags! {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -25,7 +25,7 @@ use rustc_middle::ty::{
 };
 use rustc_type_ir::RegionKind::{ReEarlyBound, ReStatic};
 use std::collections::HashMap;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::ops::Index;
 
 bitflags! {
@@ -276,6 +276,9 @@ pub struct GlobalAnalysisCtxt<'tcx> {
     pub fn_callers: HashMap<DefId, Vec<DefId>>,
 
     pub fn_sigs: HashMap<DefId, LFnSig<'tcx>>,
+    /// `DefId`s of functions where analysis failed, and a `String` explaining the reason for each
+    /// failure.
+    pub fns_failed: HashMap<DefId, String>,
 
     pub field_ltys: HashMap<DefId, LTy<'tcx>>,
 
@@ -527,6 +530,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             ptr_info: GlobalPointerTable::empty(),
             fn_callers: HashMap::new(),
             fn_sigs: HashMap::new(),
+            fns_failed: HashMap::new(),
             field_ltys: HashMap::new(),
             static_tys: HashMap::new(),
             addr_of_static: HashMap::new(),
@@ -572,6 +576,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             ref mut ptr_info,
             fn_callers: _,
             ref mut fn_sigs,
+            fns_failed: _,
             ref mut field_ltys,
             ref mut static_tys,
             ref mut addr_of_static,
@@ -623,6 +628,24 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
     pub fn assign_pointer_to_fields(&mut self, did: DefId) {
         for field in self.tcx.adt_def(did).all_fields() {
             self.assign_pointer_to_field(field);
+        }
+    }
+
+    pub fn fn_failed(&mut self, did: DefId) -> bool {
+        self.fns_failed.contains_key(&did)
+    }
+
+    pub fn mark_fn_failed(&mut self, did: DefId, reason: impl Display) {
+        if self.fns_failed.contains_key(&did) {
+            return;
+        }
+
+        self.fns_failed.insert(did, reason.to_string());
+
+        // This is the first time marking `did` as failed, so also mark all of its callers.
+        let callers = self.fn_callers.get(&did).cloned().unwrap_or(Vec::new());
+        for caller in callers {
+            self.mark_fn_failed(caller, format_args!("analysis failed on callee {:?}", did));
         }
     }
 }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -272,6 +272,9 @@ pub struct GlobalAnalysisCtxt<'tcx> {
 
     ptr_info: GlobalPointerTable<PointerInfo>,
 
+    /// Map from a function to all of its callers.
+    pub fn_callers: HashMap<DefId, Vec<DefId>>,
+
     pub fn_sigs: HashMap<DefId, LFnSig<'tcx>>,
 
     pub field_ltys: HashMap<DefId, LTy<'tcx>>,
@@ -522,6 +525,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             tcx,
             lcx: LabeledTyCtxt::new(tcx),
             ptr_info: GlobalPointerTable::empty(),
+            fn_callers: HashMap::new(),
             fn_sigs: HashMap::new(),
             field_ltys: HashMap::new(),
             static_tys: HashMap::new(),
@@ -566,6 +570,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             tcx: _,
             lcx,
             ref mut ptr_info,
+            fn_callers: _,
             ref mut fn_sigs,
             ref mut field_ltys,
             ref mut static_tys,

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -1,6 +1,7 @@
 use super::DataflowConstraints;
 use crate::c_void_casts::CVoidCastDirection;
 use crate::context::{AnalysisCtxt, LTy, PermissionSet, PointerId};
+use crate::panic_detail;
 use crate::util::{describe_rvalue, is_null_const, ty_callee, Callee, RvalueDesc};
 use assert_matches::assert_matches;
 use rustc_hir::def_id::DefId;
@@ -317,10 +318,11 @@ impl<'tcx> TypeChecker<'tcx, '_> {
 
     pub fn visit_statement(&mut self, stmt: &Statement<'tcx>, loc: Location) {
         eprintln!("visit_statement({:?})", stmt);
-
         if self.acx.c_void_casts.should_skip_stmt(loc) {
             return;
         }
+
+        let _g = panic_detail::set_current_span(stmt.source_info.span);
 
         // TODO(spernsteiner): other `StatementKind`s will be handled in the future
         #[allow(clippy::single_match)]
@@ -342,6 +344,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     pub fn visit_terminator(&mut self, term: &Terminator<'tcx>, loc: Location) {
         eprintln!("visit_terminator({:?})", term.kind);
         let tcx = self.acx.tcx();
+        let _g = panic_detail::set_current_span(term.source_info.span);
         // TODO(spernsteiner): other `TerminatorKind`s will be handled in the future
         #[allow(clippy::single_match)]
         match term.kind {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -300,11 +300,24 @@ fn run(tcx: TyCtxt) {
 
     // Follow a postorder traversal, so that callers are visited after their callees.  This means
     // callee signatures will usually be up to date when we visit the call site.
-    let all_fn_ldids = fn_body_owners_postorder(tcx);
+    let (all_fn_ldids, fn_callers) = fn_body_owners_postorder(tcx);
     eprintln!("callgraph traversal order:");
     for &ldid in &all_fn_ldids {
         eprintln!("  {:?}", ldid);
     }
+
+    gacx.fn_callers = fn_callers
+        .into_iter()
+        .map(|(ldid, caller_ldids)| {
+            (
+                ldid.to_def_id(),
+                caller_ldids
+                    .into_iter()
+                    .map(|caller_ldid| caller_ldid.to_def_id())
+                    .collect(),
+            )
+        })
+        .collect();
 
     // Assign global `PointerId`s for all pointers that appear in function signatures.
     for &ldid in &all_fn_ldids {
@@ -741,10 +754,14 @@ fn all_static_items(tcx: TyCtxt) -> Vec<DefId> {
 }
 
 /// Return all `LocalDefId`s for all `fn`s that are `body_owners`, ordered according to a postorder
-/// traversal of the graph of references between bodies.
-fn fn_body_owners_postorder(tcx: TyCtxt) -> Vec<LocalDefId> {
+/// traversal of the graph of references between bodies.  Also returns the callgraph itself, in the
+/// form of a map from callee `LocalDefId` to a set of caller `LocalDefId`s.
+fn fn_body_owners_postorder(
+    tcx: TyCtxt,
+) -> (Vec<LocalDefId>, HashMap<LocalDefId, HashSet<LocalDefId>>) {
     let mut seen = HashSet::new();
     let mut order = Vec::new();
+    let mut callers = HashMap::<_, HashSet<_>>::new();
     enum Visit {
         Pre(LocalDefId),
         Post(LocalDefId),
@@ -773,6 +790,7 @@ fn fn_body_owners_postorder(tcx: TyCtxt) -> Vec<LocalDefId> {
                         stack.push(Visit::Post(ldid));
                         for_each_callee(tcx, ldid, |callee_ldid| {
                             stack.push(Visit::Pre(callee_ldid));
+                            callers.entry(callee_ldid).or_default().insert(ldid);
                         });
                     }
                 }
@@ -783,7 +801,7 @@ fn fn_body_owners_postorder(tcx: TyCtxt) -> Vec<LocalDefId> {
         }
     }
 
-    order
+    (order, callers)
 }
 
 fn for_each_callee(tcx: TyCtxt, ldid: LocalDefId, f: impl FnMut(LocalDefId)) {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -937,7 +937,10 @@ impl rustc_driver::Callbacks for AnalysisCallbacks {
 
 fn main() -> rustc_interface::interface::Result<()> {
     init_logger();
-    panic::set_hook(Box::new(panic_detail::panic_hook));
+    let default_panic_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
+        panic_detail::panic_hook(&default_panic_hook, info)
+    }));
     let args = env::args().collect::<Vec<_>>();
     rustc_driver::RunCompiler::new(&args, &mut AnalysisCallbacks).run()
 }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -938,7 +938,7 @@ impl rustc_driver::Callbacks for AnalysisCallbacks {
 fn main() -> rustc_interface::interface::Result<()> {
     init_logger();
 
-    let dont_catch = env::var_os("C2RUST_TEST_ANALYZE_DONT_CATCH_PANIC").is_some();
+    let dont_catch = env::var_os("C2RUST_ANALYZE_TEST_DONT_CATCH_PANIC").is_some();
     if !dont_catch {
         panic_detail::set_hook();
     }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -35,7 +35,6 @@ use rustc_middle::mir::{
 };
 use rustc_middle::ty::{Ty, TyCtxt, TyKind, WithOptConstParam};
 use rustc_span::Span;
-use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt::{Debug, Display};

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -39,7 +39,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt::{Debug, Display};
 use std::ops::{Deref, DerefMut, Index};
-use std::panic::{self, AssertUnwindSafe};
+use std::panic::AssertUnwindSafe;
 
 mod borrowck;
 mod c_void_casts;
@@ -937,10 +937,7 @@ impl rustc_driver::Callbacks for AnalysisCallbacks {
 
 fn main() -> rustc_interface::interface::Result<()> {
     init_logger();
-    let default_panic_hook = panic::take_hook();
-    panic::set_hook(Box::new(move |info| {
-        panic_detail::panic_hook(&default_panic_hook, info)
-    }));
+    panic_detail::set_hook();
     let args = env::args().collect::<Vec<_>>();
     rustc_driver::RunCompiler::new(&args, &mut AnalysisCallbacks).run()
 }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -937,7 +937,13 @@ impl rustc_driver::Callbacks for AnalysisCallbacks {
 
 fn main() -> rustc_interface::interface::Result<()> {
     init_logger();
-    panic_detail::set_hook();
+
+    let dont_catch = env::var_os("C2RUST_TEST_ANALYZE_DONT_CATCH_PANIC").is_some();
+    if !dont_catch {
+        panic_detail::set_hook();
+    }
+
     let args = env::args().collect::<Vec<_>>();
+
     rustc_driver::RunCompiler::new(&args, &mut AnalysisCallbacks).run()
 }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -173,6 +173,8 @@ fn label_rvalue_tys<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>) {
                 continue;
             }
 
+            let _g = panic_detail::set_current_span(stmt.source_info.span);
+
             let lty = match rv {
                 Rvalue::Aggregate(ref kind, ref _ops) => match **kind {
                     AggregateKind::Array(elem_ty) => {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -558,6 +558,11 @@ fn run(tcx: TyCtxt) {
             Some(x) => x,
             None => continue,
         };
+
+        if gacx.fn_failed(ldid.to_def_id()) {
+            continue;
+        }
+
         let ldid_const = WithOptConstParam::unknown(ldid);
         let name = tcx.item_name(ldid.to_def_id());
         let mir = tcx.mir_built(ldid_const);
@@ -589,21 +594,31 @@ fn run(tcx: TyCtxt) {
         rewrite::dump_rewritten_local_tys(&acx, &asn, &mir, describe_local);
 
         eprintln!();
-        let hir_body_id = tcx.hir().body_owned_by(ldid);
-        let expr_rewrites = rewrite::gen_expr_rewrites(&acx, &asn, &mir, hir_body_id);
-        let ty_rewrites = rewrite::gen_ty_rewrites(&acx, &asn, &mir, ldid);
-        // Print rewrites
-        eprintln!(
-            "\ngenerated {} expr rewrites + {} ty rewrites for {:?}:",
-            expr_rewrites.len(),
-            ty_rewrites.len(),
-            name
-        );
-        for &(span, ref rw) in expr_rewrites.iter().chain(ty_rewrites.iter()) {
-            eprintln!("  {}: {}", describe_span(tcx, span), rw);
+
+        let r = panic::catch_unwind(AssertUnwindSafe(|| {
+            let hir_body_id = tcx.hir().body_owned_by(ldid);
+            let expr_rewrites = rewrite::gen_expr_rewrites(&acx, &asn, &mir, hir_body_id);
+            let ty_rewrites = rewrite::gen_ty_rewrites(&acx, &asn, &mir, ldid);
+            // Print rewrites
+            eprintln!(
+                "\ngenerated {} expr rewrites + {} ty rewrites for {:?}:",
+                expr_rewrites.len(),
+                ty_rewrites.len(),
+                name
+            );
+            for &(span, ref rw) in expr_rewrites.iter().chain(ty_rewrites.iter()) {
+                eprintln!("  {}: {}", describe_span(tcx, span), rw);
+            }
+            all_rewrites.extend(expr_rewrites);
+            all_rewrites.extend(ty_rewrites);
+        }));
+        match r {
+            Ok(()) => {}
+            Err(e) => {
+                gacx.mark_fn_failed(ldid.to_def_id(), panic_to_string(e));
+                continue;
+            }
         }
-        all_rewrites.extend(expr_rewrites);
-        all_rewrites.extend(ty_rewrites);
     }
 
     // Print results for `static` items.

--- a/c2rust-analyze/src/panic_detail.rs
+++ b/c2rust-analyze/src/panic_detail.rs
@@ -3,7 +3,7 @@ use log::warn;
 use std::any::Any;
 use std::cell::Cell;
 use std::fmt::Write as _;
-use std::panic::{Location, PanicInfo};
+use std::panic::PanicInfo;
 
 #[derive(Clone, Debug)]
 pub struct PanicDetail {

--- a/c2rust-analyze/src/panic_detail.rs
+++ b/c2rust-analyze/src/panic_detail.rs
@@ -92,7 +92,7 @@ pub fn panic_hook(default_hook: &dyn Fn(&PanicInfo), info: &PanicInfo) {
             }
             PanicState::InsideCatchUnwind => {}
             PanicState::Unwinding(pd) => {
-                warn!("discarding old panic detail: {:?}", pd);
+                unreachable!("started unwinding while already unwinding (from {pd:?})");
             }
         }
 

--- a/c2rust-analyze/src/panic_detail.rs
+++ b/c2rust-analyze/src/panic_detail.rs
@@ -28,7 +28,11 @@ impl PanicDetail {
     }
 
     pub fn to_string_short(&self) -> String {
-        let loc_str = self.relevant_loc.as_ref().map_or("[unknown]", |s| &*s);
+        let loc_str = self
+            .relevant_loc
+            .as_ref()
+            .or(self.loc.as_ref())
+            .map_or("[unknown]", |s| &*s);
         format!("{}: {}", loc_str, self.msg.trim())
     }
 

--- a/c2rust-analyze/src/panic_detail.rs
+++ b/c2rust-analyze/src/panic_detail.rs
@@ -1,0 +1,118 @@
+use backtrace::Backtrace;
+use log::warn;
+use std::any::Any;
+use std::cell::Cell;
+use std::fmt::Write as _;
+use std::panic::{Location, PanicInfo};
+
+#[derive(Clone, Debug)]
+pub struct PanicDetail {
+    msg: String,
+    loc: Option<String>,
+    relevant_loc: Option<String>,
+    backtrace: Option<Backtrace>,
+}
+
+impl PanicDetail {
+    pub fn new(msg: String) -> PanicDetail {
+        PanicDetail {
+            msg,
+            loc: None,
+            relevant_loc: None,
+            backtrace: None,
+        }
+    }
+
+    pub fn has_backtrace(&self) -> bool {
+        self.backtrace.is_some()
+    }
+
+    pub fn to_string_short(&self) -> String {
+        let loc_str = self.relevant_loc.as_ref().map_or("[unknown]", |s| &*s);
+        format!("{}: {}", loc_str, self.msg.trim())
+    }
+
+    pub fn to_string_full(&self) -> String {
+        let mut s = String::new();
+        let loc_str = self.loc.as_ref().map_or("[unknown]", |s| &*s);
+        writeln!(s, "panic at {}: {}", loc_str, self.msg).unwrap();
+        if let Some(ref bt) = self.backtrace {
+            writeln!(s, "{:?}", bt).unwrap();
+        }
+        s
+    }
+}
+
+thread_local! {
+    static CURRENT_PANIC_DETAIL: Cell<Option<PanicDetail>> = Cell::new(None);
+}
+
+pub fn panic_hook(info: &PanicInfo) {
+    let bt = Backtrace::new();
+    let detail = PanicDetail {
+        msg: panic_to_string(info.payload()),
+        loc: info.location().map(|l| l.to_string()),
+        relevant_loc: guess_relevant_loc(&bt),
+        backtrace: Some(bt),
+    };
+    let old = CURRENT_PANIC_DETAIL.with(|cell| cell.replace(Some(detail)));
+    if let Some(old) = old {
+        warn!("discarding old panic detail: {:?}", old);
+    }
+}
+
+pub fn take_current() -> Option<PanicDetail> {
+    CURRENT_PANIC_DETAIL.with(|cell| cell.take())
+}
+
+pub fn catch(e: &(dyn Any + Send + 'static)) -> PanicDetail {
+    take_current().unwrap_or_else(|| {
+        let msg = panic_to_string(e);
+        warn!("missing panic detail; caught message {:?}", msg);
+        PanicDetail::new(msg)
+    })
+}
+
+fn guess_relevant_loc(bt: &Backtrace) -> Option<String> {
+    for frame in bt.frames() {
+        for symbol in frame.symbols() {
+            let name = match symbol.name() {
+                Some(x) => x.to_string(),
+                None => continue,
+            };
+            if name.starts_with("c2rust_analyze::dataflow")
+                || name.starts_with("c2rust_analyze::borrowck")
+                || name.starts_with("c2rust_analyze::rewrite")
+                || name.contains("type_of_rvalue")
+                || name.contains("lty_project")
+            {
+                let filename_str = match symbol.filename() {
+                    Some(x) => x.display().to_string(),
+                    None => "[unknown]".to_string(),
+                };
+                return Some(format!(
+                    "{} @ {}:{}:{}",
+                    name,
+                    filename_str,
+                    symbol.lineno().unwrap_or(0),
+                    symbol.colno().unwrap_or(0)
+                ));
+            }
+        }
+    }
+    None
+}
+
+fn panic_to_string(e: &(dyn Any + Send + 'static)) -> String {
+    match e.downcast_ref::<&'static str>() {
+        Some(s) => return s.to_string(),
+        None => {}
+    }
+
+    match e.downcast_ref::<String>() {
+        Some(s) => return (*s).clone(),
+        None => {}
+    }
+
+    format!("unknown error: {:?}", e.type_id())
+}

--- a/c2rust-analyze/src/panic_detail.rs
+++ b/c2rust-analyze/src/panic_detail.rs
@@ -40,14 +40,14 @@ impl PanicDetail {
             .relevant_loc
             .as_ref()
             .or(self.loc.as_ref())
-            .map_or("[unknown]", |s| &*s);
+            .map_or("[unknown]", |s| s);
         format!("{}: {}", loc_str, self.msg.trim())
     }
 
     /// Return a full description of this panic, including a complete backtrace if available.
     pub fn to_string_full(&self) -> String {
         let mut s = String::new();
-        let loc_str = self.loc.as_ref().map_or("[unknown]", |s| &*s);
+        let loc_str = self.loc.as_ref().map_or("[unknown]", |s| s);
         writeln!(s, "panic at {}: {}", loc_str, self.msg).unwrap();
         if let Some(ref relevant_loc) = self.relevant_loc {
             writeln!(s, "related location: {}", relevant_loc).unwrap();

--- a/c2rust-analyze/src/panic_detail.rs
+++ b/c2rust-analyze/src/panic_detail.rs
@@ -13,7 +13,7 @@ pub struct PanicDetail {
     loc: Option<String>,
     relevant_loc: Option<String>,
     backtrace: Option<Backtrace>,
-    sp: Span,
+    span: Span,
 }
 
 impl PanicDetail {
@@ -25,7 +25,7 @@ impl PanicDetail {
             loc: None,
             relevant_loc: None,
             backtrace: None,
-            sp: DUMMY_SP,
+            span: DUMMY_SP,
         }
     }
 
@@ -52,8 +52,8 @@ impl PanicDetail {
         if let Some(ref relevant_loc) = self.relevant_loc {
             writeln!(s, "related location: {}", relevant_loc).unwrap();
         }
-        if !self.sp.is_dummy() {
-            writeln!(s, "source location: {:?}", self.sp).unwrap();
+        if !self.span.is_dummy() {
+            writeln!(s, "source location: {:?}", self.span).unwrap();
         }
         if let Some(ref bt) = self.backtrace {
             writeln!(s, "{:?}", bt).unwrap();
@@ -75,7 +75,7 @@ pub fn panic_hook(info: &PanicInfo) {
         loc: info.location().map(|l| l.to_string()),
         relevant_loc: guess_relevant_loc(&bt),
         backtrace: Some(bt),
-        sp: CURRENT_SPAN.with(|cell| cell.get()),
+        span: CURRENT_SPAN.with(|cell| cell.get()),
     };
     let old = CURRENT_PANIC_DETAIL.with(|cell| cell.replace(Some(detail)));
     if let Some(old) = old {
@@ -162,7 +162,7 @@ impl Drop for CurrentSpanGuard {
 
 /// Set the current span.  Returns a guard that will reset the current span to its previous value
 /// on drop.
-pub fn set_current_span(sp: Span) -> CurrentSpanGuard {
-    let old = CURRENT_SPAN.with(|cell| cell.replace(sp));
+pub fn set_current_span(span: Span) -> CurrentSpanGuard {
+    let old = CURRENT_SPAN.with(|cell| cell.replace(span));
     CurrentSpanGuard { old }
 }

--- a/c2rust-analyze/src/panic_detail.rs
+++ b/c2rust-analyze/src/panic_detail.rs
@@ -135,14 +135,12 @@ fn guess_relevant_loc(bt: &Backtrace) -> Option<String> {
 }
 
 fn panic_to_string(e: &(dyn Any + Send + 'static)) -> String {
-    match e.downcast_ref::<&'static str>() {
-        Some(s) => return s.to_string(),
-        None => {}
+    if let Some(s) = e.downcast_ref::<&'static str>() {
+        return s.to_string();
     }
 
-    match e.downcast_ref::<String>() {
-        Some(s) => return (*s).clone(),
-        None => {}
+    if let Some(s) = e.downcast_ref::<String>() {
+        return (*s).clone();
     }
 
     format!("unknown error: {:?}", e.type_id())

--- a/c2rust-analyze/src/panic_detail.rs
+++ b/c2rust-analyze/src/panic_detail.rs
@@ -79,7 +79,7 @@ thread_local! {
 }
 
 /// Panic hook for use with [`std::panic::set_hook`].  This builds a `PanicDetail` for each panic
-/// and stores it for later retrieval by [`take_current`].
+/// and stores it for later retrieval by [`catch_unwind`].
 fn panic_hook(default_hook: &dyn Fn(&PanicInfo), info: &PanicInfo) {
     CURRENT_PANIC_DETAIL.with(|cell| {
         // Take the old value, replacing it with something arbitrary.

--- a/c2rust-analyze/src/panic_detail.rs
+++ b/c2rust-analyze/src/panic_detail.rs
@@ -80,7 +80,7 @@ thread_local! {
 
 /// Panic hook for use with [`std::panic::set_hook`].  This builds a `PanicDetail` for each panic
 /// and stores it for later retrieval by [`take_current`].
-pub fn panic_hook(default_hook: &dyn Fn(&PanicInfo), info: &PanicInfo) {
+fn panic_hook(default_hook: &dyn Fn(&PanicInfo), info: &PanicInfo) {
     CURRENT_PANIC_DETAIL.with(|cell| {
         // Take the old value, replacing it with something arbitrary.
         let old = cell.replace(PanicState::OutsideCatchUnwind);
@@ -108,6 +108,11 @@ pub fn panic_hook(default_hook: &dyn Fn(&PanicInfo), info: &PanicInfo) {
         };
         cell.set(PanicState::Unwinding(detail));
     });
+}
+
+pub fn set_hook() {
+    let default_panic_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |info| panic_hook(&default_panic_hook, info)));
 }
 
 /// Like `std::panic::catch_unwind`, but returns a `PanicDetail` instead of `Box<dyn Any>` on

--- a/c2rust-analyze/src/rewrite/expr/hir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/hir_op.rs
@@ -1,3 +1,4 @@
+use crate::panic_detail;
 use crate::rewrite::expr::mir_op::{self, MirRewrite};
 use crate::rewrite::span_index::SpanIndex;
 use crate::rewrite::{build_span_index, Rewrite, SoleLocationError};
@@ -255,6 +256,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirRewriteVisitor<'a, 'tcx> {
     }
 
     fn visit_expr(&mut self, ex: &'tcx hir::Expr<'tcx>) {
+        let _g = panic_detail::set_current_span(ex.span);
         let mut hir_rw = Rewrite::Identity;
 
         // This span will be used to apply the actual rewrite.

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -8,6 +8,7 @@
 //! materialize adjustments only on code that's subject to some rewrite.
 
 use crate::context::{AnalysisCtxt, Assignment, FlagSet, LTy, PermissionSet};
+use crate::panic_detail;
 use crate::pointer_id::PointerTable;
 use crate::type_desc::{self, Ownership, Quantity, TypeDesc};
 use crate::util::{ty_callee, Callee};
@@ -136,6 +137,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     }
 
     fn visit_statement(&mut self, stmt: &Statement<'tcx>, loc: Location) {
+        let _g = panic_detail::set_current_span(stmt.source_info.span);
         self.loc = loc;
         debug_assert!(self.sub_loc.is_empty());
 
@@ -227,6 +229,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
 
     fn visit_terminator(&mut self, term: &Terminator<'tcx>, loc: Location) {
         let tcx = self.acx.tcx();
+        let _g = panic_detail::set_current_span(term.source_info.span);
         self.loc = loc;
         debug_assert!(self.sub_loc.is_empty());
 

--- a/c2rust-analyze/tests/analyze.rs
+++ b/c2rust-analyze/tests/analyze.rs
@@ -10,7 +10,7 @@ fn check_for_missing_tests() {
 fn test(file_name: &str) {
     let analyze = Analyze::resolve();
     let path = test_dir_for(file!(), true).join(file_name);
-    analyze.dont_catch_panic().run(&path);
+    analyze.run(&path);
 }
 
 macro_rules! define_test {

--- a/c2rust-analyze/tests/analyze.rs
+++ b/c2rust-analyze/tests/analyze.rs
@@ -10,7 +10,7 @@ fn check_for_missing_tests() {
 fn test(file_name: &str) {
     let analyze = Analyze::resolve();
     let path = test_dir_for(file!(), true).join(file_name);
-    analyze.run(&path);
+    analyze.dont_catch_panic().run(&path);
 }
 
 macro_rules! define_test {

--- a/c2rust-analyze/tests/common/mod.rs
+++ b/c2rust-analyze/tests/common/mod.rs
@@ -122,7 +122,7 @@ impl Analyze {
 
         let mut cmd = Command::new(&self.path);
         if self.dont_catch_panic {
-            cmd.env("C2RUST_TEST_ANALYZE_DONT_CATCH_PANIC", "1");
+            cmd.env("C2RUST_ANALYZE_TEST_DONT_CATCH_PANIC", "1");
         }
         cmd.arg(&rs_path)
             .arg("-L")

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -40,6 +40,7 @@ define_tests! {
     as_ptr,
     call1,
     cast,
+    catch_panic,
     cell,
     clone1,
     extern_fn1,

--- a/c2rust-analyze/tests/filecheck/catch_panic.rs
+++ b/c2rust-analyze/tests/filecheck/catch_panic.rs
@@ -1,0 +1,29 @@
+// This test deliberately exercises unsupported code to check that c2rust-analyze can recover from
+// panics during the analysis.
+
+use std::ptr::NonNull;
+
+// CHECK: final labeling for "good"
+unsafe fn good(p: *mut u8) {
+    *p = 1;
+}
+
+// Analysis of `bad` should fail because it calls an unsupported library function involving raw
+// pointers, namely `NonNull::as_ptr`.
+// CHECK-NOT: final labeling for "bad"
+unsafe fn bad(p: NonNull<u8>) {
+    *p.as_ptr() = 1;
+}
+
+// Analysis of `bad2` should also fail because it has a callee on which analysis failed.
+// CHECK-NOT: final labeling for "bad2"
+unsafe fn bad2(p: NonNull<u8>) {
+    bad(p);
+}
+
+// CHECK: analysis of DefId({{.*}}::bad) failed:
+// CHECK-SAME: UnknownDef
+// CHECK-SAME: NonNull::<u8>::as_ptr
+
+// CHECK: analysis of DefId({{.*}}::bad2) failed:
+// CHECK-SAME: analysis failed on callee DefId({{.*}}::bad)

--- a/c2rust-analyze/tests/filecheck/catch_panic.rs
+++ b/c2rust-analyze/tests/filecheck/catch_panic.rs
@@ -1,3 +1,5 @@
+//! --catch-panics
+
 // This test deliberately exercises unsupported code to check that c2rust-analyze can recover from
 // panics during the analysis.
 


### PR DESCRIPTION
This branch adds a basic implementation of error recovery: if the static analysis panics on some function, it now catches the panic, marks that function as invalid, and continues with analysis of the remaining functions.  At the end, after completing as much analysis and rewriting as it could, the tool prints a report of all the panics it encountered, including a stack trace for each one.

Currently, when marking a function as failed/invalid, we immediately mark all of its (transitive) callers invalid as well.  In the future we can probably relax this, falling back on something like `Trivial` or on dynamic analysis results to let the callers reason about the unanalyzed function.

The current approach produces a lot of invalid Rust code.  Suppose `f` calls `g`, `f` fails analysis, but `g` succeeds and gets rewritten.  Currently we don't rewrite `f` at all due to the previous failure, and if `g`'s signature gets rewritten, `f`'s call to `g` will no longer be valid.  In the future we'll need a better scheme for calling back and forth between analyzed and unanalyzed functions.