### PR TITLE
analyze: preserve refs

### DIFF
--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -194,10 +194,8 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                             {
                                 let local_lty = self.acx.local_tys[rv_place.local];
                                 let local_ptr = local_lty.label;
-                                let perms = self.perms[local_ptr];
                                 let flags = self.flags[local_ptr];
-                                let desc = type_desc::perms_to_desc(local_lty.ty, perms, flags);
-                                if desc.own == Ownership::Cell {
+                                if flags.contains(FlagSet::CELL) {
                                     // this is an assignment like `let x = *y` but `y` has CELL permissions
                                     self.enter_assign_rvalue(|v| {
                                         v.enter_rvalue_operand(0, |v| v.emit(RewriteKind::CellGet))

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -464,14 +464,27 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             return;
         }
 
+        let orig_from = from;
+        let mut from = orig_from;
+
+        if (from.qty, to.qty) == (Quantity::OffsetPtr, Quantity::Slice) {
+            // TODO: emit rewrite
+            from.qty = to.qty;
+        }
+
         if from.qty == to.qty && (from.own, to.own) == (Ownership::Mut, Ownership::Imm) {
             self.emit(RewriteKind::MutToImm);
-            return;
+            from.own = to.own;
         }
 
         // TODO: handle Slice -> Single here instead of special-casing in `offset`
 
-        eprintln!("unsupported cast kind: {:?} -> {:?}", from, to);
+        if from != to {
+            eprintln!(
+                "unsupported cast kind: {:?} -> {:?} (original input: {:?})",
+                from, to, orig_from
+            );
+        }
     }
 
     fn emit_cast_lty_desc(&mut self, from_lty: LTy<'tcx>, to: TypeDesc<'tcx>) {

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -409,6 +409,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 Quantity::Single => Quantity::Slice,
                 Quantity::Slice => Quantity::Slice,
                 Quantity::OffsetPtr => Quantity::OffsetPtr,
+                Quantity::Array => unreachable!("perms_to_desc should not return Quantity::Array"),
             },
             pointee_ty: result_desc.pointee_ty,
         };

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -17,7 +17,7 @@ use rustc_middle::mir::{
     BasicBlock, Body, Location, Operand, Place, Rvalue, Statement, StatementKind, Terminator,
     TerminatorKind,
 };
-use rustc_middle::ty::TyKind;
+use rustc_middle::ty::{Ty, TyKind};
 use std::collections::HashMap;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -256,8 +256,8 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                         self.visit_ptr_offset(&args[0], pl_ty);
                         return;
                     }
-                    Callee::SliceAsPtr { .. } => {
-                        self.visit_slice_as_ptr(&args[0], pl_ty);
+                    Callee::SliceAsPtr { elem_ty, .. } => {
+                        self.visit_slice_as_ptr(elem_ty, &args[0], pl_ty);
                         return;
                     }
                     _ => {}
@@ -425,23 +425,31 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         }
     }
 
