### PR TITLE
Fix c2rust-ast-exporter's bugs when compiling on FreeBSD

### DIFF
--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -205,7 +205,7 @@ fn build_native(llvm_info: &LLVMInfo) {
     }
 
     // Link against the C++ std library.
-    if cfg!(target_os = "macos") {
+    if cfg!(target_os = "macos") || cfg!(target_os = "freebsd") {
         println!("cargo:rustc-link-lib=c++");
     } else {
         println!("cargo:rustc-link-lib=stdc++");

--- a/c2rust-ast-exporter/src/CMakeLists.txt
+++ b/c2rust-ast-exporter/src/CMakeLists.txt
@@ -14,6 +14,12 @@ set(TINYCBOR_TAG "d393c16f3eb30d0c47e6f9d92db62272f0ec4dc7" CACHE STRING "tinycb
 
 set(TINYCBOR_PREFIX "${CMAKE_BINARY_DIR}/tinycbor" CACHE STRING "tinycbor install prefix")
 
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(MAKE "gmake")
+else()
+    set(MAKE "make")
+endif()
+
 include(ExternalProject)
 ExternalProject_Add(tinycbor_build
             PREFIX ${TINYCBOR_PREFIX}
@@ -24,9 +30,9 @@ ExternalProject_Add(tinycbor_build
             # patch from upstream:
             # https://github.com/intel/tinycbor/commit/6176e0a28d7c5ef3a5e9cbd02521999c412de72c
             PATCH_COMMAND patch --forward -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/tinycbor_fix_build.patch || true
-            CONFIGURE_COMMAND make .config && cat ${CMAKE_CURRENT_SOURCE_DIR}/tinycbor.config >> .config
-            BUILD_COMMAND make --quiet prefix=<INSTALL_DIR> CFLAGS=-fPIC
-            INSTALL_COMMAND make --quiet prefix=<INSTALL_DIR> install
+            CONFIGURE_COMMAND ${MAKE} .config && cat ${CMAKE_CURRENT_SOURCE_DIR}/tinycbor.config >> .config
+            BUILD_COMMAND ${MAKE} --quiet prefix=<INSTALL_DIR> CFLAGS=-fPIC
+            INSTALL_COMMAND ${MAKE} --quiet prefix=<INSTALL_DIR> install
             BUILD_IN_SOURCE 1
             BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/lib/libtinycbor.a
 )


### PR DESCRIPTION
1. FreeBSD 10 and later versions remove libstd++ and switch to libc++. This is the same as macOS, so build.rs should detect `cfg!(target_os = "freebsd")`

2. FreeBSD make does not support gmake's -j option without an argument. Use gmake instead of make on FreeBSD when compiling tinycbor.