### PR TITLE
analyze: README: fix invocation

### DIFF
--- a/c2rust-analyze/README.md
+++ b/c2rust-analyze/README.md
@@ -1,5 +1,5 @@
 ```sh
-cargo run --bin c2rust-analyze -- tests/filecheck/insertion_sort.rs -L "$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/lib" --crate-type rlib
+cargo run --bin c2rust-analyze -- tests/filecheck/insertion_sort.rs -L "$(rustc --print target-libdir)" --crate-type rlib
 ```
 
 This should produce a large amount of debug output, including a table at the


### PR DESCRIPTION
This makes things a little more concise and a little less brittle (e.g. not Linux-specific, if someone is using macOS or BSD).