### PR TITLE
(`c2rust-analyze/tests`) Use absolute paths for locating test files so it works from all CWDs

### DIFF
--- a/c2rust-analyze/tests/analyze.rs
+++ b/c2rust-analyze/tests/analyze.rs
@@ -1,8 +1,6 @@
 pub mod common;
 
-use std::path::PathBuf;
-
-use crate::common::{check_for_missing_tests_for, Analyze};
+use crate::common::{check_for_missing_tests_for, test_dir_for, Analyze};
 
 #[test]
 fn check_for_missing_tests() {
@@ -11,7 +9,7 @@ fn check_for_missing_tests() {
 
 fn test(file_name: &str) {
     let analyze = Analyze::resolve();
-    let path = ["tests", "analyze", file_name].iter().collect::<PathBuf>();
+    let path = test_dir_for(file!(), true).join(file_name);
     analyze.run(&path);
 }
 

--- a/c2rust-analyze/tests/common/mod.rs
+++ b/c2rust-analyze/tests/common/mod.rs
@@ -203,11 +203,20 @@ fn get_absolute_main_test_path(main_test_path: &Path) -> PathBuf {
         .join(main_test_path.file_name().unwrap())
 }
 
-fn test_dir_for(main_test_path: &Path) -> PathBuf {
-    main_test_path
-        .parent()
-        .unwrap()
-        .join(main_test_path.file_stem().unwrap())
+pub fn test_dir_for(main_test_path: impl AsRef<Path>, absolute: bool) -> PathBuf {
+    fn inner(main_test_path: &Path) -> PathBuf {
+        main_test_path
+            .parent()
+            .unwrap()
+            .join(main_test_path.file_stem().unwrap())
+    }
+
+    let main_test_path = main_test_path.as_ref();
+    if absolute {
+        inner(&get_absolute_main_test_path(main_test_path))
+    } else {
+        inner(main_test_path)
+    }
 }
 
 fn list_all_test_filestems_in(dir: &Path) -> impl Iterator<Item = String> {
@@ -220,8 +229,8 @@ fn list_all_test_filestems_in(dir: &Path) -> impl Iterator<Item = String> {
 
 pub fn check_for_missing_tests_for(main_test_path: impl AsRef<Path>) {
     let main_test_path = main_test_path.as_ref();
-    let abs_test_dir = test_dir_for(&get_absolute_main_test_path(main_test_path));
-    let rel_test_dir = test_dir_for(main_test_path);
+    let abs_test_dir = test_dir_for(main_test_path, true);
+    let rel_test_dir = test_dir_for(main_test_path, false);
     let test_names = list_all_tests::<HashSet<_>>();
     let missing_tests = list_all_test_filestems_in(&abs_test_dir)
         .filter(|test_name| !test_names.contains(test_name))

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -1,8 +1,6 @@
 pub mod common;
 
-use std::path::PathBuf;
-
-use crate::common::{check_for_missing_tests_for, Analyze, FileCheck};
+use crate::common::{check_for_missing_tests_for, test_dir_for, Analyze, FileCheck};
 
 #[test]
 fn check_for_missing_tests() {
@@ -12,9 +10,7 @@ fn check_for_missing_tests() {
 fn test(file_name: &str) {
     let analyze = Analyze::resolve();
     let file_check = FileCheck::resolve();
-    let path = ["tests", "filecheck", file_name]
-        .iter()
-        .collect::<PathBuf>();
+    let path = test_dir_for(file!(), true).join(file_name);
     let output_path = analyze.run(&path);
     file_check.run(&path, &output_path);
 }


### PR DESCRIPTION
I came across this in debugging #931 and coming up with the fix in #932.  When trying to debug the tests, it would use a different working directory, and not be able to find the correct test file paths.  This just uses the same (correct) logic that I already used in `check_for_missing_tests_for`.