### PR TITLE
rewrite: add #[derive(Clone)] test case

### DIFF
--- a/c2rust-analyze/tests/filecheck/aggregate1.rs
+++ b/c2rust-analyze/tests/filecheck/aggregate1.rs
@@ -54,3 +54,9 @@ pub unsafe fn repeat() {
     let x = 22;
     let _buf: [u32; 22] = [x; 22];
 }
+
+// CHECK-DAG: #[derive(Clone)]
+#[derive(Clone)]
+struct Foo {
+    x: i32,
+}


### PR DESCRIPTION
It turns out #952 was addressed indirectly via #956. This adds a test case to demonstrate the functionality is now working as expected.