### PR TITLE
Feat.rewrite.lifetime

### DIFF
--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -119,14 +119,12 @@ pub fn borrowck_mir<'tcx>(
     hypothesis: &mut PointerTableMut<PermissionSet>,
     name: &str,
     mir: &Body<'tcx>,
-    adt_metadata: &AdtMetadataTable<'tcx>,
     field_ltys: HashMap<DefId, crate::LTy<'tcx>>,
 ) {
     let mut i = 0;
     loop {
         eprintln!("run polonius");
-        let (facts, maps, output) =
-            run_polonius(acx, hypothesis, name, mir, adt_metadata, &field_ltys);
+        let (facts, maps, output) = run_polonius(acx, hypothesis, name, mir, &field_ltys);
         eprintln!(
             "polonius: iteration {}: {} errors, {} move_errors",
             i,
@@ -200,7 +198,6 @@ fn run_polonius<'tcx>(
     hypothesis: &PointerTableMut<PermissionSet>,
     name: &str,
     mir: &Body<'tcx>,
-    adt_metadata: &AdtMetadataTable<'tcx>,
     field_ltys: &HashMap<DefId, crate::LTy<'tcx>>,
 ) -> (AllFacts, AtomMaps<'tcx>, Output) {
     let tcx = acx.tcx();
@@ -274,7 +271,7 @@ fn run_polonius<'tcx>(
             hypothesis,
             &mut facts,
             &mut maps,
-            adt_metadata,
+            &acx.gacx.adt_metadata,
             acx.local_tys[local],
         );
         let var = maps.variable(local);
@@ -310,7 +307,7 @@ fn run_polonius<'tcx>(
         &local_ltys,
         &field_permissions,
         mir,
-        adt_metadata,
+        &acx.gacx.adt_metadata,
         &acx.c_void_casts,
     );
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -15,20 +15,15 @@ extern crate rustc_span;
 extern crate rustc_target;
 extern crate rustc_type_ir;
 
-use crate::borrowck::{AdtMetadata, FieldMetadata, OriginArg, OriginParam};
 use crate::context::{
     AnalysisCtxt, AnalysisCtxtData, FlagSet, GlobalAnalysisCtxt, GlobalAssignment, LFnSig, LTy,
     LTyCtxt, LocalAssignment, PermissionSet, PointerId, PointerInfo,
 };
 use crate::dataflow::DataflowConstraints;
 use crate::equiv::{GlobalEquivSet, LocalEquivSet};
-use crate::labeled_ty::LabeledTyCtxt;
 use crate::log::init_logger;
 use crate::util::Callee;
-use assert_matches::assert_matches;
-use indexmap::IndexSet;
-use labeled_ty::LabeledTy;
-use rustc_ast::Mutability;
+use context::AdtMetadataTable;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::vec::IndexVec;
@@ -110,254 +105,6 @@ impl<T> Deref for MaybeUnset<T> {
 impl<T> DerefMut for MaybeUnset<T> {
     fn deref_mut(&mut self) -> &mut T {
         self.get_mut()
-    }
-}
-
-fn construct_adt_metadata<'tcx>(tcx: TyCtxt<'tcx>) -> AdtMetadataTable {
-    let struct_dids: Vec<_> = tcx
-        .hir_crate_items(())
-        .definitions()
-        .filter_map(|ldid: LocalDefId| {
-            use DefKind::*;
-            let did = ldid.to_def_id();
-            if matches!(tcx.def_kind(did), Struct | Enum | Union) {
-                return Some(did);
-            }
-
-            None
-        })
-        .collect();
-
-    let mut adt_metadata_table = AdtMetadataTable {
-        table: HashMap::new(),
-        struct_dids,
-    };
-
-    // Gather known lifetime parameters for each struct
-    for struct_did in &adt_metadata_table.struct_dids {
-        let struct_ty = tcx.type_of(struct_did);
-        if let TyKind::Adt(adt_def, substs) = struct_ty.kind() {
-            adt_metadata_table
-                .table
-                .insert(adt_def.did(), AdtMetadata::default());
-            eprintln!("gathering known lifetimes for {adt_def:?}");
-            for sub in substs.iter() {
-                if let GenericArgKind::Lifetime(r) = sub.unpack() {
-                    eprintln!("\tfound lifetime {r:?} in {adt_def:?}");
-                    assert_matches!(r.kind(), ReEarlyBound(eb) => {
-                        let _ = adt_metadata_table
-                        .table
-                        .entry(adt_def.did())
-                        .and_modify(|metadata| {
-                            metadata.lifetime_params.insert(OriginParam::Actual(eb));
-                        });
-                    });
-                }
-            }
-        } else {
-            panic!("{struct_ty:?} is not a struct");
-        }
-    }
-
-    let ltcx = LabeledTyCtxt::<'tcx, &[OriginArg<'tcx>]>::new(tcx);
-    let mut loop_count = 0;
-    loop {
-        /*
-            This loop iterates over all structs and gathers metadata for each.
-            If there were no recursive or mutually-recursive data structures,
-            this loop would only need one iteration to complete. To support
-            recursive and mutually-recursive structs, the loop iterates until
-            the metadata gathered for each struct reaches a fixed point.
-        */
-        loop_count += 1;
-        assert!(loop_count < 1000);
-
-        eprintln!("---- running fixed point struct field analysis iteration #{loop_count:?} ----");
-        let old_adt_metadata = adt_metadata_table.table.clone();
-        let mut next_hypo_origin_id = 0;
-
-        // for each struct, gather lifetime information (actual and hypothetical)
-        for struct_did in &adt_metadata_table.struct_dids {
-            let adt_def = tcx.adt_def(struct_did);
-            eprintln!("gathering lifetimes and lifetime parameters for {adt_def:?}");
-            for field in adt_def.all_fields() {
-                let field_ty: Ty = tcx.type_of(field.did);
-                eprintln!("\t{adt_def:?}.{:}", field.name);
-                let field_origin_args = ltcx.label(field_ty, &mut |ty| {
-                    let mut field_origin_args = IndexSet::new();
-                    match ty.kind() {
-                        TyKind::RawPtr(ty) => {
-                            eprintln!(
-                                "\t\tfound pointer that requires hypothetical lifetime: *{:}",
-                                if let Mutability::Mut = ty.mutbl {
-                                    "mut"
-                                } else {
-                                    "const"
-                                }
-                            );
-                            adt_metadata_table
-                                .table
-                                .entry(*struct_did)
-                                .and_modify(|adt| {
-                                    let origin_arg = OriginArg::Hypothetical(next_hypo_origin_id);
-                                    let origin_param =
-                                        OriginParam::Hypothetical(next_hypo_origin_id);
-                                    eprintln!(
-                                        "\t\t\tinserting origin {origin_param:?} into {adt_def:?}"
-                                    );
-
-                                    adt.lifetime_params.insert(origin_param);
-                                    next_hypo_origin_id += 1;
-                                    field_origin_args.insert(origin_arg);
-                                });
-                        }
-                        TyKind::Ref(reg, _ty, _mutability) => {
-                            eprintln!("\t\tfound reference field lifetime: {reg:}");
-                            assert_matches!(reg.kind(), ReEarlyBound(..) | ReStatic);
-                            let origin_arg = OriginArg::Actual(*reg);
-                            adt_metadata_table
-                                .table
-                                .entry(*struct_did)
-                                .and_modify(|adt| {
-                                    if let ReEarlyBound(eb) = reg.kind() {
-                                        eprintln!("\t\t\tinserting origin {eb:?} into {adt_def:?}");
-                                        adt.lifetime_params.insert(OriginParam::Actual(eb));
-                                    }
-
-                                    field_origin_args.insert(origin_arg);
-                                });
-                        }
-                        TyKind::Adt(adt_field, substs) => {
-                            eprintln!("\t\tfound ADT field base type: {adt_field:?}");
-                            for sub in substs.iter() {
-                                if let GenericArgKind::Lifetime(r) = sub.unpack() {
-                                    eprintln!("\tfound field lifetime {r:?} in {adt_def:?}.{adt_field:?}");
-                                    eprintln!("\t\t\tinserting {adt_field:?} lifetime param {r:?} into {adt_def:?}.{:} lifetime parameters", field.name);
-                                    assert_matches!(r.kind(), ReEarlyBound(..) | ReStatic);
-                                    field_origin_args.insert(OriginArg::Actual(r));
-                                }
-                            }
-                            if let Some(adt_field_metadata) =
-                                adt_metadata_table.table.get(&adt_field.did()).cloned()
-                            {
-                                // add a metadata entry for the struct field matching the metadata entry
-                                // for the struct definition of said field
-                                adt_metadata_table
-                                    .table
-                                    .insert(field.did, adt_field_metadata.clone());
-
-                                for adt_field_lifetime_param in adt_field_metadata.lifetime_params.iter() {
-                                    adt_metadata_table.table.entry(*struct_did).and_modify(|adt| {
-                                        if let OriginParam::Hypothetical(h) = adt_field_lifetime_param {
-                                            eprintln!("\t\t\tbubbling {adt_field:?} origin {adt_field_lifetime_param:?} up into {adt_def:?} origins");
-                                            field_origin_args.insert(OriginArg::Hypothetical(*h));
-                                            adt.lifetime_params.insert(*adt_field_lifetime_param);
-                                        }
-                                    });
-                                }
-                            }
-                        }
-                        _ => (),
-                    }
-
-                    if field_origin_args.is_empty() {
-                        return &[];
-                    }
-                    let field_origin_args: Vec<_> = field_origin_args.into_iter().collect();
-                    ltcx.arena().alloc_slice(&field_origin_args[..])
-                });
-
-                adt_metadata_table
-                    .table
-                    .entry(*struct_did)
-                    .and_modify(|adt| {
-                        adt.field_info.insert(
-                            field.did,
-                            FieldMetadata {
-                                origin_args: field_origin_args,
-                            },
-                        );
-                    });
-            }
-
-            eprintln!();
-        }
-
-        if adt_metadata_table.table == old_adt_metadata {
-            eprintln!("reached a fixed point in struct lifetime reconciliation\n");
-            break;
-        }
-    }
-
-    adt_metadata_table
-}
-
-pub struct AdtMetadataTable<'tcx> {
-    pub table: HashMap<DefId, AdtMetadata<'tcx>>,
-    pub struct_dids: Vec<DefId>,
-}
-
-impl<'tcx> Debug for AdtMetadataTable<'tcx> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        fn fmt_string(lty: LabeledTy<'_, &[OriginArg]>) -> String {
-            let args: Vec<String> = lty.args.iter().map(|t| fmt_string(t)).collect();
-            use rustc_type_ir::TyKind::*;
-            match lty.kind() {
-                Ref(..) | RawPtr(..) => {
-                    format!("&{:?} {:}", lty.label[0], args[0])
-                }
-                Adt(adt, _) => {
-                    let mut s = format!("{adt:?}");
-                    let params = lty
-                        .label
-                        .iter()
-                        .map(|p| format!("{:?}", p))
-                        .into_iter()
-                        .chain(args.into_iter())
-                        .collect::<Vec<_>>()
-                        .join(",");
-
-                    if !params.is_empty() {
-                        s.push('<');
-                        s.push_str(&params);
-                        s.push('>');
-                    }
-                    s
-                }
-                Tuple(_) => {
-                    format!("({:})", args.join(","))
-                }
-                _ => format!("{:?}", lty.ty),
-            }
-        }
-
-        tls::with_opt(|tcx| {
-            let tcx = tcx.unwrap();
-            for k in &self.struct_dids {
-                let adt = &self.table[k];
-                write!(f, "struct {:}", tcx.item_name(*k))?;
-                write!(f, "<")?;
-                let lifetime_params_str = adt
-                    .lifetime_params
-                    .iter()
-                    .map(|p| format!("{:?}", p))
-                    .collect::<Vec<_>>()
-                    .join(",");
-                write!(f, "{lifetime_params_str:}")?;
-                writeln!(f, "> {{")?;
-                for (fdid, fmeta) in &adt.field_info {
-                    write!(f, "\t{:}: ", tcx.item_name(*fdid))?;
-                    let field_string_lty = fmt_string(fmeta.origin_args);
-
-                    write!(f, "{field_string_lty:}")?;
-
-                    writeln!(f)?;
-                }
-
-                writeln!(f, "}}\n")?;
-            }
-            writeln!(f)
-        })
     }
 }
 
