### PR TITLE
Do not rewrite ADTs mentioned in extern blocks

### DIFF
--- a/analysis/tests/lighttpd-minimal/src/main.rs
+++ b/analysis/tests/lighttpd-minimal/src/main.rs
@@ -1195,12 +1195,12 @@ unsafe extern "C" fn connection_init(
         );
     }
     (*con).srv = srv;
-    (*con).plugin_slots = (*srv).plugin_slots;
-    (*con).config_data_base = (*srv).config_data_base;
+    // (*con).plugin_slots = (*srv).plugin_slots;
+    // (*con).config_data_base = (*srv).config_data_base;
     let r: *mut request_st = &mut (*con).request;
     // request_init_data(r, con, srv);
-    (*con).write_queue = &mut (*r).write_queue;
-    (*con).read_queue = &mut (*r).read_queue;
+    // (*con).write_queue = &mut (*r).write_queue;
+    // (*con).read_queue = &mut (*r).read_queue;
     // (*con).plugin_ctx = calloc(
     //     1 as libc::c_int as libc::c_ulong,
     //     (((*srv).plugins.used).wrapping_add(1 as libc::c_int as libc::c_uint) as libc::c_ulong)
@@ -1223,18 +1223,18 @@ unsafe extern "C" fn connections_get_new_connection(
 ) -> *mut connection {
     // let mut con: *mut connection = 0 as *mut connection;
     (*srv).lim_conns = ((*srv).lim_conns).wrapping_sub(1);
-    if !((*srv).conns_pool).is_null() {
-        con = (*srv).conns_pool;
-        (*srv).conns_pool = (*con).next;
-    } else {
+    // if !((*srv).conns_pool).is_null() {
+        // con = (*srv).conns_pool;
+        // (*srv).conns_pool = (*con).next;
+    // } else {
         con = connection_init(srv, con);
         connection_reset(con);
-    }
-    (*con).next = (*srv).conns;
-    if !((*con).next).is_null() {
-        (*(*con).next).prev = con;
-    }
-    (*srv).conns = con;
+    // }
+    // (*con).next = (*srv).conns;
+    // if !((*con).next).is_null() {
+        // (*(*con).next).prev = con;
+    // }
+    // (*srv).conns = con;
     return (*srv).conns;
 }
 
