### PR TITLE
analyze: minor fixes

### DIFF
--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -323,6 +323,7 @@ impl<'a, T> PointerTable<'a, T> {
 impl<'a, T> Index<PointerId> for PointerTable<'a, T> {
     type Output = T;
     fn index(&self, id: PointerId) -> &T {
+        debug_assert!(!id.is_none());
         if id.is_global() {
             &self.global[id]
         } else {
@@ -372,6 +373,7 @@ impl<'a, T> PointerTableMut<'a, T> {
 impl<'a, T> Index<PointerId> for PointerTableMut<'a, T> {
     type Output = T;
     fn index(&self, id: PointerId) -> &T {
+        debug_assert!(!id.is_none());
         if id.is_global() {
             &self.global[id]
         } else {
@@ -382,6 +384,7 @@ impl<'a, T> Index<PointerId> for PointerTableMut<'a, T> {
 
 impl<'a, T> IndexMut<PointerId> for PointerTableMut<'a, T> {
     fn index_mut(&mut self, id: PointerId) -> &mut T {
+        debug_assert!(!id.is_none());
         if id.is_global() {
             &mut self.global[id]
         } else {
@@ -438,6 +441,7 @@ impl<T> OwnedPointerTable<T> {
 impl<T> Index<PointerId> for OwnedPointerTable<T> {
     type Output = T;
     fn index(&self, id: PointerId) -> &T {
+        debug_assert!(!id.is_none());
         if id.is_global() {
             &self.global[id]
         } else {
@@ -448,6 +452,7 @@ impl<T> Index<PointerId> for OwnedPointerTable<T> {
 
 impl<T> IndexMut<PointerId> for OwnedPointerTable<T> {
     fn index_mut(&mut self, id: PointerId) -> &mut T {
+        debug_assert!(!id.is_none());
         if id.is_global() {
             &mut self.global[id]
         } else {

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -7,7 +7,9 @@ use rustc_middle::mir::{
     BasicBlock, BasicBlockData, Constant, Field, Local, Location, Mutability, Operand, Place,
     PlaceElem, PlaceRef, ProjectionElem, Rvalue, Statement, StatementKind,
 };
-use rustc_middle::ty::{self, AdtDef, DefIdTree, SubstsRef, Ty, TyCtxt, TyKind, UintTy};
+use rustc_middle::ty::{
+    self, AdtDef, DefIdTree, EarlyBinder, Subst, SubstsRef, Ty, TyCtxt, TyKind, UintTy,
+};
 use std::fmt::Debug;
 
 #[derive(Debug)]
@@ -168,7 +170,7 @@ pub fn ty_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Callee<'tcx> {
         ty::FnDef(did, substs) => {
             if is_trivial() {
                 Callee::Trivial
-            } else if let Some(callee) = builtin_callee(tcx, did) {
+            } else if let Some(callee) = builtin_callee(tcx, did, substs) {
                 callee
             } else if !did.is_local() || tcx.def_kind(tcx.parent(did)) == DefKind::ForeignMod {
                 Callee::UnknownDef { ty }
@@ -190,7 +192,7 @@ pub fn ty_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Callee<'tcx> {
     }
 }
 
-fn builtin_callee(tcx: TyCtxt, did: DefId) -> Option<Callee> {
+fn builtin_callee<'tcx>(tcx: TyCtxt<'tcx>, did: DefId, substs: SubstsRef<'tcx>) -> Option<Callee> {
     let name = tcx.item_name(did);
 
     match name.as_str() {
@@ -203,7 +205,7 @@ fn builtin_callee(tcx: TyCtxt, did: DefId) -> Option<Callee> {
             if tcx.impl_trait_ref(parent_did).is_some() {
                 return None;
             }
-            let parent_impl_ty = tcx.type_of(parent_did);
+            let parent_impl_ty = EarlyBinder(tcx.type_of(parent_did)).subst(tcx, substs);
             let (pointee_ty, mutbl) = match parent_impl_ty.kind() {
                 TyKind::RawPtr(tm) => (tm.ty, tm.mutbl),
                 _ => return None,
@@ -220,7 +222,7 @@ fn builtin_callee(tcx: TyCtxt, did: DefId) -> Option<Callee> {
             if tcx.impl_trait_ref(parent_did).is_some() {
                 return None;
             }
-            let parent_impl_ty = tcx.type_of(parent_did);
+            let parent_impl_ty = EarlyBinder(tcx.type_of(parent_did)).subst(tcx, substs);
             let elem_ty = match *parent_impl_ty.kind() {
                 TyKind::Array(ty, _) => ty,
                 TyKind::Slice(ty) => ty,
@@ -276,7 +278,7 @@ fn builtin_callee(tcx: TyCtxt, did: DefId) -> Option<Callee> {
             if tcx.impl_trait_ref(parent_did).is_some() {
                 return None;
             }
-            let parent_impl_ty = tcx.type_of(parent_did);
+            let parent_impl_ty = EarlyBinder(tcx.type_of(parent_did)).subst(tcx, substs);
             let (_pointee_ty, _mutbl) = match parent_impl_ty.kind() {
                 TyKind::RawPtr(tm) => (tm.ty, tm.mutbl),
                 _ => return None,


### PR DESCRIPTION
Identical to #918, but I forgot to change the target branch before hitting merge on that one.

---

A couple small fixes split out from the `FIXED` work

* 85bd2ac11982dcd4892331f59bd7c1dc20dfa8e4: Makes `pointer_table[PointerId::NONE]` panic with a clearer message (it already panics, but the message is rather opaque).
* e02e0b8ade0a98519cd1fcd78306860b8cb40c4f: The `pointee_ty` field of `Callee::PtrOffset` currently is always set to the `T` from `impl<T> *mut T { ... }`; this commit fixes it to be the actual pointee type at the use site.  For example, on `(x: *mut i32).offset(...)`, `pointee_ty` will now be `i32`.