### PR TITLE
analyze: bring static handling in line with locals

### DIFF
--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -7,6 +7,7 @@ use crate::pointer_id::{
 use crate::util::{self, describe_rvalue, PhantomLifetime, RvalueDesc};
 use crate::AssignPointerIds;
 use bitflags::bitflags;
+use log::*;
 use rustc_hir::def_id::DefId;
 use rustc_index::vec::IndexVec;
 use rustc_middle::mir::interpret::{self, AllocId, ConstValue, GlobalAlloc};
@@ -158,6 +159,7 @@ pub struct GlobalAnalysisCtxt<'tcx> {
     pub field_tys: HashMap<DefId, LTy<'tcx>>,
 
     pub static_tys: HashMap<DefId, LTy<'tcx>>,
+    pub addr_of_static: HashMap<DefId, PointerId>,
 
     next_ptr_id: NextGlobalPointerId,
 }
@@ -167,8 +169,8 @@ pub struct AnalysisCtxt<'a, 'tcx> {
 
     pub local_decls: &'a LocalDecls<'tcx>,
     pub local_tys: IndexVec<Local, LTy<'tcx>>,
-    pub c_void_casts: CVoidCasts<'tcx>,
     pub addr_of_local: IndexVec<Local, PointerId>,
+    pub c_void_casts: CVoidCasts<'tcx>,
     /// Types for certain [`Rvalue`]s.  Some `Rvalue`s introduce fresh [`PointerId`]s; to keep
     /// those `PointerId`s consistent, the `Rvalue`'s type must be stored rather than recomputed on
     /// the fly.
@@ -224,6 +226,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             fn_sigs: HashMap::new(),
             field_tys: HashMap::new(),
             static_tys: HashMap::new(),
+            addr_of_static: HashMap::new(),
             next_ptr_id: NextGlobalPointerId::new(),
         }
     }
@@ -262,6 +265,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             ref mut fn_sigs,
             ref mut field_tys,
             ref mut static_tys,
+            ref mut addr_of_static,
             ref mut next_ptr_id,
         } = *self;
 
@@ -283,12 +287,21 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             *labeled_static = remap_lty_pointers(lcx, map, labeled_static);
         }
 
