### PR TITLE
(`c2rust-analyze`) Fix bleeding of `RUST_LOG` into `RUST_LOG_PANIC`'s logger

### DIFF
--- a/c2rust-analyze/src/log.rs
+++ b/c2rust-analyze/src/log.rs
@@ -33,8 +33,8 @@ pub fn init_logger() {
     let log_env = Env::default().default_filter_or(LevelFilter::Debug.as_str());
     let panic_env = Env::default().filter_or("RUST_LOG_PANIC", LevelFilter::Error.as_str());
 
-    let log_logger = env_logger::builder().parse_env(log_env).build();
-    let panic_logger = env_logger::builder().parse_env(panic_env).build();
+    let log_logger = env_logger::Builder::from_env(log_env).build();
+    let panic_logger = env_logger::Builder::from_env(panic_env).build();
 
     // Create the actual [`Logger`] to log everything ([`LevelFilter::max()]`),
     // and then we can do the specific matching for `log_logger` and `panic_logger` inside the formatter,

--- a/c2rust-analyze/src/log.rs
+++ b/c2rust-analyze/src/log.rs
@@ -53,3 +53,10 @@ pub fn init_logger() {
         })
         .init();
 }
+
+#[test]
+fn rust_log_doesnt_affect_panicking() {
+    std::env::set_var("RUST_LOG", "c2rust_analyze::log=trace");
+    init_logger();
+    ::log::trace!("test");
+}


### PR DESCRIPTION
Fixes #931.

Use `env_logger::Builder::from_env` instead of `env_logger::builder().parse_env`, as the latter first reads from the default env (`RUST_LOG`) and thus reads `RUST_LOG` for `RUST_LOG_PANIC`.