### PR TITLE
analyze: generate casts around call arguments and results

### DIFF
--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -25,6 +25,7 @@ use crate::labeled_ty::LabeledTyCtxt;
 use crate::log::init_logger;
 use crate::util::Callee;
 use context::AdtMetadataTable;
+use rustc_ast::ast::AttrKind;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_index::vec::IndexVec;
@@ -34,10 +35,12 @@ use rustc_middle::mir::{
     Rvalue, StatementKind,
 };
 use rustc_middle::ty::{Ty, TyCtxt, TyKind, WithOptConstParam};
+use rustc_span::symbol::Symbol;
 use rustc_span::Span;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fmt::{Debug, Display, Write as _};
+use std::iter;
 use std::ops::{Deref, DerefMut, Index};
 use std::panic::AssertUnwindSafe;
 
@@ -493,6 +496,19 @@ fn run(tcx: TyCtxt) {
         info.lasn.set(lasn);
     }
 
+    // For testing, putting #[c2rust_analyze_test::fixed_signature] on a function makes all
+    // pointers in its signature FIXED.
+    for &ldid in &all_fn_ldids {
+        if !has_test_attr(tcx, ldid, "fixed_signature") {
+            continue;
+        }
+        let lsig = match gacx.fn_sigs.get(&ldid.to_def_id()) {
+            Some(x) => x,
+            None => continue,
+        };
+        make_sig_fixed(&mut gasn, lsig);
+    }
+
     eprintln!("=== ADT Metadata ===");
     eprintln!("{:?}", gacx.adt_metadata);
 
@@ -769,6 +785,21 @@ impl<'tcx> AssignPointerIds<'tcx> for AnalysisCtxt<'_, 'tcx> {
     }
 }
 