@@ -710,9 +457,8 @@ fn run(tcx: TyCtxt) {
         info.lasn.set(lasn);
     }
 
-    let adt_metadata = construct_adt_metadata(tcx);
     eprintln!("=== ADT Metadata ===");
-    eprintln!("{adt_metadata:?}");
+    eprintln!("{:?}", gacx.adt_metadata);
 
     let mut loop_count = 0;
     loop {
@@ -743,7 +489,6 @@ fn run(tcx: TyCtxt) {
                 &mut asn.perms_mut(),
                 name.as_str(),
                 &mir,
-                &adt_metadata,
                 field_ltys,
             );
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -21,6 +21,7 @@ use crate::context::{
 };
 use crate::dataflow::DataflowConstraints;
 use crate::equiv::{GlobalEquivSet, LocalEquivSet};
+use crate::labeled_ty::LabeledTyCtxt;
 use crate::log::init_logger;
 use crate::util::Callee;
 use context::AdtMetadataTable;
@@ -32,10 +33,8 @@ use rustc_middle::mir::{
     AggregateKind, BindingForm, Body, Constant, LocalDecl, LocalInfo, LocalKind, Location, Operand,
     Rvalue, StatementKind,
 };
-use rustc_middle::ty::tls;
-use rustc_middle::ty::{GenericArgKind, Ty, TyCtxt, TyKind, WithOptConstParam};
+use rustc_middle::ty::{Ty, TyCtxt, TyKind, WithOptConstParam};
 use rustc_span::Span;
-use rustc_type_ir::RegionKind::{ReEarlyBound, ReStatic};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt::{Debug, Display};

--- a/c2rust-analyze/src/rewrite/apply.rs
+++ b/c2rust-analyze/src/rewrite/apply.rs
@@ -289,6 +289,16 @@ impl<'a, F: FnMut(&str)> Emitter<'a, F> {
             Rewrite::PrintTy(ref s) => {
                 self.emit_str(s);
             }
+            Rewrite::TyGenericParams(ref rws) => {
+                self.emit_str("<");
+                for (index, rw) in rws.iter().enumerate() {
+                    self.emit_rewrite(rw, 0, emit_expr, emit_subexpr);
+                    if index < rws.len() - 1 {
+                        self.emit_str(",");
+                    }
+                }
+                self.emit_str(">");
+            }
             Rewrite::Call(ref func, ref arg_rws) => {
                 self.emit_str(func);
                 self.emit_parenthesized(true, |slf| {
@@ -342,8 +352,11 @@ impl<'a, F: FnMut(&str)> Emitter<'a, F> {
             Rewrite::TyCtor(ref name, ref rws) => {
                 self.emit_str(name);
                 self.emit_str("<");
-                for rw in rws {
+                for (index, rw) in rws.iter().enumerate() {
                     self.emit_rewrite(rw, 0, emit_expr, emit_subexpr);
+                    if index < rws.len() - 1 {
+                        self.emit_str(",");
+                    }
                 }
                 self.emit_str(">");
             }

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -7,12 +7,15 @@
 use std::collections::HashMap;
 use std::ops::Index;
 
+use crate::borrowck::{OriginArg, OriginParam};
 use crate::context::{AnalysisCtxt, Assignment, FlagSet, LTy, PermissionSet};
 use crate::labeled_ty::{LabeledTy, LabeledTyCtxt};
 use crate::pointer_id::PointerId;
 use crate::rewrite::Rewrite;
 use crate::type_desc::{self, Ownership, Quantity};
-use hir::{ItemKind, VariantData};
+use crate::AdtMetadataTable;
+use hir::{GenericParamKind, ItemKind, Path, PathSegment, VariantData};
+use indexmap::IndexSet;
 use rustc_ast::ast;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Namespace, Res};

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -117,31 +117,25 @@ where
 }
 
 fn hir_generic_ty_args<'tcx>(ty: &hir::Ty<'tcx>) -> Option<Vec<&'tcx hir::Ty<'tcx>>> {
-    if let hir::TyKind::Path(hir::QPath::Resolved(
-        _,
-        Path {
-            segments: [.., PathSegment {
-                args: Some(args), ..
-            }],
-            ..
-        },
-    )) = &ty.kind
-    {
-        Some(
-            args.args
-                .iter()
-                .filter_map(|k| {
-                    if let hir::GenericArg::Type(ty) = k {
-                        Some(ty)
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-        )
-    } else {
-        None
-    }
+    let args = match ty.kind {
+        hir::TyKind::Path(hir::QPath::Resolved(
+            _,
+            Path {
+                segments: [.., PathSegment { args, .. }],
+                ..
+            },
+        )) => args,
+        _ => &None,
+    };
+    args.map(|args| {
+        args.args
+            .iter()
+            .filter_map(|arg| match arg {
+                hir::GenericArg::Type(ty) => Some(ty),
+                _ => None,
+            })
+            .collect()
+    })
 }
 
 /// Extract arguments from `hir_ty` if it corresponds to the tcx type `ty`.  If the two types

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -37,7 +37,7 @@ struct RewriteLabel<'a> {
     ty_desc: Option<(Ownership, Quantity)>,
     /// If set, a child or other descendant of this type requires rewriting.
     descendant_has_rewrite: bool,
-    // A lifetime rewrite for a pointer or reference
+    /// A lifetime rewrite for a pointer or reference.
     lifetime: &'a [OriginArg<'a>],
 }
 

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -80,17 +80,17 @@ fn create_rewrite_label<'tcx>(
     lifetime: &'tcx [OriginArg<'tcx>],
     adt_metadata: &AdtMetadataTable,
 ) -> RewriteLabel<'tcx> {
-    let ty_desc = Some(pointer_lty.label)
-        .filter(|ptr| !ptr.is_none())
-        .map(|ptr| {
-            let perms = perms[ptr];
-            let flags = flags[ptr];
-            // TODO: if the `Ownership` and `Quantity` exactly match `lty.ty`, then `ty_desc` can
-            // be `None` (no rewriting required).  This might let us avoid inlining a type alias
-            // for some pointers where no actual improvement was possible.
-            let desc = type_desc::perms_to_desc(pointer_lty.ty, perms, flags);
-            (desc.own, desc.qty)
-        });
+    let ty_desc = if pointer_lty.label.is_none() {
+        None
+    } else {
+        let perms = perms[pointer_lty.label];
+        let flags = flags[pointer_lty.label];
+        // TODO: if the `Ownership` and `Quantity` exactly match `lty.ty`, then `ty_desc` can
+        // be `None` (no rewriting required).  This might let us avoid inlining a type alias
+        // for some pointers where no actual improvement was possible.
+        let desc = type_desc::perms_to_desc(pointer_lty.ty, perms, flags);
+        Some((desc.own, desc.qty))
+    };
 
     RewriteLabel {
         ty_desc,

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -24,8 +24,8 @@ use rustc_hir::Mutability;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::mir::{self, Body, LocalDecl};
 use rustc_middle::ty::print::{FmtPrinter, Print};
+use rustc_middle::ty::TyKind;
 use rustc_middle::ty::{self, AdtDef, GenericArg, GenericArgKind, List, ReErased, TyCtxt};
-use rustc_middle::ty::{subst, TyKind};
 use rustc_span::Span;
 
 use super::LifetimeName;
@@ -300,7 +300,7 @@ fn mk_cell<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
     };
 
     let cell_adt = tcx.adt_def(cell_struct_did);
-    let substs = tcx.mk_substs([subst::GenericArg::from(ty)].into_iter());
+    let substs = tcx.mk_substs([GenericArg::from(ty)].into_iter());
     tcx.mk_adt(cell_adt, substs)
 }
 

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -25,56 +25,123 @@ use rustc_hir::Mutability;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::mir::{self, Body, LocalDecl};
 use rustc_middle::ty::print::{FmtPrinter, Print};
-use rustc_middle::ty::subst::GenericArg;
-use rustc_middle::ty::{self, ReErased, TyCtxt};
+use rustc_middle::ty::{self, AdtDef, GenericArg, GenericArgKind, List, ReErased, TyCtxt};
+use rustc_middle::ty::{subst, TyKind};
 use rustc_span::Span;
 
 use super::LifetimeName;
 
 /// A label for use with `LabeledTy` to indicate what rewrites to apply at each position in a type.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
-struct RewriteLabel {
+struct RewriteLabel<'a> {
     /// Rewrite a raw pointer, whose ownership and quantity have been inferred as indicated.
     ty_desc: Option<(Ownership, Quantity)>,
     /// If set, a child or other descendant of this type requires rewriting.
     descendant_has_rewrite: bool,
+    // A lifetime rewrite for a pointer or reference
+    lifetime: Option<&'a OriginArg<'a>>,
 }
 
-type RwLTy<'tcx> = LabeledTy<'tcx, RewriteLabel>;
+type RwLTy<'tcx> = LabeledTy<'tcx, RewriteLabel<'tcx>>;
+
+fn has_lifetime_rws(rw_lty: &RwLTy, adt_metadata: &AdtMetadataTable) -> bool {
+    let has_pointer_lifetime = rw_lty
+        .label
+        .lifetime
+        .iter()
+        .any(|lt| matches!(lt, OriginArg::Hypothetical(..)));
+    let has_adt_lifetime = match rw_lty.ty.kind() {
+        TyKind::Adt(adt_def, _) => adt_metadata
+            .table
+            .get(&adt_def.did())
+            .map(|adt| {
+                adt.lifetime_params
+                    .iter()
+                    .any(|lt| matches!(lt, OriginParam::Hypothetical(..)))
+            })
+            .unwrap_or(false),
+        _ => false,
+    };
+    has_adt_lifetime || has_pointer_lifetime
+}
+
+fn descendant_has_rewrite(args: &[RwLTy], adt_metadata: &AdtMetadataTable) -> bool {
+    args.iter().any(|child| {
+        child.label.ty_desc.is_some()
+            || child.label.descendant_has_rewrite
+            || has_lifetime_rws(child, adt_metadata)
+    })
+}
+
+fn create_rewrite_label<'tcx>(
+    pointer_lty: LTy<'tcx>,
+    args: &[RwLTy<'tcx>],
+    perms: &impl Index<PointerId, Output = PermissionSet>,
+    flags: &impl Index<PointerId, Output = FlagSet>,
+    lifetime: Option<&'tcx OriginArg<'tcx>>,
+    adt_metadata: &AdtMetadataTable,
+) -> RewriteLabel<'tcx> {
+    let ty_desc = if pointer_lty.label.is_none() {
+        None
+    } else {
+        let perms = perms[pointer_lty.label];
+        let flags = flags[pointer_lty.label];
+        // TODO: if the `Ownership` and `Quantity` exactly match `lty.ty`, then `ty_desc` can
+        // be `None` (no rewriting required).  This might let us avoid inlining a type alias
+        // for some pointers where no actual improvement was possible.
+        let desc = type_desc::perms_to_desc(pointer_lty.ty, perms, flags);
+        Some((desc.own, desc.qty))
+    };
+
+    RewriteLabel {
+        ty_desc,
+        descendant_has_rewrite: descendant_has_rewrite(args, adt_metadata),
+        lifetime,
+    }
+}
 
 fn relabel_rewrites<'tcx, P, F>(
     perms: &P,
     flags: &F,
-    lcx: LabeledTyCtxt<'tcx, RewriteLabel>,
+    lcx: LabeledTyCtxt<'tcx, RewriteLabel<'tcx>>,
     lty: LTy<'tcx>,
+    adt_metadata: &AdtMetadataTable,
 ) -> RwLTy<'tcx>
 where
     P: Index<PointerId, Output = PermissionSet>,
     F: Index<PointerId, Output = FlagSet>,
 {
-    lcx.relabel_with_args(lty, &mut |lty, args| {
-        let ty_desc = if lty.label.is_none() {
-            None
-        } else {
-            let perms = perms[lty.label];
-            let flags = flags[lty.label];
-            // TODO: if the `Ownership` and `Quantity` exactly match `lty.ty`, then `ty_desc` can
-            // be `None` (no rewriting required).  This might let us avoid inlining a type alias
-            // for some pointers where no actual improvement was possible.
-            let desc = type_desc::perms_to_desc(lty.ty, perms, flags);
-            Some((desc.own, desc.qty))
-        };
-        // `args` were already rewritten, so we can compute `descendant_has_rewrite` just by
-        // visiting the direct children.
-        let descendant_has_rewrite = args.iter().any(|child| {
-            let has_rewrite = child.label.ty_desc.is_some();
-            has_rewrite || child.label.descendant_has_rewrite
-        });
-        RewriteLabel {
-            ty_desc,
-            descendant_has_rewrite,
-        }
+    lcx.relabel_with_args(lty, &mut |pointer_lty, args| {
+        create_rewrite_label(pointer_lty, args, perms, flags, None, adt_metadata)
     })
+}
+
+fn hir_generic_ty_args<'tcx>(ty: &hir::Ty<'tcx>) -> Option<Vec<&'tcx hir::Ty<'tcx>>> {
+    if let hir::TyKind::Path(hir::QPath::Resolved(
+        _,
+        Path {
+            segments: [.., PathSegment {
+                args: Some(args), ..
+            }],
+            ..
+        },
+    )) = &ty.kind
+    {
+        Some(
+            args.args
+                .iter()
+                .filter_map(|k| {
+                    if let hir::GenericArg::Type(ty) = k {
+                        Some(ty)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        )
+    } else {
+        None
+    }
 }
 
 /// Extract arguments from `hir_ty` if it corresponds to the tcx type `ty`.  If the two types
@@ -139,7 +206,28 @@ fn deconstruct_hir_ty<'a, 'tcx>(
             }
         }
 
-        _ => None,
+        (&ty::TyKind::Adt(adt_def, substs), &hir::TyKind::Path(..)) => {
+            match hir_generic_ty_args(hir_ty) {
+                Some(type_args) => {
+                    if type_args.len() < substs.types().count() {
+                        // this situation occurs when there are hidden type arguments
+                        // such as the allocator `std::alloc::Global` type argument in `Vec`
+                        eprintln!("warning: extra MIR type argument for {adt_def:?}:");
+                        for mir_arg in substs.types().into_iter().skip(type_args.len()) {
+                            eprintln!("\t{:?}", mir_arg)
+                        }
+                    } else if type_args.len() != substs.types().count() {
+                        panic!("mismatched number of type arguments for {adt_def:?} and {hir_ty:?}")
+                    }
+                    Some(type_args)
+                }
+                _ => None,
+            }
+        }
+        (tk, hir_tk) => {
+            eprintln!("deconstruct_hir_ty: {tk:?} -- {hir_tk:?} not supported");
+            None
+        }
     }
 }
 
@@ -221,13 +309,13 @@ fn mk_cell<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
     };
 
     let cell_adt = tcx.adt_def(cell_struct_did);