@@ -1246,15 +1246,15 @@ pub unsafe extern "C" fn fdevent_register(
     // mut ctx: *mut libc::c_void,
     fdn: *mut fdnode,
 ) -> *mut fdnode {
-    let ref mut fresh0 = *((*ev).fdarray).offset(fd as isize);
-    *fresh0 = fdnode_init(fdn);
-    let mut fdn: *mut fdnode = *fresh0;
+    // let ref mut fresh0 = *((*ev).fdarray).offset(fd as isize);
+    // *fresh0 = fdnode_init(fdn);
+    // let mut fdn: *mut fdnode = *fresh0;
     // (*fdn).handler = handler;
-    (*fdn).fd = fd;
+    // (*fdn).fd = fd;
     // (*fdn).ctx = ctx;
-    (*fdn).events = 0 as libc::c_int;
-    (*fdn).fde_ndx = -(1 as libc::c_int);
-    return fdn;
+    // (*fdn).events = 0 as libc::c_int;
+    // (*fdn).fde_ndx = -(1 as libc::c_int);
+    return 0 as *mut fdnode;
 }
 
 unsafe extern "C" fn fdnode_init(fdn: *mut fdnode) -> *mut fdnode {
@@ -1275,17 +1275,17 @@ unsafe extern "C" fn fdnode_init(fdn: *mut fdnode) -> *mut fdnode {
 }
 
 unsafe extern "C" fn connection_del(mut srv: *mut server, mut con: *mut connection) {
-    if !((*con).next).is_null() {
-        (*(*con).next).prev = (*con).prev;
-    }
-    if !((*con).prev).is_null() {
-        (*(*con).prev).next = (*con).next;
-    } else {
-        (*srv).conns = (*con).next;
-    }
-    (*con).prev = con; // 0 as *mut connection;
-    (*con).next = (*srv).conns_pool;
-    (*srv).conns_pool = con;
+    // if !((*con).next).is_null() {
+        // (*(*con).next).prev = (*con).prev;
+    // }
+    // if !((*con).prev).is_null() {
+    //     (*(*con).prev).next = (*con).next;
+    // } else {
+    //     (*srv).conns = (*con).next;
+    // }
+    // (*con).prev = con; // 0 as *mut connection;
+    // (*con).next = (*srv).conns_pool;
+    // (*srv).conns_pool = con;
     (*srv).lim_conns = ((*srv).lim_conns).wrapping_add(1);
 }
 
@@ -1302,7 +1302,7 @@ unsafe extern "C" fn connection_close(mut con: *mut connection) {
     (*con).request_count = 0 as libc::c_int as uint32_t;
     (*con).is_ssl_sock = 0 as libc::c_int as libc::c_char;
     (*con).revents_err = 0 as libc::c_int as uint16_t;
-    fdevent_fdnode_event_del((*srv).ev, (*con).fdn);
+    // fdevent_fdnode_event_del((*srv).ev, (*con).fdn);
     fdevent_unregister((*srv).ev, (*con).fd);
     // (*con).fdn = 0 as *mut fdnode;
     if 0 as libc::c_int == close((*con).fd) {
@@ -1348,11 +1348,11 @@ unsafe extern "C" fn fdevent_fdnode_event_unsetter(mut ev: *mut fdevents, mut fd
 
 #[no_mangle]
 pub unsafe extern "C" fn fdevent_unregister(mut ev: *mut fdevents, mut fd: libc::c_int) {
-    let mut fdn: *mut fdnode = *((*ev).fdarray).offset(fd as isize);
-    if fdn as uintptr_t & 0x3 as libc::c_int as libc::c_ulong != 0 {
-        return;
-    }
-    let ref mut fresh1 = *((*ev).fdarray).offset(fd as isize);
+    // let mut fdn: *mut fdnode = *((*ev).fdarray).offset(fd as isize);
+    // if fdn as uintptr_t & 0x3 as libc::c_int as libc::c_ulong != 0 {
+    //     return;
+    // }
+    // let ref mut fresh1 = *((*ev).fdarray).offset(fd as isize);
     // *fresh1 = 0 as *mut fdnode;
     // fdnode_free(fdn);
 }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -288,7 +288,7 @@ pub struct GlobalAnalysisCtxt<'tcx> {
 
     pub adt_metadata: AdtMetadataTable<'tcx>,
 
-    pub foreign_mentioned_tys: HashSet<Ty<'tcx>>,
+    pub foreign_mentioned_tys: HashSet<DefId>,
 }
 
 pub struct AnalysisCtxt<'a, 'tcx> {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -25,7 +25,7 @@ use rustc_middle::ty::{
     tls, AdtDef, FieldDef, GenericArgKind, GenericParamDefKind, Ty, TyCtxt, TyKind,
 };
 use rustc_type_ir::RegionKind::{ReEarlyBound, ReStatic};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::ops::Index;
 
@@ -287,6 +287,8 @@ pub struct GlobalAnalysisCtxt<'tcx> {
     pub addr_of_static: HashMap<DefId, PointerId>,
 
     pub adt_metadata: AdtMetadataTable<'tcx>,
+
+    pub foreign_mentioned_tys: HashSet<Ty<'tcx>>,
 }
 
 pub struct AnalysisCtxt<'a, 'tcx> {
@@ -536,6 +538,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             static_tys: HashMap::new(),
             addr_of_static: HashMap::new(),
             adt_metadata: construct_adt_metadata(tcx),
+            foreign_mentioned_tys: HashSet::new(),
         }
     }
 
@@ -582,6 +585,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             ref mut static_tys,
             ref mut addr_of_static,
             adt_metadata: _,
+            foreign_mentioned_tys: _,
         } = *self;
 
         *ptr_info = remap_global_ptr_info(ptr_info, map, counter.num_pointers());

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -280,6 +280,9 @@ fn update_pointer_info<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>)
 
 /// Walks the type `ty` and applies a function `f` to it if it's an ADT
 /// `f` gets applied recursively to `ty`'s generic types and fields (if applicable)
