### PR TITLE
(`c2rust-analyze`) Add more (still incomplete) dataflow constraints for ptr casts

### DIFF
--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -141,6 +141,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             CastKind::Misc => {
                 match is_transmutable_ptr_cast(from_ty, to_ty) {
                     Some(true) => {
+                        self.do_assign_pointer_ids(to_lty.label, from_lty.label);
                         // TODO add other dataflow constraints
                     },
                     Some(false) => ::log::error!("TODO: unsupported ptr-to-ptr cast between pointee types not yet supported as safely transmutable: `{from_ty:?} as {to_ty:?}`"),

--- a/c2rust-analyze/tests/analyze/string_casts.rs
+++ b/c2rust-analyze/tests/analyze/string_casts.rs
@@ -33,3 +33,57 @@ pub fn cast_from_literal() {
 pub fn cast_from_literal_explicit() {
     std::ptr::addr_of!(*b"\0") as *const u8 as *const core::ffi::c_char;
 }
+
+/// [`PointerCast::ReifyFnPointer`]
+/// Can't figure out how to create a [`PointerCast::ReifyFnPointer`].
+#[cfg(any())]
+pub fn cast_fn_item_to_fn_ptr(f: impl Fn(u8) -> i8) {
+    f as fn(u8) -> i8;
+}
+
+/// [`PointerCast::UnsafeFnPointer`]
+/// 
+/// ```shell
+/// thread 'rustc' panicked at 'not yet implemented', c2rust-analyze/src/labeled_ty.rs:372:17
+/// ```
+#[cfg(any())]
+pub fn cast_fn_ptr_to_unsafe_fn_ptr(f: fn(u8) -> i8) {
+    f as unsafe fn(u8) -> i8;
+}
+
+/// [`PointerCast::ClosureFnPointer`]
+/// Unhandled very early on.
+#[cfg(any())]
+pub fn cast_closure_to_fn_ptr() {
+    (|b: u8| b as i8) as fn(u8) -> i8;
+}
+
+/// [`PointerCast::MutToConstPointer`]
+/// 
+/// ```shell
+/// thread 'rustc' panicked at 'not yet implemented', c2rust-analyze/src/labeled_ty.rs:372:17
+/// ```
+#[cfg(any())]
+pub fn cast_mut_to_const_ptr(p: *mut i32) {
+    p as *const i32;
+}
+
+/// Meant to be [`PointerCast::ArrayToPointer`], but is [`CastKind::Misc`].
+pub fn cast_array_ptr_to_ptr(p: *const [i32; 1]) {
+    p as *const i32;
+}
+
+/// [`PointerCast::Unsize`]
+///
+/// ```shell
+/// thread 'rustc' panicked at 'expected to find only one Assign statement, but got multiple', c2rust-analyze/src/rewrite/expr/hir_op.rs:126:21
+/// ```
+#[cfg(any())]
+pub fn cast_unsize_direct(a: &[i32; 1]) {
+    a as &[i32];
+}
+
+/// [`PointerCast::Unsize`]
+pub fn cast_unsize_indirect(a: &[i32; 1]) {
+    let _ = a.as_ptr();
+}


### PR DESCRIPTION
3c038606a32329d3e4ce21e308e8a49635a6d44f adds the simple (still incomplete) dataflow constraints for `CastKind::Misc`.  The full constraints are trickier since the types can be recursive, so I wanted to split this simpler part out into its own smaller PR first.

b20cea742881dee4c5b4dfe3003345c7db161250 adds complete dataflow constraints for `CastKind::Pointer`, which is modeled on `do_assign`, but adjusted given its a ptr cast.