-    let substs = tcx.mk_substs([GenericArg::from(ty)].into_iter());
+    let substs = tcx.mk_substs([subst::GenericArg::from(ty)].into_iter());
     tcx.mk_adt(cell_adt, substs)
 }
 
 /// Produce a `Ty` reflecting the rewrites indicated by the labels in `rw_lty`.
 fn mk_rewritten_ty<'tcx>(
-    lcx: LabeledTyCtxt<'tcx, RewriteLabel>,
+    lcx: LabeledTyCtxt<'tcx, RewriteLabel<'tcx>>,
     rw_lty: RwLTy<'tcx>,
 ) -> ty::Ty<'tcx> {
     let tcx = *lcx;
@@ -269,20 +357,37 @@ fn mk_rewritten_ty<'tcx>(
 struct HirTyVisitor<'a, 'tcx> {
     asn: &'a Assignment<'a>,
     acx: &'a AnalysisCtxt<'a, 'tcx>,
-    rw_lcx: LabeledTyCtxt<'tcx, RewriteLabel>,
+    rw_lcx: LabeledTyCtxt<'tcx, RewriteLabel<'tcx>>,
     mir: &'a Body<'tcx>,
     hir_rewrites: Vec<(Span, Rewrite)>,
     hir_span_to_mir_local: HashMap<Span, rustc_middle::mir::Local>,
 }
 
