### PR TITLE
(`c2rust-analyze/tests`) Add tests for ways to call `addr_of!`

### DIFF
--- a/c2rust-analyze/tests/analyze.rs
+++ b/c2rust-analyze/tests/analyze.rs
@@ -31,9 +31,10 @@ macro_rules! define_tests {
 }
 
 define_tests! {
+    macros,
+    ptr_addr_of,
     string_literals,
     string_casts,
-    macros,
 }
 
 #[test]

--- a/c2rust-analyze/tests/analyze/ptr_addr_of.rs
+++ b/c2rust-analyze/tests/analyze/ptr_addr_of.rs
@@ -1,0 +1,27 @@
+pub fn std_ptr_addr_of(x: ()) {
+    std::ptr::addr_of!(x);
+}
+
+pub fn abs_std_ptr_addr_of(x: ()) {
+    ::std::ptr::addr_of!(x);
+}
+
+pub fn core_ptr_addr_of(x: ()) {
+    core::ptr::addr_of!(x);
+}
+
+#[cfg(any())]
+pub fn abs_core_ptr_addr_of(x: ()) {
+    ::core::ptr::addr_of!(x);
+}
+
+pub fn use_std_ptr_addr_of(x: ()) {
+    use std::ptr::addr_of;
+    addr_of!(x);
+}
+
+#[cfg(any())]
+pub fn use_core_ptr_addr_of(x: ()) {
+    use core::ptr::addr_of;
+    addr_of!(x);
+}


### PR DESCRIPTION
This adds tests for #912.  The ones that are failing are currently disabled.