### PR TITLE
(`c2rust-analyze`) Handle inline `const` refs, including string literals

### DIFF
--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -53,16 +53,16 @@ bitflags! {
 }
 
 impl PermissionSet {
-    pub fn for_const(constant: ConstantKind) -> PermissionSet {
+    pub fn for_const(constant: ConstantKind) -> Self {
         let ref_ty = constant.ty();
         let ty = match ref_ty.kind() {
             ty::Ref(_, ty, _) => ty,
             _ => panic!("expected only `Ref`s for constants: {ref_ty:?}"),
         };
         if ty.is_array() || ty.is_str() {
-            PermissionSet::READ | PermissionSet::OFFSET_ADD
+            Self::READ | Self::OFFSET_ADD
         } else if ty.is_primitive_ty() {
-            PermissionSet::READ
+            Self::READ
         } else {
             panic!("expected an array, str, or primitive type: {ty:?}");
         }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -53,7 +53,7 @@ bitflags! {
 }
 
 impl PermissionSet {
-    pub fn for_const(constant: ConstantKind) -> Self {
+    pub fn for_const_ref(constant: ConstantKind) -> Self {
         let ref_ty = constant.ty();
         let ty = match ref_ty.kind() {
             ty::Ref(_, ty, _) => ty,

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -4,7 +4,7 @@ use crate::pointer_id::{
     GlobalPointerTable, LocalPointerTable, NextGlobalPointerId, NextLocalPointerId, PointerTable,
     PointerTableMut,
 };
-use crate::util::{self, describe_rvalue, RvalueDesc};
+use crate::util::{self, describe_rvalue, PhantomLifetime, RvalueDesc};
 use crate::AssignPointerIds;
 use bitflags::bitflags;
 use rustc_hir::def_id::DefId;
@@ -124,6 +124,13 @@ pub struct AnalysisCtxt<'a, 'tcx> {
 impl<'a, 'tcx> AnalysisCtxt<'_, 'tcx> {
     pub fn const_ref_tys(&'a self) -> impl Iterator<Item = LTy<'tcx>> + 'a {
         self.const_ref_locs.iter().map(|loc| self.rvalue_tys[loc])
+    }
+
+    pub fn const_ref_perms(
+        &'a self,
+    ) -> impl Iterator<Item = (PointerId, PermissionSet)> + PhantomLifetime<'tcx> + 'a {
+        self.const_ref_tys()
+            .map(|lty| (lty.label, PermissionSet::for_const_ref_ty(lty.ty)))
     }
 
     pub fn check_const_ref_perms(&self, asn: &Assignment) {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -53,11 +53,10 @@ bitflags! {
 }
 
 impl PermissionSet {
-    pub fn for_const_ref(constant: ConstantKind) -> Self {
-        let ref_ty = constant.ty();
-        let ty = match ref_ty.kind() {
+    pub fn for_const_ref_ty(ty: Ty) -> Self {
+        let ty = match ty.kind() {
             ty::Ref(_, ty, _) => ty,
-            _ => panic!("expected only `Ref`s for constants: {ref_ty:?}"),
+            _ => panic!("expected only `Ref`s for constants: {ty:?}"),
         };
         if ty.is_array() || ty.is_str() {
             Self::READ | Self::OFFSET_ADD
@@ -66,6 +65,10 @@ impl PermissionSet {
         } else {
             panic!("expected an array, str, or primitive type: {ty:?}");
         }
+    }
+
+    pub fn for_const_ref(constant: ConstantKind) -> Self {
+        Self::for_const_ref_ty(constant.ty())
     }
 }
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -116,9 +116,15 @@ pub struct AnalysisCtxt<'a, 'tcx> {
     pub rvalue_tys: HashMap<Location, LTy<'tcx>>,
 
     /// [`Location`]s of const ref [`rvalue_tys`](Self::rvalue_tys).
-    pub const_ref_locs: Vec<Location>,
+    const_ref_locs: Vec<Location>,
 
     next_ptr_id: NextLocalPointerId,
+}
+
+impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
+    pub fn const_ref_tys(&'a self) -> impl Iterator<Item = LTy<'tcx>> + 'a {
+        self.const_ref_locs.iter().map(|loc| self.rvalue_tys[loc])
+    }
 }
 
 pub struct AnalysisCtxtData<'tcx> {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -115,7 +115,7 @@ pub struct AnalysisCtxt<'a, 'tcx> {
     pub rvalue_tys: HashMap<Location, LTy<'tcx>>,
 
     /// [`Location`]s of const ref [`rvalue_tys`](Self::rvalue_tys).
-    const_ref_locs: Vec<Location>,
+    pub const_ref_locs: Vec<Location>,
 
     next_ptr_id: NextLocalPointerId,
 }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -467,7 +467,7 @@ pub fn visit<'tcx>(
 
     for (&constant, const_lty) in &acx.const_ref_tys {
         tc.constraints
-            .add_all_perms(const_lty.label, PermissionSet::for_const(constant));
+            .add_all_perms(const_lty.label, PermissionSet::for_const_ref(constant));
     }
 
     for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -465,8 +465,7 @@ pub fn visit<'tcx>(
         equiv_constraints: Vec::new(),
     };
 
-    for loc in &acx.const_ref_locs {
-        let const_ref_lty = acx.rvalue_tys[loc];
+    for const_ref_lty in acx.const_ref_tys() {
         tc.constraints.add_all_perms(
             const_ref_lty.label,
             PermissionSet::for_const_ref_ty(const_ref_lty.ty),

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -489,11 +489,5 @@ pub fn visit<'tcx>(
         );
     }
 
-    for (&constant, const_lty) in &acx.const_ref_tys {
-        let _ptr_id = const_lty.label;
-        let _expected_perms = PermissionSet::for_const(constant);
-        // TODO: check that perms match the expected ones
-    }
-
     (tc.constraints, tc.equiv_constraints)
 }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -465,9 +465,12 @@ pub fn visit<'tcx>(
         equiv_constraints: Vec::new(),
     };
 
-    for (&constant, const_lty) in &acx.const_ref_tys {
-        tc.constraints
-            .add_all_perms(const_lty.label, PermissionSet::for_const_ref(constant));
+    for loc in &acx.const_ref_locs {
+        let const_ref_lty = acx.rvalue_tys[loc];
+        tc.constraints.add_all_perms(
+            const_ref_lty.label,
+            PermissionSet::for_const_ref_ty(const_ref_lty.ty),
+        );
     }
 
     for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -465,11 +465,8 @@ pub fn visit<'tcx>(
         equiv_constraints: Vec::new(),
     };
 
-    for const_ref_lty in acx.const_ref_tys() {
-        tc.constraints.add_all_perms(
-            const_ref_lty.label,
-            PermissionSet::for_const_ref_ty(const_ref_lty.ty),
-        );
+    for (ptr, perms) in acx.const_ref_perms() {
+        tc.constraints.add_all_perms(ptr, perms);
     }
 
     for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -628,7 +628,11 @@ fn run(tcx: TyCtxt) {
         for (&constant, const_lty) in &acx.const_ref_tys {
             let ptr_id = const_lty.label;
             let expected_perms = PermissionSet::for_const(constant);
-            let actual_perms = asn.perms()[ptr_id];
+            let mut actual_perms = asn.perms()[ptr_id];
+            // Ignore `UNIQUE` as it gets automatically added to all permissions
+            // and then removed later if it can't apply.
+            // We don't care about `UNIQUE` for const refs, so just unset it here.
+            actual_perms.set(PermissionSet::UNIQUE, false);
             assert_eq!(expected_perms, actual_perms);
         }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -403,6 +403,7 @@ fn label_rvalue_tys<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>) {
                         // The [`Constant`] is an inline value and thus local to this function,
                         // as opposed to a global, named `const`s, for example.
                         // This might miss local, named `const`s,
+                        acx.const_ref_locs.push(loc);
                         acx.assign_pointer_ids(ty)
                     } else {
                         // TODO: Handle global, named `const`s.

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -620,8 +620,7 @@ fn run(tcx: TyCtxt) {
         let mut asn = gasn.and(&mut info.lasn);
         info.dataflow.propagate_cell(&mut asn);
 
-        for loc in &acx.const_ref_locs {
-            let const_ref_lty = acx.rvalue_tys[loc];
+        for const_ref_lty in acx.const_ref_tys() {
             let ptr_id = const_ref_lty.label;
             let expected_perms = PermissionSet::for_const_ref_ty(const_ref_lty.ty);
             let mut actual_perms = asn.perms()[ptr_id];

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -620,16 +620,7 @@ fn run(tcx: TyCtxt) {
         let mut asn = gasn.and(&mut info.lasn);
         info.dataflow.propagate_cell(&mut asn);
 
-        for const_ref_lty in acx.const_ref_tys() {
-            let ptr_id = const_ref_lty.label;
-            let expected_perms = PermissionSet::for_const_ref_ty(const_ref_lty.ty);
-            let mut actual_perms = asn.perms()[ptr_id];
-            // Ignore `UNIQUE` as it gets automatically added to all permissions
-            // and then removed later if it can't apply.
-            // We don't care about `UNIQUE` for const refs, so just unset it here.
-            actual_perms.set(PermissionSet::UNIQUE, false);
-            assert_eq!(expected_perms, actual_perms);
-        }
+        acx.check_const_ref_perms(&asn);
 
         // Print labeling and rewrites for the current function.
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -411,8 +411,10 @@ fn label_rvalue_tys<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>) {
                             acx.const_ref_locs.push(loc);
                             acx.assign_pointer_ids(ty)
                         }
-                        ConstantKind::Ty(_) => {
-                            // TODO: Handle global, named `const`s.
+                        ConstantKind::Ty(ty) => {
+                            ::log::error!(
+                                "TODO: handle global, named `const` refs: {c:?}, ty = {ty:?}"
+                            );
                             continue;
                         }
                     }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -625,6 +625,13 @@ fn run(tcx: TyCtxt) {
         let mut asn = gasn.and(&mut info.lasn);
         info.dataflow.propagate_cell(&mut asn);
 
+        for (&constant, const_lty) in &acx.const_ref_tys {
+            let ptr_id = const_lty.label;
+            let expected_perms = PermissionSet::for_const(constant);
+            let actual_perms = asn.perms()[ptr_id];
+            assert_eq!(expected_perms, actual_perms);
+        }
+
         // Print labeling and rewrites for the current function.
 
         eprintln!("\nfinal labeling for {:?}:", name);

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -627,7 +627,7 @@ fn run(tcx: TyCtxt) {
 
         for (&constant, const_lty) in &acx.const_ref_tys {
             let ptr_id = const_lty.label;
-            let expected_perms = PermissionSet::for_const(constant);
+            let expected_perms = PermissionSet::for_const_ref(constant);
             let mut actual_perms = asn.perms()[ptr_id];
             // Ignore `UNIQUE` as it gets automatically added to all permissions
             // and then removed later if it can't apply.

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -348,3 +348,6 @@ pub fn is_null_const(constant: Constant) -> bool {
         _ => false,
     }
 }
+
+pub trait PhantomLifetime<'a> {}
+impl<'a, T: ?Sized> PhantomLifetime<'a> for T {}

--- a/c2rust-analyze/tests/analyze/string_literals.rs
+++ b/c2rust-analyze/tests/analyze/string_literals.rs
@@ -2,19 +2,33 @@ pub fn inline_desugared_bstr() -> &'static [u8; 0] {
     &[]
 }
 
-pub const DESUGARED_BSTR: &'static [u8; 0] = &[];
+const DESUGARED_BSTR: &'static [u8; 0] = &[];
 
 #[cfg(any())]
-pub fn const_desugared_bstr() -> &'static [u8; 0] {
+pub fn outline_desugared_bstr() -> &'static [u8; 0] {
     DESUGARED_BSTR
 }
 
 #[cfg(any())]
-pub fn bstr() -> &'static [u8; 0] {
+pub fn inline_bstr() -> &'static [u8; 0] {
     b""
 }
 
+const BSTR: &'static [u8; 0] = b"";
+
 #[cfg(any())]
-pub fn str() -> &'static str {
+pub fn outline_bstr() -> &'static [u8; 0] {
+    BSTR
+}
+
+#[cfg(any())]
+pub fn inline_str() -> &'static str {
     ""
+}
+
+const STR: &'static str = "";
+
+#[cfg(any())]
+pub fn outline_str() -> &'static str {
+    STR
 }

--- a/c2rust-analyze/tests/analyze/string_literals.rs
+++ b/c2rust-analyze/tests/analyze/string_literals.rs
@@ -9,7 +9,6 @@ pub fn outline_desugared_bstr() -> &'static [u8; 0] {
     DESUGARED_BSTR
 }
 
-#[cfg(any())]
 pub fn inline_bstr() -> &'static [u8; 0] {
     b""
 }
@@ -21,7 +20,6 @@ pub fn outline_bstr() -> &'static [u8; 0] {
     BSTR
 }
 
-#[cfg(any())]
 pub fn inline_str() -> &'static str {
     ""
 }

--- a/c2rust-analyze/tests/analyze/string_literals.rs
+++ b/c2rust-analyze/tests/analyze/string_literals.rs
@@ -1,9 +1,20 @@
+pub fn inline_desugared_bstr() -> &'static [u8; 0] {
+    &[]
+}
+
+pub const DESUGARED_BSTR: &'static [u8; 0] = &[];
+
 #[cfg(any())]
-pub fn str() {
-    "";
+pub fn const_desugared_bstr() -> &'static [u8; 0] {
+    DESUGARED_BSTR
 }
 
 #[cfg(any())]
-pub fn bstr() {
-    b"";
+pub fn bstr() -> &'static [u8; 0] {
+    b""
+}
+
+#[cfg(any())]
+pub fn str() -> &'static str {
+    ""
 }


### PR DESCRIPTION
Fixes #837.

This only handles `const` refs that are inline and thus local to a function, as determined by being `ConstantKind::Val`.  Thus, this handles string literals like `""` (`inline_str`) and `b""` (`inline_bstr`), which is the main thing we're trying to support.

This PR also adds tests for other similar string usages, though they're not handled and turned off for now.  The outline cases, where the `const` ref/string literal is used through a named constant, aren't handled, as they are globally accessible and that makes them more complex.  Since supporting them isn't necessary for string literals, which is the main usage in `lighttpd-rust`.