### PR TITLE
analyze: refactor struct and static rewrites

### DIFF
--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -950,7 +950,10 @@ fn run(tcx: TyCtxt) {
         }
     }
 
-    let static_rewrites = rewrite::gen_static_rewrites(&gacx, &gasn);
+    let mut static_rewrites = Vec::new();
+    for (&def_id, &ptr) in gacx.addr_of_static.iter() {
+        static_rewrites.extend(rewrite::gen_static_rewrites(tcx, &gasn, def_id, ptr));
+    }
     let mut statics_report = String::new();
     writeln!(
         statics_report,

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -976,6 +976,11 @@ fn run(tcx: TyCtxt) {
     // Generate rewrites for ADTs
     let mut adt_reports = HashMap::<DefId, String>::new();
     for &def_id in gacx.adt_metadata.table.keys() {
+        if gacx.foreign_mentioned_tys.contains(&def_id) {
+            eprintln!("Avoiding rewrite for foreign-mentioned type: {def_id:?}");
+            continue;
+        }
+
         let adt_rewrites = rewrite::gen_adt_ty_rewrites(&gacx, &gasn, def_id);
         let report = adt_reports.entry(def_id).or_default();
         writeln!(

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -721,7 +721,7 @@ fn run(tcx: TyCtxt) {
         }
         let lsig = match gacx.fn_sigs.get(&ldid.to_def_id()) {
             Some(x) => x,
-            None => continue,
+            None => panic!("missing fn_sig for {:?}", ldid),
         };
         make_sig_fixed(&mut gasn, lsig);
     }

--- a/c2rust-analyze/src/rewrite/mod.rs
+++ b/c2rust-analyze/src/rewrite/mod.rs
@@ -42,7 +42,7 @@ pub use self::shim::{gen_shim_call_rewrites, gen_shim_definition_rewrite};
 use self::span_index::SpanIndex;
 pub use self::statics::gen_static_rewrites;
 pub use self::ty::dump_rewritten_local_tys;
-pub use self::ty::gen_ty_rewrites;
+pub use self::ty::{gen_adt_ty_rewrites, gen_ty_rewrites};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum LifetimeName {

--- a/c2rust-analyze/src/rewrite/statics.rs
+++ b/c2rust-analyze/src/rewrite/statics.rs
@@ -22,11 +22,10 @@ pub fn gen_static_rewrites<'tcx>(
     } else {
         panic!("def id {:?} not found", def_id);
     };
-    let mutbl = match item.kind {
-        ItemKind::Static(_ty, mutbl, _body_id) => mutbl,
+    let is_mutable = match item.kind {
+        ItemKind::Static(_ty, mutbl, _body_id) => mutbl == Mutability::Mut,
         _ => panic!("expected item {:?} to be a `static`", item),
     };
-    let is_mutable = mutbl == Mutability::Mut;
     let perms = gasn.perms[ptr];
     let written_to = perms.contains(PermissionSet::WRITE);
     if written_to != is_mutable {

--- a/c2rust-analyze/src/rewrite/statics.rs
+++ b/c2rust-analyze/src/rewrite/statics.rs
@@ -1,51 +1,52 @@
 use crate::context::PermissionSet;
+use crate::pointer_id::PointerId;
 use crate::rewrite::Rewrite;
-use crate::{GlobalAnalysisCtxt, GlobalAssignment};
+use crate::GlobalAssignment;
+use rustc_hir::def_id::DefId;
 use rustc_hir::{ItemKind, Mutability, Node};
+use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
 
 /// For every static, if its write permission does not match its declared mutability, emit a rewrite
 /// changing the declaration to match observed/analyzed usage.
 pub fn gen_static_rewrites<'tcx>(
-    gacx: &GlobalAnalysisCtxt<'tcx>,
+    tcx: TyCtxt<'tcx>,
     gasn: &GlobalAssignment,
-) -> Vec<(Span, Rewrite)> {
-    let mut hir_rewrites = Vec::new();
-    for (did, &ptr) in gacx.addr_of_static.iter() {
-        // The map of statics and their ty + permissions tracks statics by did; map this to an Item
-        // node to look at the static's spans and declared mutability.
-        let item = if let Some(Node::Item(item)) = gacx.tcx.hir().get_if_local(*did) {
-            item
-        } else {
-            panic!("def id {:?} not found", did);
-        };
-        if let ItemKind::Static(_ty, mutbl, _body_id) = item.kind {
-            let perms = gasn.perms[ptr];
-            let written_to = perms.contains(PermissionSet::WRITE);
-            let is_mutable = mutbl == Mutability::Mut;
-            if written_to != is_mutable {
-                let ident = gacx
-                    .tcx
-                    .opt_item_ident(*did)
-                    .expect("did not find ident when trying to generate rewrite for static item");
-                // Generate a span from beginning of ident to end of body.
-                let span = ident.span.with_hi(item.span.hi());
-                hir_rewrites.push((
-                    item.span,
-                    Rewrite::StaticMut(
-                        if written_to {
-                            Mutability::Mut
-                        } else {
-                            Mutability::Not
-                        },
-                        span,
-                    ),
-                ))
-            }
-        } else {
-            panic!("expected item {:?} to be a `static`", item);
-        }
+    def_id: DefId,
+    ptr: PointerId,
+) -> Option<(Span, Rewrite)> {
+    // The map of statics and their ty + permissions tracks statics by DefId; map this to an Item
+    // node to look at the static's spans and declared mutability.
+    let item = if let Some(Node::Item(item)) = tcx.hir().get_if_local(def_id) {
+        item
+    } else {
+        panic!("def id {:?} not found", def_id);
+    };
+    let mutbl = match item.kind {
+        ItemKind::Static(_ty, mutbl, _body_id) => mutbl,
+        _ => panic!("expected item {:?} to be a `static`", item),
+    };
+    let is_mutable = mutbl == Mutability::Mut;
+    let perms = gasn.perms[ptr];
+    let written_to = perms.contains(PermissionSet::WRITE);
+    if written_to != is_mutable {
+        let ident = tcx
+            .opt_item_ident(def_id)
+            .expect("def_id has no ident when trying to generate rewrite for static item");
+        // Generate a span from beginning of ident to end of body.
+        let span = ident.span.with_hi(item.span.hi());
+        Some((
+            item.span,
+            Rewrite::StaticMut(
+                if written_to {
+                    Mutability::Mut
+                } else {
+                    Mutability::Not
+                },
+                span,
+            ),
+        ))
+    } else {
+        None
     }
-
-    hir_rewrites
 }

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -588,10 +588,6 @@ pub fn gen_adt_ty_rewrites(
         _ => panic!("expected struct, enum, or union, but got {:?}", item.kind),
     };
 
-    if gacx.foreign_mentioned_tys.contains(&did) {
-        eprintln!("Avoiding rewrite for foreign-mentioned type: {did:?}");
-        return Vec::new();
-    }
     let adt_metadata = &gacx.adt_metadata.table[&did];
     let updated_lifetime_params = &adt_metadata.lifetime_params;
 

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -573,8 +573,7 @@ pub fn gen_adt_ty_rewrites(
     let item = if let Some(Node::Item(item)) = tcx.hir().get_if_local(did) {
         item
     } else {
-        //panic!("def id {:?} not found", did);
-        return Vec::new();
+        panic!("def id {:?} not found", did);
     };
 
     let field_ltys = &gacx.field_ltys;


### PR DESCRIPTION
This branch refactors rewrite generation for structs and statics to make it easier for `main.rs` to control exactly which items get rewritten.  This is in preparation for adding a filtering option that can disable rewriting for any `DefId`.  In particular, rewriting of structs and fields has been separated from rewriting of function signatures, and static rewriting has been broken up, so that all `rewrite::gen_*_rewrites` functions work on a single item per call rather than internally iterating over all relevant items.