+fn make_ty_fixed(gasn: &mut GlobalAssignment, lty: LTy) {
+    for lty in lty.iter() {
+        let ptr = lty.label;
+        if !ptr.is_none() {
+            gasn.flags[ptr].insert(FlagSet::FIXED);
+        }
+    }
+}
+
+fn make_sig_fixed(gasn: &mut GlobalAssignment, lsig: &LFnSig) {
+    for lty in lsig.inputs.iter().copied().chain(iter::once(lsig.output)) {
+        make_ty_fixed(gasn, lty);
+    }
+}
+
 fn describe_local(tcx: TyCtxt, decl: &LocalDecl) -> String {
     let mut span = decl.source_info.span;
     if let Some(ref info) = decl.local_info {
@@ -949,6 +980,26 @@ fn for_each_callee(tcx: TyCtxt, ldid: LocalDefId, f: impl FnMut(LocalDefId)) {
     }
 
     CalleeVisitor { tcx, mir, f }.visit_body(mir);
+}
+
+fn has_test_attr(tcx: TyCtxt, ldid: LocalDefId, name: &str) -> bool {
+    let tool_sym = Symbol::intern("c2rust_analyze_test");
+    let name_sym = Symbol::intern(name);
+
+    for attr in tcx.get_attrs_unchecked(ldid.to_def_id()) {
+        let path = match attr.kind {
+            AttrKind::Normal(ref item, _) => &item.path,
+            AttrKind::DocComment(..) => continue,
+        };
+        let (a, b) = match &path.segments[..] {
+            &[ref a, ref b] => (a, b),
+            _ => continue,
+        };
+        if a.ident.name == tool_sym && b.ident.name == name_sym {
+            return true;
+        }
+    }
+    false
 }
 
 struct AnalysisCallbacks;

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -23,6 +23,7 @@ use crate::dataflow::DataflowConstraints;
 use crate::equiv::{GlobalEquivSet, LocalEquivSet};
 use crate::labeled_ty::LabeledTyCtxt;
 use crate::log::init_logger;
+use crate::panic_detail::PanicDetail;
 use crate::util::Callee;
 use context::AdtMetadataTable;
 use rustc_ast::ast::AttrKind;
@@ -509,6 +510,17 @@ fn run(tcx: TyCtxt) {
         make_sig_fixed(&mut gasn, lsig);
     }
 
+    // For testing, putting #[c2rust_analyze_test::fail_analysis] on a function marks it as failed.
+    for &ldid in &all_fn_ldids {
+        if !has_test_attr(tcx, ldid, "fail_analysis") {
+            continue;
+        }
+        gacx.mark_fn_failed(
+            ldid.to_def_id(),
+            PanicDetail::new("explicit fail_analysis for testing".to_owned()),
+        );
+    }
+
     eprintln!("=== ADT Metadata ===");
     eprintln!("{:?}", gacx.adt_metadata);
 
@@ -574,6 +586,9 @@ fn run(tcx: TyCtxt) {
     let mut all_rewrites = Vec::new();
     for &ldid in &all_fn_ldids {
         if gacx.fn_failed(ldid.to_def_id()) {
+            continue;
+        }
+        if has_test_attr(tcx, ldid, "skip_rewrite") {
             continue;
         }
 

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -163,6 +163,10 @@ impl<'tcx> intravisit::Visitor<'tcx> for ConvertVisitor<'tcx> {
                     let ty = if *to_mutbl { "*mut _" } else { "*const _" };
                     Rewrite::Cast(Box::new(hir_rw), ty.to_owned())
                 }
+                mir_op::RewriteKind::UnsafeCastRawToRef { mutbl } => {
+                    let rw_pl = Rewrite::Deref(Box::new(hir_rw));
+                    Rewrite::Ref(Box::new(rw_pl), mutbl_from_bool(*mutbl))
+                }
 
                 mir_op::RewriteKind::CellNew => {
                     // `x` to `Cell::new(x)`

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -155,6 +155,15 @@ impl<'tcx> intravisit::Visitor<'tcx> for ConvertVisitor<'tcx> {
                     Rewrite::Ref(Box::new(self.get_subexpr(ex, 0)), mutbl_from_bool(*mutbl))
                 }
 
+                mir_op::RewriteKind::CastRefToRaw { mutbl } => {
+                    let rw_pl = Rewrite::Deref(Box::new(hir_rw));
+                    Rewrite::AddrOf(Box::new(rw_pl), mutbl_from_bool(*mutbl))
+                }
+                mir_op::RewriteKind::CastRawToRaw { to_mutbl } => {
+                    let ty = if *to_mutbl { "*mut _" } else { "*const _" };
+                    Rewrite::Cast(Box::new(hir_rw), ty.to_owned())
+                }
+
                 mir_op::RewriteKind::CellNew => {
                     // `x` to `Cell::new(x)`
                     Rewrite::Call("std::cell::Cell::new".to_string(), vec![Rewrite::Identity])

--- a/c2rust-analyze/src/rewrite/expr/distribute.rs
+++ b/c2rust-analyze/src/rewrite/expr/distribute.rs
@@ -75,7 +75,7 @@ pub fn distribute<'tcx>(
                 }
             }
 
-            if origin.desc != MirOriginDesc::Expr {
+            if origin.desc != MirOriginDesc::Expr && origin.desc != MirOriginDesc::LoadFromTemp {
                 error!(
                     "can't distribute rewrites onto {:?} origin {:?}\n\
                         key = {:?}\n\

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -495,6 +495,19 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             return;
         }
 
+        if from.own == Ownership::Imm && matches!(to.own, Ownership::Raw | Ownership::RawMut) {
+            self.emit(RewriteKind::CastRefToRaw { mutbl: false });
+            from.own = Ownership::Raw;
+        }
+        if from.own == Ownership::Mut && to.own == Ownership::RawMut {
+            self.emit(RewriteKind::CastRefToRaw { mutbl: true });
+            from.own = Ownership::RawMut;
+        }
+        if from.own == Ownership::Raw && to.own == Ownership::RawMut {
+            self.emit(RewriteKind::CastRawToRaw { to_mutbl: true });
+            from.own = Ownership::RawMut;
+        }
+
         if (from.qty, to.qty) == (Quantity::OffsetPtr, Quantity::Slice)
             || (from.qty, to.qty) == (Quantity::Slice, Quantity::OffsetPtr)
         {

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -51,6 +51,13 @@ pub enum RewriteKind {
     RemoveAsPtr,
     /// Replace &raw with & or &raw mut with &mut
     RawToRef { mutbl: bool },
+
+    /// Cast `&` to `*const` or `&mut` to `*mut`.
+    CastRefToRaw { mutbl: bool },
+    /// Cast `*const` to `*mut` or vice versa.  If `to_mutbl` is true, we are casting to `*mut`;
+    /// otherwise, we're casting to `*const`.
+    CastRawToRaw { to_mutbl: bool },
+
     /// Replace `y` in `let x = y` with `Cell::new(y)`, i.e. `let x = Cell::new(y)`
     /// TODO: ensure `y` implements `Copy`
     CellNew,

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -12,6 +12,7 @@ use crate::panic_detail;
 use crate::pointer_id::PointerTable;
 use crate::type_desc::{self, Ownership, Quantity, TypeDesc};
 use crate::util::{ty_callee, Callee};
+use log::*;
 use rustc_ast::Mutability;
 use rustc_middle::mir::{
     BasicBlock, Body, Location, Operand, Place, Rvalue, Statement, StatementKind, Terminator,
@@ -495,61 +496,156 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             return;
         }
 
-        if from.own == Ownership::Imm && matches!(to.own, Ownership::Raw | Ownership::RawMut) {
-            self.emit(RewriteKind::CastRefToRaw { mutbl: false });
-            from.own = Ownership::Raw;
-        }
-        if from.own == Ownership::Mut && to.own == Ownership::RawMut {
-            self.emit(RewriteKind::CastRefToRaw { mutbl: true });
-            from.own = Ownership::RawMut;
-        }
-        if from.own == Ownership::Raw && to.own == Ownership::RawMut {
-            self.emit(RewriteKind::CastRawToRaw { to_mutbl: true });
-            from.own = Ownership::RawMut;
-        }
-
-        if (from.qty, to.qty) == (Quantity::OffsetPtr, Quantity::Slice)
-            || (from.qty, to.qty) == (Quantity::Slice, Quantity::OffsetPtr)
-        {
-            // TODO: emit rewrite
-            from.qty = to.qty;
-        }
-
-        if matches!(
-            from.qty,
-            Quantity::Array | Quantity::OffsetPtr | Quantity::Slice
-        ) && to.qty == Quantity::Single
-        {
-            let mutbl = match from.own {
-                Ownership::Imm => Some(false),
-                Ownership::Mut => Some(true),
-                // Note that `Cell` + `Slice` is `&[Cell<T>]`, not `&Cell<[T]>`.
-                Ownership::Cell => Some(false),
-                _ => None,
-            };
-            if let Some(mutbl) = mutbl {
-                self.emit(RewriteKind::SliceFirst { mutbl });
-                from.qty = Quantity::Single;
+        // Early `Ownership` casts.  We do certain casts here in hopes of reaching an `Ownership`
+        // on which we can safely adjust `Quantity`.
+        while from.own != to.own {
+            match self.cast_ownership_one_step(from, to, true) {
+                Some(new_own) => {
+                    from.own = new_own;
+                }
+                None => break,
             }
         }
 
-        if from.qty == to.qty && (from.own, to.own) == (Ownership::Mut, Ownership::Imm) {
-            self.emit(RewriteKind::MutToImm);
-            from.own = to.own;
+        // Safe casts that change `Quantity`.
+        while from.qty != to.qty {
+            // Mutability of `from`.  `None` here means that safe `Quantity` conversions aren't
+            // possible given `from`'s `Ownership`.  For example, we can't convert `Box<[T]>` to
+            // `Box<T>`.
+            let opt_mutbl = match from.own {
+                // Note that `Cell` + `Slice` is `&[Cell<T>]`, not `&Cell<[T]>`, so it can be
+                // handled like any other `&[_]`.
+                Ownership::Imm | Ownership::Cell => Some(false),
+                Ownership::Mut => Some(true),
+                _ => None,
+            };
+            match (from.qty, to.qty) {
+                (Quantity::Array, _) => {
+                    // `Array` goes only to `Slice` directly.  All other `Array` conversions go
+                    // through `Slice` first.
+                    error!("NYI: cast Array to {:?}", to.qty);
+                    from.qty = Quantity::Slice;
+                }
+                // Bidirectional conversions between `Slice` and `OffsetPtr`.
+                (Quantity::Slice, Quantity::OffsetPtr) => {
+                    let _rw = match opt_mutbl {
+                        // Currently a no-op, since `Slice` and `OffsetPtr` are identical.
+                        Some(_mutbl) => (),
+                        None => break,
+                    };
+                    // self.emit(rw);
+                    from.qty = Quantity::OffsetPtr;
+                }
+                (Quantity::OffsetPtr, Quantity::Slice) => {
+                    let _rw = match opt_mutbl {
+                        // Currently a no-op, since `Slice` and `OffsetPtr` are identical.
+                        Some(_mutbl) => (),
+                        None => break,
+                    };
+                    // self.emit(rw);
+                    from.qty = Quantity::Slice;
+                }
+                // `Slice` and `OffsetPtr` convert to `Single` the same way.
+                (_, Quantity::Single) => {
+                    let rw = match opt_mutbl {
+                        Some(mutbl) => RewriteKind::SliceFirst { mutbl },
+                        None => break,
+                    };
+                    self.emit(rw);
+                    from.qty = Quantity::Single;
+                }
+
+                // Unsupported cases
+                (Quantity::Single, _) => break,
+                (_, Quantity::Array) => break,
+
+                // Remaining cases are impossible, since `from.qty != to.qty`.
+                (Quantity::Slice, Quantity::Slice) | (Quantity::OffsetPtr, Quantity::OffsetPtr) => {
+                    unreachable!()
+                }
+            }
         }
 
-        if (from.qty, to.qty) == (Quantity::Single, Quantity::Single)
-            && (from.own, to.own) == (Ownership::Mut, Ownership::Cell)
-        {
-            self.emit(RewriteKind::CellFromMut);
-            from.own = to.own;
+        // Late `Ownership` casts.
+        while from.own != to.own {
+            match self.cast_ownership_one_step(from, to, false) {
+                Some(new_own) => {
+                    from.own = new_own;
+                }
+                None => break,
+            }
         }
 
         if from != to {
-            panic!(
+            error!(
                 "unsupported cast kind: {:?} -> {:?} (original input: {:?})",
                 from, to, orig_from
             );
+        }
+    }
+
+    fn cast_ownership_one_step(
+        &mut self,
+        from: TypeDesc,
+        to: TypeDesc,
+        early: bool,
+    ) -> Option<Ownership> {
+        match from.own {
+            Ownership::Box => match to.own {
+                Ownership::Raw | Ownership::Imm => {
+                    error!("NYI: cast Box to Imm");
+                    Some(Ownership::Imm)
+                }
+                Ownership::RawMut | Ownership::Mut => {
+                    error!("NYI: cast Box to Mut");
+                    Some(Ownership::Mut)
+                }
+                _ => None,
+            },
+            Ownership::Rc => match to.own {
+                Ownership::Imm | Ownership::Raw | Ownership::RawMut => {
+                    error!("NYI: cast Rc to Imm");
+                    Some(Ownership::Imm)
+                }
+                _ => None,
+            },
+            Ownership::Mut => match to.own {
+                Ownership::Imm | Ownership::Raw => {
+                    self.emit(RewriteKind::MutToImm);
+                    Some(Ownership::Imm)
+                }
+                Ownership::Cell => {
+                    self.emit(RewriteKind::CellFromMut);
+                    Some(Ownership::Cell)
+                }
+                Ownership::RawMut if !early => {
+                    self.emit(RewriteKind::CastRefToRaw { mutbl: true });
+                    Some(Ownership::RawMut)
+                }
+                _ => None,
+            },
+            Ownership::Cell => None,
+            Ownership::Imm => match to.own {
+                Ownership::Raw | Ownership::RawMut if !early => {
+                    self.emit(RewriteKind::CastRefToRaw { mutbl: false });
+                    Some(Ownership::Raw)
+                }
+                _ => None,
+            },
+            Ownership::RawMut => match to.own {
+                Ownership::Raw if !early => {
+                    self.emit(RewriteKind::CastRawToRaw { to_mutbl: false });
+                    Some(Ownership::Raw)
+                }
+                _ => None,
+            },
+            Ownership::Raw => match to.own {
+                Ownership::RawMut if !early => {
+                    self.emit(RewriteKind::CastRawToRaw { to_mutbl: true });
+                    Some(Ownership::RawMut)
+                }
+                _ => None,
+            },
         }
     }
 

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -546,6 +546,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                     from.qty = Quantity::Slice;
                 }
                 // `Slice` and `OffsetPtr` convert to `Single` the same way.
+                // TODO: may be better to use `slice.as_ptr()` to avoid panic on 0-length inputs
                 (_, Quantity::Single) => {
                     let rw = match opt_mutbl {
                         Some(mutbl) => RewriteKind::SliceFirst { mutbl },

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -293,6 +293,10 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                                         continue;
                                     }
                                 }
+
+                                if !pl_ty.label.is_none() {
+                                    v.emit_cast_lty_lty(lsig.output, pl_ty);
+                                }
                             });
                         }
                     }

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -58,6 +58,8 @@ pub enum RewriteKind {
     /// Cast `*const` to `*mut` or vice versa.  If `to_mutbl` is true, we are casting to `*mut`;
     /// otherwise, we're casting to `*const`.
     CastRawToRaw { to_mutbl: bool },
+    /// Cast `*const` to `&` or `*mut` to `&mut`.
+    UnsafeCastRawToRef { mutbl: bool },
 
     /// Replace `y` in `let x = y` with `Cell::new(y)`, i.e. `let x = Cell::new(y)`
     /// TODO: ensure `y` implements `Copy`
@@ -634,16 +636,26 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 _ => None,
             },
             Ownership::RawMut => match to.own {
-                Ownership::Raw if !early => {
+                // For `RawMut` to `Imm`, we go through `Raw` instead of through `Mut` because
+                // `&mut` adds more implicit constraints under the Rust memory model.
+                Ownership::Raw | Ownership::Imm if !early => {
                     self.emit(RewriteKind::CastRawToRaw { to_mutbl: false });
                     Some(Ownership::Raw)
+                }
+                Ownership::Mut if !early => {
+                    self.emit(RewriteKind::UnsafeCastRawToRef { mutbl: true });
+                    Some(Ownership::Mut)
                 }
                 _ => None,
             },
             Ownership::Raw => match to.own {
-                Ownership::RawMut if !early => {
+                Ownership::RawMut | Ownership::Mut if !early => {
                     self.emit(RewriteKind::CastRawToRaw { to_mutbl: true });
                     Some(Ownership::RawMut)
+                }
+                Ownership::Imm if !early => {
+                    self.emit(RewriteKind::UnsafeCastRawToRef { mutbl: false });
+                    Some(Ownership::Imm)
                 }
                 _ => None,
             },

--- a/c2rust-analyze/src/rewrite/expr/unlower.rs
+++ b/c2rust-analyze/src/rewrite/expr/unlower.rs
@@ -79,6 +79,10 @@ pub enum MirOriginDesc {
     Expr,
     /// This MIR stores the result of the HIR expression into a MIR local of some kind.
     StoreIntoLocal,
+    /// This MIR loads the result of the HIR expression from a MIR temporary where it was
+    /// previously stored.  Loads from user-visible locals, which originate from HIR local variable
+    /// expressions, use the `Expr` variant instead.
+    LoadFromTemp,
 }
 
 struct UnlowerVisitor<'a, 'tcx> {
@@ -134,6 +138,30 @@ impl<'a, 'tcx> UnlowerVisitor<'a, 'tcx> {
                 }
             }
         }
+    }
+
+    /// Special `record` variant for MIR [`Operand`]s.  This sets the [`MirOriginDesc`] to
+    /// `LoadFromLocal` if `op` is a MIR temporary and otherwise sets it to `Expr`.
+    fn record_operand(
+        &mut self,
+        loc: Location,
+        sub_loc: &[SubLoc],
+        ex: &hir::Expr,
+        op: &mir::Operand<'tcx>,
+    ) {
+        let op_is_temp = match *op {
+            mir::Operand::Copy(pl) | mir::Operand::Move(pl) => {
+                self.is_var(pl) && self.mir.local_kind(pl.local) == mir::LocalKind::Temp
+            }
+            mir::Operand::Constant(..) => false,
+        };
+
+        let desc = if op_is_temp {
+            MirOriginDesc::LoadFromTemp
+        } else {
+            MirOriginDesc::Expr
+        };
+        self.record_desc(loc, sub_loc, ex, desc);
     }
 
     fn get_sole_assign(
@@ -250,7 +278,7 @@ impl<'a, 'tcx> UnlowerVisitor<'a, 'tcx> {
                 self.record_desc(loc, &[], ex, MirOriginDesc::StoreIntoLocal);
                 self.record(loc, &[SubLoc::Rvalue], ex);
                 for (i, (arg, mir_arg)) in args.iter().zip(mir_args).enumerate() {
-                    self.record(loc, &[SubLoc::Rvalue, SubLoc::CallArg(i)], arg);
+                    self.record_operand(loc, &[SubLoc::Rvalue, SubLoc::CallArg(i)], arg, mir_arg);
                     // TODO: distribute extra `locs` among the various args
                     self.visit_expr_operand(arg, mir_arg, &[]);
                 }

--- a/c2rust-analyze/src/rewrite/expr/unlower.rs
+++ b/c2rust-analyze/src/rewrite/expr/unlower.rs
@@ -142,6 +142,8 @@ impl<'a, 'tcx> UnlowerVisitor<'a, 'tcx> {
 
     /// Special `record` variant for MIR [`Operand`]s.  This sets the [`MirOriginDesc`] to
     /// `LoadFromLocal` if `op` is a MIR temporary and otherwise sets it to `Expr`.
+    ///
+    /// [`Operand`]: mir::Operand
     fn record_operand(
         &mut self,
         loc: Location,

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -39,6 +39,7 @@ define_tests! {
     alloc,
     as_ptr,
     call1,
+    call_cast,
     cast,
     catch_panic,
     cell,

--- a/c2rust-analyze/tests/filecheck/call1.rs
+++ b/c2rust-analyze/tests/filecheck/call1.rs
@@ -16,6 +16,7 @@ pub unsafe fn call1(x: *mut i32) {
     let y = read(q);
 }
 
+// CHECK-LABEL: final labeling for "call2"
 pub unsafe fn call2(x: *mut i32) {
     // CHECK-DAG: ([[@LINE+1]]: p): &mut i32
     let p = x;

--- a/c2rust-analyze/tests/filecheck/call_cast.rs
+++ b/c2rust-analyze/tests/filecheck/call_cast.rs
@@ -1,0 +1,15 @@
+#![feature(register_tool)]
+#![register_tool(c2rust_analyze_test)]
+// Tests the insertion of casts at call sites.
+
+// CHECK-LABEL: fn use_single(x: *mut i32)
+#[c2rust_analyze_test::fixed_signature]
+unsafe fn use_single(x: *mut i32) {
+    *x = 1;
+}
+
+// CHECK-LABEL: fn f(x: &mut (i32))
+unsafe fn f(x: *mut i32) {
+    // CHECK: use_single(core::ptr::addr_of_mut!(*(x)))
+    use_single(x);
+}

--- a/c2rust-analyze/tests/filecheck/call_cast.rs
+++ b/c2rust-analyze/tests/filecheck/call_cast.rs
@@ -4,12 +4,30 @@
 
 // CHECK-LABEL: fn use_single(x: *mut i32)
 #[c2rust_analyze_test::fixed_signature]
+#[c2rust_analyze_test::skip_rewrite]
 unsafe fn use_single(x: *mut i32) {
     *x = 1;
 }
+
+// CHECK-LABEL: fn use_slice(x: *mut i32)
+#[c2rust_analyze_test::fixed_signature]
+#[c2rust_analyze_test::skip_rewrite]
+unsafe fn use_slice(x: *mut i32) {
+    *x.offset(1) = 1;
+}
+
 
 // CHECK-LABEL: fn f(x: &mut (i32))
 unsafe fn f(x: *mut i32) {
     // CHECK: use_single(core::ptr::addr_of_mut!(*(x)))
     use_single(x);
+}
+
+// CHECK-LABEL: fn g(x: &mut [(i32)])
+unsafe fn g(x: *mut i32) {
+    // CHECK: use_single(core::ptr::addr_of_mut!(*&mut (x)[0]))
+    use_single(x);
+
+    // CHECK: use_slice(core::ptr::addr_of_mut!(*&mut (x)[0]))
+    use_slice(x);
 }

--- a/c2rust-analyze/tests/filecheck/call_cast.rs
+++ b/c2rust-analyze/tests/filecheck/call_cast.rs
@@ -16,11 +16,32 @@ unsafe fn use_slice(x: *mut i32) {
     *x.offset(1) = 1;
 }
 
+// CHECK-LABEL: fn pass_single(x: *mut i32) -> *mut i32
+#[c2rust_analyze_test::fixed_signature]
+#[c2rust_analyze_test::skip_rewrite]
+unsafe fn pass_single(x: *mut i32) -> *mut i32 {
+    use_single(x);
+    x
+}
+
+// CHECK-LABEL: fn pass_slice(x: *mut i32) -> *mut i32
+#[c2rust_analyze_test::fixed_signature]
+#[c2rust_analyze_test::skip_rewrite]
+unsafe fn pass_slice(x: *mut i32) -> *mut i32 {
+    use_slice(x);
+    x
+}
+
 
 // CHECK-LABEL: fn f(x: &mut (i32))
 unsafe fn f(x: *mut i32) {
     // CHECK: use_single(core::ptr::addr_of_mut!(*(x)))
     use_single(x);
+
+    // CHECK: let y: &mut (i32)
+    // CHECK-SAME: pass_single(core::ptr::addr_of_mut!(*(x)))
+    let y: *mut i32 = pass_single(x);
+    use_single(y);
 }
 
 // CHECK-LABEL: fn g(x: &mut [(i32)])
@@ -30,4 +51,17 @@ unsafe fn g(x: *mut i32) {
 
     // CHECK: use_slice(core::ptr::addr_of_mut!(*&mut (x)[0]))
     use_slice(x);
+
+    // CHECK: let y: &mut (i32)
+    // CHECK-SAME: &mut *(pass_single(core::ptr::addr_of_mut!(*&mut (x)[0])))
+    let y: *mut i32 = pass_single(x);
+    // CHECK: use_single(core::ptr::addr_of_mut!(*(y)))
+    use_single(y);
+
+    // Currently impossible: this would require a cast from `*mut i32` to `&mut [i32]`, but we
+    // don't have any way to obtain the slice length.
+    /*
+    let z: *mut i32 = pass_slice(x);
+    use_slice(z);
+    */
 }


### PR DESCRIPTION
This branch updates the rewriter to add casts around function calls and their arguments.  We mainly need this so we can add casts to and from raw pointers around calls to non-rewritten functions.

More specifically, this branch does the following:

* Updates `rewrite::expr::mir_op` to emit casts around function calls.  Given the MIR statement `_2 = f(_1)`, we now generate a cast from the type (`LTy`) of `_1` to the argument type of `f` and a cast from the return type of `f` to the type of `_2`.
* Updates `rewrite::expr::distribute` to handle rewrites from multiple MIR locations being applied to the same HIR node.  For example, the HIR code `f(x)` compiles down to `_tmp = _x; f(_tmp)`; in some test cases, code like this resulted in a cast on the rvalue `_x` of the first assignment and another cast on the argument `_tmp` of the call.  But both MIR locations originate from the same HIR expression, `x`, so having rewrites on both locations was rejected because it's ambiguous which set of rewrites should be applied first to the HIR.  On this branch, `distribute` now properly prioritizes these rewrites and allows this case.
* Adds support for casts between `TyKind::Ref`s and `TyKind::RawPtr`s and between different `RawPtr` types.  This consists of some cleanup and expansion of `emit_cast_desc_desc` in `rewrite::expr::mir_op` and the addition of a few new `Rewrite` variants.
* Adds some new function attributes `#[c2rust_analyze_test::fixed_signature]`, `#[c2rust_analyze_test::skip_rewrite]`, and `#[c2rust_analyze_test::fail_analysis]` for use in test cases.
