### PR TITLE
fix mismatch in number of origin parameters for cast result

### DIFF
--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -316,13 +316,6 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             }
             Rvalue::Cast(CastKind::Pointer(PointerCast::MutToConstPointer), ref op, _ty) => {
                 let op_lty = self.visit_operand(op);
-                // TODO: handle Unsize casts at minimum
-                /*
-                assert!(
-                    !matches!(ty.kind(), TyKind::RawPtr(..) | TyKind::Ref(..)),
-                    "pointer Cast NYI"
-                );
-                */
                 // Here we relabel `expect_ty` to utilize the permissions it carries
                 // but substitute the rest of its `Label`s' parts with fresh origins
                 // Othwerise, this is conceptually similar to labeling the cast target

--- a/c2rust-analyze/tests/filecheck/cast.rs
+++ b/c2rust-analyze/tests/filecheck/cast.rs
@@ -39,3 +39,10 @@ pub unsafe fn cell_as_mut_as_cell(mut x: *mut i32, mut f: Foo) {
     // CHECK-DAG: x = &*((f.y) as *const std::cell::Cell<i32>);
     x = f.y;
 }
+pub struct fdnode {
+    pub ctx: *mut u8,
+}
+
+unsafe extern "C" fn server_free(fdn: *mut fdnode) {
+    let _fdn2 = fdn as *const fdnode;
+}


### PR DESCRIPTION
Fixes #944. Previously cast result types were labeled with the default label, which have no `OriginParams`. This PR mimics the behavior of labeling cast results in the special case that the cast was from a null const type, where we relabled the `expected_ty` with fresh origins.