### PR TITLE
analyze: add support for some unsupported casts

### DIFF
--- a/c2rust-analyze/src/rewrite/expr/hir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/hir_op.rs
@@ -344,6 +344,10 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirRewriteVisitor<'a, 'tcx> {
                     let ty = if *to_mutbl { "*mut _" } else { "*const _" };
                     Rewrite::Cast(Box::new(hir_rw), ty.to_owned())
                 }
+                mir_op::RewriteKind::UnsafeCastRawToRef { mutbl } => {
+                    let rw_pl = Rewrite::Deref(Box::new(hir_rw));
+                    Rewrite::Ref(Box::new(rw_pl), mutbl_from_bool(*mutbl))
+                }
 
                 mir_op::RewriteKind::CellNew => {
                     // `x` to `Cell::new(x)`

--- a/c2rust-analyze/src/rewrite/expr/hir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/hir_op.rs
@@ -336,6 +336,15 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirRewriteVisitor<'a, 'tcx> {
                     Rewrite::Ref(Box::new(self.get_subexpr(ex, 0)), mutbl_from_bool(*mutbl))
                 }
 
+                mir_op::RewriteKind::CastRefToRaw { mutbl } => {
+                    let rw_pl = Rewrite::Deref(Box::new(hir_rw));
+                    Rewrite::AddrOf(Box::new(rw_pl), mutbl_from_bool(*mutbl))
+                }
+                mir_op::RewriteKind::CastRawToRaw { to_mutbl } => {
+                    let ty = if *to_mutbl { "*mut _" } else { "*const _" };
+                    Rewrite::Cast(Box::new(hir_rw), ty.to_owned())
+                }
+
                 mir_op::RewriteKind::CellNew => {
                     // `x` to `Cell::new(x)`
                     Rewrite::Call("std::cell::Cell::new".to_string(), vec![Rewrite::Identity])

--- a/c2rust-analyze/src/rewrite/expr/hir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/hir_op.rs
@@ -357,6 +357,14 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirRewriteVisitor<'a, 'tcx> {
                     let rhs = self.get_subexpr(ex, 1);
                     Rewrite::MethodCall("set".to_string(), Box::new(lhs), vec![rhs])
                 }
+
+                mir_op::RewriteKind::CellFromMut => {
+                    // `x` to `Cell::from_mut(x)`
+                    Rewrite::Call(
+                        "std::cell::Cell::from_mut".to_string(),
+                        vec![Rewrite::Identity],
+                    )
+                }
             }
         };
 

--- a/c2rust-analyze/src/rewrite/expr/hir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/hir_op.rs
@@ -341,8 +341,8 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirRewriteVisitor<'a, 'tcx> {
                     Rewrite::AddrOf(Box::new(rw_pl), mutbl_from_bool(*mutbl))
                 }
                 mir_op::RewriteKind::CastRawToRaw { to_mutbl } => {
-                    let ty = if *to_mutbl { "*mut _" } else { "*const _" };
-                    Rewrite::Cast(Box::new(hir_rw), ty.to_owned())
+                    let method = if *to_mutbl { "cast_mut" } else { "cast_const" };
+                    Rewrite::MethodCall(method.to_string(), Box::new(hir_rw), vec![])
                 }
                 mir_op::RewriteKind::UnsafeCastRawToRef { mutbl } => {
                     let rw_pl = Rewrite::Deref(Box::new(hir_rw));

--- a/c2rust-analyze/src/rewrite/expr/hir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/hir_op.rs
@@ -337,6 +337,8 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirRewriteVisitor<'a, 'tcx> {
                 }
 
                 mir_op::RewriteKind::CastRefToRaw { mutbl } => {
+                    // `addr_of!(*p)` is cleaner than `p as *const _`; we don't know the pointee
+                    // type here, so we can't emit `p as *const T`.
                     let rw_pl = Rewrite::Deref(Box::new(hir_rw));
                     Rewrite::AddrOf(Box::new(rw_pl), mutbl_from_bool(*mutbl))
                 }

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -494,6 +494,19 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             return;
         }
 
