### PR TITLE
(`c2rust-analyze`) Cleanup/simplify `visit_cast` (extracted from #883)

### DIFF
--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -127,14 +127,12 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 assert_matches!(op_lty.kind(), TyKind::Ref(..) | TyKind::RawPtr(..));
                 let op_pointee_lty = assert_matches!(op_lty.args, [lty] => lty);
 
-                assert_matches!(pointee_ty.kind(), TyKind::Slice(..));
-                if let TyKind::Slice(elem_ty) = *pointee_ty.kind() {
-                    assert!(matches!(op_pointee_lty.kind(), TyKind::Array(..)));
-                    let elem_lty = assert_matches!(op_pointee_lty.args, [lty] => lty);
-                    assert_eq!(elem_lty.ty, elem_ty);
-                    assert_eq!(op_pointee_lty.label, PointerId::NONE);
-                    self.do_assign_pointer_ids(rvalue_lty.label, op_lty.label);
-                }
+                let elem_ty = assert_matches!(pointee_ty.kind(), &TyKind::Slice(ty) => ty);
+                assert!(matches!(op_pointee_lty.kind(), TyKind::Array(..)));
+                let elem_lty = assert_matches!(op_pointee_lty.args, [lty] => lty);
+                assert_eq!(elem_lty.ty, elem_ty);
+                assert_eq!(op_pointee_lty.label, PointerId::NONE);
+                self.do_assign_pointer_ids(rvalue_lty.label, op_lty.label);
             }
             CastKind::Pointer(..) => {
                 // The source and target types are both pointers, and they have identical

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -1,7 +1,7 @@
 use super::DataflowConstraints;
 use crate::c_void_casts::CVoidCastDirection;
 use crate::context::{AnalysisCtxt, LTy, PermissionSet, PointerId};
-use crate::util::{self, describe_rvalue, ty_callee, Callee, RvalueDesc};
+use crate::util::{describe_rvalue, is_null_const, ty_callee, Callee, RvalueDesc};
 use assert_matches::assert_matches;
 use rustc_hir::def_id::DefId;
 use rustc_middle::mir::{
@@ -112,8 +112,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             CastKind::PointerFromExposedAddress => {
                 // We support only one case here, which is the case of null pointers
                 // constructed via casts such as `0 as *const T`
-                if let Some(true) = op.constant().cloned().map(util::is_null_const) {
-                } else {
+                if !op.constant().cloned().map(is_null_const).unwrap_or(false) {
                     panic!("Creating non-null pointers from exposed addresses not supported");
                 }
             }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -119,11 +119,10 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 }
             }
             CastKind::Pointer(PointerCast::Unsize) => {
-                let pointee_ty = match *ty.kind() {
-                    TyKind::Ref(_, ty, _) => ty,
-                    TyKind::RawPtr(tm) => tm.ty,
-                    _ => unreachable!("unsize cast has non-pointer output {:?}?", ty),
-                };
+                let pointee_ty = ty
+                    .builtin_deref(true)
+                    .unwrap_or_else(|| panic!("unsize cast has non-pointer output {:?}?", ty))
+                    .ty;
 
                 assert_matches!(op_lty.kind(), TyKind::Ref(..) | TyKind::RawPtr(..));
 

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -112,7 +112,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             CastKind::PointerFromExposedAddress => {
                 // We support only one case here, which is the case of null pointers
                 // constructed via casts such as `0 as *const T`
-                if !op.constant().cloned().map(is_null_const).unwrap_or(false) {
+                if !op.constant().copied().map(is_null_const).unwrap_or(false) {
                     panic!("Creating non-null pointers from exposed addresses not supported");
                 }
             }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -125,17 +125,12 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     .ty;
 
                 assert_matches!(op_lty.kind(), TyKind::Ref(..) | TyKind::RawPtr(..));
-
-                let op_pointee_lty = assert_matches!(op_lty.args, [op_pointee_lty] => {
-                    op_pointee_lty
-                });
+                let op_pointee_lty = assert_matches!(op_lty.args, [lty] => lty);
 
                 assert_matches!(pointee_ty.kind(), TyKind::Slice(..));
                 if let TyKind::Slice(elem_ty) = *pointee_ty.kind() {
                     assert!(matches!(op_pointee_lty.kind(), TyKind::Array(..)));
-                    let elem_lty = assert_matches!(op_pointee_lty.args, [elem_lty] => {
-                        elem_lty
-                    });
+                    let elem_lty = assert_matches!(op_pointee_lty.args, [lty] => lty);
                     assert_eq!(elem_lty.ty, elem_ty);
                     assert_eq!(op_pointee_lty.label, PointerId::NONE);
                     self.do_assign_pointer_ids(rvalue_lty.label, op_lty.label);

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -113,7 +113,6 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 // We support only one case here, which is the case of null pointers
                 // constructed via casts such as `0 as *const T`
                 if let Some(true) = op.constant().cloned().map(util::is_null_const) {
-                    self.visit_operand(op)
                 } else {
                     panic!("Creating non-null pointers from exposed addresses not supported");
                 }
@@ -142,8 +141,6 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     assert_eq!(op_pointee_lty.label, PointerId::NONE);
                     self.do_assign_pointer_ids(rvalue_lty.label, op_lty.label);
                 }
-
-                self.visit_operand(op)
             }
             CastKind::Pointer(..) => {
                 let op_lty = self.acx.type_of(op);
@@ -154,16 +151,16 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 assert!(op_lty.args[0].ty == rvalue_lty.args[0].ty);
 
                 assert!(is_castable_to(op_lty, rvalue_lty));
-                self.visit_operand(op)
             }
             _ => {
                 // A cast such as `T as U`
                 let casted_from = self.acx.type_of(op);
                 let casted_to = rvalue_lty;
                 assert!(is_castable_to(casted_from, casted_to));
-                self.visit_operand(op)
             }
         }
+
+        self.visit_operand(op)
     }
 
     pub fn visit_rvalue(&mut self, rv: &Rvalue<'tcx>, rvalue_lty: LTy<'tcx>) {

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -101,13 +101,8 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         }
     }
 