-    fn visit_slice_as_ptr(&mut self, op: &Operand<'tcx>, result_lty: LTy<'tcx>) {
+    fn visit_slice_as_ptr(&mut self, elem_ty: Ty<'tcx>, op: &Operand<'tcx>, result_lty: LTy<'tcx>) {
         let op_lty = self.acx.type_of(op);
         let op_ptr = op_lty.label;
         let result_ptr = result_lty.label;
 
-        let op_desc = type_desc::perms_to_desc(op_lty.ty, self.perms[op_ptr], self.flags[op_ptr]);
-        let result_desc = type_desc::perms_to_desc(
+        let op_desc = type_desc::perms_to_desc_with_pointee(
+            self.acx.tcx(),
+            elem_ty,
+            op_lty.ty,
+            self.perms[op_ptr],
+            self.flags[op_ptr],
+        );
+
+        let result_desc = type_desc::perms_to_desc_with_pointee(
+            self.acx.tcx(),
+            elem_ty,
             result_lty.ty,
             self.perms[result_ptr],
             self.flags[result_ptr],
         );
 
-        if op_desc.own == result_desc.own && op_desc.qty == result_desc.qty {
-            // Input and output types will be the same after rewriting, so the `as_ptr` call is not
-            // needed.
-            self.emit(RewriteKind::RemoveAsPtr);
-        }
+        // Generate a cast of our own, replacing the `as_ptr` call.
+        // TODO: leave the `as_ptr` in place if we can't produce a working cast
+        self.emit(RewriteKind::RemoveAsPtr);
+        self.emit_cast_desc_desc(op_desc, result_desc);
     }
 
     fn emit(&mut self, rw: RewriteKind) {

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -496,7 +496,9 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     }
 
     fn emit_cast_lty_desc(&mut self, from_lty: LTy<'tcx>, to: TypeDesc<'tcx>) {
-        let from = type_desc::perms_to_desc(
+        let from = type_desc::perms_to_desc_with_pointee(
+            self.acx.tcx(),
+            to.pointee_ty,
             from_lty.ty,
             self.perms[from_lty.label],
             self.flags[from_lty.label],
@@ -506,7 +508,9 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
 
     #[allow(dead_code)]
     fn emit_cast_desc_lty(&mut self, from: TypeDesc<'tcx>, to_lty: LTy<'tcx>) {
-        let to = type_desc::perms_to_desc(
+        let to = type_desc::perms_to_desc_with_pointee(
+            self.acx.tcx(),
+            from.pointee_ty,
             to_lty.ty,
             self.perms[to_lty.label],
             self.flags[to_lty.label],
@@ -516,6 +520,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
 
     fn emit_cast_lty_lty(&mut self, from_lty: LTy<'tcx>, to_lty: LTy<'tcx>) {
         if from_lty.label.is_none() && to_lty.label.is_none() {
+            // Input and output are both non-pointers.
             return;
         }
 
@@ -526,13 +531,34 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             return;
         }
 
+        let from_fixed = self.flags[from_lty.label].contains(FlagSet::FIXED);
+        let to_fixed = self.flags[to_lty.label].contains(FlagSet::FIXED);
+
         let lty_to_desc = |slf: &mut Self, lty: LTy<'tcx>| {
             type_desc::perms_to_desc(lty.ty, slf.perms[lty.label], slf.flags[lty.label])
         };
 
-        let from = lty_to_desc(self, from_lty);
-        let to = lty_to_desc(self, to_lty);
-        self.emit_cast_desc_desc(from, to);
+        match (from_fixed, to_fixed) {
+            (false, false) => {
+                let from = lty_to_desc(self, from_lty);
+                let to = lty_to_desc(self, to_lty);
+                self.emit_cast_desc_desc(from, to);
+            }
+
+            (false, true) => {
+                let from = lty_to_desc(self, from_lty);
+                self.emit_cast_desc_lty(from, to_lty);
+            }
+
+            (true, false) => {
+                let to = lty_to_desc(self, to_lty);
+                self.emit_cast_lty_desc(from_lty, to);
+            }
+
+            (true, true) => {
+                // No-op.  Both sides are `FIXED`, so we assume the existing code is already valid.
+            }
+        }
     }
 }
 

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -329,6 +329,7 @@ fn mk_rewritten_ty<'tcx>(
             Quantity::Slice => tcx.mk_slice(ty),
             // TODO: This should generate `OffsetPtr<T>` rather than `&[T]`, but `OffsetPtr` is NYI
             Quantity::OffsetPtr => tcx.mk_slice(ty),
+            Quantity::Array => panic!("can't mk_rewritten_ty with Quantity::Array"),
         };
 
         ty = match own {
@@ -413,6 +414,7 @@ impl<'a, 'tcx> HirTyVisitor<'a, 'tcx> {
                 // TODO: This should generate `OffsetPtr<T>` rather than `&[T]`, but `OffsetPtr` is
                 // NYI
                 Quantity::OffsetPtr => Rewrite::TySlice(Box::new(rw)),
+                Quantity::Array => panic!("can't rewrite to Quantity::Array"),
             };
 
             let lifetime_type = match rw_lty.label.lifetime {

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -85,11 +85,15 @@ fn create_rewrite_label<'tcx>(
     } else {
         let perms = perms[pointer_lty.label];
         let flags = flags[pointer_lty.label];
-        // TODO: if the `Ownership` and `Quantity` exactly match `lty.ty`, then `ty_desc` can
-        // be `None` (no rewriting required).  This might let us avoid inlining a type alias
-        // for some pointers where no actual improvement was possible.
-        let desc = type_desc::perms_to_desc(pointer_lty.ty, perms, flags);
-        Some((desc.own, desc.qty))
+        if flags.contains(FlagSet::FIXED) {
+            None
+        } else {
+            // TODO: if the `Ownership` and `Quantity` exactly match `lty.ty`, then `ty_desc`
+            // can be `None` (no rewriting required).  This might let us avoid inlining a type
+            // alias for some pointers where no actual improvement was possible.
+            let desc = type_desc::perms_to_desc(pointer_lty.ty, perms, flags);
+            Some((desc.own, desc.qty))
+        }
     };
 
     RewriteLabel {

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -1,6 +1,6 @@
 use crate::context::{FlagSet, PermissionSet};
 use rustc_middle::mir::Mutability;
-use rustc_middle::ty::{AdtDef, Ty, TyCtxt, TyKind, TypeAndMut};
+use rustc_middle::ty::{AdtDef, Ty, TyCtxt, TyKind};
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
@@ -250,28 +250,20 @@ pub fn unpack_pointer_type<'tcx>(
     (own, qty)
 }
 
-/// If `ty` is `Cell<T>`, returns `Some(T)`.  Otherwise, returns `None`.
-fn unpack_cell<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
-    match *ty.kind() {
-        TyKind::Adt(adt_def, substs) if is_cell(tcx, adt_def) => Some(substs.type_at(0)),
-        _ => None,
-    }
-}
-
 /// Returns `true` if `adt_def` is the type `std::cell::Cell`.
-fn is_cell<'tcx>(tcx: TyCtxt<'tcx>, adt_def: AdtDef<'tcx>) -> bool {
+fn is_cell<'tcx>(_tcx: TyCtxt<'tcx>, _adt_def: AdtDef<'tcx>) -> bool {
     // TODO
     false
 }
 
 /// Returns `true` if `adt_def` is the type `std::rc::Rc`.
-fn is_rc<'tcx>(tcx: TyCtxt<'tcx>, adt_def: AdtDef<'tcx>) -> bool {
+fn is_rc<'tcx>(_tcx: TyCtxt<'tcx>, _adt_def: AdtDef<'tcx>) -> bool {
     // TODO
     false
 }
 
 /// Returns `true` if `adt_def` is the type `OffsetPtr` from the C2Rust support library.
-fn is_offset_ptr<'tcx>(tcx: TyCtxt<'tcx>, adt_def: AdtDef<'tcx>) -> bool {
+fn is_offset_ptr<'tcx>(_tcx: TyCtxt<'tcx>, _adt_def: AdtDef<'tcx>) -> bool {
     // TODO
     false
 }

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -71,6 +71,12 @@ pub fn perms_to_desc<'tcx>(
     perms: PermissionSet,
     flags: FlagSet,
 ) -> TypeDesc<'tcx> {