+        if from.own == Ownership::Imm && matches!(to.own, Ownership::Raw | Ownership::RawMut) {
+            self.emit(RewriteKind::CastRefToRaw { mutbl: false });
+            from.own = Ownership::Raw;
+        }
+        if from.own == Ownership::Mut && to.own == Ownership::RawMut {
+            self.emit(RewriteKind::CastRefToRaw { mutbl: true });
+            from.own = Ownership::RawMut;
+        }
+        if from.own == Ownership::Raw && to.own == Ownership::RawMut {
+            self.emit(RewriteKind::CastRawToRaw { to_mutbl: true });
+            from.own = Ownership::RawMut;
+        }
+
         if (from.qty, to.qty) == (Quantity::OffsetPtr, Quantity::Slice)
             || (from.qty, to.qty) == (Quantity::Slice, Quantity::OffsetPtr)
         {

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -51,6 +51,13 @@ pub enum RewriteKind {
     RemoveAsPtr,
     /// Replace &raw with & or &raw mut with &mut
     RawToRef { mutbl: bool },
+
+    /// Cast `&` to `*const` or `&mut` to `*mut`.
+    CastRefToRaw { mutbl: bool },
+    /// Cast `*const` to `*mut` or vice versa.  If `to_mutbl` is true, we are casting to `*mut`;
+    /// otherwise, we're casting to `*const`.
+    CastRawToRaw { to_mutbl: bool },
+
     /// Replace `y` in `let x = y` with `Cell::new(y)`, i.e. `let x = Cell::new(y)`
     /// TODO: ensure `y` implements `Copy`
     CellNew,

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -477,19 +477,17 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     }
 
     fn emit_cast_desc_desc(&mut self, from: TypeDesc<'tcx>, to: TypeDesc<'tcx>) {
+        let orig_from = from;
+        let mut from = orig_from;
+
+        // The `from` and `to` pointee types should only differ in their lifetimes.
         assert_eq!(
             self.acx.tcx().erase_regions(from.pointee_ty),
             self.acx.tcx().erase_regions(to.pointee_ty),
         );
-
-        let orig_from = from;
-        let mut from = orig_from;
-
-        // Ignore differences in lifetimes.  Note we asserted above that the types are equal after
-        // erasing lifetimes, so the only difference possible here is in the lifetimes.
-        if from.pointee_ty != to.pointee_ty {
-            from.pointee_ty = to.pointee_ty;
-        }
+        // There might still be differences in lifetimes, which we don't care about here.
+        // Overwriting `from.pointee_ty` allows the final `from == to` check to succeed below.
+        from.pointee_ty = to.pointee_ty;
 
         if from == to {
             return;

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -528,25 +528,13 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                     from.qty = Quantity::Slice;
                 }
                 // Bidirectional conversions between `Slice` and `OffsetPtr`.
-                (Quantity::Slice, Quantity::OffsetPtr) => {
-                    let _rw = match opt_mutbl {
-                        // Currently a no-op, since `Slice` and `OffsetPtr` are identical.
-                        Some(_mutbl) => (),
-                        None => break,
-                    };
-                    // self.emit(rw);
-                    from.qty = Quantity::OffsetPtr;
-                }
-                (Quantity::OffsetPtr, Quantity::Slice) => {
-                    let _rw = match opt_mutbl {
-                        // Currently a no-op, since `Slice` and `OffsetPtr` are identical.
-                        Some(_mutbl) => (),
-                        None => break,
-                    };
-                    // self.emit(rw);
-                    from.qty = Quantity::Slice;
+                (Quantity::Slice, Quantity::OffsetPtr) | (Quantity::OffsetPtr, Quantity::Slice) => {
+                    // Currently a no-op, since `Slice` and `OffsetPtr` are identical.
+                    from.qty = to.qty;
                 }
                 // `Slice` and `OffsetPtr` convert to `Single` the same way.
+                // TODO: when converting to `Ownership::Raw`/`RawMut`, use `slice.as_ptr()` to
+                // avoid panic on 0-length inputs
                 (_, Quantity::Single) => {
                     let rw = match opt_mutbl {
                         Some(mutbl) => RewriteKind::SliceFirst { mutbl },

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -550,7 +550,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         from.own = self.cast_ownership(from, to, false);
 
         if from != to {
-            eprintln!(
+            panic!(
                 "unsupported cast kind: {:?} -> {:?} (original input: {:?})",
                 from, to, orig_from
             );

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -53,12 +53,12 @@ pub enum RewriteKind {
     /// Replace &raw with & or &raw mut with &mut
     RawToRef { mutbl: bool },
 
-    /// Cast `&` to `*const` or `&mut` to `*mut`.
+    /// Cast `&T` to `*const T` or `&mut T` to `*mut T`.
     CastRefToRaw { mutbl: bool },
-    /// Cast `*const` to `*mut` or vice versa.  If `to_mutbl` is true, we are casting to `*mut`;
-    /// otherwise, we're casting to `*const`.
+    /// Cast `*const T` to `*mut T` or vice versa.  If `to_mutbl` is true, we are casting to
+    /// `*mut T`; otherwise, we're casting to `*const T`.
     CastRawToRaw { to_mutbl: bool },
-    /// Cast `*const` to `&` or `*mut` to `&mut`.
+    /// Cast `*const T` to `& T` or `*mut T` to `&mut T`.
     UnsafeCastRawToRef { mutbl: bool },
 
     /// Replace `y` in `let x = y` with `Cell::new(y)`, i.e. `let x = Cell::new(y)`

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -485,7 +485,9 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             return;
         }
 
-        if (from.qty, to.qty) == (Quantity::OffsetPtr, Quantity::Slice) {
+        if (from.qty, to.qty) == (Quantity::OffsetPtr, Quantity::Slice)
+            || (from.qty, to.qty) == (Quantity::Slice, Quantity::OffsetPtr)
+        {
             // TODO: emit rewrite
             from.qty = to.qty;
         }

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -498,6 +498,8 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             let mutbl = match from.own {
                 Ownership::Imm => Some(false),
                 Ownership::Mut => Some(true),
+                // Note that `Cell` + `Slice` is `&[Cell<T>]`, not `&Cell<[T]>`.
+                Ownership::Cell => Some(false),
                 _ => None,
             };
             if let Some(mutbl) = mutbl {

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -473,12 +473,18 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             self.acx.tcx().erase_regions(to.pointee_ty),
         );
 
+        let orig_from = from;
+        let mut from = orig_from;
+
+        // Ignore differences in lifetimes.  Note we asserted above that the types are equal after
+        // erasing lifetimes, so the only difference possible here is in the lifetimes.
+        if from.pointee_ty != to.pointee_ty {
+            from.pointee_ty = to.pointee_ty;
+        }
+
         if from == to {
             return;
         }
-
-        let orig_from = from;
-        let mut from = orig_from;
 
         if (from.qty, to.qty) == (Quantity::OffsetPtr, Quantity::Slice) {
             // TODO: emit rewrite

--- a/c2rust-analyze/tests/filecheck/addr_of.rs
+++ b/c2rust-analyze/tests/filecheck/addr_of.rs
@@ -27,7 +27,6 @@ fn shared_ref_with_struct() {
 
 // CHECK-LABEL: fn cast_array_to_ptr_explicit(s: &[u8; 0]) {
 pub fn cast_array_to_ptr_explicit(s: &[u8; 0]) {
-    // For now, this doesn't get rewritten - we're just checking that the analysis doesn't panic.
-    // CHECK-DAG: std::ptr::addr_of!(*s) as *const u8
+    // CHECK-DAG: &*(std::ptr::addr_of!(*s)) as *const u8
     std::ptr::addr_of!(*s) as *const u8;
 }


### PR DESCRIPTION
This adds various cases to `emit_cast_desc_desc` to eliminate all the "unsupported cast" warnings in the current tests, and also changes "unsupported cast" to a panic.  In general, "unsupported cast" normally means we're generating code that won't compile (due to type errors), so this is actually a major error for the rewriter.

Currently based on #923; I will rebase onto `master` once that's been merged.