### PR TITLE
analyze: introduce FlagSet::FIXED

### DIFF
--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -136,6 +136,12 @@ bitflags! {
         /// way, and it can't be freely discarded (or its inverse freely added) as is the case for
         /// everything in `PermissionSet`.
         const CELL = 0x0001;
+
+        /// This pointer's type is fixed; rewrites must not change it.  This is used for all safe
+        /// references (which we assume already have the correct types), for raw pointers that
+        /// cross an FFI boundary, and for arguments and return values of functions we can't
+        /// rewrite.
+        const FIXED = 0x0002;
     }
 }
 
@@ -407,6 +413,10 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         self.gacx.ptr_info.and(&self.ptr_info)
     }
 
+    pub fn local_ptr_info(&self) -> &LocalPointerTable<PointerInfo> {
+        &self.ptr_info
+    }
+
     pub fn type_of<T: TypeOf<'tcx>>(&self, x: T) -> LTy<'tcx> {
         x.type_of(self)
     }
@@ -550,6 +560,10 @@ impl<'tcx> AnalysisCtxtData<'tcx> {
         for lty in rvalue_tys.values_mut() {
             *lty = remap_lty_pointers(lcx, &map, lty);
         }
+    }
+
+    pub fn local_ptr_info(&self) -> &LocalPointerTable<PointerInfo> {
+        &self.ptr_info
     }
 
     pub fn num_pointers(&self) -> usize {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -423,7 +423,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         self.ptr_info.len()
     }
 
-    pub fn ptr_info(&self) -> PointerTable<PointerInfo> {
+    pub fn _ptr_info(&self) -> PointerTable<PointerInfo> {
         self.gacx.ptr_info.and(&self.ptr_info)
     }
 
@@ -431,7 +431,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         self.gacx.ptr_info.and_mut(&mut self.ptr_info)
     }
 
-    pub fn local_ptr_info(&self) -> &LocalPointerTable<PointerInfo> {
+    pub fn _local_ptr_info(&self) -> &LocalPointerTable<PointerInfo> {
         &self.ptr_info
     }
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -266,9 +266,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
     }
 
     pub fn new_pointer(&mut self, info: PointerInfo) -> PointerId {
-        let i = self.ptr_info.len();
-        self.ptr_info.push(info);
-        PointerId::global(u32::try_from(i).unwrap())
+        self.ptr_info.push(info)
     }
 
     pub fn num_pointers(&self) -> usize {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -604,9 +604,22 @@ fn run(tcx: TyCtxt) {
 
     let mut gasn =
         GlobalAssignment::new(gacx.num_pointers(), PermissionSet::UNIQUE, FlagSet::empty());
+    for (ptr, info) in gacx.ptr_info().iter() {
+        if info.contains(PointerInfo::REF) {
+            gasn.flags[ptr].insert(FlagSet::FIXED);
+        }
+    }
+
     for info in func_info.values_mut() {
         let num_pointers = info.acx_data.num_pointers();
-        let lasn = LocalAssignment::new(num_pointers, PermissionSet::UNIQUE, FlagSet::empty());
+        let mut lasn = LocalAssignment::new(num_pointers, PermissionSet::UNIQUE, FlagSet::empty());
+
+        for (ptr, info) in info.acx_data.local_ptr_info().iter() {
+            if info.contains(PointerInfo::REF) {
+                lasn.flags[ptr].insert(FlagSet::FIXED);
+            }
+        }
+
         info.lasn.set(lasn);
     }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -456,6 +456,77 @@ fn label_rvalue_tys<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>) {
     }
 }
 
