### PR TITLE
`c2rust-ast-exporter`: fix segfault from iterator invalidation

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -811,7 +811,11 @@ class TranslateASTVisitor final
         size_t size;
         do {
             size = files.size();
-            for (auto const &file : files) {
+            /* Cannot use iterator over files here, as getExporterFileId
+             * potentially modifies files. This also prevents use of
+             * for (auto const &file : files) here. */
+            for (size_t idx = 0; idx < size; idx++) {
+                auto const &file = files[idx];
                 getExporterFileId(manager.getFileID(file.second), false);
             }
         } while (size != files.size());


### PR DESCRIPTION
Using an iterator to iterate over an vector while modifying the underlying vector is invalid. This caused an segfault for a specific input, which is fixed by using operator[] for accessing the vector members instead.