### PR TITLE
Support llvm 17.0.0

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -389,14 +389,6 @@ class TypeEncoder final : public TypeVisitor<TypeEncoder> {
 
         const TypeTag tag = [&] {
             switch (kind) {
-            default: {
-                auto pol = clang::PrintingPolicy(Context->getLangOpts());
-                auto warning = std::string("Encountered unsupported BuiltinType kind ") +
-                               std::to_string((int)kind) + " for type " +
-                               T->getName(pol).str();
-                printWarning(warning, clang::FullSourceLoc());
-                return TagTypeUnknown;
-            }
             case BuiltinType::BuiltinFn: return TagBuiltinFn;
             case BuiltinType::UInt128: return TagUInt128;
             case BuiltinType::Int128: return TagInt128;
@@ -412,9 +404,9 @@ class TypeEncoder final : public TypeVisitor<TypeEncoder> {
             // built-in to normal vector types.
             case BuiltinType::Float16: return TagHalf;
             case BuiltinType::Half: return TagHalf;
-            #if CLANG_VERSION_MAJOR >= 11
+#if CLANG_VERSION_MAJOR >= 11
             case BuiltinType::BFloat16: return TagBFloat16;
-            #endif
+#endif
             case BuiltinType::Float: return TagFloat;
             case BuiltinType::Double: return TagDouble;
             case BuiltinType::LongDouble: return TagLongDouble;
@@ -432,6 +424,13 @@ class TypeEncoder final : public TypeVisitor<TypeEncoder> {
             case BuiltinType::SveBoolx2: return TagSveBoolx2;
             case BuiltinType::SveBoolx4: return TagSveBoolx4;
 #endif
+            default:
+                auto pol = clang::PrintingPolicy(Context->getLangOpts());
+                auto warning = std::string("Encountered unsupported BuiltinType kind ") +
+                               std::to_string((int)kind) + " for type " +
+                               T->getName(pol).str();
+                printWarning(warning, clang::FullSourceLoc());
+                return TagTypeUnknown;
             }
         }();
 

--- a/c2rust-ast-exporter/src/ast_tags.hpp
+++ b/c2rust-ast-exporter/src/ast_tags.hpp
@@ -142,6 +142,11 @@ enum TypeTag {
     TagComplexType,
     TagHalf,
     TagBFloat16,
+
+    TagSveCount,
+    TagSveBool,
+    TagSveBoolx2,
+    TagSveBoolx4,
 };
 
 enum StringTypeTag {
@@ -150,6 +155,7 @@ enum StringTypeTag {
     TagUTF8,
     TagUTF16,
     TagUTF32,
+    TagUnevaluated,
 };
 
 // From `clang/Basic/TargetInfo.h`

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -799,7 +799,7 @@ impl ConversionContext {
                 }
 
                 TypeTag::TagBFloat16 => {
-                    let ty = CTypeKind::BuiltinFn;
+                    let ty = CTypeKind::BFloat16;
                     self.add_type(new_id, not_located(ty));
                     self.processed_nodes.insert(new_id, OTHER_TYPE);
                 }

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -804,6 +804,15 @@ impl ConversionContext {
                     self.processed_nodes.insert(new_id, OTHER_TYPE);
                 }
 
+                TypeTag::TagSveCount
+                | TypeTag::TagSveBool
+                | TypeTag::TagSveBoolx2
+                | TypeTag::TagSveBoolx4 => {
+                    let ty = CTypeKind::UnhandledSveType;
+                    self.add_type(new_id, not_located(ty));
+                    self.processed_nodes.insert(new_id, OTHER_TYPE);
+                }
+
                 TypeTag::TagVectorType => {
                     let elt =
                         from_value(ty_node.extras[0].clone()).expect("Vector child not found");

--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -285,7 +285,7 @@ fn immediate_type_children(kind: &CTypeKind) -> Vec<SomeId> {
         TypeOfExpr(e) => intos![e],
         Void | Bool | Short | Int | Long | LongLong | UShort | UInt | ULong | ULongLong | SChar
         | UChar | Char | Double | LongDouble | Float | Int128 | UInt128 | BuiltinFn | Half
-        | BFloat16 => {
+        | BFloat16 | UnhandledSveType => {
             vec![]
         }
 

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1672,6 +1672,10 @@ pub enum CTypeKind {
 
     Half,
     BFloat16,
+
+    // ARM Scalable Vector Extention types
+    // TODO: represent all the individual types in AArch64SVEACLETypes.def
+    UnhandledSveType,
 }
 
 impl CTypeKind {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4921,6 +4921,9 @@ impl<'c> Translation<'c> {
                 // Handled in `import_simd_typedef`
             }
             TypeOfExpr(_) | BuiltinFn => {}
+            UnhandledSveType => {
+                // TODO: handle SVE types
+            }
         }
     }
 


### PR DESCRIPTION
* Fixes #1039.

This adds support for `llvm`/`clang` `17.0.0`, as well as just enough support for ARM SVE types so that things don't crash on Apple Silicon.