+fn update_pointer_info<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>) {
+    let mut write_count = HashMap::with_capacity(mir.local_decls.len());
+    let mut rhs_is_ref = HashSet::new();
+
+    for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
+        for (i, stmt) in bb_data.statements.iter().enumerate() {
+            let (pl, rv) = match &stmt.kind {
+                StatementKind::Assign(x) => &**x,
+                _ => continue,
+            };
+
+            eprintln!(
+                "update_pointer_info: visit assignment: {:?}[{}]: {:?}",
+                bb, i, stmt
+            );
+
+            // Note we ignore `c_void_casts` here.  It shouldn't affect any of the patterns we're
+            // looking for.
+
+            if !pl.is_indirect() {
+                // This is a write directly to `pl.local`.
+                *write_count.entry(pl.local).or_insert(0) += 1;
+                eprintln!("  record write to LHS {:?}", pl);
+            }
+
+            let ref_pl = match *rv {
+                Rvalue::Ref(_rg, _kind, pl) => Some(pl),
+                Rvalue::AddressOf(_mutbl, pl) => Some(pl),
+                _ => None,
+            };
+            if let Some(ref_pl) = ref_pl {
+                // For simplicity, we consider taking the address of a local to be a write.  We
+                // expect this not to happen for the sorts of temporary refs we're looking for.
+                if !ref_pl.is_indirect() {
+                    eprintln!("  record write to ref target {:?}", ref_pl);
+                    *write_count.entry(ref_pl.local).or_insert(0) += 1;
+                }
+
+                rhs_is_ref.insert(pl.local);
+            }
+        }
+    }
+
+    for local in mir.local_decls.indices() {
+        if mir.local_kind(local) != LocalKind::Temp {
+            eprintln!(
+                "local {:?}: kind is {:?}, not Temp",
+                local,
+                mir.local_kind(local)
+            );
+            continue;
+        }
+        if write_count.get(&local).copied().unwrap_or(0) != 1 {
+            eprintln!(
+                "local {:?}: write count is {:?}, not 1",
+                local,
+                write_count.get(&local)
+            );
+            continue;
+        }
+        if !rhs_is_ref.contains(&local) {
+            eprintln!("local {:?}: rhs is not Rvalue::Ref", local);
+            continue;
+        }
+        let ptr = acx
+            .ptr_of(local)
+            .unwrap_or_else(|| panic!("{local:?} was initialized to Ref but has no PointerId?"));
+        acx.ptr_info_mut()[ptr].insert(PointerInfo::RECOGNIZED_TEMPORARY_REF);
+    }
+}
+
 fn run(tcx: TyCtxt) {
     let mut gacx = GlobalAnalysisCtxt::new(tcx);
     let mut func_info = HashMap::new();
@@ -564,6 +635,7 @@ fn run(tcx: TyCtxt) {
         }
 
         label_rvalue_tys(&mut acx, &mir);
+        update_pointer_info(&mut acx, &mir);
 
         // Compute local equivalence classes and dataflow constraints.
         let (dataflow, equiv_constraints) = dataflow::generate_constraints(&acx, &mir);
@@ -615,7 +687,9 @@ fn run(tcx: TyCtxt) {
         let mut lasn = LocalAssignment::new(num_pointers, PermissionSet::UNIQUE, FlagSet::empty());
 
         for (ptr, info) in info.acx_data.local_ptr_info().iter() {
-            if info.contains(PointerInfo::REF) {
+            if info.contains(PointerInfo::REF)
+                && !info.contains(PointerInfo::RECOGNIZED_TEMPORARY_REF)
+            {
                 lasn.flags[ptr].insert(FlagSet::FIXED);
             }
         }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -809,8 +809,11 @@ fn run(tcx: TyCtxt) {
     eprintln!("\nfinal labeling for static items:");
     let lcx1 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
     let lcx2 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
-    for (did, lty) in gacx.static_tys.iter() {
-        let name = tcx.item_name(*did);
+    let mut static_dids = gacx.static_tys.keys().cloned().collect::<Vec<_>>();
+    static_dids.sort();
+    for did in static_dids {
+        let lty = gacx.static_tys[&did];
+        let name = tcx.item_name(did);
         print_labeling_for_var(
             lcx1,
             lcx2,
@@ -823,8 +826,11 @@ fn run(tcx: TyCtxt) {
     }
 
     eprintln!("\nfinal labeling for fields:");
-    for (did, field_lty) in gacx.field_ltys.iter() {
-        let name = tcx.item_name(*did);
+    let mut field_dids = gacx.field_ltys.keys().cloned().collect::<Vec<_>>();
+    field_dids.sort();
+    for did in field_dids {
+        let field_lty = gacx.field_ltys[&did];
+        let name = tcx.item_name(did);
         let pid = field_lty.label;
         if pid != PointerId::NONE {
             let ty_perms = gasn.perms[pid];

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -456,6 +456,9 @@ fn label_rvalue_tys<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>) {
     }
 }
 
+/// Set flags in `acx.ptr_info` based on analysis of the `mir`.  This is used for `PointerInfo`
+/// flags that represent non-local properties or other properties that can't be set easily when the
+/// `PointerId` is first allocated.
 fn update_pointer_info<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>) {
     let mut write_count = HashMap::with_capacity(mir.local_decls.len());
     let mut rhs_is_ref = HashSet::new();

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -138,6 +138,12 @@ impl<T> PointerTableInner<T> {
     pub fn into_raw(self) -> Vec<T> {
         self.0
     }
+
+    pub fn push(&mut self, x: T) -> u32 {
+        let i = self.0.len();
+        self.0.push(x);
+        u32::try_from(i).unwrap()
+    }
 }
 
 impl<T> Index<u32> for PointerTableInner<T> {
@@ -183,6 +189,11 @@ impl<T> LocalPointerTable<T> {
         T: Clone,
     {
         self.0 .0.fill(x);
+    }
+
+    pub fn push(&mut self, x: T) -> PointerId {
+        let raw = self.0.push(x);
+        PointerId::local(raw)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (PointerId, &T)> {
@@ -240,6 +251,11 @@ impl<T> GlobalPointerTable<T> {
 
     pub fn len(&self) -> usize {
         self.0 .0.len()
+    }
+
+    pub fn push(&mut self, x: T) -> PointerId {
+        let raw = self.0.push(x);
+        PointerId::global(raw)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (PointerId, &T)> {

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -49,6 +49,7 @@ define_tests! {
     extern_fn1,
     fields,
     field_temp,
+    fixed,
     insertion_sort,
     insertion_sort_driver,
     insertion_sort_rewrites,

--- a/c2rust-analyze/tests/filecheck/fixed.rs
+++ b/c2rust-analyze/tests/filecheck/fixed.rs
@@ -1,0 +1,33 @@
+use std::ptr;
+
+// CHECK-LABEL: final labeling for "func"
+// Ref-typed function arguments and results should be marked `FIXED`.
+// CHECK: ([[@LINE+2]]: &'a u8): {{.*}}, type flags = FIXED#&u8[{{.*}}]
+// CHECK: ([[@LINE+1]]: x): {{.*}}, type flags = FIXED#&&u8[FIXED#&u8[{{.*}}]]
+unsafe fn func<'a>(x: &'a &'a u8) -> &'a u8 {
+    // Locals declared as ref type should be marked `FIXED`
+    // CHECK: ([[@LINE+1]]: y): {{.*}}, type flags = FIXED#&u8[{{.*}}]
+    let y: &u8 = *x;
+
+    // Locals inferred as ref type should be marked `FIXED`
+    // CHECK: ([[@LINE+1]]: y): {{.*}}, type flags = FIXED#&u8[{{.*}}]
+    let y = *x;
+
+    // Locals inferred as non-refs should not marked `FIXED`, and neither should temporary refs.
+    // CHECK: ([[@LINE+2]]: y): {{.*}}, type flags = (empty)#*const u8[{{.*}}]
+    // CHECK: ([[@LINE+1]]: &**x): {{.*}}, type flags = (empty)#&u8[{{.*}}]
+    let y = &**x as *const u8;
+
+    // CHECK: ([[@LINE+1]]: &*y): {{.*}}, type flags = (empty)#&u8[{{.*}}]
+    &*y
+}
+
+// CHECK-LABEL: final labeling for static items
+
+// Refs in statics should be marked `FIXED`.
+// CHECK: "REF_STATIC": {{.*}}, type flags = FIXED#&'static u8[{{.*}}]
+static REF_STATIC: &'static u8 = &1;
+
+// CHECK: "NON_REF_STATIC": {{.*}}, type flags = (empty)#*mut u8[{{.*}}]
+static mut NON_REF_STATIC: *mut u8 = ptr::null_mut();
+


### PR DESCRIPTION
Adds a new flag, `FIXED`, which indicates that the pointer type must not be changed during rewriting.  This branch only adds the flag and sets it on some `PointerId`s where it's appropriate; nothing consumes this new flag (yet).

For now, we set the `FIXED` flag on all `TyKind::Ref`s in the input program.  This will eventually allow us to avoid rewriting code that's already safe.  However, we don't set the `FIXED` flag for MIR temporaries introduced to hold the results of `&x` or `&mut x` expressions.  This is because c2rust-transpile still uses `&mut x as *mut T` instead of `addr_of_mut!(x)` for the C address-of operator, and we sometimes need to rewrite these expressions in a way that changes their types.  This also applies to cases like `array.as_mut_ptr()`, which implicitly works like `(&mut array).as_mut_ptr()`.

Based on #919 for now; once this is approved, I'll rebase onto `master`.