-    fn visit_cast(
-        &mut self,
-        cast_kind: CastKind,
-        op: &Operand<'tcx>,
-        to_ty: Ty<'tcx>,
-        to_lty: LTy<'tcx>,
-    ) {
+    fn visit_cast(&mut self, cast_kind: CastKind, op: &Operand<'tcx>, to_lty: LTy<'tcx>) {
+        let to_ty = to_lty.ty;
         let from_lty = self.acx.type_of(op);
 
         match cast_kind {
@@ -197,7 +192,8 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 self.visit_place(pl, Mutability::Not);
             }
             Rvalue::Cast(cast_kind, ref op, ty) => {
-                self.visit_cast(cast_kind, op, ty, rvalue_lty);
+                assert_eq!(ty, rvalue_lty.ty);
+                self.visit_cast(cast_kind, op, rvalue_lty);
             }
             Rvalue::BinaryOp(BinOp::Offset, _) => todo!("visit_rvalue BinOp::Offset"),
             Rvalue::BinaryOp(_, ref ops) => {

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -108,6 +108,8 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         ty: Ty<'tcx>,
         rvalue_lty: LTy<'tcx>,
     ) {
+        let op_lty = self.acx.type_of(op);
+
         match cast_kind {
             CastKind::PointerFromExposedAddress => {
                 // We support only one case here, which is the case of null pointers
@@ -123,7 +125,6 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     _ => unreachable!("unsize cast has non-pointer output {:?}?", ty),
                 };
 
-                let op_lty = self.acx.type_of(op);
                 assert_matches!(op_lty.kind(), TyKind::Ref(..) | TyKind::RawPtr(..));
 
                 let op_pointee_lty = assert_matches!(op_lty.args, [op_pointee_lty] => {
@@ -142,8 +143,6 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 }
             }
             CastKind::Pointer(..) => {
-                let op_lty = self.acx.type_of(op);
-
                 // The source and target types are both pointers, and they have identical
                 // pointee types.
                 // TODO: remove or move check to `is_castable_to`
@@ -153,7 +152,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             }
             _ => {
                 // A cast such as `T as U`
-                let casted_from = self.acx.type_of(op);
+                let casted_from = op_lty;
                 let casted_to = rvalue_lty;
                 assert!(is_castable_to(casted_from, casted_to));
             }


### PR DESCRIPTION
This cleans up and simplifies some of the code from #883 in preparation for the string cast PRs, #739 and #741.

It extracts things into a separate `visit_cast` method, simplifies a few things, and clarifies exactly which `Ty`s and `LTy`s are from and to in a cast.  This makes it easier to understand and read, and makes it simpler to rebase #739 onto it.