+        for ptr in addr_of_static.values_mut() {
+            if !ptr.is_none() {
+                *ptr = map[*ptr];
+            }
+        }
+
         *next_ptr_id = counter;
     }
 
     pub fn assign_pointer_to_static(&mut self, did: DefId) {
-        let lty = self.assign_pointer_ids(self.tcx.static_ptr_ty(did));
+        trace!("assign_pointer_to_static({:?})", did);
+        let lty = self.assign_pointer_ids(self.tcx.type_of(did));
+        let ptr = self.new_pointer();
         self.static_tys.insert(did, lty);
+        self.addr_of_static.insert(did, ptr);
     }
 
     pub fn assign_pointer_to_field(&mut self, field: &FieldDef) {
@@ -601,10 +614,24 @@ impl<'tcx> TypeOf<'tcx> for Operand<'tcx> {
                 if c.ty().is_any_ptr() {
                     if let Some(alloc_id) = const_alloc_id(c) {
                         if let Some(did) = find_static_for_alloc(&acx.gacx.tcx, alloc_id) {
-                            match acx.gacx.static_tys.get(&did) {
-                                Some(lty) => lty,
-                                None => panic!("did {:?} not found", did),
-                            }
+                            let lty = acx
+                                .gacx
+                                .static_tys
+                                .get(&did)
+                                .cloned()
+                                .unwrap_or_else(|| panic!("did {:?} not found", did));
+                            let ptr = acx
+                                .gacx
+                                .addr_of_static
+                                .get(&did)
+                                .cloned()
+                                .unwrap_or_else(|| panic!("did {:?} not found", did));
+                            let args = acx.lcx().mk_slice(&[lty]);
+                            assert!(matches!(
+                                *c.ty().kind(),
+                                TyKind::Ref(..) | TyKind::RawPtr(..)
+                            ));
+                            acx.lcx().mk(c.ty(), args, ptr)
                         } else {
                             panic!("no static found for alloc id {:?}", alloc_id)
                         }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -716,11 +716,19 @@ fn run(tcx: TyCtxt) {
 
     // Print results for `static` items.
     eprintln!("\nfinal labeling for static items:");
+    let lcx1 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
+    let lcx2 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
     for (did, lty) in gacx.static_tys.iter() {
         let name = tcx.item_name(*did);
-        let ty_perms = gasn.perms[lty.label];
-        let ty_flags = gasn.flags[lty.label];
-        eprintln!("{name:?}: perms = {ty_perms:?}, flags = {ty_flags:?}");
+        print_labeling_for_var(
+            lcx1,
+            lcx2,
+            format_args!("{name:?}"),
+            gacx.addr_of_static[&did],
+            lty,
+            &gasn.perms,
+            &gasn.flags,
+        );
     }
 
     let static_rewrites = rewrite::gen_static_rewrites(&gacx, &gasn);

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -43,8 +43,8 @@ use rustc_span::Span;
 use rustc_type_ir::RegionKind::{ReEarlyBound, ReStatic};
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::fmt::Debug;
-use std::ops::{Deref, DerefMut};
+use std::fmt::{Debug, Display};
+use std::ops::{Deref, DerefMut, Index};
 
 mod borrowck;
 mod c_void_casts;
@@ -682,46 +682,14 @@ fn run(tcx: TyCtxt) {
         let lcx1 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
         let lcx2 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
         for (local, decl) in mir.local_decls.iter_enumerated() {
-            let addr_of1 = asn.perms()[acx.addr_of_local[local]];
-            let ty1 = lcx1.relabel(acx.local_tys[local], &mut |lty| {
-                if lty.label == PointerId::NONE {
-                    PermissionSet::empty()
-                } else {
-                    asn.perms()[lty.label]
-                }
-            });
-            eprintln!(
-                "{:?} ({}): addr_of = {:?}, type = {:?}",
-                local,
-                describe_local(tcx, decl),
-                addr_of1,
-                ty1,
-            );
-
-            let addr_of2 = asn.flags()[acx.addr_of_local[local]];
-            let ty2 = lcx2.relabel(acx.local_tys[local], &mut |lty| {
-                if lty.label == PointerId::NONE {
-                    FlagSet::empty()
-                } else {
-                    asn.flags()[lty.label]
-                }
-            });
-            eprintln!(
-                "{:?} ({}): addr_of flags = {:?}, type flags = {:?}",
-                local,
-                describe_local(tcx, decl),
-                addr_of2,
-                ty2,
-            );
-
-            let addr_of3 = acx.addr_of_local[local];
-            let ty3 = acx.local_tys[local];
-            eprintln!(
-                "{:?} ({}): addr_of = {:?}, type = {:?}",
-                local,
-                describe_local(tcx, decl),
-                addr_of3,
-                ty3,
+            print_labeling_for_var(
+                lcx1,
+                lcx2,
+                format_args!("{:?} ({})", local, describe_local(tcx, decl)),
+                acx.addr_of_local[local],
+                acx.local_tys[local],
+                &asn.perms(),
+                &asn.flags(),
             );
         }
 
@@ -836,6 +804,43 @@ fn describe_span(tcx: TyCtxt, span: Span) -> String {
     };
     let line = tcx.sess.source_map().lookup_char_pos(span.lo()).line;
     format!("{}: {}{}{}", line, src1, src2, src3)
+}
+
+fn print_labeling_for_var<'tcx>(
+    lcx1: LabeledTyCtxt<'tcx, PermissionSet>,
+    lcx2: LabeledTyCtxt<'tcx, FlagSet>,
+    desc: impl Display,
+    addr_of_ptr: PointerId,
+    lty: LTy<'tcx>,
+    perms: &impl Index<PointerId, Output = PermissionSet>,
+    flags: &impl Index<PointerId, Output = FlagSet>,
+) {
+    let addr_of1 = perms[addr_of_ptr];
+    let ty1 = lcx1.relabel(lty, &mut |lty| {
+        if lty.label == PointerId::NONE {
+            PermissionSet::empty()
+        } else {
+            perms[lty.label]
+        }
+    });
+    eprintln!("{}: addr_of = {:?}, type = {:?}", desc, addr_of1, ty1);
+
+    let addr_of2 = flags[addr_of_ptr];
+    let ty2 = lcx2.relabel(lty, &mut |lty| {
+        if lty.label == PointerId::NONE {
+            FlagSet::empty()
+        } else {
+            flags[lty.label]
+        }
+    });
+    eprintln!(
+        "{}: addr_of flags = {:?}, type flags = {:?}",
+        desc, addr_of2, ty2
+    );
+
+    let addr_of3 = addr_of_ptr;
+    let ty3 = lty;
+    eprintln!("{}: addr_of = {:?}, type = {:?}", desc, addr_of3, ty3);
 }
 
 /// Return `LocalDefId`s for all `static`s.

--- a/c2rust-analyze/tests/filecheck/statics.rs
+++ b/c2rust-analyze/tests/filecheck/statics.rs
@@ -1,15 +1,15 @@
 #![allow(dead_code)]
 
 // CHECK: final labeling for static items:
-// CHECK-DAG: "UNUSED": perms = UNIQUE, flags = (empty)
+// CHECK-DAG: "UNUSED": addr_of = UNIQUE
 static UNUSED: usize = 2;
-// CHECK-DAG: "UNUSED_MUT": perms = UNIQUE, flags = (empty)
+// CHECK-DAG: "UNUSED_MUT": addr_of = UNIQUE
 static mut UNUSED_MUT: usize = 6;
-// CHECK-DAG: "READ": perms = READ | UNIQUE, flags = (empty)
+// CHECK-DAG: "READ": addr_of = READ | UNIQUE
 static READ: usize = 9;
-// CHECK-DAG: "READ_MUT": perms = READ | UNIQUE, flags = (empty)
+// CHECK-DAG: "READ_MUT": addr_of = READ | UNIQUE
 static mut READ_MUT: usize = 21;
-// CHECK-DAG: "WRITTEN_MUT": perms = READ | WRITE | UNIQUE, flags = (empty)
+// CHECK-DAG: "WRITTEN_MUT": addr_of = READ | WRITE | UNIQUE
 static mut WRITTEN_MUT: usize = 3;
 
 // CHECK: generated 2 static rewrites:


### PR DESCRIPTION
Gives statics separate `addr_of_static` (`PointerId`) and `static_tys` (`LTy`) information, analogous to `addr_of_local` and `local_tys`.  Previously they had only a single `LTy` based on `tcx.static_ptr_ty(did)`, which gives somewhat weird results (it's either a `RawPtr` or a `Ref` depending on whether or not the static is declared as mut).