### PR TITLE
analyze: add DefId filter

### DIFF
--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -387,6 +387,11 @@ fn mark_foreign_fixed<'tcx>(
 }
 
 fn run(tcx: TyCtxt) {
+    eprintln!("all defs:");
+    for ldid in tcx.hir_crate_items(()).definitions() {
+        eprintln!("{:?}", ldid);
+    }
+
     let mut gacx = GlobalAnalysisCtxt::new(tcx);
     let mut func_info = HashMap::new();
 


### PR DESCRIPTION
Adds an environment variable `C2RUST_ANALYZE_FIXED_DEFS_LIST`, which can be set to a file path containing a list of `DefId`s.  Each def on this list will have its pointers marked `FIXED`.  Rewriting is also skipped for these defs (for now - this might not be strictly necessary).

The def list file (if provided) is expected to contain `DefId`s in their `fmt::Debug` format, one per line.  That is, each line should look like `DefId(0:6 ~ alias1[0dc4]::alias1_good)` (the short form `DefId(0:6)` is also accepted, but is less readable).  Blank lines and comments (starting with `#`) are ignored.  For convenience, `c2rust-analyze` now prints all the `DefId`s in the crate at startup, so that output can be used to build the def list file.