### PR TITLE
Bump CXX_STANDARD to 17 for LLVM 16

### DIFF
--- a/c2rust-ast-exporter/src/CMakeLists.txt
+++ b/c2rust-ast-exporter/src/CMakeLists.txt
@@ -26,7 +26,7 @@ ExternalProject_Add(tinycbor_build
             PATCH_COMMAND patch --forward -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/tinycbor_fix_build.patch || true
             CONFIGURE_COMMAND make .config && cat ${CMAKE_CURRENT_SOURCE_DIR}/tinycbor.config >> .config
             BUILD_COMMAND make --quiet prefix=<INSTALL_DIR> CFLAGS=-fPIC
-            INSTALL_COMMAND make --quiet prefix=<INSTALL_DIR> install            
+            INSTALL_COMMAND make --quiet prefix=<INSTALL_DIR> install
             BUILD_IN_SOURCE 1
             BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/lib/libtinycbor.a
 )
@@ -98,7 +98,7 @@ target_link_libraries(c2rust-ast-exporter PRIVATE
   )
 
 set_target_properties(clangAstExporter PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17 # will decay to 14 if compiler doesn't support c++17
   CXX_EXTENSIONS OFF
   )
 target_link_libraries(clangAstExporter PRIVATE

--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -233,6 +233,10 @@ class TestDirectory:
         # set self.target to a known-working target tuple for it
         self.target = None
 
+        # include the compiler resource directory in compile_commands.json
+        _, stdout, _ = clang["-print-resource-dir"].run(retcode=None)
+        self.clang_resource_dir = " \"-I{}/include\",".format(stdout.strip())
+
         # parse target arch from directory name if it includes a dot
         split_by_dots = self.name.split('.')
         if len(split_by_dots) > 1:
@@ -319,12 +323,12 @@ class TestDirectory:
         compile_commands = """ \
         [
           {{
-            "arguments": [ "cc", "-D_FORTIFY_SOURCE=0", "-c", {2}"{0}" ],
+            "arguments": [ "cc", "-D_FORTIFY_SOURCE=0",{3} "-c", {2}"{0}" ],
             "directory": "{1}",
             "file": "{0}"
           }}
         ]
-        """.format(cfile, directory, target_args)
+        """.format(cfile, directory, target_args, self.clang_resource_dir)
 
         cc_db = os.path.join(directory, "compile_commands.json")
 


### PR DESCRIPTION
Summary of changes:

1. Request C++17 in the makefiles for the ASTExtractor. This should gracefully fall back to C++14 if the compiler is too old and nothing seems to break in CI. Closes #891 which independently suggested that C++17 was needed on Darwin. 

2. Add the compiler resource dir such that the transpiler test suite passes on Darwin.