### PR TITLE
analyze: omit unused hypothetical lifetimes during rewriting

### DIFF
--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -703,8 +703,12 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
     /// in the crate have already been labeled in `field_ltys`.
     pub fn construct_region_metadata(&mut self) {
         debug_assert!(self.adt_metadata.table.is_empty());
-        self.adt_metadata = construct_adt_metadata(self.tcx, &self.field_ltys, |_| true);
         debug_assert!(self.fn_origins.fn_info.is_empty());
+        self.construct_region_metadata_filtered(|_| true);
+    }
+
+    pub fn construct_region_metadata_filtered(&mut self, filter: impl FnMut(LTy<'tcx>) -> bool) {
+        self.adt_metadata = construct_adt_metadata(self.tcx, &self.field_ltys, filter);
         self.fn_origins = fn_origin_args_params(self.tcx, &self.adt_metadata);
     }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -539,6 +539,10 @@ fn run(tcx: TyCtxt) {
         gacx.assign_pointer_to_fields(did);
     }
 
+    // Compute hypothetical region data for all ADTs and functions.  This can only be done after
+    // all field types are labeled.
+    gacx.construct_region_metadata();
+
     // ----------------------------------
     // Compute dataflow constraints
     // ----------------------------------

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -26,6 +26,7 @@ use crate::labeled_ty::LabeledTyCtxt;
 use crate::log::init_logger;
 use crate::panic_detail::PanicDetail;
 use crate::util::{Callee, TestAttr};
+use ::log::warn;
 use context::AdtMetadataTable;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, DefId, DefIndex, LocalDefId};
@@ -944,8 +945,30 @@ fn run(tcx: TyCtxt) {
     eprintln!("reached fixpoint in {} iterations", loop_count);
 
     // Check that these perms haven't changed.
+    let mut known_perm_error_ptrs = HashSet::new();
     for (ptr, perms) in gacx.known_fn_ptr_perms() {
-        assert_eq!(perms, gasn.perms[ptr]);
+        if gasn.perms[ptr] != perms {
+            known_perm_error_ptrs.insert(ptr);
+            warn!(
+                "known permissions changed for PointerId {ptr:?}: {perms:?} -> {:?}",
+                gasn.perms[ptr]
+            );
+        }
+    }
+
+    let mut known_perm_error_fns = HashSet::new();
+    for (&def_id, lsig) in &gacx.fn_sigs {
+        if !tcx.is_foreign_item(def_id) {
+            continue;
+        }
+        for lty in lsig.inputs_and_output().flat_map(|lty| lty.iter()) {
+            let ptr = lty.label;
+            if !ptr.is_none() && known_perm_error_ptrs.contains(&ptr) {
+                known_perm_error_fns.insert(def_id);
+                warn!("known permissions changed for {def_id:?}: {lsig:?}");
+                break;
+            }
+        }
     }
 
     // ----------------------------------
@@ -1263,6 +1286,13 @@ fn run(tcx: TyCtxt) {
         gacx.fns_failed.len(),
         all_fn_ldids.len()
     );
+
+    if known_perm_error_fns.len() > 0 {
+        eprintln!(
+            "saw permission errors in {} known fns",
+            known_perm_error_fns.len()
+        );
+    }
 }
 
 trait AssignPointerIds<'tcx> {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -25,6 +25,7 @@ use crate::equiv::{GlobalEquivSet, LocalEquivSet};
 use crate::labeled_ty::LabeledTyCtxt;
 use crate::log::init_logger;
 use crate::panic_detail::PanicDetail;
+use crate::type_desc::Ownership;
 use crate::util::{Callee, TestAttr};
 use ::log::warn;
 use context::AdtMetadataTable;