+    // The FIXED case should be handled by calling `perm_to_desc_with_pointee` instead.
+    assert!(
+        !flags.contains(FlagSet::FIXED),
+        "building TypeDesc for FIXED pointer requires a related pointee type"
+    );
+
     let (own, qty) = perms_to_own_and_qty(perms, flags);
 
     let pointee_ty = match *ptr_ty.kind() {

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -129,7 +129,9 @@ pub fn perms_to_desc_with_pointee<'tcx>(
     }
 }
 
-/// Unpack an existing `Ty` into its ownership, quantity, and pointee type.
+/// Unpack an existing `Ty` into its ownership and quantity.  The pointee type must already be
+/// known.  Panics if there are no `Ownership` and `Quantity` that combine with `pointee_ty` to
+/// produce `ty`.
 pub fn unpack_pointer_type<'tcx>(
     tcx: TyCtxt<'tcx>,
     ty: Ty<'tcx>,

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -1,5 +1,6 @@
 use crate::context::{FlagSet, PermissionSet};
-use rustc_middle::ty::{Ty, TyKind};
+use rustc_middle::mir::Mutability;
+use rustc_middle::ty::{AdtDef, Ty, TyCtxt, TyKind, TypeAndMut};
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
@@ -101,4 +102,170 @@ pub fn local_perms_to_desc<'tcx>(
         qty,
         pointee_ty,
     }
