### PR TITLE
`c2rust transpile`: When casting `bool`s to floats, go through the integral type `u8`

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4275,6 +4275,10 @@ impl<'c> Translation<'c> {
                     let expr =
                         expr.ok_or_else(|| format_err!("Casts to enums require a C ExprId"))?;
                     Ok(self.enum_cast(ty.ctype, enum_decl_id, expr, val, source_ty, target_ty))
+                } else if target_ty_ctype.is_floating_type() && source_ty_kind.is_bool() {
+                    val.and_then(|x| {
+                        Ok(WithStmts::new_val(mk().cast_expr(mk().cast_expr(x, mk().path_ty(vec!["u8"])), target_ty)))
+                    })
                 } else {
                     // Other numeric casts translate to Rust `as` casts,
                     // unless the cast is to a function pointer then use `transmute`.

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4277,7 +4277,10 @@ impl<'c> Translation<'c> {
                     Ok(self.enum_cast(ty.ctype, enum_decl_id, expr, val, source_ty, target_ty))
                 } else if target_ty_ctype.is_floating_type() && source_ty_kind.is_bool() {
                     val.and_then(|x| {
-                        Ok(WithStmts::new_val(mk().cast_expr(mk().cast_expr(x, mk().path_ty(vec!["u8"])), target_ty)))
+                        Ok(WithStmts::new_val(mk().cast_expr(
+                            mk().cast_expr(x, mk().path_ty(vec!["u8"])),
+                            target_ty,
+                        )))
                     })
                 } else {
                     // Other numeric casts translate to Rust `as` casts,

--- a/tests/casts/src/casts.c
+++ b/tests/casts/src/casts.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdbool.h>
 
 void cast_stuff(void) {
         int inta[10] = {0};
@@ -26,4 +27,7 @@ void cast_stuff(void) {
         // need to make sure we handle this correctly.
         const int const_i = -1;
         int *x14 = (int*) &const_i;
+
+        bool b = true;
+        float x15 = b;
 }


### PR DESCRIPTION
Previously, C code that cast `bool`s to floating types, like this

```c
#include <stdbool.h>

void cast_stuff(void) {
    bool b = true;
    float x15 = b;
}
```

would try to do so directly in Rust, like this

```rust
#[no_mangle]
pub unsafe extern "C" fn cast_stuff() {
    let mut b: bool = 1 as libc::c_int != 0;
    let mut x15: libc::c_float = b as libc::c_float;
}
```

which isn't allowed, resulting in errors like this

```shell
error[E0606]: casting `bool` as `f32` is invalid
  --> src/casts.rs:31:34
   |
31 |     let mut x15: libc::c_float = b as libc::c_float;
   |                                  ^^^^^^^^^^^^^^^^^^
   |
   = help: cast through an integer first
```

This fixes things by emitting this Rust instead by casting through the integral type `u8`:

```rust
#[no_mangle]
pub unsafe extern "C" fn cast_stuff() {
    let mut b: bool = 1 as libc::c_int != 0;
    let mut x15: libc::c_float = b as u8 as libc::c_float;
}
```