+fn adt_ty_rw<S>(
+    adt_def: &AdtDef,
+    lifetime_params: &IndexSet<OriginParam>,
+    substs: &&List<GenericArg>,
+) -> Rewrite<S> {
+    let lifetime_names = lifetime_params
+        .iter()
+        .map(|p| Rewrite::PrintTy(format!("{p:?}")));
+    let other_param_names = substs.iter().filter_map(|p| match p.unpack() {
+        GenericArgKind::Lifetime(..) => None,
+        _ => Some(Rewrite::PrintTy(format!("{p:?}"))),
+    });
+
+    Rewrite::TyCtor(
+        format!("{adt_def:?}"),
+        lifetime_names.chain(other_param_names).collect(),
+    )
+}
+
 impl<'a, 'tcx> HirTyVisitor<'a, 'tcx> {
-    fn handle_ty(
-        &mut self,
-        rw_lty: RwLTy<'tcx>,
-        hir_ty: &hir::Ty<'tcx>,
-        lifetime_type: LifetimeName,
-    ) {
-        if rw_lty.label.ty_desc.is_none() && !rw_lty.label.descendant_has_rewrite {
+    fn handle_ty(&mut self, rw_lty: RwLTy<'tcx>, hir_ty: &hir::Ty<'tcx>) {
+        if !matches!(rw_lty.ty.kind(), TyKind::Adt(..))
+            && rw_lty.label.ty_desc.is_none()
+            && !rw_lty.label.descendant_has_rewrite
+        {
             // No rewrites here or in any descendant of this HIR node.
             return;
         }
@@ -304,6 +409,7 @@ impl<'a, 'tcx> HirTyVisitor<'a, 'tcx> {
 
         if let Some((own, qty)) = rw_lty.label.ty_desc {
             assert_eq!(hir_args.len(), 1);
+
             let mut rw = Rewrite::Sub(0, hir_args[0].span);
 
             if own == Ownership::Cell {
@@ -318,6 +424,10 @@ impl<'a, 'tcx> HirTyVisitor<'a, 'tcx> {
                 Quantity::OffsetPtr => Rewrite::TySlice(Box::new(rw)),
             };
 
+            let lifetime_type = match rw_lty.label.lifetime {
+                Some(lifetime) => LifetimeName::Explicit(format!("{lifetime:?}")),
+                _ => LifetimeName::Elided,
+            };
             rw = match own {
                 Ownership::Raw => Rewrite::TyPtr(Box::new(rw), Mutability::Not),
                 Ownership::RawMut => Rewrite::TyPtr(Box::new(rw), Mutability::Mut),
@@ -331,10 +441,19 @@ impl<'a, 'tcx> HirTyVisitor<'a, 'tcx> {
             self.hir_rewrites.push((hir_ty.span, rw));
         }
 
+        if let TyKind::Adt(adt_def, substs) = rw_lty.ty.kind() {
+            if let Some(adt_metadata) = &self.acx.gacx.adt_metadata.table.get(&adt_def.did()) {
+                self.hir_rewrites.push((
+                    hir_ty.span,
+                    adt_ty_rw(adt_def, &adt_metadata.lifetime_params, substs),
+                ));
+            }
+        }
+
         if rw_lty.label.descendant_has_rewrite {
             for (&arg_rw_lty, arg_hir_ty) in rw_lty.args.iter().zip(hir_args.into_iter()) {
                 // FIXME: get the actual lifetime from ADT/Field Metadata
-                self.handle_ty(arg_rw_lty, arg_hir_ty, LifetimeName::Elided);
+                self.handle_ty(arg_rw_lty, arg_hir_ty);
             }
         }
     }
@@ -348,10 +467,63 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirTyVisitor<'a, 'tcx> {
     }
 
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
+        let did = item.def_id.to_def_id();
         let field_ltys = &self.acx.gacx.field_ltys;
+
         #[allow(clippy::single_match)]
         match &item.kind {
-            ItemKind::Struct(VariantData::Struct(field_defs, _), _generics) => {
+            ItemKind::Struct(VariantData::Struct(field_defs, _), generics) => {
+                let adt_metadata = &self.acx.gacx.adt_metadata.table[&did];
+                let updated_lifetime_params = &adt_metadata.lifetime_params;
+
+                let original_lifetime_param_count = generics
+                    .params
+                    .iter()
+                    .filter(|p| matches!(p.kind, GenericParamKind::Lifetime { .. }))
+                    .count();
+
+                if updated_lifetime_params.len() != original_lifetime_param_count {
+                    let new_substs: Vec<_> = {
+                        let mut new_lifetime_params_iter = updated_lifetime_params.iter();
+
+                        let mut updated_lifetimes = vec![];
+                        let mut new_lifetimes = vec![];
+                        let mut other_params = vec![];
+
+                        for gp in generics.params {
+                            match gp.kind {
+                                GenericParamKind::Lifetime { .. } => {
+                                    let updated_lifetime_param = new_lifetime_params_iter
+                                        .next()
+                                        .expect("Not enough updated_lifetime_params");
+                                    updated_lifetimes.push(Rewrite::PrintTy(format!(
+                                        "{:?}",
+                                        updated_lifetime_param
+                                    )))
+                                }
+                                _ => {
+                                    other_params.push(Rewrite::PrintTy(gp.name.ident().to_string()))
+                                }
+                            }
+                        }
+
+                        for ul in new_lifetime_params_iter {
+                            new_lifetimes.push(Rewrite::PrintTy(format!("{:?}", ul)))
+                        }
+
+                        updated_lifetimes
+                            .into_iter()
+                            .chain(new_lifetimes.into_iter())
+                            .chain(other_params.into_iter())
+                            .collect()
+                    };
+
+                    // only the generic parameters need to be rewritten, not the
+                    // struct name itself
+                    self.hir_rewrites
+                        .push((generics.span, Rewrite::TyGenericParams(new_substs)));
+                }
+
                 for field_def in field_defs.iter() {
                     let fdid = self
                         .acx
@@ -360,15 +532,35 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirTyVisitor<'a, 'tcx> {
                         .hir()
                         .local_def_id(field_def.hir_id)
                         .to_def_id();
+                    let field_metadata = &adt_metadata.field_info[&fdid];
                     let f_lty = field_ltys[&fdid];
-                    let rw_lty =
-                        relabel_rewrites(&self.asn.perms(), &self.asn.flags(), self.rw_lcx, f_lty);
-                    // FIXME: get the actual lifetime from ADT/Field Metadata
-                    self.handle_ty(
-                        rw_lty,
-                        field_def.ty,
-                        LifetimeName::Explicit("'static".into()),
+                    let lcx = LabeledTyCtxt::<'tcx, RewriteLabel>::new(self.acx.tcx());
+                    let rw_lty = lcx.zip_labels_with(
+                        f_lty,
+                        field_metadata.origin_args,
+                        &mut |pointer_lty, lifetime_lty, args| {
+                            {
+                                let lifetime_rw = match lifetime_lty.label {
+                                    [lt] => Some(lt),
+                                    [] => None,
+                                    _ => {
+                                        // Not a pointer or reference type
+                                        None
+                                    }
+                                };
+                                create_rewrite_label(
+                                    pointer_lty,
+                                    args,
+                                    &self.asn.perms(),
+                                    &self.asn.flags(),
+                                    lifetime_rw,
+                                    &self.acx.gacx.adt_metadata,
+                                )
+                            }
+                        },
                     );
+
+                    self.handle_ty(rw_lty, field_def.ty);
                 }
             }
             _ => (),
@@ -383,10 +575,15 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirTyVisitor<'a, 'tcx> {
                     let mir_local_decl = &self.mir.local_decls[*mir_local];
                     assert_eq!(mir_local_decl.source_info.span, hir_local.pat.span);
                     let lty = self.acx.local_tys[*mir_local];
-                    let rw_lty =
-                        relabel_rewrites(&self.asn.perms(), &self.asn.flags(), self.rw_lcx, lty);
+                    let rw_lty = relabel_rewrites(
+                        &self.asn.perms(),
+                        &self.asn.flags(),
+                        self.rw_lcx,
+                        lty,
+                        &self.acx.gacx.adt_metadata,
+                    );
                     let hir_ty = hir_local.ty.unwrap();
-                    self.handle_ty(rw_lty, hir_ty, LifetimeName::Elided);
+                    self.handle_ty(rw_lty, hir_ty);
                 }
             }
             _ => (),
@@ -424,16 +621,27 @@ pub fn gen_ty_rewrites<'tcx>(
         .unwrap_or_else(|| panic!("expected def {:?} to be a function", ldid));
 
     let lty_sig = acx.gacx.fn_sigs.get(&ldid.to_def_id()).unwrap();
-
     assert_eq!(lty_sig.inputs.len(), hir_sig.decl.inputs.len());
     for (&lty, hir_ty) in lty_sig.inputs.iter().zip(hir_sig.decl.inputs.iter()) {
-        let rw_lty = relabel_rewrites(&asn.perms(), &asn.flags(), rw_lcx, lty);
-        v.handle_ty(rw_lty, hir_ty, LifetimeName::Elided);
+        let rw_lty = relabel_rewrites(
+            &asn.perms(),
+            &asn.flags(),
+            rw_lcx,
+            lty,
+            &acx.gacx.adt_metadata,
+        );
+        v.handle_ty(rw_lty, hir_ty);
     }
 
     if let hir::FnRetTy::Return(hir_ty) = hir_sig.decl.output {
-        let rw_lty = relabel_rewrites(&asn.perms(), &asn.flags(), rw_lcx, lty_sig.output);
-        v.handle_ty(rw_lty, hir_ty, LifetimeName::Elided);
+        let rw_lty = relabel_rewrites(
+            &asn.perms(),
+            &asn.flags(),
+            rw_lcx,
+            lty_sig.output,
+            &acx.gacx.adt_metadata,
+        );
+        v.handle_ty(rw_lty, hir_ty);
     }
 
     let hir_body_id = acx.tcx().hir().body_owned_by(ldid);
@@ -462,7 +670,13 @@ pub fn dump_rewritten_local_tys<'tcx>(
     let rw_lcx = LabeledTyCtxt::new(acx.tcx());
     for (local, decl) in mir.local_decls.iter_enumerated() {
         // TODO: apply `Cell` if `addr_of_local` indicates it's needed
-        let rw_lty = relabel_rewrites(&asn.perms(), &asn.flags(), rw_lcx, acx.local_tys[local]);
+        let rw_lty = relabel_rewrites(
+            &asn.perms(),
+            &asn.flags(),
+            rw_lcx,
+            acx.local_tys[local],
+            &acx.gacx.adt_metadata,
+        );
         let ty = mk_rewritten_ty(rw_lcx, rw_lty);
         eprintln!(
             "{:?} ({}): {:?}",

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -375,7 +375,7 @@ fn adt_ty_rw<S>(
 
 impl<'a, 'tcx> HirTyVisitor<'a, 'tcx> {
     fn handle_ty(&mut self, rw_lty: RwLTy<'tcx>, hir_ty: &hir::Ty<'tcx>) {
-        if !matches!(rw_lty.ty.kind(), TyKind::Adt(..))
+        if !rw_lty.ty.is_adt()
             && rw_lty.label.ty_desc.is_none()
             && !rw_lty.label.descendant_has_rewrite
         {

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -503,11 +503,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirTyVisitor<'a, 'tcx> {
                             new_lifetimes.push(Rewrite::PrintTy(format!("{:?}", ul)))
                         }
 
-                        updated_lifetimes
-                            .into_iter()
-                            .chain(new_lifetimes.into_iter())
-                            .chain(other_params.into_iter())
-                            .collect()
+                        [updated_lifetimes, new_lifetimes, other_params].into_iter().flatten().collect()
                     };
 
                     // only the generic parameters need to be rewritten, not the

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -503,7 +503,10 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirTyVisitor<'a, 'tcx> {
                             new_lifetimes.push(Rewrite::PrintTy(format!("{:?}", ul)))
                         }
 
-                        [updated_lifetimes, new_lifetimes, other_params].into_iter().flatten().collect()
+                        [updated_lifetimes, new_lifetimes, other_params]
+                            .into_iter()
+                            .flatten()
+                            .collect()
                     };
 
                     // only the generic parameters need to be rewritten, not the

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -357,7 +357,7 @@ struct HirTyVisitor<'a, 'tcx> {
 fn adt_ty_rw<S>(
     adt_def: &AdtDef,
     lifetime_params: &[OriginArg],
-    substs: &&List<GenericArg>,
+    substs: &List<GenericArg>,
 ) -> Rewrite<S> {
     let lifetime_names = lifetime_params
         .iter()

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -72,10 +72,14 @@ unsafe fn _field_access<'d>(ra: &'d mut A<'d>, ppd: *mut *mut Data<'d>) {
     (*(**ppd).pa).pra = (*(**ppd).pa).pra;
 }
 
-// CHECK-DAG: pub struct Data<'d> {
-// CHECK-DAG: pub pi: &'static mut (i32),
-// CHECK-DAG: pub pa: &'static mut (A<'d>),
+// CHECK-DAG: pub struct Data<'d,'h0,'h1,'h2> {
+// CHECK-DAG: pub pi: &'h0 mut (i32),
+// CHECK-DAG: pub pa: &'h1 mut (A<'a,'h0,'h1,'h2>),
+// CHECK-DAG: pub a: A<'a,'h0,'h1,'h2>,
 
-// CHECK-DAG: pub struct A<'a> {
-// CHECK-DAG: pub rd: &'static (Data<'a>),
-// CHECK-DAG: pub pra: &'static core::cell::Cell<(&(A<'a>))>,
+// CHECK-DAG: pub struct A<'a,'h0,'h1,'h2> {
+// CHECK-DAG: pub rd: &'a (Data<'d,'h0,'h1,'h2>),
+// CHECK-DAG: pub pra: &'h2 core::cell::Cell<(&'a (A<'a,'h0,'h1,'h2>))>,
+// CHECK-DAG: bar: &'h3 (Vec<(VecTup<'a,'h3,'h4,'h0,'h1,'h2>, &'h4 (A<'a,'h0,'h1,'h2>))>),
+
+// CHECK-DAG: unsafe fn _field_access<'d>(ra: &(A<'a,'h0,'h1,'h2>), ppd: &mut (&mut (Data<'d,'h0,'h1,'h2>)))

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -74,12 +74,10 @@ unsafe fn _field_access<'d>(ra: &'d mut A<'d>, ppd: *mut *mut Data<'d>) {
 
 // CHECK-DAG: pub struct Data<'d,'h0,'h1,'h2> {
 // CHECK-DAG: pub pi: &'h0 mut (i32),
-// CHECK-DAG: pub pa: &'h1 mut (A<'a,'h0,'h1,'h2>),
-// CHECK-DAG: pub a: A<'a,'h0,'h1,'h2>,
+// CHECK-DAG: pub pa: &'h1 mut (A<'d,'h0,'h1,'h2>),
+// CHECK-DAG: pub a: A<'d,'h0,'h1,'h2>,
 
 // CHECK-DAG: pub struct A<'a,'h0,'h1,'h2> {
-// CHECK-DAG: pub rd: &'a (Data<'d,'h0,'h1,'h2>),
+// CHECK-DAG: pub rd: &'a (Data<'a,'h0,'h1,'h2>),
 // CHECK-DAG: pub pra: &'h2 core::cell::Cell<(&'a (A<'a,'h0,'h1,'h2>))>,
 // CHECK-DAG: bar: &'h3 (Vec<(VecTup<'a,'h3,'h4,'h0,'h1,'h2>, &'h4 (A<'a,'h0,'h1,'h2>))>),
-
-// CHECK-DAG: unsafe fn _field_access<'d>(ra: &(A<'a,'h0,'h1,'h2>), ppd: &mut (&mut (Data<'d,'h0,'h1,'h2>)))


### PR DESCRIPTION
Rewrites structs to reflect hypothetical lifetimes accepted by polonius.

e.g.
```rust
pub struct Data<'d> {
    pub pi: *mut i32,
    pub pa: *mut A<'d>,
    pub a: A<'d>,
}
pub struct A<'a> {
    pub rd: &'a Data<'a>,
    pub pra: *mut &'a mut A<'a>,
}

struct VecTup<'a> {
    bar: *mut Vec<(VecTup<'a>, *mut A<'a>)>,
}
```

gets rewritten to

```rust
pub struct Data<'d,'h0,'h1,'h2> {
    pub pi: &'h0 mut (i32),
    pub pa: &'h1 mut (A<'d,'h0,'h1,'h2>),
    pub a: A<'d,'h0,'h1,'h2>,
}

pub struct A<'a,'h0,'h1,'h2> {
    pub rd: &'a (Data<'a,'h0,'h1,'h2>),
    pub pra: &'h2 core::cell::Cell<(&'a (A<'a,'h0,'h1,'h2>))>,
}

struct VecTup<'a,'h3,'h4,'h0,'h1,'h2> {
    bar: &'h3 (Vec<(VecTup<'a,'h3,'h4,'h0,'h1,'h2>, &'h4 (A<'a,'h0,'h1,'h2>))>),
}
```