+/// If `f` returns false, recursion terminates.
+/// We only look for ADTs rather than other FFI-crossing types because ADTs
+/// are the only nominal ones, which are the ones that we may rewrite.
 fn walk_args_and_fields<'tcx, F>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, f: &mut F)
 where
     F: FnMut(DefId) -> bool,

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -303,7 +303,9 @@ fn foreign_mentioned_tys(tcx: TyCtxt) -> HashSet<DefId> {
 
 /// Walks the type `ty` and applies a function `f` to it if it's an ADT
 /// `f` gets applied recursively to `ty`'s generic types and fields (if applicable)
-/// If `f` returns false, recursion terminates.
+/// If `f` returns false, recursion terminates cases where the ADT is recursive,
+/// otherwise the function will naturally terminate given that the generic types
+/// of a type are finite in length.
 /// We only look for ADTs rather than other FFI-crossing types because ADTs
 /// are the only nominal ones, which are the ones that we may rewrite.
 fn walk_ffi_safe_ty<'tcx, F>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, f: &mut F)

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -537,16 +537,15 @@ fn run(tcx: TyCtxt) {
     // FIX the fields of structs mentioned in extern blocks
     for adt_did in &gacx.adt_metadata.struct_dids {
         if gacx.foreign_mentioned_tys.contains(adt_did) {
-            if let TyKind::Adt(adt_def, _) = tcx.type_of(adt_did).kind() {
-                let fields = adt_def.all_fields();
-                for field in fields {
-                    let field_lty = gacx.field_ltys[&field.did];
-                    eprintln!(
-                        "adding FIXED permission for {adt_did:?} field {:?}",
-                        field.did
-                    );
-                    make_ty_fixed(&mut gasn, field_lty);
-                }
+            let adt_def = tcx.adt_def(adt_did);
+            let fields = adt_def.all_fields();
+            for field in fields {
+                let field_lty = gacx.field_ltys[&field.did];
+                eprintln!(
+                    "adding FIXED permission for {adt_did:?} field {:?}",
+                    field.did
+                );
+                make_ty_fixed(&mut gasn, field_lty);
             }
         }
     }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -278,8 +278,8 @@ fn update_pointer_info<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>)
     }
 }
 
-// Walks the type `ty` and applies a function `f` to it if it's an ADT
-// `f` gets applied recursively to `ty`'s generic types and fields (if applicable)
+/// Walks the type `ty` and applies a function `f` to it if it's an ADT
+/// `f` gets applied recursively to `ty`'s generic types and fields (if applicable)
 fn walk_args_and_fields<'tcx, F>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, f: &mut F)
 where
     F: FnMut(DefId) -> bool,

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -294,10 +294,9 @@ where
         if !f(adt_def.did()) {
             return;
         }
-        let fields = adt_def.all_fields();
-        for field in fields {
-            let field_lty = tcx.type_of(field.did);
-            for arg in field_lty.walk() {
+        for field in adt_def.all_fields() {
+            let field_ty = tcx.type_of(field.did);
+            for arg in field_ty.walk() {
                 if let GenericArgKind::Type(ty) = arg.unpack() {
                     walk_args_and_fields(tcx, ty, f)
                 }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -290,7 +290,7 @@ fn foreign_mentioned_tys(tcx: TyCtxt) -> HashSet<DefId> {
             _ => None,
         })
     {
-        walk_args_and_fields(tcx, ty, &mut |did| foreign_mentioned_tys.insert(did));
+        walk_adts(tcx, ty, &mut |did| foreign_mentioned_tys.insert(did));
     }
     foreign_mentioned_tys
 }
@@ -302,7 +302,7 @@ fn foreign_mentioned_tys(tcx: TyCtxt) -> HashSet<DefId> {
 /// of a type are finite in length.
 /// We only look for ADTs rather than other FFI-crossing types because ADTs
 /// are the only nominal ones, which are the ones that we may rewrite.
-fn walk_args_and_fields<'tcx, F>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, f: &mut F)
+fn walk_adts<'tcx, F>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, f: &mut F)
 where
     F: FnMut(DefId) -> bool,
 {
@@ -310,7 +310,7 @@ where
     // relevant handling for that is below, so we can skip it here
     for arg in ty.walk().skip(1) {
         if let GenericArgKind::Type(ty) = arg.unpack() {
-            walk_args_and_fields(tcx, ty, f);
+            walk_adts(tcx, ty, f);
         }
     }
 
@@ -320,7 +320,7 @@ where
         }
         for field in adt_def.all_fields() {
             let field_ty = tcx.type_of(field.did);
-            walk_args_and_fields(tcx, field_ty, f);
+            walk_adts(tcx, field_ty, f);
         }
     }
 }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -487,6 +487,10 @@ fn run(tcx: TyCtxt) {
                     foreign_mentioned_tys.insert(ty);
                 }
             }
