### PR TITLE
analyze: generate shims for calls from non-rewritten to rewritten code

### DIFF
--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -657,6 +657,10 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             );
         }
     }
+
+    pub fn iter_fns_failed<'a>(&'a self) -> impl Iterator<Item = DefId> + 'a {
+        self.fns_failed.keys().copied()
+    }
 }
 
 impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -647,15 +647,6 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         }
 
         self.fns_failed.insert(did, detail);
-
-        // This is the first time marking `did` as failed, so also mark all of its callers.
-        let callers = self.fn_callers.get(&did).cloned().unwrap_or(Vec::new());
-        for caller in callers {
-            self.mark_fn_failed(
-                caller,
-                PanicDetail::new(format!("analysis failed on callee {:?}", did)),
-            );
-        }
     }
 
     pub fn iter_fns_failed<'a>(&'a self) -> impl Iterator<Item = DefId> + 'a {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -273,9 +273,6 @@ pub struct GlobalAnalysisCtxt<'tcx> {
 
     ptr_info: GlobalPointerTable<PointerInfo>,
 
-    /// Map from a function to all of its callers.
-    pub fn_callers: HashMap<DefId, Vec<DefId>>,
-
     pub fn_sigs: HashMap<DefId, LFnSig<'tcx>>,
 
     /// `DefId`s of functions where analysis failed, and a [`PanicDetail`] explaining the reason
@@ -532,7 +529,6 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             tcx,
             lcx: LabeledTyCtxt::new(tcx),
             ptr_info: GlobalPointerTable::empty(),
-            fn_callers: HashMap::new(),
             fn_sigs: HashMap::new(),
             fns_failed: HashMap::new(),
             field_ltys: HashMap::new(),
@@ -579,7 +575,6 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             tcx: _,
             lcx,
             ref mut ptr_info,
-            fn_callers: _,
             ref mut fn_sigs,
             fns_failed: _,
             ref mut field_ltys,

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -27,6 +27,7 @@ use rustc_middle::ty::{
 use rustc_type_ir::RegionKind::{ReEarlyBound, ReStatic};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
+use std::iter;
 use std::ops::Index;
 
 bitflags! {
@@ -164,6 +165,12 @@ pub type LTyCtxt<'tcx> = LabeledTyCtxt<'tcx, PointerId>;
 pub struct LFnSig<'tcx> {
     pub inputs: &'tcx [LTy<'tcx>],
     pub output: LTy<'tcx>,
+}
+
+impl<'tcx> LFnSig<'tcx> {
+    pub fn inputs_and_output(&self) -> impl Iterator<Item = LTy<'tcx>> + 'tcx {
+        self.inputs.iter().copied().chain(iter::once(self.output))
+    }
 }
 
 bitflags! {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -644,7 +644,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         self.fns_failed.insert(did, detail);
     }
 
-    pub fn iter_fns_failed<'a>(&'a self) -> impl Iterator<Item = DefId> + 'a {
+    pub fn iter_fns_failed(&self) -> impl Iterator<Item = DefId> + '_ {
         self.fns_failed.keys().copied()
     }
 }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -803,10 +803,7 @@ fn run(tcx: TyCtxt) {
     // Before generating rewrites, add the FIXED flag to the signatures of all functions that
     // failed analysis.
     for did in gacx.iter_fns_failed() {
-        let lsig = match gacx.fn_sigs.get(&did) {
-            Some(x) => x,
-            None => continue,
-        };
+        let lsig = gacx.fn_sigs[&did];
         for sig_lty in lsig.inputs.iter().copied().chain(iter::once(lsig.output)) {
             for lty in sig_lty.iter() {
                 let ptr = lty.label;
@@ -877,8 +874,8 @@ fn run(tcx: TyCtxt) {
         info.acx_data.set(acx.into_data());
     }
 
-    let (shim_rewrites, shim_fn_def_ids) = rewrite::gen_shim_call_rewrites(&gacx, &gasn);
-    all_rewrites.extend(shim_rewrites);
+    let (shim_call_rewrites, shim_fn_def_ids) = rewrite::gen_shim_call_rewrites(&gacx, &gasn);
+    all_rewrites.extend(shim_call_rewrites);
 
     // Generate shims for functions that need them.
     for def_id in shim_fn_def_ids {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -864,6 +864,9 @@ fn run(tcx: TyCtxt) {
         info.acx_data.set(acx.into_data());
     }
 
+    let (shim_rewrites, _) = rewrite::gen_shim_call_rewrites(&gacx, &gasn);
+    all_rewrites.extend(shim_rewrites);
+
     // Print analysis results for each function in `all_fn_ldids`, going in declaration order.
     // Concretely, we iterate over `body_owners()`, which is a superset of `all_fn_ldids`, and
     // filter based on membership in `func_info`, which contains an entry for each ID in

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -874,6 +874,8 @@ fn run(tcx: TyCtxt) {
         info.acx_data.set(acx.into_data());
     }
 
+    // This call never panics, which is important because this is the fallback if the more
+    // sophisticated analysis and rewriting above did panic.
     let (shim_call_rewrites, shim_fn_def_ids) = rewrite::gen_shim_call_rewrites(&gacx, &gasn);
     all_rewrites.extend(shim_call_rewrites);
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -877,8 +877,10 @@ fn run(tcx: TyCtxt) {
         info.acx_data.set(acx.into_data());
     }
 
-    let (shim_rewrites, _) = rewrite::gen_shim_call_rewrites(&gacx, &gasn);
+    let (shim_rewrites, shim_fn_def_ids) = rewrite::gen_shim_call_rewrites(&gacx, &gasn);
     all_rewrites.extend(shim_rewrites);
+    let shim_def_rewrites = rewrite::gen_shim_definition_rewrites(&gacx, &gasn, shim_fn_def_ids);
+    all_rewrites.extend(shim_def_rewrites);
 
     // Print analysis results for each function in `all_fn_ldids`, going in declaration order.
     // Concretely, we iterate over `body_owners()`, which is a superset of `all_fn_ldids`, and

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -804,7 +804,7 @@ fn run(tcx: TyCtxt) {
     // failed analysis.
     for did in gacx.iter_fns_failed() {
         let lsig = gacx.fn_sigs[&did];
-        for sig_lty in lsig.inputs.iter().copied().chain(iter::once(lsig.output)) {
+        for sig_lty in lsig.inputs_and_output() {
             for lty in sig_lty.iter() {
                 let ptr = lty.label;
                 if !ptr.is_none() {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -700,14 +700,15 @@ fn run(tcx: TyCtxt) {
         make_sig_fixed(&mut gasn, lsig);
     }
 
-    // For testing, putting #[c2rust_analyze_test::fail_analysis] on a function marks it as failed.
+    // For testing, putting #[c2rust_analyze_test::fail_before_analysis] on a function marks it as
+    // failed at this point.
     for &ldid in &all_fn_ldids {
-        if !util::has_test_attr(tcx, ldid, TestAttr::FailAnalysis) {
+        if !util::has_test_attr(tcx, ldid, TestAttr::FailBeforeAnalysis) {
             continue;
         }
         gacx.mark_fn_failed(
             ldid.to_def_id(),
-            PanicDetail::new("explicit fail_analysis for testing".to_owned()),
+            PanicDetail::new("explicit fail_before_analysis for testing".to_owned()),
         );
     }
 
@@ -786,6 +787,18 @@ fn run(tcx: TyCtxt) {
         }
     }
     eprintln!("reached fixpoint in {} iterations", loop_count);
+
+    // For testing, putting #[c2rust_analyze_test::fail_before_rewriting] on a function marks it as
+    // failed at this point.
+    for &ldid in &all_fn_ldids {
+        if !util::has_test_attr(tcx, ldid, TestAttr::FailBeforeRewriting) {
+            continue;
+        }
+        gacx.mark_fn_failed(
+            ldid.to_def_id(),
+            PanicDetail::new("explicit fail_before_rewriting for testing".to_owned()),
+        );
+    }
 
     // Before generating rewrites, add the FIXED flag to the signatures of all functions that
     // failed analysis.

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -336,6 +336,14 @@ impl<'a, T> PointerTable<'a, T> {
     }
 }
 
+impl<'a, T> Clone for PointerTable<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for PointerTable<'a, T> {}
+
 impl<'a, T> Index<PointerId> for PointerTable<'a, T> {
     type Output = T;
     fn index(&self, id: PointerId) -> &T {

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -129,20 +129,6 @@ impl<'tcx> Visitor<'tcx> for ConvertVisitor<'tcx> {
                     Rewrite::Ref(Box::new(elem), mutbl_from_bool(*mutbl))
                 }
 
-                mir_op::RewriteKind::SliceFirst { mutbl } => {
-                    // `p` -> `&p[0]`
-                    let arr = hir_rw;
-                    let idx = Rewrite::LitZero;
-                    let elem = Rewrite::Index(Box::new(arr), Box::new(idx));
-                    Rewrite::Ref(Box::new(elem), mutbl_from_bool(*mutbl))
-                }
-
-                mir_op::RewriteKind::MutToImm => {
-                    // `p` -> `&*p`
-                    let place = Rewrite::Deref(Box::new(hir_rw));
-                    Rewrite::Ref(Box::new(place), hir::Mutability::Not)
-                }
-
                 mir_op::RewriteKind::RemoveAsPtr => {
                     // `slice.as_ptr()` -> `slice`
                     assert!(matches!(hir_rw, Rewrite::Identity));
@@ -152,21 +138,6 @@ impl<'tcx> Visitor<'tcx> for ConvertVisitor<'tcx> {
                 mir_op::RewriteKind::RawToRef { mutbl } => {
                     // &raw _ to &_ or &raw mut _ to &mut _
                     Rewrite::Ref(Box::new(self.get_subexpr(ex, 0)), mutbl_from_bool(*mutbl))
-                }
-
-                mir_op::RewriteKind::CastRefToRaw { mutbl } => {
-                    // `addr_of!(*p)` is cleaner than `p as *const _`; we don't know the pointee
-                    // type here, so we can't emit `p as *const T`.
-                    let rw_pl = Rewrite::Deref(Box::new(hir_rw));
-                    Rewrite::AddrOf(Box::new(rw_pl), mutbl_from_bool(*mutbl))
-                }
-                mir_op::RewriteKind::CastRawToRaw { to_mutbl } => {
-                    let method = if *to_mutbl { "cast_mut" } else { "cast_const" };
-                    Rewrite::MethodCall(method.to_string(), Box::new(hir_rw), vec![])
-                }
-                mir_op::RewriteKind::UnsafeCastRawToRef { mutbl } => {
-                    let rw_pl = Rewrite::Deref(Box::new(hir_rw));
-                    Rewrite::Ref(Box::new(rw_pl), mutbl_from_bool(*mutbl))
                 }
 
                 mir_op::RewriteKind::CellNew => {
@@ -191,13 +162,7 @@ impl<'tcx> Visitor<'tcx> for ConvertVisitor<'tcx> {
                     Rewrite::MethodCall("set".to_string(), Box::new(lhs), vec![rhs])
                 }
 
-                mir_op::RewriteKind::CellFromMut => {
-                    // `x` to `Cell::from_mut(x)`
-                    Rewrite::Call(
-                        "std::cell::Cell::from_mut".to_string(),
-                        vec![Rewrite::Identity],
-                    )
-                }
+                _ => convert_cast_rewrite(rw, hir_rw),
             }
         };
 
@@ -274,6 +239,55 @@ fn materialize_adjustments<'tcx>(
         (rw @ Rewrite::Ref(..), &[Adjust::Deref(..), Adjust::Borrow(..)]) => rw,
         (rw, &[]) => rw,
         (rw, adjs) => panic!("rewrite {rw:?} and materializations {adjs:?} NYI"),
+    }
+}
+
+/// Convert a single `RewriteKind` representing a cast into a `Span`-based `Rewrite`.  This panics
+/// on rewrites that modify the original expression; only rewrites that wrap the expression in some
+/// kind of cast or conversion are supported.
+pub fn convert_cast_rewrite(kind: &mir_op::RewriteKind, hir_rw: Rewrite) -> Rewrite {
+    match *kind {
+        mir_op::RewriteKind::SliceFirst { mutbl } => {
+            // `p` -> `&p[0]`
+            let arr = hir_rw;
+            let idx = Rewrite::LitZero;
+            let elem = Rewrite::Index(Box::new(arr), Box::new(idx));
+            Rewrite::Ref(Box::new(elem), mutbl_from_bool(mutbl))
+        }
+
+        mir_op::RewriteKind::MutToImm => {
+            // `p` -> `&*p`
+            let place = Rewrite::Deref(Box::new(hir_rw));
+            Rewrite::Ref(Box::new(place), hir::Mutability::Not)
+        }
+
+        mir_op::RewriteKind::CastRefToRaw { mutbl } => {
+            // `addr_of!(*p)` is cleaner than `p as *const _`; we don't know the pointee
+            // type here, so we can't emit `p as *const T`.
+            let rw_pl = Rewrite::Deref(Box::new(hir_rw));
+            Rewrite::AddrOf(Box::new(rw_pl), mutbl_from_bool(mutbl))
+        }
+        mir_op::RewriteKind::CastRawToRaw { to_mutbl } => {
+            let method = if to_mutbl { "cast_mut" } else { "cast_const" };
+            Rewrite::MethodCall(method.to_string(), Box::new(hir_rw), vec![])
+        }
+        mir_op::RewriteKind::UnsafeCastRawToRef { mutbl } => {
+            let rw_pl = Rewrite::Deref(Box::new(hir_rw));
+            Rewrite::Ref(Box::new(rw_pl), mutbl_from_bool(mutbl))
+        }
+
+        mir_op::RewriteKind::CellFromMut => {
+            // `x` to `Cell::from_mut(x)`
+            Rewrite::Call(
+                "std::cell::Cell::from_mut".to_string(),
+                vec![Rewrite::Identity],
+            )
+        }
+
+        _ => panic!(
+            "rewrite {:?} is not supported by convert_cast_rewrite",
+            kind
+        ),
     }
 }
 

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -140,11 +140,6 @@ impl<'tcx> Visitor<'tcx> for ConvertVisitor<'tcx> {
                     Rewrite::Ref(Box::new(self.get_subexpr(ex, 0)), mutbl_from_bool(*mutbl))
                 }
 
-                mir_op::RewriteKind::CellNew => {
-                    // `x` to `Cell::new(x)`
-                    Rewrite::Call("std::cell::Cell::new".to_string(), vec![Rewrite::Identity])
-                }
-
                 mir_op::RewriteKind::CellGet => {
                     // `*x` to `Cell::get(x)`
                     Rewrite::MethodCall(
@@ -274,6 +269,11 @@ pub fn convert_cast_rewrite(kind: &mir_op::RewriteKind, hir_rw: Rewrite) -> Rewr
         mir_op::RewriteKind::UnsafeCastRawToRef { mutbl } => {
             let rw_pl = Rewrite::Deref(Box::new(hir_rw));
             Rewrite::Ref(Box::new(rw_pl), mutbl_from_bool(mutbl))
+        }
+
+        mir_op::RewriteKind::CellNew => {
+            // `x` to `Cell::new(x)`
+            Rewrite::Call("std::cell::Cell::new".to_string(), vec![Rewrite::Identity])
         }
 
         mir_op::RewriteKind::CellFromMut => {

--- a/c2rust-analyze/src/rewrite/expr/mod.rs
+++ b/c2rust-analyze/src/rewrite/expr/mod.rs
@@ -9,6 +9,10 @@ mod distribute;
 mod mir_op;
 mod unlower;
 
+// Helpers used by the shim builder.
+pub use self::convert::convert_cast_rewrite;
+pub use self::mir_op::CastBuilder;
+
 pub fn gen_expr_rewrites<'tcx>(
     acx: &AnalysisCtxt<'_, 'tcx>,
     asn: &Assignment,

--- a/c2rust-analyze/src/rewrite/mod.rs
+++ b/c2rust-analyze/src/rewrite/mod.rs
@@ -50,9 +50,10 @@ pub enum LifetimeName {
     Elided,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub enum Rewrite<S = Span> {
     /// Take the original expression unchanged.
+    #[default]
     Identity,
     /// Extract the subexpression at the given index.
     Sub(usize, S),

--- a/c2rust-analyze/src/rewrite/mod.rs
+++ b/c2rust-analyze/src/rewrite/mod.rs
@@ -38,7 +38,7 @@ mod statics;
 mod ty;
 
 pub use self::expr::gen_expr_rewrites;
-pub use self::shim::gen_shim_call_rewrites;
+pub use self::shim::{gen_shim_call_rewrites, gen_shim_definition_rewrites};
 use self::span_index::SpanIndex;
 pub use self::statics::gen_static_rewrites;
 pub use self::ty::dump_rewritten_local_tys;

--- a/c2rust-analyze/src/rewrite/mod.rs
+++ b/c2rust-analyze/src/rewrite/mod.rs
@@ -38,7 +38,7 @@ mod statics;
 mod ty;
 
 pub use self::expr::gen_expr_rewrites;
-pub use self::shim::{gen_shim_call_rewrites, gen_shim_definition_rewrites};
+pub use self::shim::{gen_shim_call_rewrites, gen_shim_definition_rewrite};
 use self::span_index::SpanIndex;
 pub use self::statics::gen_static_rewrites;
 pub use self::ty::dump_rewritten_local_tys;

--- a/c2rust-analyze/src/rewrite/mod.rs
+++ b/c2rust-analyze/src/rewrite/mod.rs
@@ -32,11 +32,13 @@ use std::fmt;
 
 mod apply;
 mod expr;
+mod shim;
 mod span_index;
 mod statics;
 mod ty;
 
 pub use self::expr::gen_expr_rewrites;
+pub use self::shim::gen_shim_call_rewrites;
 use self::span_index::SpanIndex;
 pub use self::statics::gen_static_rewrites;
 pub use self::ty::dump_rewritten_local_tys;

--- a/c2rust-analyze/src/rewrite/shim.rs
+++ b/c2rust-analyze/src/rewrite/shim.rs
@@ -11,7 +11,6 @@ use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::{DefIdTree, TyCtxt, TypeckResults};
 use rustc_span::Span;
 use std::collections::HashSet;
-use std::iter;
 use std::mem;
 
 struct ShimCallVisitor<'a, 'tcx> {
@@ -53,10 +52,7 @@ impl<'a, 'tcx> ShimCallVisitor<'a, 'tcx> {
             None => return,
         };
         let has_non_fixed_ptr = lsig
-            .inputs
-            .iter()
-            .copied()
-            .chain(iter::once(lsig.output))
+            .inputs_and_output()
             .flat_map(|lty| lty.iter())
             .any(|lty| {
                 let ptr = lty.label;

--- a/c2rust-analyze/src/rewrite/shim.rs
+++ b/c2rust-analyze/src/rewrite/shim.rs
@@ -1,0 +1,146 @@
+use crate::context::{FlagSet, GlobalAnalysisCtxt, GlobalAssignment};
+use crate::rewrite::Rewrite;
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def_id::DefId;
+use rustc_hir::intravisit;
+use rustc_hir::{Expr, ExprKind};
+use rustc_middle::hir::nested_filter;
+use rustc_middle::ty::{DefIdTree, TypeckResults};
+use rustc_span::Span;
+use std::collections::HashSet;
+use std::iter;
+
+struct ShimCallVisitor<'a, 'tcx> {
+    gacx: &'a GlobalAnalysisCtxt<'tcx>,
+    gasn: &'a GlobalAssignment,
+    typeck_results: &'tcx TypeckResults<'tcx>,
+    rewrites: Vec<(Span, Rewrite)>,
+    mentioned_fns: HashSet<DefId>,
+}
+
+impl<'a, 'tcx> ShimCallVisitor<'a, 'tcx> {
+    fn handle_def_mention(&mut self, def_id: DefId, span: Span) {
+        let tcx = self.gacx.tcx;
+
+        // We only care about mentions of local functions, not including trait methods.
+        if !def_id.is_local() {
+            return;
+        }
+
+        match tcx.def_kind(def_id) {
+            DefKind::Fn => {}
+            DefKind::AssocFn => {
+                let parent_def_id = tcx.parent(def_id);
+                if tcx.def_kind(parent_def_id) == DefKind::Trait {
+                    return;
+                }
+                if tcx.impl_trait_ref(parent_def_id).is_some() {
+                    // Ignore calls to trait methods.
+                    return;
+                }
+            }
+            _ => return,
+        }
+
+        // Only functions whose signatures might change are relevant here.  Check that the function
+        // has at least one non-`FIXED` pointer in its signature.
+        let lsig = match self.gacx.fn_sigs.get(&def_id) {
+            Some(x) => x,
+            None => return,
+        };
+        let has_non_fixed_ptr = lsig
+            .inputs
+            .iter()
+            .cloned()
+            .chain(iter::once(lsig.output))
+            .flat_map(|lty| lty.iter())
+            .any(|lty| {
+                let ptr = lty.label;
+                !ptr.is_none() && !self.gasn.flags[ptr].contains(FlagSet::FIXED)
+            });
+        if !has_non_fixed_ptr {
+            return;
+        }
+
+        // Change this mention to refer to the function's unsafe shim instead.
+        let insert_span = span.shrink_to_hi();
+        self.rewrites
+            .push((insert_span, Rewrite::Text("_shim".to_owned())));
+        self.mentioned_fns.insert(def_id);
+    }
+}
+
+impl<'a, 'tcx> intravisit::Visitor<'tcx> for ShimCallVisitor<'a, 'tcx> {
+    type NestedFilter = nested_filter::OnlyBodies;
+
+    fn nested_visit_map(&mut self) -> Self::Map {
+        self.gacx.tcx.hir()
+    }
+
+    fn visit_expr(&mut self, ex: &'tcx Expr<'tcx>) {
+        match ex.kind {
+            ExprKind::Path(ref qp) => {
+                let res = self.typeck_results.qpath_res(qp, ex.hir_id);
+                match res {
+                    Res::Def(DefKind::Fn, def_id) | Res::Def(DefKind::AssocFn, def_id) => {
+                        let ident_span = qp.last_segment_span();
+                        self.handle_def_mention(def_id, ident_span);
+                    }
+                    _ => {}
+                }
+            }
+
+            ExprKind::MethodCall(ps, _, _) => {
+                if let Some(def_id) = self.typeck_results.type_dependent_def_id(ex.hir_id) {
+                    self.handle_def_mention(def_id, ps.ident.span);
+                }
+            }
+
+            _ => {}
+        }
+
+        intravisit::walk_expr(self, ex);
+    }
+}
+
+/// For each failed function that calls or mentions a non-failed function meeting certain criteria,
+/// generate rewrites to change calls to `foo` into calls to `foo_shim`.  Also produces a set of
+/// callee `DefId`s for the calls that were rewritten this way.
+///
+/// The criteria we look for are:
+/// * The callee must be a local function.
+/// * The callee must have at least one non-`FIXED` pointer type in its signature.
+/// * The callee must not be a trait method.  Adding shims for trait methods is more complex than
+///   handling free functions or inherent methods.
+pub fn gen_shim_call_rewrites<'tcx>(
+    gacx: &GlobalAnalysisCtxt<'tcx>,
+    gasn: &GlobalAssignment,
+) -> (Vec<(Span, Rewrite)>, HashSet<DefId>) {
+    let tcx = gacx.tcx;
+
+    let mut rewrites = Vec::new();
+    let mut mentioned_fns = HashSet::new();
+
+    for &failed_def_id in gacx.fns_failed.keys() {
+        let failed_def_id = match failed_def_id.as_local() {
+            Some(x) => x,
+            None => continue,
+        };
+        let hir_body_id = tcx.hir().body_owned_by(failed_def_id);
+        let hir = tcx.hir().body(hir_body_id);
+        let typeck_results = tcx.typeck_body(hir_body_id);
+        let mut v = ShimCallVisitor {
+            gacx,
+            gasn,
+            typeck_results,
+            rewrites,
+            mentioned_fns,
+        };
+        intravisit::Visitor::visit_body(&mut v, hir);
+
+        rewrites = v.rewrites;
+        mentioned_fns = v.mentioned_fns;
+    }
+
+    (rewrites, mentioned_fns)
+}

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -446,8 +446,12 @@ pub enum TestAttr {
     /// `#[c2rust_analyze_test::fixed_signature]`: Mark all pointers in the function signature as
     /// [`FIXED`](crate::context::FlagSet::FIXED).
     FixedSignature,
-    /// `#[c2rust_analyze_test::fail_analysis]`: Force an analysis failure for the function.
-    FailAnalysis,
+    /// `#[c2rust_analyze_test::fail_before_analysis]`: Mark the function as failed before running
+    /// analysis.
+    FailBeforeAnalysis,
+    /// `#[c2rust_analyze_test::fail_before_rewriting]`: Mark the function as failed after analysis
+    /// but before rewriting.
+    FailBeforeRewriting,
     /// `#[c2rust_analyze_test::skip_rewrite]`: Skip generating rewrites for the function.
     SkipRewrite,
 }
@@ -456,7 +460,8 @@ impl TestAttr {
     pub fn name(self) -> &'static str {
         match self {
             TestAttr::FixedSignature => "fixed_signature",
-            TestAttr::FailAnalysis => "fail_analysis",
+            TestAttr::FailBeforeAnalysis => "fail_before_analysis",
+            TestAttr::FailBeforeRewriting => "fail_before_rewriting",
             TestAttr::SkipRewrite => "skip_rewrite",
         }
     }

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -59,4 +59,5 @@ define_tests! {
     test_attrs,
     trivial,
     type_annotation_rewrite,
+    unrewritten_calls,
 }

--- a/c2rust-analyze/tests/filecheck/catch_panic.rs
+++ b/c2rust-analyze/tests/filecheck/catch_panic.rs
@@ -17,8 +17,8 @@ unsafe fn bad(p: NonNull<u8>) {
     *p.as_ptr() = 1;
 }
 
-// Analysis of `call_bad` should also fail because it has a callee on which analysis failed.
-// CHECK-NOT: final labeling for "call_bad"
+// Analysis of `call_bad` should succeed.
+// CHECK: final labeling for "call_bad"
 unsafe fn call_bad(p: NonNull<u8>) {
     bad(p);
 }
@@ -35,11 +35,8 @@ unsafe fn bad_call_good(p: NonNull<u8>) {
 // CHECK-SAME: UnknownDef
 // CHECK-SAME: NonNull::<u8>::as_ptr
 
-// CHECK: analysis of DefId({{.*}}::call_bad) failed:
-// CHECK-SAME: analysis failed on callee DefId({{.*}}::bad)
-
 // CHECK: analysis of DefId({{.*}}::bad_call_good) failed:
 // CHECK-SAME: UnknownDef
 // CHECK-SAME: NonNull::<u8>::as_ptr
 
-// CHECK: saw errors in 3 / 4 functions
+// CHECK: saw errors in 2 / 4 functions

--- a/c2rust-analyze/tests/filecheck/test_attrs.rs
+++ b/c2rust-analyze/tests/filecheck/test_attrs.rs
@@ -17,8 +17,14 @@ fn g(x: *mut i32) -> *mut i32 {
     x
 }
 
-// CHECK: analysis of DefId({{.*}} ~ test_attrs[{{.*}}]::h) failed: [unknown]: explicit fail_analysis for testing
-#[c2rust_analyze_test::fail_analysis]
+// CHECK: analysis of DefId({{.*}} ~ test_attrs[{{.*}}]::h) failed: [unknown]: explicit fail_before_analysis for testing
+#[c2rust_analyze_test::fail_before_analysis]
 fn h(x: *mut i32) -> *mut i32 {
+    x
+}
+
+// CHECK: analysis of DefId({{.*}} ~ test_attrs[{{.*}}]::i) failed: [unknown]: explicit fail_before_rewriting for testing
+#[c2rust_analyze_test::fail_before_rewriting]
+fn i(x: *mut i32) -> *mut i32 {
     x
 }

--- a/c2rust-analyze/tests/filecheck/unrewritten_calls.rs
+++ b/c2rust-analyze/tests/filecheck/unrewritten_calls.rs
@@ -1,0 +1,23 @@
+#![feature(register_tool)]
+#![register_tool(c2rust_analyze_test)]
+// Test calls between rewritten and non-rewritten functions.
+
+// CHECK-LABEL: fn f(x: &mut (i32))
+unsafe fn f(x: *mut i32) {
+    // CHECK: g(core::ptr::addr_of_mut!(*(x)))
+    g(x);
+}
+
+// The middle function, `g`, will be marked as failed.  We wait until analysis has finished before
+// marking it so that the `WRITE` requirement from `h` will be propagated up to `f`.
+#[c2rust_analyze_test::fail_before_rewriting]
+// CHECK-LABEL: fn g(x: *mut i32)
+unsafe fn g(x: *mut i32) {
+    // CHECK: h_shim(x)
+    h(x);
+}
+
+// CHECK-LABEL: fn h(x: &mut (i32))
+unsafe fn h(x: *mut i32) {
+    *x = 1;
+}

--- a/c2rust-analyze/tests/filecheck/unrewritten_calls.rs
+++ b/c2rust-analyze/tests/filecheck/unrewritten_calls.rs
@@ -25,4 +25,4 @@ unsafe fn h(x: *mut i32) -> *mut i32 {
     x
 }
 // CHECK: fn h_shim(arg0: *mut i32) -> *mut i32
-// CHECK: h(arg0)
+// CHECK: core::ptr::addr_of!(*h(&mut *arg0)).cast_mut()

--- a/c2rust-analyze/tests/filecheck/unrewritten_calls.rs
+++ b/c2rust-analyze/tests/filecheck/unrewritten_calls.rs
@@ -2,27 +2,27 @@
 #![register_tool(c2rust_analyze_test)]
 // Test calls between rewritten and non-rewritten functions.
 
-// CHECK-LABEL: fn f(x: &mut (i32))
-unsafe fn f(x: *mut i32) -> i32 {
-    // CHECK: let y = &*(g(core::ptr::addr_of_mut!(*(x)))).cast_const();
-    let y = g(x);
+// CHECK-LABEL: fn good1(x: &mut (i32))
+unsafe fn good1(x: *mut i32) -> i32 {
+    // CHECK: let y = &*(bad(core::ptr::addr_of_mut!(*(x)))).cast_const();
+    let y = bad(x);
     *y
 }
 
-// The middle function, `g`, will be marked as failed.  We wait until analysis has finished before
-// marking it so that the `WRITE` requirement from `h` will be propagated up to `f`.
+// The middle function, `bad`, will be marked as failed.  We wait until analysis has finished
+// before marking it so that the `WRITE` requirement from `good2` will be propagated up to `good1`.
 #[c2rust_analyze_test::fail_before_rewriting]
-// CHECK-LABEL: fn g(x: *mut i32) -> *mut i32
-unsafe fn g(x: *mut i32) -> *mut i32 {
-    // CHECK: h_shim(x)
-    h(x)
+// CHECK-LABEL: fn bad(x: *mut i32) -> *mut i32
+unsafe fn bad(x: *mut i32) -> *mut i32 {
+    // CHECK: good2_shim(x)
+    good2(x)
 }
 
-// CHECK-LABEL: fn h(x: &mut (i32)) -> &(i32)
-unsafe fn h(x: *mut i32) -> *mut i32 {
+// CHECK-LABEL: fn good2(x: &mut (i32)) -> &(i32)
+unsafe fn good2(x: *mut i32) -> *mut i32 {
     *x = 1;
     // CHECK: &*(x)
     x
 }
-// CHECK: fn h_shim(arg0: *mut i32) -> *mut i32
-// CHECK: core::ptr::addr_of!(*h(&mut *arg0)).cast_mut()
+// CHECK: unsafe fn good2_shim(arg0: *mut i32) -> *mut i32
+// CHECK: core::ptr::addr_of!(*good2(&mut *arg0)).cast_mut()

--- a/c2rust-analyze/tests/filecheck/unrewritten_calls.rs
+++ b/c2rust-analyze/tests/filecheck/unrewritten_calls.rs
@@ -3,21 +3,26 @@
 // Test calls between rewritten and non-rewritten functions.
 
 // CHECK-LABEL: fn f(x: &mut (i32))
-unsafe fn f(x: *mut i32) {
-    // CHECK: g(core::ptr::addr_of_mut!(*(x)))
-    g(x);
+unsafe fn f(x: *mut i32) -> i32 {
+    // CHECK: let y = &*(g(core::ptr::addr_of_mut!(*(x)))).cast_const();
+    let y = g(x);
+    *y
 }
 
 // The middle function, `g`, will be marked as failed.  We wait until analysis has finished before
 // marking it so that the `WRITE` requirement from `h` will be propagated up to `f`.
 #[c2rust_analyze_test::fail_before_rewriting]
-// CHECK-LABEL: fn g(x: *mut i32)
-unsafe fn g(x: *mut i32) {
+// CHECK-LABEL: fn g(x: *mut i32) -> *mut i32
+unsafe fn g(x: *mut i32) -> *mut i32 {
     // CHECK: h_shim(x)
-    h(x);
+    h(x)
 }
 
-// CHECK-LABEL: fn h(x: &mut (i32))
-unsafe fn h(x: *mut i32) {
+// CHECK-LABEL: fn h(x: &mut (i32)) -> &(i32)
+unsafe fn h(x: *mut i32) -> *mut i32 {
     *x = 1;
+    // CHECK: &*(x)
+    x
 }
+// CHECK: fn h_shim(arg0: *mut i32) -> *mut i32
+// CHECK: h(arg0)


### PR DESCRIPTION
Implements generation of unsafe shims when calling rewritten code from non-rewritten code.  Given this input:

```Rust
fn bad(x: *const i32) {
    good(x);
    // Do some unsupported operation
}

fn good(x: *const i32) {
    // ...
}
```

The tool now produces output like this:

```Rust
fn bad(x: *const i32) {
    good_shim(x);
    // Do some unsupported operation
}

fn good(x: &i32) {
    // ...
}

unsafe fn good_shim(x: *const i32) {
    good(&*x);
}
```

Here, the tool has rewritten `good` to change its argument type from `*const i32` to `&i32`, but analysis failed on `bad`, so the tool can't apply corresponding rewrites in the body of `bad`.  Previously, this would cause a type error: `bad` would continue passing `*const i32` to `good`, but `good` now expects `&i32`.  Now, the tool generates a helper function `good_shim`, which wraps `good` but keeps the original signature from before rewriting, and rewrites `bad` to call `good_shim` instead of `good`, resulting in a well-typed program.  Renaming the callee in `bad` doesn't require any analysis results, so it works even though analysis failed on `bad`.

Implementation strategy: for each failed (non-rewritten) function, we walk over the HIR and look for `ExprKind::Path`s and `ExprKind::MethodCall`s that resolve to rewritten functions.  For each one, we generate a rewrite that appends `_shim` to the end of the function name and record the `DefId` of the callee.  Then, for each callee we encountered, we generate a rewrite that inserts the shim function definition after the definition of the callee.  The shim function has to cast arguments and return values between the original unsafe types and the safe types produced by rewriting; for this, we reuse the cast-generation machinery from `rewrite::expr::mir_op` and `rewrite::expr::convert`.

This is a counterpart to #936: that one handles calls from rewritten code into non-rewritten code, and this one handles the reverse.

This PR also marks failed `fn`s as `FIXED` and thus doesn't propagate analysis failures to callers.