### PR TITLE
Update Vector Operations

### DIFF
--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -1966,6 +1966,16 @@ impl Builder {
         }
     }
 
+    pub fn struct_field_anon(self, ty: Box<Type>) -> Field {
+        Field {
+            ident: None,
+            vis: self.vis,
+            attrs: self.attrs,
+            ty: *ty,
+            colon_token: None,
+        }
+    }
+
     pub fn enum_field(self, ty: Box<Type>) -> Field {
         Field {
             ident: None,

--- a/c2rust-transpile/src/rust_ast/item_store.rs
+++ b/c2rust-transpile/src/rust_ast/item_store.rs
@@ -41,7 +41,6 @@ impl MultiImport {
         S: Into<Cow<'a, str>>,
     {
         let leaf: Cow<'a, str> = leaf.into();
-        self.leaves.insert(leaf.clone().into_owned());
         self.renames
             .insert(leaf.into_owned(), rename.into().into_owned());
     }
@@ -85,8 +84,8 @@ impl PathedMultiImports {
             } else {
                 attrs.use_multiple_item_rename(
                     path,
-                    leaves.clone().into_iter(),
-                    leaves.iter().map(|l| imports.renames.get(l).cloned()),
+                    leaves.into_iter(),
+                    imports.renames.into_iter(),
                 )
             }
         }

--- a/c2rust-transpile/src/rust_ast/item_store.rs
+++ b/c2rust-transpile/src/rust_ast/item_store.rs
@@ -9,7 +9,7 @@ use std::mem::swap;
 pub struct MultiImport {
     attrs: Option<Builder>,
     leaves: IndexSet<String>,
-    renames: IndexMap<String, String>,
+    renames: IndexMap<String, IndexSet<String>>,
 }
 
 impl MultiImport {
@@ -40,9 +40,17 @@ impl MultiImport {
     where
         S: Into<Cow<'a, str>>,
     {
-        let leaf: Cow<'a, str> = leaf.into();
-        self.renames
-            .insert(leaf.into_owned(), rename.into().into_owned());
+        let leaf: String = leaf.into().into_owned();
+        let rename: String = rename.into().into_owned();
+        if let Some(renames) = self.renames.get_mut(&leaf) {
+            renames.insert(rename);
+        } else {
+            let mut set = IndexSet::new();
+            set.insert(rename);
+            self.renames.insert(leaf.clone(), set);
+        };
+
+        self.insert(leaf);
     }
 
     pub fn insert_with_attr_rename<'a, S>(&mut self, leaf: S, attrs: Builder, rename: S)
@@ -76,16 +84,24 @@ impl PathedMultiImports {
             let attrs = imports.attrs.unwrap_or_else(mk);
 
             if leaves.len() == 1 {
-                path.push(leaves.pop().unwrap());
+                let leaf = leaves.pop().unwrap();
+                path.push(leaf.clone());
 
-                let rename = path.last().and_then(|l| imports.renames.get(l).cloned());
+                let renames = imports
+                    .renames
+                    .get(&leaf)
+                    .map(|r| Some((leaf.clone(), r.clone().into_iter())))
+                    .unwrap_or(None);
 
-                attrs.use_simple_item(path, rename)
+                attrs.use_simple_item_rename(path, renames)
             } else {
                 attrs.use_multiple_item_rename(
                     path,
                     leaves.into_iter(),
-                    imports.renames.into_iter(),
+                    imports
+                        .renames
+                        .iter()
+                        .map(|(leaf, renames)| (leaf.clone(), renames.clone().into_iter())),
                 )
             }
         }

--- a/c2rust-transpile/src/rust_ast/item_store.rs
+++ b/c2rust-transpile/src/rust_ast/item_store.rs
@@ -1,6 +1,6 @@
 use c2rust_ast_builder::{mk, Builder};
 use indexmap::{IndexMap, IndexSet};
-use syn::{ForeignItem, Ident, Item};
+use syn::{ForeignItem, Item};
 
 use std::borrow::Cow;
 use std::mem::swap;

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -44,8 +44,6 @@ impl<'c> Translation<'c> {
             }
         };
 
-        println!("translating builtin_name: {}", builtin_name);
-
         match builtin_name {
             "__builtin_huge_valf" => Ok(WithStmts::new_val(
                 mk().abs_path_expr(vec!["core", "f32", "INFINITY"]),

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -44,6 +44,8 @@ impl<'c> Translation<'c> {
             }
         };
 
+        println!("translating builtin_name: {}", builtin_name);
+
         match builtin_name {
             "__builtin_huge_valf" => Ok(WithStmts::new_val(
                 mk().abs_path_expr(vec!["core", "f32", "INFINITY"]),

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -441,6 +441,19 @@ impl<'c> Translation<'c> {
             "__builtin_ia32_pcmpestris128" => self.convert_simd_builtin(ctx, "_mm_cmpestrs", args),
             "__builtin_ia32_pcmpestriz128" => self.convert_simd_builtin(ctx, "_mm_cmpestrz", args),
 
+            "__builtin_ia32_vcvtph2ps" => self.convert_simd_builtin(ctx, "_mm_cvtph_ps", args),
+            "__builtin_ia32_vcvtps2ph256" => {
+                self.convert_simd_builtin(ctx, "_mm256_cvtps_ph", args)
+            }
+            "__builtin_ia32_vextractf128_ps256" => {
+                self.convert_simd_builtin(ctx, "_mm256_extractf128_ps", args)
+            }
+            "__builtin_ia32_vextractf128_si256" => {
+                self.convert_simd_builtin(ctx, "_mm256_extractf128_ps", args)
+            }
+            "__builtin_ia32_roundps256" => self.convert_simd_builtin(ctx, "_mm256_round_ps", args),
+            "__builtin_ia32_vcvtps2ph" => self.convert_simd_builtin(ctx, "_mm_cvtps_ph", args),
+
             "__sync_val_compare_and_swap_1"
             | "__sync_val_compare_and_swap_2"
             | "__sync_val_compare_and_swap_4"

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -797,7 +797,6 @@ pub fn translate(
                 if tcfg.reorganize_definitions {
                     t.use_feature("register_tool");
                 }
-                println!("Making submodule for {:?}", file_id);
                 let mut submodule = make_submodule(
                     &t.ast_context,
                     mod_item_store,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3595,37 +3595,6 @@ impl<'c> Translation<'c> {
                     (rhs, lhs, rhs_node)
                 };
 
-                let lhs_node_type = lhs_node
-                    .get_type()
-                    .ok_or_else(|| format_err!("lhs node bad type"))?;
-                // if self
-                //     .ast_context
-                //     .resolve_type(lhs_node_type)
-                //     .kind
-                //     .is_vector()
-                // {
-                //     println!("Trying to index vectory type:");
-                //     println!("LHS node: {:?}", lhs_node);
-                //     println!("LHS node type: {:?}", lhs_node_type);
-                //     println!("LHS node kind: {:?}", lhs_node_kind);
-                //     println!("LHS is indexable: {:?}", lhs_is_indexable);
-                //     println!("LHS: {:?}", lhs);
-                //     println!("RHS: {:?}", rhs);
-                //     let rhs = self.convert_expr(ctx.used(), *rhs)?;
-                //     println!("RHS converted: {:?}", rhs);
-                //     println!("RHS node: {:?}", rhs_node);
-                //     if let CTypeKind::Vector(vkind, size) = lhs_node_kind {
-                //         let vector_kind = self.ast_context.resolve_type(vkind.ctype);
-                //         println!("Vector kind: {:?} of size {}", vector_kind.kind, size);
-                //     }
-
-                //     return Err(TranslationError::new(
-                //         self.ast_context.display_loc(src_loc),
-                //         err_msg("Attempting to index a vector type")
-                //             .context(TranslationErrorKind::OldLLVMSimd),
-                //     ));
-                // }
-
                 let rhs = self.convert_expr(ctx.used(), *rhs)?;
                 rhs.and_then(|rhs| {
                     let simple_index_array = if ctx.needs_address() {
@@ -3699,27 +3668,28 @@ impl<'c> Translation<'c> {
                         // LHS is a vector type, we just need to do a transmute to an array and
                         // take the type
                         match lhs_node_kind {
-                            CTypeKind::Vector(vkind, size) => {
-                                // let vector_kind = self.ast_context.resolve_type(vkind.ctype);
-                                let vector_kind_size =
+                            CTypeKind::Vector(vkind, _vsize) => {
+                                let vector_kind_size_of =
                                     self.compute_size_of_type(ctx, vkind.ctype)?;
-
                                 let vector_ty = self.convert_type(vkind.ctype)?;
 
-                                // Array size is vector_kind_size * size
-                                let array_ty = mk().array_ty(
-                                    vector_ty,
-                                    // No need for this, we know it's packed ty x size already, we are
-                                    // just subscripting 1 ty
-                                    // mk().binary_expr(
-                                    //     BinOp::Mul(Default::default()),
-                                    vector_kind_size.to_expr(),
-                                    //     mk().lit_expr(mk().int_lit(*size as u128, "usize")),
-                                    // ),
-                                );
-
                                 let lhs = self.convert_expr(ctx.used(), *lhs)?;
+                                let lhs_type = lhs_node
+                                    .get_type()
+                                    .ok_or_else(|| format_err!("bad lhs type"))?;
+                                let lhs_type_size_of = self.compute_size_of_type(ctx, lhs_type)?;
+
                                 Ok(lhs.map(|lhs| {
+                                    // Array size is vector_kind_size (e.g. size_of::<__mm256>()) / element size (e.g. size_of::<u16>())
+                                    let array_ty = mk().array_ty(
+                                        vector_ty,
+                                        mk().binary_expr(
+                                            BinOp::Div(Default::default()),
+                                            // mk().lit_expr(mk().int_lit(*size as u128, "usize")),
+                                            lhs_type_size_of.to_expr(),
+                                            vector_kind_size_of.to_expr(),
+                                        ),
+                                    );
                                     mk().unsafe_().index_expr(
                                         transmute_expr(mk().infer_ty(), array_ty, lhs),
                                         cast_int(rhs, "usize", false),
@@ -3768,6 +3738,7 @@ impl<'c> Translation<'c> {
                             })?,
                         )
                         .map(|ty| &self.ast_context.resolve_type(ty.ctype).kind);
+
                 let is_variadic = match fn_ty {
                     Some(CTypeKind::Function(_, _, is_variadic, _, _)) => *is_variadic,
                     _ => false,
@@ -3786,6 +3757,7 @@ impl<'c> Translation<'c> {
                     CExprKind::ImplicitCast(_, fexp, CastKind::BuiltinFnToFnPtr, _, _) => {
                         return self.convert_builtin(ctx, fexp, args);
                     }
+
 
                     // Function pointer call
                     _ => {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -797,6 +797,7 @@ pub fn translate(
                 if tcfg.reorganize_definitions {
                     t.use_feature("register_tool");
                 }
+                println!("Making submodule for {:?}", file_id);
                 let mut submodule = make_submodule(
                     &t.ast_context,
                     mod_item_store,

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -306,7 +306,7 @@ impl<'c> Translation<'c> {
         match self.ast_context[expr_id].kind {
             // For some reason there seems to be an incorrect implicit cast here to char
             // it's possible the builtin takes a char even though the function takes an int
-            ImplicitCast(_, expr_id, IntegralCast, _, _) => expr_id,
+            ImplicitCast(_, _, IntegralCast, _, _) => expr_id,
             // (internal)(external)(vector input)
             ExplicitCast(qty, _, BitCast, _, _) => {
                 if let CTypeKind::Vector(..) = self.ast_context.resolve_type(qty.ctype).kind {
@@ -345,6 +345,7 @@ impl<'c> Translation<'c> {
             let call = mk().call_expr(mk().ident_expr(fn_name), call_params);
 
             if ctx.is_used() {
+                // Get the ty of the return value of the call
                 Ok(WithStmts::new_val(call))
             } else {
                 Ok(WithStmts::new(

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -11,14 +11,14 @@ use crate::c_ast::CastKind::{BitCast, IntegralCast};
 
 /// As of rustc 1.29, rust is known to be missing some SIMD functions.
 /// See <https://github.com/rust-lang-nursery/stdsimd/issues/579>
-static MISSING_SIMD_FUNCTIONS: [&str; 36] = [
+static MISSING_SIMD_FUNCTIONS: [&str; 35] = [
     "_mm_and_si64",
     "_mm_andnot_si64",
     "_mm_cmpeq_pi16",
     "_mm_cmpeq_pi32",
     "_mm_cmpeq_pi8",
     "_mm_cvtm64_si64",
-    "_mm_cvtph_ps",
+    // "_mm_cvtph_ps",
     "_mm_cvtsi32_si64",
     "_mm_cvtsi64_m64",
     "_mm_cvtsi64_si32",
@@ -249,9 +249,9 @@ impl<'c> Translation<'c> {
             (Float, 8) => ("_mm256_setzero_ps", 32),
             (Double, 2) => ("_mm_setzero_pd", 16),
             (Double, 4) => ("_mm256_setzero_pd", 32),
-            (Char, 16) | (Int, 4) | (LongLong, 2) => ("_mm_setzero_si128", 16),
-            (Char, 32) | (Int, 8) | (LongLong, 4) => ("_mm256_setzero_si256", 32),
-            (Char, 8) | (Int, 2) | (LongLong, 1) => {
+            (Char, 16) | (Short, 8) | (Int, 4) | (LongLong, 2) => ("_mm_setzero_si128", 16),
+            (Char, 32) | (Short, 16) | (Int, 8) | (LongLong, 4) => ("_mm256_setzero_si256", 32),
+            (Char, 8) | (Short, 4) | (Int, 2) | (LongLong, 1) => {
                 // __m64 is still unstable as of rust 1.29
                 self.use_feature("stdsimd");
 

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -158,10 +158,17 @@ impl<'c> Translation<'c> {
                 true
             }
             "__m128_u" | "__m128i_u" | "__m128d_u" | "__m256_u" | "__m256i_u" | "__m256d_u" => {
-                // FOr these, we need to `use core::arch::x86::x as __m128i_u` and so on
+                // Rust doesn't have unaligned SIMD types, but it's not incorrect to use an unaligned
+                // type instead, it's just slightly less efficient. We'll just use the aligned type
+                // and rename it to the unaligned type.
                 self.with_cur_file_item_store(|item_store| {
-                    add_arch_use_rename(item_store, "x86", name, &name.replace("_u", ""));
-                    add_arch_use_rename(item_store, "x86_64", name, &name.replace("_u", ""));
+                    add_arch_use_rename(item_store, "x86", &name.replace("_u", ""), name);
+                    add_arch_use_rename(item_store, "x86_64", &name.replace("_u", ""), name);
+                });
+
+                self.with_cur_file_item_store(|item_store| {
+                    add_arch_use(item_store, "x86", &name.replace("_u", ""));
+                    add_arch_use(item_store, "x86_64", &name.replace("_u", ""));
                 });
 
                 true


### PR DESCRIPTION
I discovered several issues when trying to transpile `ggml.c` (Attached along with a `compile_commands.json`) and decided to learn a little bit about `c2rust` and try and tackle them. I'm submitting as a draft PR for reference, I'm interested in tackling some of this myself but I'm not a member of the project so I wanted to start a discussion before putting in that effort. The issues I spotted are:

- Many builtins added since Rust 1.29.0 are not present in `translator/builtins.rs` (I added the builtins I needed, but the list in `std::core::(x86|x86_64)` is now quite long and more [intrinsics](https://github.com/gcc-mirror/gcc/tree/master/gcc/config/i386) can be supported than when it looks like this was initially written)
- Indexing vector types was not allowed. I've taken a stab at implementing this and it seems to work.
- Unrelated to vector operations, `use path::elem::X as Y;` was difficult to access. I've added some functionality to the `ItemStore` and `Builder` to make it easier to emit this type of use statement.
- Vector types like `__v8hi` are emitted when translating C builtins like `_cvtss_sh` but were undefined. I've added `use as` aliasing to define them, although this is unlikely to be correct in all cases.
- The missing and x86 only SIMD lists were out of date.
- Unaligned vector types were not supported. I've added `use as` aliasing for these too. I'm not sure if there is any case where it's incorrect to emit an aligned vector type where an unaligned type was before (although I suspect there may be some performance impact).
- I've removed stripping of implicit casts of vector builtin parameters as I found it was incorrectly stripping cast levels that were previously correct (e.g. `0 as libc::c_uint as libc::c_int` would become `0 as libc::c_uint` when the parameter type was indeed `libc::c_int`). I couldn't find a case where this caused more errors than it fixed, although again this may be the wrong approach.
- Added short packed values to the list of valid arrangements of vector integral type initializers.


There is one problem I didn't address which is that implicit casting *between* vector types doesn't seem to be supported anywhere. I couldn't figure out where I could access the "destination type" of these casts, but in general vector type cast builtins like [_mm256_castps_pd](https://doc.rust-lang.org/core/arch/x86/fn._mm256_castps_pd.html) can be emitted (these calls are free, they're just casts) to explicitly convert these types whenever an implicit cast is found.