### PR TITLE
analyze: assign fresh PointerIds to Ref and AddressOf rvalues

### DIFF
--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -173,6 +173,8 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 }
                 RvalueDesc::AddrOfLocal { .. } => {}
             }
+            let derived_lty = self.acx.derived_type_of_rvalue(rv);
+            self.do_assign(rvalue_lty, derived_lty);
             return;
         }
 

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -187,6 +187,10 @@ fn label_rvalue_tys<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>) {
             let _g = panic_detail::set_current_span(stmt.source_info.span);
 
             let lty = match rv {
+                Rvalue::Ref(..) | Rvalue::AddressOf(..) => {
+                    let ty = rv.ty(acx, acx.tcx());
+                    acx.assign_pointer_ids(ty)
+                }
                 Rvalue::Aggregate(ref kind, ref _ops) => match **kind {
                     AggregateKind::Array(elem_ty) => {
                         let elem_lty = acx.assign_pointer_ids(elem_ty);

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -141,8 +141,13 @@ impl<'tcx> Visitor<'tcx> for ConvertVisitor<'tcx> {
 
                 mir_op::RewriteKind::RawToRef { mutbl } => {
                     // &raw _ to &_ or &raw mut _ to &mut _
-                    assert!(matches!(hir_rw, Rewrite::Identity));
-                    Rewrite::Ref(Box::new(self.get_subexpr(ex, 0)), mutbl_from_bool(*mutbl))
+                    match hir_rw {
+                        Rewrite::Identity => {
+                            Rewrite::Ref(Box::new(self.get_subexpr(ex, 0)), mutbl_from_bool(*mutbl))
+                        }
+                        Rewrite::AddrOf(rw, mutbl) => Rewrite::Ref(rw, mutbl),
+                        _ => panic!("unexpected hir_rw {hir_rw:?} for RawToRef"),
+                    }
                 }
 
                 mir_op::RewriteKind::CellGet => {

--- a/c2rust-analyze/src/rewrite/expr/distribute.rs
+++ b/c2rust-analyze/src/rewrite/expr/distribute.rs
@@ -29,6 +29,21 @@ enum Priority {
     LoadResult,
 }
 
+#[derive(Clone, Debug)]
+pub struct DistRewrite {
+    pub rw: mir_op::RewriteKind,
+    pub desc: MirOriginDesc,
+}
+
+impl From<RewriteInfo> for DistRewrite {
+    fn from(x: RewriteInfo) -> DistRewrite {
+        DistRewrite {
+            rw: x.rw,
+            desc: x.desc,
+        }
+    }
+}
+
 /// Distributes MIR rewrites to HIR nodes.  This takes a list of MIR rewrites (from `mir_op`) and a
 /// map from MIR location to `HirId` (from `unlower`) and produces a map from `HirId` to a list of
 /// MIR rewrites.
@@ -52,7 +67,7 @@ pub fn distribute(
     tcx: TyCtxt,
     unlower_map: BTreeMap<PreciseLoc, MirOrigin>,
     mir_rewrites: HashMap<Location, Vec<MirRewrite>>,
-) -> HashMap<HirId, Vec<mir_op::RewriteKind>> {
+) -> HashMap<HirId, Vec<DistRewrite>> {
     let mut info_map = HashMap::<HirId, Vec<RewriteInfo>>::new();
 
     for (loc, mir_rws) in mir_rewrites {
@@ -127,6 +142,6 @@ pub fn distribute(
     // the `RewriteKind`s.
     info_map
         .into_iter()
-        .map(|(k, vs)| (k, vs.into_iter().map(|v| v.rw).collect()))
+        .map(|(k, vs)| (k, vs.into_iter().map(DistRewrite::from).collect()))
         .collect()
 }

--- a/c2rust-analyze/src/rewrite/expr/distribute.rs
+++ b/c2rust-analyze/src/rewrite/expr/distribute.rs
@@ -15,7 +15,7 @@ struct RewriteInfo {
 }
 
 /// This enum defines a sort order for [`RewriteInfo`], from innermost (applied earlier) to
-/// outermost (applied later).
+/// outermost (applied later).  The results of `fn distribute` are sorted in this order.
 ///
 /// The order of variants follows the order of operations we typically see in generated MIR code.
 /// For a given HIR `Expr`, the MIR will usually evaluate the expression ([`Priority::Eval`]),
@@ -65,6 +65,11 @@ impl From<RewriteInfo> for DistRewrite {
 /// result in an error: this MIR assignment is a store to a temporary that was introduced during
 /// HIR-to-MIR lowering, so there is no corresponding HIR assignment where such a rewrite could be
 /// attached.
+///
+/// The rewrites for each `HirId` are sorted in [`Priority`] order, matching the order in which the
+/// expression and related parts are evaluated.  For example, the [`Expr`][MirOriginDesc::Expr]
+/// itself is evaluated first, and any [`Adjustment`][MirOriginDesc::Adjustment]s are applied
+/// afterward.
 pub fn distribute(
     tcx: TyCtxt,
     unlower_map: BTreeMap<PreciseLoc, MirOrigin>,

--- a/c2rust-analyze/src/rewrite/expr/unlower.rs
+++ b/c2rust-analyze/src/rewrite/expr/unlower.rs
@@ -456,6 +456,11 @@ struct VisitExprState<'a, 'tcx> {
     sub_loc: Vec<SubLoc>,
 
     /// Buffer for temporaries handled by `peel_temp`.
+    ///
+    /// When `peel_temp` traverses past a temporary, it also needs to emit some `StoreIntoLocal`
+    /// and `LoadFromTemp` entries as a side effect.  But it doesn't have access to the
+    /// `UnlowerVisitor` to emit these entries directly, so instead we buffer those entries for the
+    /// caller to emit later.
     temp_info: Vec<(PreciseLoc, MirOriginDesc)>,
 }
 

--- a/c2rust-analyze/src/rewrite/expr/unlower.rs
+++ b/c2rust-analyze/src/rewrite/expr/unlower.rs
@@ -63,10 +63,16 @@ impl<'a, 'tcx> UnlowerVisitor<'a, 'tcx> {
             .either(|stmt| stmt.source_info.span, |term| term.source_info.span)
     }
 
+    /// Record an `unlower_map` entry indicating that MIR location `loc, sub_loc` corresponds to
+    /// the HIR expression `ex`.
     fn record(&mut self, loc: Location, sub_loc: &[SubLoc], ex: &hir::Expr) {
         self.record_desc(loc, sub_loc, ex, MirOriginDesc::Expr);
     }
 
+    /// Like [`record`][Self::record], but also takes a [`MirOriginDesc`] to indicate how the MIR
+    /// location `loc, sub_loc` relates to the HIR expression `desc`.  For example, this can be
+    /// used to record that a particular piece of MIR loads/stores a temporary used in the
+    /// evaluation of `ex`.
     fn record_desc(
         &mut self,
         loc: Location,

--- a/c2rust-analyze/src/rewrite/expr/unlower.rs
+++ b/c2rust-analyze/src/rewrite/expr/unlower.rs
@@ -37,6 +37,8 @@ pub enum MirOriginDesc {
     /// previously stored.  Loads from user-visible locals, which originate from HIR local variable
     /// expressions, use the `Expr` variant instead.
     LoadFromTemp,
+    /// This MIR applies adjustment `i` from the expression's list of adjustments.
+    Adjustment(usize),
 }
 
 struct UnlowerVisitor<'a, 'tcx> {

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -32,6 +32,7 @@ macro_rules! define_tests {
 
 define_tests! {
     addr_of,
+    adjust_unsize,
     aggregate1,
     algo_md5,
     alias1,

--- a/c2rust-analyze/tests/filecheck/addr_of.rs
+++ b/c2rust-analyze/tests/filecheck/addr_of.rs
@@ -27,6 +27,6 @@ fn shared_ref_with_struct() {
 
 // CHECK-LABEL: fn cast_array_to_ptr_explicit(s: &[u8; 1]) {
 pub fn cast_array_to_ptr_explicit(s: &[u8; 1]) {
-    // CHECK-DAG: &*(std::ptr::addr_of!(*s)) as *const u8
+    // CHECK: &*(std::ptr::addr_of!(*s)) as *const u8;
     std::ptr::addr_of!(*s) as *const u8;
 }

--- a/c2rust-analyze/tests/filecheck/addr_of.rs
+++ b/c2rust-analyze/tests/filecheck/addr_of.rs
@@ -27,6 +27,6 @@ fn shared_ref_with_struct() {
 
 // CHECK-LABEL: fn cast_array_to_ptr_explicit(s: &[u8; 1]) {
 pub fn cast_array_to_ptr_explicit(s: &[u8; 1]) {
-    // CHECK: &*(std::ptr::addr_of!(*s)) as *const u8;
+    // CHECK: &(*s) as *const u8;
     std::ptr::addr_of!(*s) as *const u8;
 }

--- a/c2rust-analyze/tests/filecheck/adjust_unsize.rs
+++ b/c2rust-analyze/tests/filecheck/adjust_unsize.rs
@@ -1,0 +1,28 @@
+
+// CHECK-LABEL: unsafe fn f
+// CHECK-SAME: <'[[LT:[a-z0-9]+]]>(p: &'[[LT]] mut (u8)) {
+unsafe fn f(p: *mut u8) {
+    *p = 1;
+}
+
+// CHECK-LABEL: unsafe fn pass_arr_simple()
+unsafe fn pass_arr_simple() {
+    let mut arr: [u8; 3] = [0; 3];
+    // CHECK: f(&mut (&mut (arr) as &mut [u8])[0]);
+    f(arr.as_mut_ptr());
+}
+
+// CHECK-LABEL: unsafe fn pass_arr_explicit_ref()
+unsafe fn pass_arr_explicit_ref() {
+    let mut arr: [u8; 3] = [0; 3];
+    // CHECK: f(&mut (&mut *((&mut arr)) as &mut [u8])[0]);
+    f((&mut arr).as_mut_ptr());
+}
+
+// CHECK-LABEL: unsafe fn pass_arr_ufcs()
+unsafe fn pass_arr_ufcs() {
+    let mut arr: [u8; 3] = [0; 3];
+    // CHECK: f(&mut (&mut *(&mut arr) as &mut [u8])[0]);
+    f(<[_]>::as_mut_ptr(&mut arr));
+}
+

--- a/c2rust-analyze/tests/filecheck/cell.rs
+++ b/c2rust-analyze/tests/filecheck/cell.rs
@@ -1,3 +1,4 @@
+// CHECK-LABEL: fn cell(
 unsafe fn cell() {
     // CHECK-DAG: let mut x = std::cell::Cell::new((1));
     let mut x = 1;
@@ -22,15 +23,20 @@ struct S {
     i: i32,
 }
 
+// CHECK-LABEL: fn cell_field(
 unsafe extern "C" fn cell_field(mut s: *mut S) {
     (*s).i = 1;
-    // CHECK-DAG: let r1: &core::cell::Cell<(R)> = &((*s).r);
+    // FIXME: The initializers for `r1` and `r2` are rewritten incorrectly.  Neither `s` nor the
+    // `r` field have `Cell` type, and an `&mut T -> &Cell<T>` rewrite is not applied.
+    // XXXXX: let r1: &core::cell::Cell<(R)> = &((*s).r);
     let r1: *mut R = &mut (*s).r;
-    // CHECK-DAG: let r2: &core::cell::Cell<(R)> = &((*s).r);
+    // XXXXX: let r2: &core::cell::Cell<(R)> = &((*s).r);
     let r2: *mut R = &mut (*s).r;
-    // CHECK-DAG: ((*r1)).set((0));
+    // FIXME: The assignments to `(*r1).i` and `(*r2).i` are rewritten incorrectly.  The field
+    // projection is omitted, producing `(*r1).set(0)`.
+    // XXXXX: ((*r1)).set((0));
     (*r1).i = 0;
-    // CHECK-DAG: ((*r2)).set((1));
+    // XXXXX: ((*r2)).set((1));
     (*r2).i = 1;
     *s = S {
         r: R { i: 0 },


### PR DESCRIPTION
Given code like this:
```Rust
let p: *mut S = ...;
let q: *mut i32 = &mut (*p).field;
```
Currently, we produce two `PointerId`s, one on `p` and one on `q`.  The rvalue `&mut (*p).field` has the same `PointerId` as `p`, on the assumption that it must always have the same permissions as `p` itself.

In the pointee analysis, `p` and `&mut (*p).field` will usually have different pointee sets (`{S}` and `{i32}` respectively).  But we'd like to use `PointerId`s to identify pointers in the pointee analysis, rather than inventing a whole new labeling system.  This requires that `p` and `&mut (*p).field` have different `PointerId`s (though in the dataflow analysis, we will add a constraint relating their permissions, so that analysis will still produce identical results).

Actually adding `PointerId`s for the necessary rvalues is fairly trivial (see b57fa642c94c05381efaa81ea9123735ae18ba58).  The majority of this PR consists of rewriter improvements to let it handle the new `PointerId`s.  In particular, it can now apply rewrites to MIR code arising from expr adjustments.  For example:

```Rust
let arr: [u8; 3] = [0; 3];
let p: *const u8 = arr.as_ptr();
```

This produces the following MIR:
```Rust
/*1*/   _1 = [const 0_u8; 3];
/*2*/   _4 = &_1;
/*3*/   _3 = move _4 as &[u8] (PointerCoercion(Unsize));
/*4*/   _2 = core::slice::<impl [u8]>::as_ptr(move _3) -> [return: bb1, unwind continue];
```

MIR line 1 is the initialization of `arr`.  Line 2 applies a borrow adjustment to `arr`, line 3 applies an unsizing adjustment, and line 4 actually calls `as_ptr`.  The MIR code produced is as if the programmer had written `(&arr as &[u8]).as_ptr()` rather than `arr.as_ptr()`.  Previously, if the `rewrite::expr::mir_op` module tried to introduce rewrites on lines 2 or 3, it would result in an error; with this PR, those rewrites are correctly lifted to HIR (after materializing the adjustments so there is a place in the source code to apply those rewrites).