@@ -1008,6 +1009,25 @@ fn run(tcx: TyCtxt) {
     // ----------------------------------
     // Generate rewrites
     // ----------------------------------
+
+    // Regenerate region metadata, with hypothetical regions only in places where we intend to
+    // introduce refs.
+    gacx.construct_region_metadata_filtered(|lty| {
+        let ptr = lty.label;
+        if ptr.is_none() {
+            return false;
+        }
+        let flags = gasn.flags[ptr];
+        if flags.contains(FlagSet::FIXED) {
+            return false;
+        }
+        let perms = gasn.perms[ptr];
+        let desc = type_desc::perms_to_desc(lty.ty, perms, flags);
+        match desc.own {
+            Ownership::Imm | Ownership::Cell | Ownership::Mut => true,
+            Ownership::Raw | Ownership::RawMut | Ownership::Rc | Ownership::Box => false,
+        }
+    });
 
     // For testing, putting #[c2rust_analyze_test::fail_before_rewriting] on a function marks it as
     // failed at this point.

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -56,6 +56,7 @@ define_tests! {
     offset1,
     offset2,
     ptrptr1,
+    regions_fixed,
     statics,
     test_attrs,
     trivial,

--- a/c2rust-analyze/tests/filecheck/aggregate1.rs
+++ b/c2rust-analyze/tests/filecheck/aggregate1.rs
@@ -71,7 +71,7 @@ pub union Onion {
     y: *mut u8,
 }
 
-// CHECK-DAG: struct UseOnion<'h2,'h1> {
+// CHECK-DAG: struct UseOnion<'h1,'h2> {
 struct UseOnion {
     // CHECK-DAG: foo: &'h2 (Onion<'h1>)
     foo: *mut Onion,

--- a/c2rust-analyze/tests/filecheck/cast.rs
+++ b/c2rust-analyze/tests/filecheck/cast.rs
@@ -27,7 +27,7 @@ extern "C" {
     fn bar(f: Foo);
 }
 
-// CHECK-LABEL: pub unsafe fn cell_as_mut_as_cell<'h0,'h1>(mut x: &'h0 core::cell::Cell<(i32)>, mut f: Foo<'h1>) {
+// CHECK-LABEL: pub unsafe fn cell_as_mut_as_cell<'h0>(mut x: &'h0 core::cell::Cell<(i32)>, mut f: Foo) {
 pub unsafe fn cell_as_mut_as_cell(mut x: *mut i32, mut f: Foo) {
     let z = x;
     let r = x;

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -29,9 +29,9 @@ pub struct A<'a> {
     pub pra: *mut &'a mut A<'a>,
 }
 
-// CHECK-DAG: struct VecTup<'a,'h3,'h4,'h0,'h1,'h2> {
+// CHECK-DAG: struct VecTup<'a,'h0,'h1,'h2,'h3,'h4> {
 struct VecTup<'a> {
-    // CHECK-DAG: bar: &'h3 std::vec::Vec<(VecTup<'a,'h3,'h4,'h0,'h1,'h2>,&'h4 A<'a,'h0,'h1,'h2>),std::alloc::Global>
+    // CHECK-DAG: bar: &'h4 std::vec::Vec<(VecTup<'a,'h0,'h1,'h2,'h3,'h4>,&'h3 A<'a,'h0,'h1,'h2>),std::alloc::Global>
     bar: *mut Vec<(VecTup<'a>, *mut A<'a>)>,
 }
 
@@ -86,9 +86,9 @@ unsafe fn _field_access<'d, 'a: 'd, T: Clone + Copy>(ra: &'d mut A<'d>, ppd: *mu
 // CHECK-DAG: pub struct A<'a,'h0,'h1,'h2> {
 // CHECK-DAG: pub rd: &'a Data<'a,'h0,'h1,'h2>,
 // CHECK-DAG: pub pra: &'h2 core::cell::Cell<(&'a mut A<'a,'h0,'h1,'h2>)>,
-// CHECK-DAG: bar: &'h3 (Vec<(VecTup<'a,'h3,'h4,'h0,'h1,'h2>, &'h4 (A<'a,'h0,'h1,'h2>))>),
+// CHECK-DAG: bar: &'h4 (Vec<(VecTup<'a,'h0,'h1,'h2,'h3,'h4>, &'h3 (A<'a,'h0,'h1,'h2>))>),
 
-// CHECK-DAG: struct HypoWrapper<'h6,'h5>
+// CHECK-DAG: struct HypoWrapper<'h5,'h6>
 // CHECK-DAG: hw: &'h6 (Hypo<'h5>)
 
 // CHECK-DAG: unsafe fn _field_access<'d, 'a: 'd,'h0,'h1,'h2,'h3,'h4,'h5,'h6,'h7, T: Clone + Copy>(ra: &'d mut A<'d,'h0,'h1,'h2>, ppd: &'h3 mut (&'h4 mut (Data<'d,'h5,'h6,'h7>))) {

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -67,3 +67,23 @@ extern "C" {
     // CHECK-DAG: fn f(bin: *mut Bin)
     fn f(bin: *mut Bin);
 }
+
+extern "C" {
+    // CHECK-DAG: fn epoll_wait(events: *mut epoll_event);
+    fn epoll_wait(events: *mut epoll_event);
+}
+
+// CHECK-DAG: pub struct fdevents<'h0> {
+pub struct fdevents {
+    // CHECK-DAG: pub epoll_events: &'h0 (epoll_event),
+    pub epoll_events: *mut epoll_event,
+}
+
+// CHECK-DAG: pub struct epoll_event {
+pub struct epoll_event {
+    // CHECK-DAG: pub ptr: *mut u8,
+    pub ptr: *mut u8,
+}
+
+// CHECK-DAG: fn events<'h0>(f: fdevents<'h0>) {}
+fn events(f: fdevents) {}

--- a/c2rust-analyze/tests/filecheck/regions_fixed.rs
+++ b/c2rust-analyze/tests/filecheck/regions_fixed.rs
@@ -1,0 +1,39 @@
+#![feature(register_tool)]
+#![register_tool(c2rust_analyze_test)]
+
+use std::ptr;
+
+// CHECK-LABEL: struct WrapPtr<'h0>
+struct WrapPtr {
+    // CHECK: x: *mut u8,
+    #[c2rust_analyze_test::fixed_signature]
+    x: *mut u8,
+    // CHECK: y: &'h0 mut (u8),
+    y: *mut u8,
+}
+
+// CHECK-LABEL: struct UseWrapPtr<'h0,'h1>
+struct UseWrapPtr {
+    // CHECK: p: *mut WrapPtr<'h0>,
+    #[c2rust_analyze_test::fixed_signature]
+    p: *mut WrapPtr,
+    // CHECK: q: &'h1 (WrapPtr<'h0>),
+    q: *mut WrapPtr,
+}
+
+// CHECK-LABEL: fn f_ptr<'h0>(x: &'h0 mut (u8))
+unsafe fn f_ptr(x: *mut u8) {
+    *x = 1;
+}
+
+// CHECK-LABEL: fn f_wrap_ptr<'h0,'h1>(p: &'h0 (WrapPtr<'h1>))
+unsafe fn f_wrap_ptr(p: *mut WrapPtr) {
+    f_ptr((*p).x);
+    f_ptr((*p).y);
+}
+
+// CHECK-LABEL: fn f_use_wrap_ptr<'h0,'h1,'h2>(u: &'h0 (UseWrapPtr<'h1,'h2>))
+unsafe fn f_use_wrap_ptr(u: *mut UseWrapPtr) {
+    f_wrap_ptr((*u).p);
+    f_wrap_ptr((*u).q);
+}


### PR DESCRIPTION
This change removes hypothetical lifetimes for pointers that are rewritten into non-ref types, such as raw pointers or `Box<T>`.  The `AdtMetadataTable` is computed normally at first so it can be used in borrowck, but once all pointer permissions have been determined, it's recomputed with an extra filter that skips creating hypothetical region params for pointers whose `type_desc::Ownership` is not `Imm`, `Cell`, or `Mut` (`&T`, `&Cell<T>`, or `&mut T`).

For example:
```Rust
struct Foo {
   p: *mut u8,
   #[c2rust_analyze_test::fixed_signature]
   q: *mut u8,
}
```
Previously, `Foo` would be rewritten to have two new region parameters, one for `p` and one for `q`.  But the region for `q` would unused: `q` is marked `FIXED`, so it's left as `*mut u8` rather than rewritten to a safe reference type.  With this change, `Foo` is rewritten to have only one region parameter, the one for `p`.  This avoids rustc errors about unused generic parameters in the rewritten code.