### PR TITLE
analyze: account for `Span`s indexing into aggregated sources, not individual files

### DIFF
--- a/c2rust-analyze/src/rewrite/apply.rs
+++ b/c2rust-analyze/src/rewrite/apply.rs
@@ -434,7 +434,11 @@ impl<'a, F: FnMut(&str)> RewriteTreeSink<'a, F> {
             .src
             .as_ref()
             .unwrap_or_else(|| panic!("source is not available for file {:?}", self.file.name));
-        self.emit_str(&src[lo.0 as usize..hi.0 as usize])
+        // `lo` and `hi` are relative to the SourceMap within which various files' data is located,
+        // so subtract the file's start to obtain indices within its data.
+        let lo_in_file = lo - self.file.start_pos;
+        let hi_in_file = hi - self.file.start_pos;
+        self.emit_str(&src[lo_in_file.0 as usize..hi_in_file.0 as usize])
     }
 
     fn emit_span_with_rewrites(


### PR DESCRIPTION
We create the root span as such:
```rust
let file_span = Span::new(file.start_pos, file.end_pos, SyntaxContext::root(), None);
```
So we have to subtract `start_pos` correspondingly from each bound when using subspans to index into the file contents as their own slice.

I can't easily push a test case for this, but ran into crashes and wrong output locally.