### PR TITLE
(`c2rust-analyze/tests`) Add a generic `extern "rust-intrinsic" foreign `fn` test (currently disabled as we crash on it)

### DIFF
--- a/c2rust-analyze/tests/analyze.rs
+++ b/c2rust-analyze/tests/analyze.rs
@@ -31,6 +31,7 @@ macro_rules! define_tests {
 define_tests! {
     macros,
     ptr_addr_of,
+    rust_intrinsic,
     string_literals,
     string_casts,
 }

--- a/c2rust-analyze/tests/analyze/rust_intrinsic.rs
+++ b/c2rust-analyze/tests/analyze/rust_intrinsic.rs
@@ -1,0 +1,9 @@
+/// Check that `extern "rust-intrinsic"` (which can be generic) foreign `fn`s
+/// like [`std::mem::transmute`] don't crash `c2rust-analyze`.
+///
+/// They currently do (in [`Instance::mono`] where there are generic args),
+/// which is why this is `#[cfg]`ed out for now.
+#[cfg(any())]
+pub unsafe fn f(x: *const u8) -> *const i8 {
+    std::mem::transmute(x)
+}


### PR DESCRIPTION
* A test for #996 and #999.