### PR TITLE
(`c2rust-analyze`) Add `known_fns!` for declaring the permissions on ptrs in known (i.e. `libc`) `UnknownDef` `fn`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "env_logger",
  "indexmap",
  "itertools",
+ "libc",
  "log",
  "polonius-engine",
  "print_bytes",
@@ -918,9 +919,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"

--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -24,6 +24,7 @@ env_logger = "0.10.0"
 log = "0.4.17"
 backtrace = "0.3.67"
 itertools = "0.10"
+libc = "0.2.147"
 
 [build-dependencies]
 c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.18.0" }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -135,7 +135,7 @@ impl PermissionSet {
     // `.union` is used here since it's a `const fn`, unlike `BitOr::bitor`.
     pub const STRING_LITERAL: Self = Self::READ.union(Self::OFFSET_ADD);
 
-    #[allow(unused)]
+    #[cfg(test)]
     pub const fn union_all<const N: usize>(a: [Self; N]) -> Self {
         let mut this = Self::empty();
         let mut i = 0;

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -134,6 +134,17 @@ impl PermissionSet {
     //
     // `.union` is used here since it's a `const fn`, unlike `BitOr::bitor`.
     pub const STRING_LITERAL: Self = Self::READ.union(Self::OFFSET_ADD);
+
+    #[allow(unused)]
+    pub const fn union_all<const N: usize>(a: [Self; N]) -> Self {
+        let mut this = Self::empty();
+        let mut i = 0;
+        while i < N {
+            this = this.union(a[i]);
+            i += 1;
+        }
+        this
+    }
 }
 
 bitflags! {

--- a/c2rust-analyze/src/known_fn.rs
+++ b/c2rust-analyze/src/known_fn.rs
@@ -1,4 +1,3 @@
-#[cfg(test)]
 use crate::context::PermissionSet;
 
 #[allow(unused)]
@@ -16,6 +15,31 @@ macro_rules! const_slice {
 macro_rules! perms_annotation {
     ([$($($perm:ident)|*),*]) => {{
         [$(PermissionSet::union_all([$(PermissionSet::$perm,)*]),)*]
+    }};
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct KnownFnTy {
+    name: &'static str,
+    ty: &'static str,
+    perms: &'static [PermissionSet],
+}
+
+#[allow(unused)]
+macro_rules! known_fn_ty {
+    ($ty:ty: $perms:tt) => {{
+        KnownFnTy {
+            name: "",
+            ty: stringify!($ty),
+            perms: const_slice!(PermissionSet, perms_annotation!($perms)),
+        }
+    }};
+    ($ty:ty) => {{
+        KnownFnTy {
+            name: "",
+            ty: stringify!($ty),
+            perms: &[],
+        }
     }};
 }
 

--- a/c2rust-analyze/src/known_fn.rs
+++ b/c2rust-analyze/src/known_fn.rs
@@ -120,13 +120,49 @@ mod tests {
     }
 
     #[test]
-    fn known_fn_ty() {
+    fn known_fn_ty_no_perms() {
         assert_eq!(
-            known_fn_ty!(*const i32: [READ]),
+            known_fn_ty!(()),
             KnownFnTy {
                 name: "",
-                ty: "*const i32",
-                perms: const_slice!(PermissionSet, [PermissionSet::READ]),
+                ty: "()",
+                perms: &[],
+            }
+        );
+    }
+
+    #[test]
+    fn known_fn_ty_with_one_perms() {
+        assert_eq!(
+            known_fn_ty!(*mut c_char: [WRITE | OFFSET_ADD]),
+            KnownFnTy {
+                name: "",
+                ty: "*mut c_char",
+                perms: const_slice!(
+                    PermissionSet,
+                    [PermissionSet::union_all([
+                        PermissionSet::WRITE,
+                        PermissionSet::OFFSET_ADD
+                    ]),]
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn known_fn_ty_with_two_perms() {
+        assert_eq!(
+            known_fn_ty!(*mut *mut c_char: [WRITE, WRITE | OFFSET_ADD]),
+            KnownFnTy {
+                name: "",
+                ty: "*mut *mut c_char",
+                perms: const_slice!(
+                    PermissionSet,
+                    [
+                        PermissionSet::union_all([PermissionSet::WRITE,]),
+                        PermissionSet::union_all([PermissionSet::WRITE, PermissionSet::OFFSET_ADD])
+                    ]
+                ),
             }
         );
     }

--- a/c2rust-analyze/src/known_fn.rs
+++ b/c2rust-analyze/src/known_fn.rs
@@ -42,6 +42,12 @@ impl KnownFnTy {
         assert!(self.perms.len() == num_ptrs);
         self
     }
+
+    #[cfg(test)]
+    const fn named(self, name: &'static str) -> Self {
+        let Self { name: _, ty, perms } = self;
+        Self { name, ty, perms }
+    }
 }
 
 #[cfg(test)]
@@ -61,6 +67,45 @@ macro_rules! known_fn_ty {
             perms: &[],
         }
         .checked()
+    }};
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct KnownFn {
+    name: &'static str,
+    inputs: &'static [KnownFnTy],
+    output: KnownFnTy,
+}
+
+#[cfg(test)]
+macro_rules! known_fns {
+    {
+        mod $module:ident {
+
+            $(
+                fn $name:ident(
+                    $($arg_name:ident: $arg_ty:ty$(: $arg_perms:tt)?,)*
+                ) -> $return_ty:ty$(: $return_perms:tt)?
+            );*;
+
+        }
+    } => {{
+        use $module::*;
+
+        const_slice!(KnownFn, [$({
+            unsafe extern "C" fn $name($($arg_name: $arg_ty,)*) -> $return_ty {
+                $(let _ = $arg_name;)*
+                todo!()
+            }
+            // ensure the definitions match
+            [$name, $module::$name];
+
+            KnownFn {
+                name: stringify!($name),
+                inputs: const_slice!(KnownFnTy, [$(known_fn_ty!($arg_ty$(: $arg_perms)?).named(stringify!($arg_name)),)*]),
+                output: known_fn_ty!($return_ty$(: $return_perms)?),
+            }
+        },)*])
     }};
 }
 
@@ -164,6 +209,154 @@ mod tests {
                     ]
                 ),
             }
+        );
+    }
+
+    #[test]
+    fn __errno_location() {
+        assert_eq!(
+            known_fns! {
+                mod libc {
+
+                    fn __errno_location() -> *mut c_int: [READ | WRITE];
+
+                }
+            },
+            const_slice!(
+                KnownFn,
+                [KnownFn {
+                    name: "__errno_location",
+                    inputs: &[],
+                    output: KnownFnTy {
+                        name: "",
+                        ty: "*mut c_int",
+                        perms: const_slice!(
+                            PermissionSet,
+                            [PermissionSet::union_all([
+                                PermissionSet::READ,
+                                PermissionSet::WRITE
+                            ])]
+                        )
+                    }
+                }]
+            )
+        );
+    }
+
+    #[test]
+    fn read() {
+        assert_eq!(
+            known_fns! {
+                mod libc {
+
+                    fn read(
+                        fd: c_int,
+                        buf: *mut c_void: [WRITE | OFFSET_ADD],
+                        count: size_t,
+                    ) -> ssize_t;
+
+                }
+            },
+            const_slice!(
+                KnownFn,
+                [KnownFn {
+                    name: "read",
+                    inputs: const_slice!(
+                        KnownFnTy,
+                        [
+                            KnownFnTy {
+                                name: "fd",
+                                ty: "c_int",
+                                perms: &[],
+                            },
+                            KnownFnTy {
+                                name: "buf",
+                                ty: "*mut c_void",
+                                perms: const_slice!(
+                                    PermissionSet,
+                                    [PermissionSet::union_all([
+                                        PermissionSet::WRITE,
+                                        PermissionSet::OFFSET_ADD
+                                    ])]
+                                ),
+                            },
+                            KnownFnTy {
+                                name: "count",
+                                ty: "size_t",
+                                perms: &[],
+                            },
+                        ]
+                    ),
+                    output: KnownFnTy {
+                        name: "",
+                        ty: "ssize_t",
+                        perms: &[],
+                    }
+                }]
+            )
+        );
+    }
+
+    #[test]
+    fn strtol() {
+        assert_eq!(
+            known_fns! {
+                mod libc {
+
+                    fn strtol(
+                        s: *const c_char: [READ | OFFSET_ADD],
+                        endp: *mut *mut c_char: [WRITE, WRITE | OFFSET_ADD],
+                        base: c_int,
+                    ) -> c_long;
+
+                }
+            },
+            const_slice!(
+                KnownFn,
+                [KnownFn {
+                    name: "strtol",
+                    inputs: const_slice!(
+                        KnownFnTy,
+                        [
+                            KnownFnTy {
+                                name: "s",
+                                ty: "*const c_char",
+                                perms: const_slice!(
+                                    PermissionSet,
+                                    [PermissionSet::union_all([
+                                        PermissionSet::READ,
+                                        PermissionSet::OFFSET_ADD
+                                    ])]
+                                ),
+                            },
+                            KnownFnTy {
+                                name: "endp",
+                                ty: "*mut *mut c_char",
+                                perms: const_slice!(
+                                    PermissionSet,
+                                    [
+                                        PermissionSet::union_all([PermissionSet::WRITE,]),
+                                        PermissionSet::union_all([
+                                            PermissionSet::WRITE,
+                                            PermissionSet::OFFSET_ADD
+                                        ])
+                                    ]
+                                ),
+                            },
+                            KnownFnTy {
+                                name: "base",
+                                ty: "c_int",
+                                perms: &[],
+                            },
+                        ]
+                    ),
+                    output: KnownFnTy {
+                        name: "",
+                        ty: "c_long",
+                        perms: &[],
+                    }
+                }]
+            )
         );
     }
 }

--- a/c2rust-analyze/src/known_fn.rs
+++ b/c2rust-analyze/src/known_fn.rs
@@ -1,0 +1,33 @@
+#[cfg(test)]
+use crate::context::PermissionSet;
+
+#[cfg(test)]
+macro_rules! perms_annotation {
+    ([$($($perm:ident)|*),*]) => {{
+        [$(PermissionSet::union_all([$(PermissionSet::$perm,)*]),)*]
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_perms_annotation() {
+        assert_eq!(
+            perms_annotation!([WRITE | OFFSET_ADD]),
+            [PermissionSet::WRITE | PermissionSet::OFFSET_ADD]
+        );
+    }
+
+    #[test]
+    fn two_perms_annotations() {
+        assert_eq!(
+            perms_annotation!([WRITE, WRITE | OFFSET_ADD]),
+            [
+                PermissionSet::WRITE,
+                PermissionSet::WRITE | PermissionSet::OFFSET_ADD
+            ]
+        );
+    }
+}

--- a/c2rust-analyze/src/known_fn.rs
+++ b/c2rust-analyze/src/known_fn.rs
@@ -1,6 +1,17 @@
 #[cfg(test)]
 use crate::context::PermissionSet;
 
+#[allow(unused)]
+macro_rules! const_slice {
+    ($ty:ty, []) => {{
+        &[]
+    }};
+    ($ty:ty, $array:expr) => {{
+        const ARRAY: [$ty; $array.len()] = $array;
+        &ARRAY
+    }};
+}
+
 #[cfg(test)]
 macro_rules! perms_annotation {
     ([$($($perm:ident)|*),*]) => {{

--- a/c2rust-analyze/src/known_fn.rs
+++ b/c2rust-analyze/src/known_fn.rs
@@ -20,9 +20,9 @@ macro_rules! perms_annotation {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct KnownFnTy {
-    name: &'static str,
-    ty: &'static str,
-    perms: &'static [PermissionSet],
+    pub name: &'static str,
+    pub ty: &'static str,
+    pub perms: &'static [PermissionSet],
 }
 
 impl KnownFnTy {
@@ -72,9 +72,9 @@ macro_rules! known_fn_ty {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct KnownFn {
-    name: &'static str,
-    inputs: &'static [KnownFnTy],
-    output: KnownFnTy,
+    pub name: &'static str,
+    pub inputs: &'static [KnownFnTy],
+    pub output: KnownFnTy,
 }
 
 #[cfg(test)]

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -50,6 +50,7 @@ mod c_void_casts;
 mod context;
 mod dataflow;
 mod equiv;
+mod known_fn;
 mod labeled_ty;
 mod log;
 mod panic_detail;


### PR DESCRIPTION
I wrote this as a `macro_rules!` macro so that we can write the pointer permission annotations inline with what the normal `extern` declaration would look like.  The macro checks that the declaration matches `libc`'s (or wherever it could be from) and that there are the correct number of `PermissionSet`s on each type corresponding to the number of pointers directly in that type (i.e., the number of `*`).

The syntax for this is an optional `: [PERM1a | PERM1b, PERM2a | PERM2b | PERM2c]` after each type in a `fn` signature, where the order of the `PermissionSet`s corresponds to the pointers in the type in left-to-right order.  For example:

```rust
known_fns! {
    mod libc {

        #[cfg(target_os = "linux")]
        fn __errno_location() -> *mut c_int: [READ | WRITE];

        #[cfg(target_os = "macos")]
        fn __error() -> *mut c_int: [READ | WRITE];

        fn _exit(
            status: c_int,
        ) -> !;

        fn abort() -> !;

        fn abs(
            i: c_int,
        ) -> c_int;

        fn accept(
            socket: c_int,
            address: *mut sockaddr: [WRITE],
            address_len: *mut socklen_t: [READ | WRITE],
        ) -> c_int;

        fn read(
            fd: c_int,
            buf: *mut c_void: [WRITE | OFFSET_ADD],
            count: size_t,
        ) -> ssize_t;

        fn write(
            fd: c_int,
            buf: *const c_void: [READ | OFFSET_ADD],
            count: size_t,
        ) -> ssize_t;

        fn strtol(
            s: *const c_char: [READ | OFFSET_ADD],
            endp: *mut *mut c_char: [WRITE, WRITE | OFFSET_ADD],
            base: c_int,
        ) -> c_long;

    }
};
```

I'm still working on the integration of these `KnownFn`s into `fn_sigs` as `LFnSig`s, but I wanted to open a separate PR for how they are declared in the first place.