### PR TITLE
Prevent foreign-mentioned field types from getting their hypothetical origins generated / propagated to encapsulating structures

### DIFF
--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -35,7 +35,7 @@ use rustc_middle::mir::{
     AggregateKind, BindingForm, Body, Constant, Local, LocalDecl, LocalInfo, LocalKind, Location,
     Operand, Rvalue, StatementKind,
 };
-use rustc_middle::ty::{GenericArgKind, Ty, TyCtxt, TyKind, WithOptConstParam};
+use rustc_middle::ty::{Ty, TyCtxt, TyKind, WithOptConstParam};
 use rustc_span::Span;
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -277,49 +277,6 @@ fn update_pointer_info<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>)
         if let Some(ptr) = acx.ptr_of(local) {
             if !is_temp_ref {
                 acx.ptr_info_mut()[ptr].insert(PointerInfo::NOT_TEMPORARY_REF);
-            }
-        }
-    }
-}
-
-fn foreign_mentioned_tys(tcx: TyCtxt) -> HashSet<DefId> {
-    let mut foreign_mentioned_tys = HashSet::new();
-    for ty in tcx
-        .hir_crate_items(())
-        .foreign_items()
-        .map(|item| item.def_id.to_def_id())
-        .filter_map(|did| match tcx.def_kind(did) {
-            DefKind::Fn | DefKind::AssocFn => Some(tcx.mk_fn_ptr(tcx.fn_sig(did))),
-            DefKind::Static(_) => Some(tcx.type_of(did)),
-            _ => None,
-        })
-    {
-        walk_adts(tcx, ty, &mut |did| foreign_mentioned_tys.insert(did));
-    }
-    foreign_mentioned_tys
-}
-
-/// Walks the type `ty` and applies a function `f` to it if it's an ADT
-/// `f` gets applied recursively to `ty`'s generic types and fields (if applicable)
-/// If `f` returns false, the fields of the ADT are not recursed into.
-/// Otherwise, the function will naturally terminate given that the generic types
-/// of a type are finite in length.
-/// We only look for ADTs rather than other FFI-crossing types because ADTs
-/// are the only nominal ones, which are the ones that we may rewrite.
-fn walk_adts<'tcx, F>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, f: &mut F)
-where
-    F: FnMut(DefId) -> bool,
-{
-    for arg in ty.walk() {
-        if let GenericArgKind::Type(ty) = arg.unpack() {
-            if let TyKind::Adt(adt_def, _) = ty.kind() {
-                if !f(adt_def.did()) {
-                    continue;
-                }
-                for field in adt_def.all_fields() {
-                    let field_ty = tcx.type_of(field.did);
-                    walk_adts(tcx, field_ty, f);
-                }
             }
         }
     }
@@ -586,10 +543,6 @@ fn run(tcx: TyCtxt) {
             && (info.contains(PointerInfo::ANNOTATED)
                 || info.contains(PointerInfo::NOT_TEMPORARY_REF))
     }
-
-    // track all types mentioned in extern blocks, we
-    // don't want to rewrite those
-    gacx.foreign_mentioned_tys = foreign_mentioned_tys(tcx);
 
     let mut gasn =
         GlobalAssignment::new(gacx.num_pointers(), PermissionSet::UNIQUE, FlagSet::empty());

--- a/c2rust-analyze/tests/filecheck/cast.rs
+++ b/c2rust-analyze/tests/filecheck/cast.rs
@@ -1,9 +1,3 @@
-// CHECK-DAG: struct S<'h0> {
-struct S {
-    // CHECK-DAG: i: &'h0 i32
-    i: *const i32,
-}
-
 // The below ensures the concrete origins for `s` and `s.i` are the same and are hypothetical
 // CHECK-DAG: assign {{.*}}#*mut S{{.*}}origin_params: [('h0, Origin([[HYPO_ORIGIN:[0-9]+]]))]{{.*}} = Label{{.*}}origin_params: [('h0, Origin({{.*}}))]
 // CHECK-DAG: assign Label { origin: Some(Origin([[HYPO_ORIGIN]])){{.*}}*const i32{{.*}} = Label
@@ -17,6 +11,12 @@ pub unsafe fn null_ptr() {
     (*s).i = 0 as *const i32;
 }
 
+// CHECK-DAG: struct S<'h0> {
+struct S {
+    // CHECK-DAG: i: &'h0 (i32)
+    i: *const i32,
+}
+
 #[repr(C)]
 pub struct Foo {
     y: *mut i32,
@@ -27,7 +27,7 @@ extern "C" {
     fn bar(f: Foo);
 }
 
-// CHECK-LABEL: pub unsafe fn cell_as_mut_as_cell<'h0,'h1>(mut x: &'h0 core::cell::Cell<(i32)>, mut f: Foo<'h1>) {
+// CHECK-LABEL: pub unsafe fn cell_as_mut_as_cell<'h0>(mut x: &'h0 core::cell::Cell<(i32)>, mut f: Foo) {
 pub unsafe fn cell_as_mut_as_cell(mut x: *mut i32, mut f: Foo) {
     let z = x;
     let r = x;

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -1,37 +1,27 @@
-// CHECK-LABEL: === ADT Metadata ===
-// CHECK-DAG: struct Data<'d,'h0,'h1,'h2> {
 pub struct Data<'d> {
     // 1: hypothetical pointer field lifetime 'h0 -> Data<'d, 'h0>
-    // CHECK-DAG: pi: &'h0 i32
     pub pi: *mut i32,
 
     // 2: hypothetical pointer field lifetime 'h1 -> Data<'d, 'h0, 'h1>
     // 3: A has no new parameters to bubble up
     // 8: A has new lifetime param 'h2 -> Data<'d, 'h0, 'h1, 'h2>
-    // CHECK-DAG: pa: &'h1 A<'d,'h0,'h1,'h2>
     pub pa: *mut A<'d>,
 
     // 4: A has no new parameters to bubble up
-    // CHECK-DAG: a: A<'d,'h0,'h1,'h2>
     pub a: A<'d>,
 }
 
-// CHECK-DAG: struct A<'a,'h0,'h1,'h2> {
 pub struct A<'a> {
     // 5: Data has new lifetime params 'h0 and 'h1 -> A<'a, 'h0, 'h1>
     // 9: Data has new lifetime param 'h2, but 'h2 is already in A
-    // CHECK-DAG: rd: &'a Data<'a,'h0,'h1,'h2>
     pub rd: &'a Data<'a>,
 
     // 6: hypothetical pointer field lifetime 'h2 -> A<'a, 'h0, 'h1, 'h2>
     // 7: A has new lifetime params to bubble up, but they're already present
-    // CHECK-DAG: pra: &'h2 &'a A<'a,'h0,'h1,'h2>
     pub pra: *mut &'a mut A<'a>,
 }
 
-// CHECK-DAG: struct VecTup<'a,'h3,'h4,'h0,'h1,'h2> {
 struct VecTup<'a> {
-    // CHECK-DAG: bar: &'h3 std::vec::Vec<(VecTup<'a,'h3,'h4,'h0,'h1,'h2>,&'h4 A<'a,'h0,'h1,'h2>),std::alloc::Global>
     bar: *mut Vec<(VecTup<'a>, *mut A<'a>)>,
 }
 