+}
+
+pub fn perms_to_desc_with_pointee<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    pointee_ty: Ty<'tcx>,
+    ptr_ty: Ty<'tcx>,
+    perms: PermissionSet,
+    flags: FlagSet,
+) -> TypeDesc<'tcx> {
+    let (own, qty) = if flags.contains(FlagSet::FIXED) {
+        unpack_pointer_type(tcx, ptr_ty, pointee_ty)
+    } else {
+        perms_to_own_and_qty(perms, flags)
+    };
+    TypeDesc {
+        own,
+        qty,
+        pointee_ty,
+    }
+}
+
+/// Unpack an existing `Ty` into its ownership, quantity, and pointee type.
+pub fn unpack_pointer_type<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ty: Ty<'tcx>,
+    pointee_ty: Ty<'tcx>,
+) -> (Ownership, Quantity) {
+    #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+    enum Step {
+        Ref(Mutability),
+        RawPtr(Mutability),
+        Cell,
+        Box,
+        Rc,
+        Slice,
+        OffsetPtr,
+        Array,
+    }
+
+    let mut steps = Vec::new();
+    let mut cur_ty = ty;
+    while cur_ty != pointee_ty {
+        match *cur_ty.kind() {
+            TyKind::Ref(_, inner_ty, mutbl) => {
+                steps.push(Step::Ref(mutbl));
+                cur_ty = inner_ty;
+            }
+            TyKind::RawPtr(tm) => {
+                steps.push(Step::RawPtr(tm.mutbl));
+                cur_ty = tm.ty;
+            }
+            TyKind::Adt(adt_def, substs) if adt_def.is_box() => {
+                steps.push(Step::Box);
+                cur_ty = substs.type_at(0);
+            }
+            TyKind::Adt(adt_def, substs) if is_rc(tcx, adt_def) => {
+                steps.push(Step::Rc);
+                cur_ty = substs.type_at(0);
+            }
+            TyKind::Adt(adt_def, substs) if is_cell(tcx, adt_def) => {
+                steps.push(Step::Cell);
+                cur_ty = substs.type_at(0);
+            }
+            TyKind::Adt(adt_def, substs) if is_offset_ptr(tcx, adt_def) => {
+                steps.push(Step::OffsetPtr);
+                cur_ty = substs.type_at(0);
+            }
+
+            TyKind::Slice(inner_ty) => {
+                steps.push(Step::Slice);
+                cur_ty = inner_ty;
+            }
+            TyKind::Array(inner_ty, _) => {
+                steps.push(Step::Array);
+                cur_ty = inner_ty;
+            }
+
+            _ => panic!(
+                "failed to deconstruct {:?} as a pointer to {:?}: unexpected {:?}",
+                ty,
+                pointee_ty,
+                cur_ty.kind()
+            ),
+        }
+    }
+
+    let mut i = 0;
+    let next = |i: &mut usize| -> Option<&Step> {
+        let s = steps.get(*i);
+        *i += 1;
+        s
+    };
+
+    let own = match next(&mut i) {
+        Some(&Step::Ref(Mutability::Not)) => {
+            if let Some(&Step::Cell) = steps.get(i) {
+                i += 1;
+                Ownership::Cell
+            } else {
+                Ownership::Imm
+            }
+        }
+        Some(&Step::Ref(Mutability::Mut)) => Ownership::Mut,
+        Some(&Step::RawPtr(Mutability::Not)) => Ownership::Raw,
+        Some(&Step::RawPtr(Mutability::Mut)) => Ownership::RawMut,
+        Some(&Step::Box) => Ownership::Box,
+        Some(&Step::Rc) => Ownership::Rc,
+        _ => {
+            // Un-consume this step.
+            i -= 1;
+            panic!(
+                "failed to deconstruct {:?} as a pointer to {:?}: \
+                    steps {:?} don't start with a pointer",
+                ty,
+                pointee_ty,
+                &steps[i - 1..]
+            );
+        }
+    };
+
+    let qty = match next(&mut i) {
+        Some(&Step::Slice) => Quantity::Slice,
+        Some(&Step::OffsetPtr) => Quantity::OffsetPtr,
+        Some(&Step::Array) => Quantity::Array,
+        _ => {
+            // Un-consume this step.
+            i -= 1;
+            Quantity::Single
+        }
+    };
+
+    assert!(
+        i == steps.len(),
+        "failed to deconstruct {:?} as a pointer to {:?}: got extra steps {:?}",
+        ty,
+        pointee_ty,
+        &steps[i..],
+    );
+
+    (own, qty)
+}
+
+/// If `ty` is `Cell<T>`, returns `Some(T)`.  Otherwise, returns `None`.
+fn unpack_cell<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
+    match *ty.kind() {
+        TyKind::Adt(adt_def, substs) if is_cell(tcx, adt_def) => Some(substs.type_at(0)),
+        _ => None,
+    }
+}
+
+/// Returns `true` if `adt_def` is the type `std::cell::Cell`.
+fn is_cell<'tcx>(tcx: TyCtxt<'tcx>, adt_def: AdtDef<'tcx>) -> bool {
+    // TODO
+    false
+}
+
+/// Returns `true` if `adt_def` is the type `std::rc::Rc`.
+fn is_rc<'tcx>(tcx: TyCtxt<'tcx>, adt_def: AdtDef<'tcx>) -> bool {
+    // TODO
+    false
+}
+
+/// Returns `true` if `adt_def` is the type `OffsetPtr` from the C2Rust support library.
+fn is_offset_ptr<'tcx>(tcx: TyCtxt<'tcx>, adt_def: AdtDef<'tcx>) -> bool {
+    // TODO
+    false
 }

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -28,6 +28,10 @@ pub enum Quantity {
     Slice,
     /// E.g. `OffsetPtr<T>`
     OffsetPtr,
+
+    /// E.g. `&[T; 10]`.  This is used only for existing `FIXED` pointers; `perms_to_desc` on a raw
+    /// pointer never produces `Array`.
+    Array,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]

