### PR TITLE
Add hypothetical lifetime to structure rewrites with empty generic type parameter lists

### DIFF
--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -35,6 +35,14 @@ struct VecTup<'a> {
     bar: *mut Vec<(VecTup<'a>, *mut A<'a>)>,
 }
 
+struct Hypo {
+    h: *mut i32
+}
+
+struct HypoWrapper {
+    hw: *const Hypo
+}
+
 // let rd = (*(**ppd).a.pra).rd
 // CHECK-DAG: Label { origin: Some(Origin([[REF_D_ORIGIN:[0-9]+]])), origin_params: []{{.*}}}#&'a Data
 // CHECK-DAG: Label { origin: None, origin_params: [('d, Origin([[REF_D_ORIGIN]]){{.*}}}#Data
@@ -79,3 +87,6 @@ unsafe fn _field_access<'d>(ra: &'d mut A<'d>, ppd: *mut *mut Data<'d>) {
 // CHECK-DAG: pub rd: &'a Data<'a,'h0,'h1,'h2>,
 // CHECK-DAG: pub pra: &'h2 core::cell::Cell<(&'a mut A<'a,'h0,'h1,'h2>)>,
 // CHECK-DAG: bar: &'h3 (Vec<(VecTup<'a,'h3,'h4,'h0,'h1,'h2>, &'h4 (A<'a,'h0,'h1,'h2>))>),
+
+// CHECK-DAG: struct HypoWrapper<'h6,'h5>
+// CHECK-DAG: hw: &'h6 (Hypo<'h5>)


### PR DESCRIPTION
Deconstructing an HIR field type would fail in the case where there where the field type had no generic parameters, in that it would not be rewritten to include the new hypothetical lifetimes. Now the type is deconstructed correctly by providing an empty generic type parameter list, which allows the hir_args to have the correct value and allows `adt_ty_rw` to run and generate a rewrite for the ADT