@@ -86,6 +76,8 @@ unsafe fn _field_access<'d, 'a: 'd, T: Clone + Copy>(ra: &'d mut A<'d>, ppd: *mu
 // CHECK-DAG: pub struct A<'a,'h0,'h1,'h2> {
 // CHECK-DAG: pub rd: &'a Data<'a,'h0,'h1,'h2>,
 // CHECK-DAG: pub pra: &'h2 core::cell::Cell<(&'a mut A<'a,'h0,'h1,'h2>)>,
+
+// CHECK-DAG: struct VecTup<'a,'h3,'h4,'h0,'h1,'h2> {
 // CHECK-DAG: bar: &'h3 (Vec<(VecTup<'a,'h3,'h4,'h0,'h1,'h2>, &'h4 (A<'a,'h0,'h1,'h2>))>),
 
 // CHECK-DAG: struct HypoWrapper<'h6,'h5>
@@ -130,7 +122,7 @@ unsafe fn f() {
 }
 
 // CHECK-LABEL: fn empty_generics<'h0>(test: &'h0 (i32))
-fn empty_generics<>(test: *const i32) {}
+fn empty_generics(test: *const i32) {}
 
 // CHECK-LABEL: fn no_generics<'h0>(test: &'h0 (i32))
 fn no_generics(test: *const i32) {}
@@ -143,5 +135,7 @@ fn lifetime_and_const_generics<'a, 't: 'a, const N: usize>(test: *const i32) {}
 
 // CHECK-LABEL: fn where_clause<'a, 'b,'h0>(x: &'a i32, y: &'b i32, test: &'h0 (i32))
 fn where_clause<'a, 'b>(x: &'a i32, y: &'b i32, test: *const i32)
-where 'a: 'b {
+where
+    'a: 'b,
+{
 }

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -67,3 +67,24 @@ extern "C" {
     // CHECK-DAG: fn f(bin: *mut Bin)
     fn f(bin: *mut Bin);
 }
+
+extern "C" {
+    // CHECK-DAG: fn epoll_wait(events: *mut epoll_event);
+    fn epoll_wait(events: *mut epoll_event);
+}
+
+// CHECK-DAG: pub struct fdevents<'h0> {
+pub struct fdevents {
+    // CHECK-DAG: pub epoll_events: &'h0 (epoll_event),
+    pub epoll_events: *mut epoll_event,
+}
+
+// CHECK-DAG: pub struct epoll_event {
+pub struct epoll_event {
+    // CHECK-DAG: pub ptr: *mut u8,
+    pub ptr: *mut u8,
+}
+
+// CHECK-DAG: fn events<'h0>(f: fdevents<'h0>) {}
+fn events(f: fdevents) {}
+


### PR DESCRIPTION
Fixes #994 