--- a/c2rust-analyze/tests/filecheck/as_ptr.rs
+++ b/c2rust-analyze/tests/filecheck/as_ptr.rs
@@ -9,8 +9,7 @@ pub unsafe fn slice_as_ptr_load(x: &[i32]) -> i32 {
 
 // CHECK-LABEL: final labeling for "slice_as_ptr_offset_load"
 // CHECK-LABEL: type assignment for "slice_as_ptr_offset_load"
-// FIXME: currently misinferred as &[[i32]]
-// CHECK-DAG: ([[@LINE+1]]: x): &{{\[\[i32]]}}
+// CHECK-DAG: ([[@LINE+1]]: x): &{{\[i32]}}
 pub unsafe fn slice_as_ptr_offset_load(x: &[i32]) -> i32 {
     // CHECK-DAG: ([[@LINE+1]]: p): &[i32]
     let p = x.as_ptr();
@@ -30,7 +29,7 @@ pub unsafe fn array_as_ptr_load(x: &[i32; 10]) -> i32 {
 
 // CHECK-LABEL: final labeling for "array_as_ptr_offset_load"
 // CHECK-LABEL: type assignment for "array_as_ptr_offset_load"
-// CHECK-DAG: ([[@LINE+1]]: x): &{{\[\[i32; 10]]}}
+// CHECK-DAG: ([[@LINE+1]]: x): &{{\[i32; 10]}}
 pub unsafe fn array_as_ptr_offset_load(x: &[i32; 10]) -> i32 {
     // CHECK-DAG: ([[@LINE+1]]: p): &[i32]
     let p = x.as_ptr();

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -52,10 +52,8 @@ struct VecTup<'a> {
 // CHECK-DAG: assign Label { origin: Some(Origin([[P_REF_A_ORIGIN]]))
 
 // CHECK-LABEL: final labeling for "_field_access"
-// CHECK-DAG: ([[@LINE+5]]: ppd): addr_of = UNIQUE, type = READ | WRITE | UNIQUE
-// FIXME: `ra: &A` is known to be incorrect - it should be `ra: &mut A`.  However, we don't
-// properly prevent rewriting of already-safe reference types at the moment.
-// CHECK-DAG: ([[@LINE+2]]: ra): &A
+// CHECK-DAG: ([[@LINE+3]]: ppd): addr_of = UNIQUE, type = READ | WRITE | UNIQUE
+// CHECK-DAG: ([[@LINE+2]]: ra): &mut A
 // CHECK-DAG: ([[@LINE+1]]: ppd): &mut &mut Data
 unsafe fn _field_access<'d>(ra: &'d mut A<'d>, ppd: *mut *mut Data<'d>) {
     // CHECK-DAG: ([[@LINE+2]]: rd): addr_of = UNIQUE, type = READ | UNIQUE
@@ -78,6 +76,6 @@ unsafe fn _field_access<'d>(ra: &'d mut A<'d>, ppd: *mut *mut Data<'d>) {
 // CHECK-DAG: pub a: A<'d,'h0,'h1,'h2>,
 
 // CHECK-DAG: pub struct A<'a,'h0,'h1,'h2> {
-// CHECK-DAG: pub rd: &'a (Data<'a,'h0,'h1,'h2>),
-// CHECK-DAG: pub pra: &'h2 core::cell::Cell<(&'a (A<'a,'h0,'h1,'h2>))>,
+// CHECK-DAG: pub rd: &'a Data<'a,'h0,'h1,'h2>,
+// CHECK-DAG: pub pra: &'h2 core::cell::Cell<(&'a mut A<'a,'h0,'h1,'h2>)>,
 // CHECK-DAG: bar: &'h3 (Vec<(VecTup<'a,'h3,'h4,'h0,'h1,'h2>, &'h4 (A<'a,'h0,'h1,'h2>))>),


### PR DESCRIPTION
This branch updates `mir_op` to respect the new `FIXED` flag, thereby stopping most rewriting of already-safe code.

The main effect is that when `emit_cast_*` sees a `FIXED` type on one side of the cast, it tries to obtain a `TypeDesc` by deconstructing the existing `Ty`, rather than by looking at the `perms` and `flags` the analysis came up with.  This ensure we keep the original `Ty` unchanged, even if the `perms` and `flags` would result in a different type.  For example, given a `FIXED` pointer of type `&[T]`, we would produce `(Ownership::Ref, Quantity::Slice, T)`, which accurately reflects the type `&[T]`, regardless of what the `perms` and `flags` say.

Currently this is only used to preserve existing refs, and in that case, the `perms` and `flags` should generally agree with the `FIXED` `Ty`.  But in the future we'll extend this to raw pointers (such as FFI and unanalyzed functions), where `perms` and `flags` will normally suggest some kind of safe rewrite (e.g. `*mut T` -> `&[T]`), but we don't actually want to perform that rewrite.

Depends on #920; once #920 is merged, I'll rebase this onto master