### PR TITLE
analyze: borrowck: cache results of polonius runs on disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "print_bytes",
  "rustc-hash",
  "serde",
+ "sha2",
  "shlex",
  "toml_edit",
 ]
@@ -576,9 +577,9 @@ checksum = "a0afaad2b26fa326569eb264b1363e8ae3357618c43982b3f285f0774ce76b69"
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -1311,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -29,6 +29,7 @@ clap = { version = "4.2.7", features = ["derive"] }
 fs-err = "2.9.0"
 anyhow = "1.0.75"
 toml_edit = "0.19.8"
+sha2 = "0.10.8"
 
 [build-dependencies]
 c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.18.0" }

--- a/c2rust-analyze/src/borrowck/atoms.rs
+++ b/c2rust-analyze/src/borrowck/atoms.rs
@@ -1,12 +1,15 @@
 use polonius_engine::{self, Atom, FactTypes};
 use rustc_middle::mir::{BasicBlock, Local, Location, Place, PlaceElem};
 use rustc_middle::ty::TyCtxt;
+use serde::{Deserialize, Serialize};
 use std::collections::hash_map::{Entry, HashMap};
 use std::hash::Hash;
 
 macro_rules! define_atom_type {
     ($Atom:ident) => {
-        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+        #[derive(
+            Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Serialize, Deserialize,
+        )]
         pub struct $Atom(usize);
 
         impl From<usize> for $Atom {

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -390,8 +390,10 @@ fn try_load_cached_output(facts_hash: &str) -> Option<Output> {
             return None;
         }
     };
-    // Tuples only implement `Deserialize` up to length 12, so split up this 17-element tuple into
-    // several pieces.
+    // The Polonius `Output` type doesn't implement `Serialize`.  Rather than define a local
+    // wrapper or proxy type and implement `Serialize` on that, we just unpack the struct into a
+    // tuple and serialize that instead.  However, tuples only implement `Deserialize` up to length
+    // 12, so we have to split up this 17-element tuple into several pieces.
     let (
         (
             errors,
@@ -463,8 +465,8 @@ fn save_cached_output(facts_hash: &str, output: &Output) -> Result<(), bincode::
         ref var_maybe_partly_initialized_on_exit,
     } = *output;
 
-    // Tuples only implement `Serialize` up to length 12, so split up this 17-element tuple into
-    // several pieces.  Note this must match the tuple format in `try_load_cached_output`.
+    // Split the tuple into several pieces, as described in `try_load_cached_output`.  The tuple
+    // format used here must match the one in `try_load_cached_output`.
     let raw = (
         (
             errors,


### PR DESCRIPTION
The Polonius stage of borrow checking takes a long time to run on certain functions, such as lighttpd's `li_MD5Transform`.  Worse, we often run Polonius multiple times on the same function as the interprocedural analysis iterates to reach a fixpoint.  This branch speeds up the analysis by caching Polonius results on disk.

The caching logic is fairly simple: the core Polonius analysis is effectively a pure function from input facts to output facts, so we hash the input facts before each call and check whether a file named after that hash is present in the cache directory.  There's no need to factor in any details of the crate, MIR, permissions, etc.  If the current Polonius query has the same input facts as a previous query, it will necessarily produce the same output facts, regardless of how those input facts were computed.

Computing the input facts still has a nontrivial cost for some functions, but this branch provides significant speedups on `algo_md5` and `lighttpd_rust_amalgamated` once `c2rust-analyze` has run once to populate the cache.