### PR TITLE
(`c2rust-analyze`) Remove `UNIQUE` from initial ptr perms before asserting it's empty

### DIFF
--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -574,8 +574,10 @@ fn run(tcx: TyCtxt) {
     mark_foreign_fixed(&mut gacx, &mut gasn, tcx);
 
     for (ptr, perms) in gacx.known_fn_ptr_perms() {
-        debug_assert_eq!(gasn.perms[ptr], PermissionSet::empty());
-        gasn.perms[ptr] = perms;
+        let existing_perms = &mut gasn.perms[ptr];
+        existing_perms.remove(PermissionSet::UNIQUE);
+        assert_eq!(*existing_perms, PermissionSet::empty());
+        *existing_perms = perms;
     }
 
     for info in func_info.values_mut() {

--- a/c2rust-analyze/tests/common/mod.rs
+++ b/c2rust-analyze/tests/common/mod.rs
@@ -184,7 +184,15 @@ impl Analyze {
                 "c2rust-analyze failed with status {status}:\n> {cmd:?} > {output_path:?} 2>&1\n"
             );
             let output = fs::read_to_string(&output_path).unwrap();
-            panic!("\n{message}\n{output}\n{message}");
+            let max_len = 10000;
+            if output.len() > max_len {
+                let (output_start, output_end) = output.split_at(output.len() / 2);
+                let output_start = &output_start[..max_len / 2];
+                let output_end = &output_end[output_end.len() - max_len / 2..];
+                panic!("\n{message}\n{output_start}\n\n...\n\n{output_end}\n{message}");
+            } else {
+                panic!("\n{message}\n{output}\n{message}");
+            };
         }
         output_path
     }


### PR DESCRIPTION
All the ptr perms are initialized to `UNIQUE`, which we forgot in a396cde371c8b22084b2e10557bed571534db6bf.  Since we know the perms exactly, we should be able to overwrite this, but we need to remove `UNIQUE` before asserting the initial perms are empty.

This also truncates the `c2rust-analyze` output printed to `stderr` when it's super long to avoid lagging `stderr`.  The full output is always available in `*.analysis.txt` and the first and last 50000 chars are printed instead now.  The test that was failing was `lighttpd_minimal`, which has a huge `*.analysis.txt`, and that made it much harder to find the actual error, so I added this.