### PR TITLE
(`c2rust-analyze`) Restrict const ref handling to just string literals

### DIFF
--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -518,7 +518,7 @@ pub fn visit<'tcx>(
         equiv_constraints: Vec::new(),
     };
 
-    for (ptr, perms) in acx.const_ref_perms() {
+    for (ptr, perms) in acx.string_literal_perms() {
         tc.constraints.add_all_perms(ptr, perms);
     }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -402,19 +402,31 @@ fn label_rvalue_tys<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>) {
                     if !c.ty().is_ref() {
                         continue;
                     }
-                    // Constants can include, for example, `""` and `b""` string literals.
+                    // Handle const refs.
+                    //
+                    // By const ref, we mean the ref itself is constant,
+                    // so this can be a reference to an inline value ([`ConstantKind::Val`]), such as:
+                    // * `1`
+                    // * `[]`
+                    // * `()`
+                    // * `""`
+                    // * `b""`
+                    //
+                    // or a reference to a named item ([`ConstantKind::Ty`])
+                    // that is accessible at compile time, such as:
+                    // * `const`s
+                    // * `static`s
+                    // * `fn`s
+                    //
+                    // Note that these named items are often global,
+                    // but could also be local to a function or smaller scope.
                     match c.literal {
                         ConstantKind::Val(_, ty) => {
-                            // The [`Constant`] is an inline value and thus local to this function,
-                            // as opposed to a global, named `const`s, for example.
-                            // This might miss local, named `const`s.
                             acx.const_ref_locs.push(loc);
                             acx.assign_pointer_ids(ty)
                         }
                         ConstantKind::Ty(ty) => {
-                            ::log::error!(
-                                "TODO: handle global, named `const` refs: {c:?}, ty = {ty:?}"
-                            );
+                            ::log::error!("TODO: handle named const refs: {c:?}, ty = {ty:?}");
                             continue;
                         }
                     }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -404,7 +404,6 @@ fn label_string_literals<'tcx>(
         acx.string_literal_locs.push(loc);
         Some(acx.assign_pointer_ids(ty))
     } else {
-        ::log::error!("TODO: handle non-string literal const refs: {c:?}, ty = {ty:?}");
         None
     }
 }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -422,10 +422,16 @@ fn label_rvalue_tys<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>) {
                     // but could also be local to a function or smaller scope.
                     match c.literal {
                         ConstantKind::Val(_, ty) => {
+                            // As these are only inline values, they do not need
+                            // dataflow constraints to their pointee (unlike their named counterparts),
+                            // because the values cannot be accessed elsewhere,
+                            // and their permissions are predetermined (see [`PermissionSet::for_const_ref_ty`]).
                             acx.const_ref_locs.push(loc);
                             acx.assign_pointer_ids(ty)
                         }
                         ConstantKind::Ty(ty) => {
+                            // TODO When these are handled, they will need to have
+                            // the correct dataflow constraints to their pointee.
                             ::log::error!("TODO: handle named const refs: {c:?}, ty = {ty:?}");
                             continue;
                         }

--- a/c2rust-analyze/tests/analyze/string_literals.rs
+++ b/c2rust-analyze/tests/analyze/string_literals.rs
@@ -30,3 +30,15 @@ const STR: &'static str = "";
 pub fn outline_str() -> &'static str {
     STR
 }
+
+#[cfg(any())]
+pub fn named_inline_str() -> &'static str {
+    const S: &str = "";
+    S
+}
+
+#[cfg(any())]
+pub fn named_inline_fn_ref() -> fn() -> () {
+    fn f() {}
+    f
+}


### PR DESCRIPTION
This restricts the current const ref handling to just string literals, as const refs are too complex as a whole.  I previously though `ConstantKind::Val` vs. `::Ty` was a good way to disambiguate them, but it works differently than I thought (statics, for example).

This currently uses a very hacky way to detect string literals from `Constant`s by using its `Display` `impl`.
~I'll replace that soon.~  On second thought, a more correct implementation derived from `Constant`'s `Display` `impl` is exceedingly complex and quite large, so I think this hacky way might actually be better.