+            DefKind::Static(_) => {
+                eprintln!("adding static def {ldid:?}");
+                foreign_mentioned_tys.insert(tcx.type_of(ldid));
+            }
             _ => continue,
         }
     }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -326,11 +326,7 @@ where
         }
         for field in adt_def.all_fields() {
             let field_ty = tcx.type_of(field.did);
-            for arg in field_ty.walk() {
-                if let GenericArgKind::Type(ty) = arg.unpack() {
-                    walk_args_and_fields(tcx, ty, f)
-                }
-            }
+            walk_args_and_fields(tcx, field_ty, f);
         }
     }
 }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -284,6 +284,8 @@ fn walk_args_and_fields<'tcx, F>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, f: &mut F)
 where
     F: FnMut(DefId) -> bool,
 {
+    // the first type encountered in the walk is `ty`, and the
+    // relevant handling for that is below, so we can skip it here
     for arg in ty.walk().skip(1) {
         if let GenericArgKind::Type(ty) = arg.unpack() {
             walk_args_and_fields(tcx, ty, f);

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -297,8 +297,8 @@ fn foreign_mentioned_tys(tcx: TyCtxt) -> HashSet<DefId> {
 
 /// Walks the type `ty` and applies a function `f` to it if it's an ADT
 /// `f` gets applied recursively to `ty`'s generic types and fields (if applicable)
-/// If `f` returns false, recursion terminates cases where the ADT is recursive,
-/// otherwise the function will naturally terminate given that the generic types
+/// If `f` returns false, the fields of the ADT are not recursed into.
+/// Otherwise, the function will naturally terminate given that the generic types
 /// of a type are finite in length.
 /// We only look for ADTs rather than other FFI-crossing types because ADTs
 /// are the only nominal ones, which are the ones that we may rewrite.

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -306,21 +306,17 @@ fn walk_adts<'tcx, F>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, f: &mut F)
 where
     F: FnMut(DefId) -> bool,
 {
-    // the first type encountered in the walk is `ty`, and the
-    // relevant handling for that is below, so we can skip it here
-    for arg in ty.walk().skip(1) {
+    for arg in ty.walk() {
         if let GenericArgKind::Type(ty) = arg.unpack() {
-            walk_adts(tcx, ty, f);
-        }
-    }
-
-    if let TyKind::Adt(adt_def, _) = ty.kind() {
-        if !f(adt_def.did()) {
-            return;
-        }
-        for field in adt_def.all_fields() {
-            let field_ty = tcx.type_of(field.did);
-            walk_adts(tcx, field_ty, f);
+            if let TyKind::Adt(adt_def, _) = ty.kind() {
+                if !f(adt_def.did()) {
+                    continue;
+                }
+                for field in adt_def.all_fields() {
+                    let field_ty = tcx.type_of(field.did);
+                    walk_adts(tcx, field_ty, f);
+                }
+            }
         }
     }
 }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -513,7 +513,7 @@ fn run(tcx: TyCtxt) {
                 for field in fields {
                     let field_lty = gacx.field_ltys[&field.did];
                     eprintln!(
-                        "adding FIX permission for {adt_did:?} field {:?}",
+                        "adding FIXED permission for {adt_did:?} field {:?}",
                         field.did
                     );
                     make_ty_fixed(&mut gasn, field_lty);

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -473,12 +473,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirTyVisitor<'a, 'tcx> {
         #[allow(clippy::single_match)]
         match &item.kind {
             ItemKind::Struct(VariantData::Struct(field_defs, _), generics) => {
-                if self
-                    .acx
-                    .gacx
-                    .foreign_mentioned_tys
-                    .contains(&self.acx.tcx().type_of(did))
-                {
+                if self.acx.gacx.foreign_mentioned_tys.contains(&did) {
                     eprintln!("Avoiding rewrite for foreign-mentioned type: {did:?}");
                     return;
                 }

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -48,6 +48,7 @@ define_tests! {
     fields,
     field_temp,
     fixed,
+    foreign,
     insertion_sort,
     insertion_sort_driver,
     insertion_sort_rewrites,

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -4,22 +4,39 @@ extern "C" {
 
 type Alias = Bar;
 
-// CHECK-DAG: p: (g1) perms = UNIQUE, flags = FIXED
-// CHECK-DAG: p: (g2) perms = UNIQUE, flags = FIXED
+// CHECK-DAG: br: ({{.*}}) perms = UNIQUE, flags = FIXED
+// CHECK-DAG: bz: ({{.*}}) perms = UNIQUE, flags = FIXED
+// CHECK-DAG: x: ({{.*}}) perms = UNIQUE, flags = FIXED
+// CHECK-DAG: y: ({{.*}}) perms = UNIQUE, flags = FIXED
 
 // CHECK-DAG: struct Bar
+#[repr(C)]
 struct Bar {
-    // CHECK-DAG: p: *mut i32
-    p: *mut i32
+    // CHECK-DAG: br: *mut i32
+    br: *mut i32
 }
 
 // CHECK-DAG: struct Baz
+#[repr(C)]
 struct Baz {
-    // CHECK-DAG: p: *mut i32
-    p: *mut i32
+    // CHECK-DAG: bz: *mut i32
+    bz: *mut i32
 }
 
 // we need something to get rewritten in order
 // to check that `Bar` and `Baz` get output
 // in the rewrite string
 fn fizz(i: *const i32) {}
+
+extern "C" {
+    static mut s: S;
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct S {
+    // CHECK-DAG: pub x: *const i32
+    pub x: *const i32,
+    // CHECK-DAG: pub y: *const i32
+    pub y: *const i32,
+}

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -1,4 +1,4 @@
-extern "Rust" {
+extern "C" {
     fn foo(bar: Alias) -> Baz;
 }
 

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -34,6 +34,7 @@ extern "C" {
 
 #[derive(Copy, Clone)]
 #[repr(C)]
+// CHECK-LABEL: struct S
 pub struct S {
     // CHECK-DAG: pub x: *const i32
     pub x: *const i32,

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -9,6 +9,8 @@ type Alias = Bar;
 // CHECK-DAG: x: ({{.*}}) perms = UNIQUE, flags = FIXED
 // CHECK-DAG: y: ({{.*}}) perms = UNIQUE, flags = FIXED
 
+// CHECK-LABEL: BEGIN{{.*}}foreign.rs
+
 // CHECK-LABEL: struct Bar
 #[repr(C)]
 struct Bar {

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -1,0 +1,25 @@
+extern "Rust" {
+    fn foo(bar: Alias) -> Baz;
+}
+
+type Alias = Bar;
+
+// CHECK-DAG: p: (g1) perms = UNIQUE, flags = FIXED
+// CHECK-DAG: p: (g2) perms = UNIQUE, flags = FIXED
+
+// CHECK-DAG: struct Bar
+struct Bar {
+    // CHECK-DAG: p: *mut i32
+    p: *mut i32
+}
+
+// CHECK-DAG: struct Baz
+struct Baz {
+    // CHECK-DAG: p: *mut i32
+    p: *mut i32
+}
+
+// we need something to get rewritten in order
+// to check that `Bar` and `Baz` get output
+// in the rewrite string
+fn fizz(i: *const i32) {}

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -9,14 +9,14 @@ type Alias = Bar;
 // CHECK-DAG: x: ({{.*}}) perms = UNIQUE, flags = FIXED
 // CHECK-DAG: y: ({{.*}}) perms = UNIQUE, flags = FIXED
 
-// CHECK-DAG: struct Bar
+// CHECK-LABEL: struct Bar
 #[repr(C)]
 struct Bar {
     // CHECK-DAG: br: *mut i32
     br: *mut i32
 }
 
-// CHECK-DAG: struct Baz
+// CHECK-LABEL: struct Baz
 #[repr(C)]
 struct Baz {
     // CHECK-DAG: bz: *mut i32
@@ -41,7 +41,7 @@ pub struct S {
     pub y: *const i32,
 }
 
-// CHECK-DAG: struct Nit
+// CHECK-LABEL: struct Nit
 #[repr(C)]
 struct Nit {
     // CHECK-DAG: x: *mut i32
@@ -50,7 +50,7 @@ struct Nit {
     y: *mut i32,
 }
 
-// CHECK-DAG: struct Bin
+// CHECK-LABEL: struct Bin
 #[repr(C)]
 struct Bin {
     // CHECK-DAG: nit: *mut Nit

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -40,3 +40,24 @@ pub struct S {
     // CHECK-DAG: pub y: *const i32
     pub y: *const i32,
 }
+
+// CHECK-DAG: struct Nit
+#[repr(C)]
+struct Nit {
+    // CHECK-DAG: x: *mut i32
+    x: *mut i32,
+    // CHECK-DAG: y: *mut i32
+    y: *mut i32,
+}
+
+// CHECK-DAG: struct Bin
+#[repr(C)]
+struct Bin {
+    // CHECK-DAG: nit: *mut Nit
+    nit: *mut Nit,
+}
+
+extern "C" {
+    // CHECK-DAG: fn f(bin: *mut Bin)
+    fn f(bin: *mut Bin);
+}


### PR DESCRIPTION
Fixes #948. Fixes an issue where we would rewrite structs and their fields even though they appear in extern blocks.