### PR TITLE
analyze: fix panic on `addr_of!(...) as ...`

### DIFF
--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -312,7 +312,9 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             Rvalue::AddressOf(mutbl, pl) => {
                 self.enter_rvalue_place(0, |v| v.visit_place(pl));
                 if let Some(expect_ty) = expect_ty {
-                    let desc = type_desc::perms_to_desc(
+                    let desc = type_desc::perms_to_desc_with_pointee(
+                        self.acx.tcx(),
+                        self.acx.type_of(pl).ty,
                         expect_ty.ty,
                         self.perms[expect_ty.label],
                         self.flags[expect_ty.label],

--- a/c2rust-analyze/tests/filecheck/addr_of.rs
+++ b/c2rust-analyze/tests/filecheck/addr_of.rs
@@ -24,3 +24,10 @@ fn shared_ref_with_struct() {
     // CHECK-DAG: let y = &(x.a);
     let y = std::ptr::addr_of!(x.a);
 }
+
+// CHECK-LABEL: fn cast_array_to_ptr_explicit(s: &[u8; 0]) {
+pub fn cast_array_to_ptr_explicit(s: &[u8; 0]) {
+    // For now, this doesn't get rewritten - we're just checking that the analysis doesn't panic.
+    // CHECK-DAG: std::ptr::addr_of!(*s) as *const u8
+    std::ptr::addr_of!(*s) as *const u8;
+}


### PR DESCRIPTION
Fixes the panic described in https://github.com/immunant/c2rust/pull/839#issuecomment-1562290887