### PR TITLE
analyze: add extern statics to gacx.static_tys

### DIFF
--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -1280,14 +1280,10 @@ fn print_labeling_for_var<'tcx>(
 fn all_static_items(tcx: TyCtxt) -> Vec<DefId> {
     let mut order = Vec::new();
 
-    for root_ldid in tcx.hir().body_owners() {
+    for root_ldid in tcx.hir_crate_items(()).definitions() {
         match tcx.def_kind(root_ldid) {
-            DefKind::Fn | DefKind::AssocFn | DefKind::AnonConst | DefKind::Const => continue,
             DefKind::Static(_) => {}
-            dk => panic!(
-                "unexpected def_kind {:?} for body_owner {:?}",
-                dk, root_ldid
-            ),
+            _ => continue,
         }
         order.push(root_ldid.to_def_id())
     }

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -357,6 +357,17 @@ fn mark_foreign_fixed<'tcx>(
         }
     }
 
+    // FIX the types of static declarations in extern blocks
+    for (did, lty) in gacx.static_tys.iter() {
+        if tcx.is_foreign_item(did) {
+            make_ty_fixed(gasn, lty);
+
+            // Also fix the `addr_of_static` permissions.
+            let ptr = gacx.addr_of_static[&did];
+            gasn.flags[ptr].insert(FlagSet::FIXED);
+        }
+    }
+
     // FIX the fields of structs mentioned in extern blocks
     for adt_did in &gacx.adt_metadata.struct_dids {
         if gacx.foreign_mentioned_tys.contains(adt_did) {

--- a/c2rust-analyze/src/rewrite/statics.rs
+++ b/c2rust-analyze/src/rewrite/statics.rs
@@ -1,4 +1,4 @@
-use crate::context::PermissionSet;
+use crate::context::{FlagSet, PermissionSet};
 use crate::pointer_id::PointerId;
 use crate::rewrite::Rewrite;
 use crate::GlobalAssignment;
@@ -15,6 +15,13 @@ pub fn gen_static_rewrites<'tcx>(
     def_id: DefId,
     ptr: PointerId,
 ) -> Option<(Span, Rewrite)> {
+    // If the `addr_of_static` `PointerId` is `FIXED`, then we're forbidden from emitting this
+    // rewrite.
+    let flags = gasn.flags[ptr];
+    if flags.contains(FlagSet::FIXED) {
+        return None;
+    }
+
     // The map of statics and their ty + permissions tracks statics by DefId; map this to an Item
     // node to look at the static's spans and declared mutability.
     let item = if let Some(Node::Item(item)) = tcx.hir().get_if_local(def_id) {

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -8,6 +8,8 @@ type Alias = Bar;
 // CHECK-DAG: bz: ({{.*}}) perms = UNIQUE, flags = FIXED
 // CHECK-DAG: x: ({{.*}}) perms = UNIQUE, flags = FIXED
 // CHECK-DAG: y: ({{.*}}) perms = UNIQUE, flags = FIXED
+// CHECK-DAG: "s": addr_of flags = FIXED
+// CHECK-DAG: "STATIC_PTR": addr_of flags = FIXED, type flags = FIXED#{{.*}}
 
 // CHECK-LABEL: BEGIN{{.*}}foreign.rs
 

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -32,6 +32,7 @@ fn fizz(i: *const i32) {}
 
 extern "C" {
     static mut s: S;
+    static mut STATIC_PTR: *mut S;
 }
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
This has three parts:

* Add extern statics to `gacx.static_tys`
* Mark all extern statics `FIXED`, covering both `static_tys[def_id]` and `addr_of_static[def_id]`
* Don't attempt to change `static` to `static mut` or vice versa if its `addr_of_static` is FIXED

Together, the last two prevent attempts to rewrite extern statics, which would otherwise panic because `gen_static_rewrites` isn't designed to handle extern statics (it expects the `DefId` to refer to a non-extern HIR item).