### PR TITLE
analyze: fix deconstruct_hir_ty adt/path case

### DIFF
--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -212,7 +212,10 @@ fn deconstruct_hir_ty<'a, 'tcx>(
             }
         }
 
-        (&ty::TyKind::Adt(adt_def, substs), &hir::TyKind::Path(..)) => {
+        (
+            &ty::TyKind::Adt(adt_def, substs),
+            &hir::TyKind::Path(hir::QPath::Resolved(_, ref path)),
+        ) if path.res.def_id() == adt_def.did() => {
             hir_generic_ty_args(hir_ty).map(|type_args| {
                 if type_args.len() < substs.types().count() {
                     // this situation occurs when there are hidden type arguments

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -61,6 +61,7 @@ define_tests! {
     statics,
     test_attrs,
     trivial,
+    type_alias,
     type_annotation_rewrite,
     unrewritten_calls,
     unrewritten_calls_shim_fail,

--- a/c2rust-analyze/tests/filecheck/type_alias.rs
+++ b/c2rust-analyze/tests/filecheck/type_alias.rs
@@ -1,0 +1,11 @@
+// Regression test: previously, type aliases for `Option<*const T>` caused a panic, as
+// `deconstruct_hir_ty` would match the HIR alias with the MIR type `Option<T>` and then get
+// confused due to the mismatched number of type arguments.
+type AliasOption = Option<*const u8>;
+
+// CHECK: struct UseAliasOption<'h0>
+struct UseAliasOption {
+    // FIXME: should be `Option<&'h0 u8>`
+    // CHECK: x: std::option::Option<&u8>
+    x: AliasOption,
+}


### PR DESCRIPTION
Previously, type aliases for `Option<*const T>` caused a panic, as `deconstruct_hir_ty` would match the HIR alias with the MIR type `Option<T>` and then get confused due to the mismatched number of type arguments.  With this fix, `deconstruct_hir_ty` will no longer match the HIR alias with the MIR type as the two have different `DefId`s.