### PR TITLE
analyze: refactor MIR rewrite generation

### DIFF
--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -213,6 +213,7 @@ impl<'a, 'tcx> AnalysisCtxt<'_, 'tcx> {
 pub struct AnalysisCtxtData<'tcx> {
     local_tys: IndexVec<Local, LTy<'tcx>>,
     addr_of_local: IndexVec<Local, PointerId>,
+    c_void_casts: CVoidCasts<'tcx>,
     rvalue_tys: HashMap<Location, LTy<'tcx>>,
     string_literal_locs: Vec<Location>,
     next_ptr_id: NextLocalPointerId,
@@ -326,8 +327,8 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
             gacx,
             local_decls: &mir.local_decls,
             local_tys: IndexVec::new(),
-            c_void_casts: CVoidCasts::new(mir, tcx),
             addr_of_local: IndexVec::new(),
+            c_void_casts: CVoidCasts::new(mir, tcx),
             rvalue_tys: HashMap::new(),
             string_literal_locs: Default::default(),
             next_ptr_id: NextLocalPointerId::new(),
@@ -342,6 +343,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         let AnalysisCtxtData {
             local_tys,
             addr_of_local,
+            c_void_casts,
             rvalue_tys,
             string_literal_locs,
             next_ptr_id,
@@ -350,8 +352,8 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
             gacx,
             local_decls: &mir.local_decls,
             local_tys,
-            c_void_casts: CVoidCasts::default(),
             addr_of_local,
+            c_void_casts,
             rvalue_tys,
             string_literal_locs,
             next_ptr_id,
@@ -362,6 +364,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         AnalysisCtxtData {
             local_tys: self.local_tys,
             addr_of_local: self.addr_of_local,
+            c_void_casts: self.c_void_casts,
             rvalue_tys: self.rvalue_tys,
             string_literal_locs: self.string_literal_locs,
             next_ptr_id: self.next_ptr_id,
@@ -503,6 +506,7 @@ impl<'tcx> AnalysisCtxtData<'tcx> {
         let Self {
             local_tys,
             addr_of_local,
+            c_void_casts: _,
             rvalue_tys,
             string_literal_locs: _,
             next_ptr_id,

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -135,6 +135,17 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         match stmt.kind {
             StatementKind::Assign(ref x) => {
                 let (pl, ref rv) = **x;
+
+                if matches!(rv, Rvalue::Cast(..)) && self.acx.c_void_casts.should_skip_stmt(loc) {
+                    // This is a cast to or from `void*` associated with a `malloc`, `free`, or
+                    // other libc call.
+                    //
+                    // TODO: we should probably emit a rewrite here to remove the cast; then when
+                    // we implement rewriting of the actual call, it won't need to deal with
+                    // additional rewrites at a separate location from the call itself.
+                    return;
+                }
+
                 let pl_lty = self.acx.type_of(pl);
 
                 if pl.is_indirect() && self.acx.local_tys[pl.local].ty.is_any_ptr() {

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -161,8 +161,9 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 // `_1` fails the `is_any_ptr()` check.
                 if pl.is_indirect() && self.acx.local_tys[pl.local].ty.is_any_ptr() {
                     let local_lty = self.acx.local_tys[pl.local];
-                    let perms = self.perms[local_lty.label];
-                    let flags = self.flags[local_lty.label];
+                    let local_ptr = local_lty.label;
+                    let perms = self.perms[local_ptr];
+                    let flags = self.flags[local_ptr];
                     let desc = type_desc::perms_to_desc(local_lty.ty, perms, flags);
                     if desc.own == Ownership::Cell {
                         // this is an assignment like `*x = 2` but `x` has CELL permissions
@@ -190,8 +191,9 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                                 && self.acx.local_tys[rv_place.local].ty.is_any_ptr()
                             {
                                 let local_lty = self.acx.local_tys[rv_place.local];
-                                let perms = self.perms[local_lty.label];
-                                let flags = self.flags[local_lty.label];
+                                let local_ptr = local_lty.label;
+                                let perms = self.perms[local_ptr];
+                                let flags = self.flags[local_ptr];
                                 let desc = type_desc::perms_to_desc(local_lty.ty, perms, flags);
                                 if desc.own == Ownership::Cell {
                                     // this is an assignment like `let x = *y` but `y` has CELL permissions

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -7,7 +7,7 @@
 //! all adjustments, as this would make even non-rewritten code extremely verbose, so we try to
 //! materialize adjustments only on code that's subject to some rewrite.
 
-use crate::context::{AnalysisCtxt, Assignment, FlagSet, LTy, PermissionSet, PointerId};
+use crate::context::{AnalysisCtxt, Assignment, FlagSet, LTy, PermissionSet};
 use crate::pointer_id::PointerTable;
 use crate::type_desc::{self, Ownership, Quantity, TypeDesc};
 use crate::util::{ty_callee, Callee};
@@ -388,7 +388,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         }
     }
 
-    fn visit_place(&mut self, pl: Place<'tcx>) {
+    fn visit_place(&mut self, _pl: Place<'tcx>) {
         // TODO: walk over `pl` to handle all derefs (casts, `*x` -> `(*x).get()`)
     }
 
@@ -479,6 +479,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         self.emit_cast_desc_desc(from, to);
     }
 
+    #[allow(dead_code)]
     fn emit_cast_desc_lty(&mut self, from: TypeDesc<'tcx>, to_lty: LTy<'tcx>) {
         let to = type_desc::perms_to_desc(
             to_lty.ty,

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -373,7 +373,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         }
     }
 
-    /// Like [`visit_operand`], but takes an expected `TypeDesc` instead of an expected `LTy`.
+    /// Like [`Self::visit_operand`], but takes an expected `TypeDesc` instead of an expected `LTy`.
     fn visit_operand_desc(&mut self, op: &Operand<'tcx>, expect_desc: TypeDesc<'tcx>) {
         match *op {
             Operand::Copy(pl) | Operand::Move(pl) => {

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -347,7 +347,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     fn visit_place(&mut self, pl: Place<'tcx>, expect_ty: LTy<'tcx>) {
         let ptr_lty = self.acx.type_of(pl);
         if !ptr_lty.label.is_none() {
-            self.emit_ptr_cast(ptr_lty, expect_ty);
+            self.emit_cast_lty_lty(ptr_lty, expect_ty);
         }
         // TODO: walk over `pl` to handle all derefs (casts, `*x` -> `(*x).get()`)
     }
@@ -357,7 +357,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             Operand::Copy(pl) | Operand::Move(pl) => {
                 let ptr_lty = self.acx.type_of(pl);
                 if !ptr_lty.label.is_none() {
-                    self.emit_cast(ptr_lty, expect_desc);
+                    self.emit_cast_lty_desc(ptr_lty, expect_desc);
                 }
 
                 // TODO: walk over `pl` to handle all derefs (casts, `*x` -> `(*x).get()`)
@@ -430,46 +430,52 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             });
     }
 
-    fn emit_ptr_cast(&mut self, ptr_lty: LTy<'tcx>, expect_lty: LTy<'tcx>) {
-        assert!(expect_lty.label != PointerId::NONE);
-
-        let desc2 = type_desc::perms_to_desc(
-            expect_lty.ty,
-            self.perms[expect_lty.label],
-            self.flags[expect_lty.label],
+    fn emit_cast_desc_desc(&mut self, from: TypeDesc<'tcx>, to: TypeDesc<'tcx>) {
+        assert_eq!(
+            self.acx.tcx().erase_regions(from.pointee_ty),
+            self.acx.tcx().erase_regions(to.pointee_ty),
         );
 
-        self.emit_cast(ptr_lty, desc2);
-    }
-
-    fn emit_cast(&mut self, ptr_lty: LTy<'tcx>, expect_desc: TypeDesc<'tcx>) {
-        assert!(ptr_lty.label != PointerId::NONE);
-
-        let ptr_desc = type_desc::perms_to_desc(
-            ptr_lty.ty,
-            self.perms[ptr_lty.label],
-            self.flags[ptr_lty.label],
-        );
-        let own1 = ptr_desc.own;
-        let qty1 = ptr_desc.qty;
-        let own2 = expect_desc.own;
-        let qty2 = expect_desc.qty;
-
-        if (own1, qty1) == (own2, qty2) {
+        if from == to {
             return;
         }
 
-        if qty1 == qty2 && (own1, own2) == (Ownership::Mut, Ownership::Imm) {
+        if from.qty == to.qty && (from.own, to.own) == (Ownership::Mut, Ownership::Imm) {
             self.emit(RewriteKind::MutToImm);
             return;
         }
 
-        eprintln!(
-            "unsupported cast kind: {:?} {:?} -> {:?}",
-            self.perms[ptr_lty.label],
-            (own1, qty1),
-            (own2, qty2)
+        // TODO: handle Slice -> Single here instead of special-casing in `offset`
+
+        eprintln!("unsupported cast kind: {:?} -> {:?}", from, to);
+    }
+
+    fn emit_cast_lty_desc(&mut self, from_lty: LTy<'tcx>, to: TypeDesc<'tcx>) {
+        let from = type_desc::perms_to_desc(
+            from_lty.ty,
+            self.perms[from_lty.label],
+            self.flags[from_lty.label],
         );
+        self.emit_cast_desc_desc(from, to);
+    }
+
+    fn emit_cast_desc_lty(&mut self, from: TypeDesc<'tcx>, to_lty: LTy<'tcx>) {
+        let to = type_desc::perms_to_desc(
+            to_lty.ty,
+            self.perms[to_lty.label],
+            self.flags[to_lty.label],
+        );
+        self.emit_cast_desc_desc(from, to);
+    }
+
+    fn emit_cast_lty_lty(&mut self, from_lty: LTy<'tcx>, to_lty: LTy<'tcx>) {
+        let lty_to_desc = |slf: &mut Self, lty: LTy<'tcx>| {
+            type_desc::perms_to_desc(lty.ty, slf.perms[lty.label], slf.flags[lty.label])
+        };
+
+        let from = lty_to_desc(self, from_lty);
+        let to = lty_to_desc(self, to_lty);
+        self.emit_cast_desc_desc(from, to);
     }
 }
 

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -155,8 +155,11 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
 
                 let pl_lty = self.acx.type_of(pl);
 
+                // FIXME: Needs changes to handle CELL pointers in struct fields.  Suppose `pl` is
+                // something like `*(_1.0)`, where the `.0` field is CELL.  This should be
+                // converted to a `Cell::get` call, but we would fail to enter this case because
+                // `_1` fails the `is_any_ptr()` check.
                 if pl.is_indirect() && self.acx.local_tys[pl.local].ty.is_any_ptr() {
-                    // FIXME: should use pl_lty instead
                     let local_lty = self.acx.local_tys[pl.local];
                     let perms = self.perms[local_lty.label];
                     let flags = self.flags[local_lty.label];

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -58,7 +58,8 @@ where
             // TODO: if the `Ownership` and `Quantity` exactly match `lty.ty`, then `ty_desc` can
             // be `None` (no rewriting required).  This might let us avoid inlining a type alias
             // for some pointers where no actual improvement was possible.
-            Some(type_desc::perms_to_desc(perms, flags))
+            let desc = type_desc::perms_to_desc(lty.ty, perms, flags);
+            Some((desc.own, desc.qty))
         };
         // `args` were already rewritten, so we can compute `descendant_has_rewrite` just by
         // visiting the direct children.

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -59,6 +59,8 @@ fn perms_to_own_and_qty(perms: PermissionSet, flags: FlagSet) -> (Ownership, Qua
     (own, qty)
 }
 
+/// Obtain the `TypeDesc` for a pointer.  `ptr_ty` should be the `Ty` of the pointer, and `perms`
+/// and `flags` should be taken from its outermost `PointerId`.
 pub fn perms_to_desc<'tcx>(
     ptr_ty: Ty<'tcx>,
     perms: PermissionSet,
@@ -81,6 +83,8 @@ pub fn perms_to_desc<'tcx>(
     }
 }
 
+/// Obtain the `TypeDesc` for a pointer to a local.  `local_ty` should be the `Ty` of the local
+/// itself, and `perms` and `flags` should be taken from its `addr_of_local` `PointerId`.
 pub fn local_perms_to_desc<'tcx>(
     local_ty: Ty<'tcx>,
     perms: PermissionSet,

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -30,7 +30,7 @@ pub enum Quantity {
     OffsetPtr,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub struct TypeDesc<'tcx> {
     pub own: Ownership,
     pub qty: Quantity,


### PR DESCRIPTION
This branch refactors `mir_op` to make the generation of conversions more uniform.  Ideally, we should call `emit_cast_*` in roughly every place where `dataflow::type_check` adds a dataflow edge.  This branch doesn't fully implement that, but gets us a little closer.

This also adds a new `TypeDesc` type, which bundles up `Ownership`, `Quantity`, and a pointee `Ty` into a complete description of a rewritten pointer type.  This is used for some of the new `emit_cast_*` machinery.

Based on #918 for now; once this is approved, I'll rebase onto `master`