### PR TITLE
analyze: CLI options

### DIFF
--- a/c2rust-analyze/README.md
+++ b/c2rust-analyze/README.md
@@ -1,7 +1,62 @@
+# Usage
+
+Build `c2rust-analyze`:
+
 ```sh
-cargo run --bin c2rust-analyze -- tests/filecheck/insertion_sort.rs -L "$(rustc --print target-libdir)" --crate-type rlib
+cargo build --release
 ```
 
-This should produce a large amount of debug output, including a table at the
-end listing the type and expression rewrites the analysis has inferred for the
-`insertion_sort` function.
+Then, in the directory of a cargo project you wish to rewrite, run
+`c2rust-analyze` on the project:
+
+```sh
+.../path/to/c2rust/target/release/c2rust-analyze build |& tee c2rust-analyze.log
+```
+
+`c2rust-analyze` is currently at a prototype stage and produces verbose debug
+output by default; the use of `tee` to capture the output to a log file allows
+inspecting the results even when they exceed the length of the terminal
+scrollback buffer.
+
+`c2rust-analyze` does not modify the target project's source code by default;
+it only prints the rewritten code to standard output.  Look for `=====
+BEGIN/END =====` markers in the output to see the proposed rewritten code for
+each file, or rerun with the `--rewrite-in-place` option (that is,
+`c2rust-analyze --rewrite-in-place build`) to apply the rewrites directly to
+the source files.
+
+`c2rust-analyze` may take a long time to run even on medium-sized codebases.
+In particular, running the Polonius analysis on very large functions may take
+several minutes (though Polonius results are cached after the first run).  For
+testing, it may be useful to comment out some modules from `lib.rs` to speed up
+the analysis.
+
+
+## Known limitations
+
+The automated safety rewrites in `c2rust-analyze` only apply to a small subset
+of unsafe Rust code.  When `c2rust-analyze` encounters unsupported code, it
+will report an error and skip rewriting the function in question.
+
+Other notable limitations:
+
+* `c2rust-analyze` does not remove the `unsafe` keyword from function
+  definitions, even when it succeeds at removing all unsafe operations from the
+  function.  The user must remove the `unsafe` keyword manually where it is
+  appropriate to do so.
+
+  Note that even if a function contains only safe operations, it might still
+  need to be marked `unsafe` if it could break an invariant that other code
+  relies on for safety.  For example, `Vec::set_len` only writes to the
+  `self.len` field (a safe operation), but it can be used to violate the
+  invariant `self.len <= self.cap`, which `Vec::as_slice` relies on for safety.
+
+* In non-amalgamated builds, where cross-module function calls use `extern "C"
+  { fn foo(); }` in the calling module and `#[no_mangle] fn foo() { ... }` in
+  the callee, `c2rust-analyze` may rewrite the signature of the `#[no_mangle]`
+  function definition in a way that's incompatible with the corresponding
+  `extern "C"` declaration in another module.  This can lead to segfaults or
+  other undefined behavior at run time.  This can be avoided by using an
+  amalgamated build of the C code (where all functions are placed in one
+  module), or by manually editing the function definition and/or declaration
+  after rewriting to ensure that the signatures match up.

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -980,6 +980,8 @@ fn run(tcx: TyCtxt) {
 
     // Items in the "fixed defs" list have all pointers in their types set to `FIXED`.  For
     // testing, putting #[c2rust_analyze_test::fixed_signature] on an item has the same effect.
+    //
+    // Functions in the list are also added to `gacx.fns_fixed`.
     for ldid in tcx.hir_crate_items(()).definitions() {
         let def_fixed = fixed_defs.contains(&ldid.to_def_id())
             || util::has_test_attr(tcx, ldid, TestAttr::FixedSignature);
@@ -990,6 +992,7 @@ fn run(tcx: TyCtxt) {
                     None => panic!("missing fn_sig for {:?}", ldid),
                 };
                 make_sig_fixed(&mut gasn, lsig);
+                gacx.fns_fixed.insert(ldid.to_def_id());
             }
 
             DefKind::Struct | DefKind::Enum | DefKind::Union => {
@@ -1257,7 +1260,7 @@ fn run(tcx: TyCtxt) {
         }
 
         for &ldid in &all_fn_ldids {
-            if gacx.fn_failed(ldid.to_def_id()) {
+            if gacx.fn_skip_rewrite(ldid.to_def_id()) {
                 continue;
             }
 

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -460,6 +460,9 @@ fn check_rewrite_path_prefixes(tcx: TyCtxt, fixed_defs: &mut HashSet<DefId>, pre
     let hir = tcx.hir();
     let prefixes: HashSet<Vec<Symbol>> = prefixes
         .split(',')
+        // Exclude empty paths.  This allows for leading/trailing commas or double commas within
+        // the list, which may result when building the list programmatically.
+        .filter(|prefix| prefix.len() > 0)
         .map(|prefix| prefix.split("::").map(Symbol::intern).collect::<Vec<_>>())
         .collect();
     let sym_impl = Symbol::intern("{impl}");

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -1421,7 +1421,13 @@ fn run(tcx: TyCtxt) {
     // ----------------------------------
 
     // Apply rewrite to all functions at once.
-    rewrite::apply_rewrites(tcx, all_rewrites);
+    let mut update_files = rewrite::UpdateFiles::No;
+    if let Ok(val) = env::var("C2RUST_ANALYZE_REWRITE_IN_PLACE") {
+        if val == "1" {
+            update_files = rewrite::UpdateFiles::Yes;
+        }
+    }
+    rewrite::apply_rewrites(tcx, all_rewrites, update_files);
 
     // ----------------------------------
     // Report caught panics

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -983,6 +983,11 @@ fn run(tcx: TyCtxt) {
     //
     // Functions in the list are also added to `gacx.fns_fixed`.
     for ldid in tcx.hir_crate_items(()).definitions() {
+        // TODO (HACK): `Clone::clone` impls are omitted from `fn_sigs` and cause a panic below.
+        if is_impl_clone(tcx, ldid.to_def_id()) {
+            continue;
+        }
+
         let def_fixed = fixed_defs.contains(&ldid.to_def_id())
             || util::has_test_attr(tcx, ldid, TestAttr::FixedSignature);
         match tcx.def_kind(ldid.to_def_id()) {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -329,6 +329,9 @@ pub struct GlobalAnalysisCtxt<'tcx> {
     /// `DefId`s of functions where analysis failed, and a [`PanicDetail`] explaining the reason
     /// for each failure.
     pub fns_failed: HashMap<DefId, PanicDetail>,
+    /// `DefId`s of functions that were marked "fixed" (non-rewritable) through command-line
+    /// arguments.
+    pub fns_fixed: HashSet<DefId>,
 
     pub field_ltys: HashMap<DefId, LTy<'tcx>>,
 
@@ -698,6 +701,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
                 .map(|known_fn| (known_fn.name, known_fn))
                 .collect(),
             fns_failed: HashMap::new(),
+            fns_fixed: HashSet::new(),
             field_ltys: HashMap::new(),
             static_tys: HashMap::new(),
             addr_of_static: HashMap::new(),
@@ -759,6 +763,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             ref mut fn_sigs,
             known_fns: _,
             fns_failed: _,
+            fns_fixed: _,
             ref mut field_ltys,
             ref mut static_tys,
             ref mut addr_of_static,
@@ -815,7 +820,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         }
     }
 
-    pub fn fn_failed(&mut self, did: DefId) -> bool {
+    pub fn fn_failed(&self, did: DefId) -> bool {
         self.fns_failed.contains_key(&did)
     }
 
@@ -829,6 +834,25 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
 
     pub fn iter_fns_failed(&self) -> impl Iterator<Item = DefId> + '_ {
         self.fns_failed.keys().copied()
+    }
+
+    pub fn fn_skip_rewrite(&self, did: DefId) -> bool {
+        self.fn_failed(did) || self.fns_fixed.contains(&did)
+    }
+
+    /// Iterate over the `DefId`s of all functions that should skip rewriting.
+    pub fn iter_fns_skip_rewrite<'a>(&'a self) -> impl Iterator<Item = DefId> + 'a {
+        // This let binding avoids a lifetime error with the closure and return-position `impl
+        // Trait`.
+        let fns_fixed = &self.fns_fixed;
+        // If the same `DefId` is in both `fns_failed` and `fns_fixed`, be sure to return it only
+        // once.
+        fns_fixed.iter().copied().chain(
+            self.fns_failed
+                .keys()
+                .copied()
+                .filter(move |did| !fns_fixed.contains(&did)),
+        )
     }
 
     pub fn known_fn(&self, def_id: DefId) -> Option<&'static KnownFn> {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -37,7 +37,7 @@ use analyze::AnalysisCallbacks;
 use anyhow::anyhow;
 use anyhow::ensure;
 use anyhow::Context;
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use rustc_driver::RunCompiler;
 use rustc_driver::TimePassesCallbacks;
 use rustc_session::config::CrateType;
@@ -75,8 +75,8 @@ struct Args {
 
     /// Comma-separated list of paths to rewrite.  Any item whose path does not start with a prefix
     /// from this list will be marked non-rewritable (`FIXED`).
-    #[clap(long)]
-    rewrite_paths: Option<OsString>,
+    #[clap(long, action(ArgAction::Append))]
+    rewrite_paths: Vec<OsString>,
     /// Rewrite source files on disk.  The default is to print the rewritten source code to stdout
     /// as part of the tool's debug output.
     #[clap(long)]
@@ -95,7 +95,7 @@ struct Args {
     /// in the crate being analyzed; the file passed to this option should list a subset of those
     /// defs.
     #[clap(long)]
-    fixed_defs_list: Option<OsString>,
+    fixed_defs_list: Option<PathBuf>,
 
     /// `cargo` args.
     cargo_args: Vec<OsString>,
@@ -395,7 +395,8 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
             cmd.env("C2RUST_ANALYZE_FIXED_DEFS_LIST", fixed_defs_list);
         }
 
-        if let Some(ref rewrite_paths) = rewrite_paths {
+        if rewrite_paths.len() > 0 {
+            let rewrite_paths = rewrite_paths.join(OsStr::new(","));
             cmd.env("C2RUST_ANALYZE_REWRITE_PATHS", rewrite_paths);
         }
 

--- a/c2rust-analyze/src/rewrite/apply.rs
+++ b/c2rust-analyze/src/rewrite/apply.rs
@@ -400,6 +400,13 @@ impl<S: Sink> Emitter<'_, S> {
                 self.emit_str(")")
             }
 
+            Rewrite::Let1(ref name, ref rw) => {
+                self.emit_str("let ")?;
+                self.emit_str(name)?;
+                self.emit_str(" = ")?;
+                self.emit(rw, 0)
+            }
+
             Rewrite::TyPtr(ref rw, mutbl) => {
                 match mutbl {
                     Mutability::Not => self.emit_str("*const ")?,

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -13,7 +13,6 @@ use crate::pointee_type::PointeeTypes;
 use crate::pointer_id::{PointerId, PointerTable};
 use crate::type_desc::{self, Ownership, Quantity, TypeDesc};
 use crate::util::{ty_callee, Callee};
-use log::*;
 use rustc_ast::Mutability;
 use rustc_middle::mir::{
     BasicBlock, Body, Location, Operand, Place, Rvalue, Statement, StatementKind, Terminator,
@@ -751,25 +750,42 @@ where
     }
 
     pub fn build_cast_desc_desc(&mut self, from: TypeDesc<'tcx>, to: TypeDesc<'tcx>) {
+        self.try_build_cast_desc_desc(from, to).unwrap()
+    }
+
+    /// Try to build a cast between `from` and `to`, emitting any intermediate rewrites that are
+    /// necessary through the `self.emit` callback.
+    ///
+    /// Note that when cast building fails, this method may still call `self.emit` one or more
+    /// times before returning `Err`.  The caller should be prepared to roll back the effects of
+    /// any `self.emit` calls if the overall operation fails.
+    pub fn try_build_cast_desc_desc(
+        &mut self,
+        from: TypeDesc<'tcx>,
+        to: TypeDesc<'tcx>,
+    ) -> Result<(), String> {
         let orig_from = from;
         let mut from = orig_from;
 
         // The `from` and `to` pointee types should only differ in their lifetimes.
-        assert_eq!(
-            self.tcx.erase_regions(from.pointee_ty),
-            self.tcx.erase_regions(to.pointee_ty),
-        );
+        let from_pointee_erased = self.tcx.erase_regions(from.pointee_ty);
+        let to_pointee_erased = self.tcx.erase_regions(to.pointee_ty);
+        if from_pointee_erased != to_pointee_erased {
+            return Err(format!(
+                "pointee type mismatch: {from_pointee_erased:?} != {to_pointee_erased:?}"
+            ));
+        }
         // There might still be differences in lifetimes, which we don't care about here.
         // Overwriting `from.pointee_ty` allows the final `from == to` check to succeed below.
         from.pointee_ty = to.pointee_ty;
 
         if from == to {
-            return;
+            return Ok(());
         }
 
         // Early `Ownership` casts.  We do certain casts here in hopes of reaching an `Ownership`
         // on which we can safely adjust `Quantity`.
-        from.own = self.cast_ownership(from, to, true);
+        from.own = self.cast_ownership(from, to, true)?;
 
         // Safe casts that change `Quantity`.
         while from.qty != to.qty {
@@ -787,8 +803,8 @@ where
                 (Quantity::Array, _) => {
                     // `Array` goes only to `Slice` directly.  All other `Array` conversions go
                     // through `Slice` first.
-                    error!("TODO: cast Array to {:?}", to.qty);
-                    from.qty = Quantity::Slice;
+                    return Err(format!("TODO: cast Array to {:?}", to.qty));
+                    //from.qty = Quantity::Slice;
                 }
                 // Bidirectional conversions between `Slice` and `OffsetPtr`.
                 (Quantity::Slice, Quantity::OffsetPtr) | (Quantity::OffsetPtr, Quantity::Slice) => {
@@ -819,14 +835,16 @@ where
         }
 
         // Late `Ownership` casts.
-        from.own = self.cast_ownership(from, to, false);
+        from.own = self.cast_ownership(from, to, false)?;
 
         if from != to {
-            panic!(
+            return Err(format!(
                 "unsupported cast kind: {:?} -> {:?} (original input: {:?})",
                 from, to, orig_from
-            );
+            ));
         }
+
+        Ok(())
     }
 
     fn cast_ownership(
@@ -834,17 +852,17 @@ where
         from: TypeDesc<'tcx>,
         to: TypeDesc<'tcx>,
         early: bool,
-    ) -> Ownership {
+    ) -> Result<Ownership, String> {
         let mut from = from;
         while from.own != to.own {
-            match self.cast_ownership_one_step(from, to, early) {
+            match self.cast_ownership_one_step(from, to, early)? {
                 Some(new_own) => {
                     from.own = new_own;
                 }
                 None => break,
             }
         }
-        from.own
+        Ok(from.own)
     }
 
     fn cast_ownership_one_step(
@@ -852,23 +870,23 @@ where
         from: TypeDesc<'tcx>,
         to: TypeDesc<'tcx>,
         early: bool,
-    ) -> Option<Ownership> {
-        match from.own {
+    ) -> Result<Option<Ownership>, String> {
+        Ok(match from.own {
             Ownership::Box => match to.own {
                 Ownership::Raw | Ownership::Imm => {
-                    error!("TODO: cast Box to Imm");
-                    Some(Ownership::Imm)
+                    return Err(format!("TODO: cast Box to Imm"));
+                    //Some(Ownership::Imm)
                 }
                 Ownership::RawMut | Ownership::Mut => {
-                    error!("TODO: cast Box to Mut");
-                    Some(Ownership::Mut)
+                    return Err(format!("TODO: cast Box to Mut"));
+                    //Some(Ownership::Mut)
                 }
                 _ => None,
             },
             Ownership::Rc => match to.own {
                 Ownership::Imm | Ownership::Raw | Ownership::RawMut => {
-                    error!("TODO: cast Rc to Imm");
-                    Some(Ownership::Imm)
+                    return Err(format!("TODO: cast Rc to Imm"));
+                    //Some(Ownership::Imm)
                 }
                 _ => None,
             },
@@ -932,7 +950,7 @@ where
                 }
                 _ => None,
             },
-        }
+        })
     }
 
     pub fn build_cast_lty_desc(&mut self, from_lty: LTy<'tcx>, to: TypeDesc<'tcx>) {

--- a/c2rust-analyze/src/rewrite/mod.rs
+++ b/c2rust-analyze/src/rewrite/mod.rs
@@ -37,7 +37,7 @@ mod statics;
 mod ty;
 
 pub use self::expr::gen_expr_rewrites;
-pub use self::shim::{gen_shim_call_rewrites, gen_shim_definition_rewrite};
+pub use self::shim::{gen_shim_call_rewrites, gen_shim_definition_rewrite, ManualShimCasts};
 pub use self::statics::gen_static_rewrites;
 pub use self::ty::dump_rewritten_local_tys;
 pub use self::ty::{gen_adt_ty_rewrites, gen_ty_rewrites};

--- a/c2rust-analyze/src/rewrite/mod.rs
+++ b/c2rust-analyze/src/rewrite/mod.rs
@@ -25,8 +25,9 @@
 
 use rustc_hir::Mutability;
 use rustc_middle::ty::TyCtxt;
-use rustc_span::Span;
+use rustc_span::{FileName, Span};
 use std::fmt;
+use std::fs;
 
 mod apply;
 mod expr;
@@ -238,23 +239,42 @@ impl apply::Sink for FormatterSink<'_, '_> {
     }
 }
 
-pub fn apply_rewrites(tcx: TyCtxt, rewrites: Vec<(Span, Rewrite)>) {
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub enum UpdateFiles {
+    No,
+    Yes,
+}
+
+pub fn apply_rewrites(tcx: TyCtxt, rewrites: Vec<(Span, Rewrite)>, update_files: UpdateFiles) {
     // TODO: emit new source code properly instead of just printing
     let new_src = apply::apply_rewrites(tcx.sess.source_map(), rewrites);
 
     for (filename, src) in new_src {
-        eprintln!("\n\n ===== BEGIN {:?} =====", filename);
+        println!("\n\n ===== BEGIN {:?} =====", filename);
         for line in src.lines() {
             // Omit filecheck directives from the debug output, as filecheck can get confused due
             // to directives matching themselves (e.g. `// CHECK: foo` will match the `foo` in the
             // line `// CHECK: foo`).
             if let Some((pre, _post)) = line.split_once("// CHECK") {
-                eprintln!("{}// (FileCheck directive omitted)", pre);
+                println!("{}// (FileCheck directive omitted)", pre);
             } else {
-                eprintln!("{}", line);
+                println!("{}", line);
             }
         }
-        eprintln!(" ===== END {:?} =====", filename);
+        println!(" ===== END {:?} =====", filename);
+
+        if update_files == UpdateFiles::Yes {
+            let mut path_ok = false;
+            if let FileName::Real(ref rfn) = filename {
+                if let Some(path) = rfn.local_path() {
+                    fs::write(path, src).unwrap();
+                    path_ok = true;
+                }
+            }
+            if !path_ok {
+                log::warn!("couldn't write to non-real file {filename:?}");
+            }
+        }
     }
 }
 

--- a/c2rust-analyze/src/rewrite/mod.rs
+++ b/c2rust-analyze/src/rewrite/mod.rs
@@ -89,11 +89,14 @@ pub enum Rewrite<S = Span> {
     /// A multi-variable `let` binding, like `let (x, y) = (rw0, rw1)`.  Note that this rewrite
     /// does not include a trailing semicolon.
     ///
-    /// Since these variable bindings are not hygienic, a `StmtBind` can invalidate the expression
-    /// produced by `Identity` or `Sub` rewrites used later in the same scope.  In general,
-    /// `StmtBind` should only be used inside a `Block`, and `Identity` and `Sub` rewrites should
-    /// not be used later in that block.
+    /// Since these variable bindings are not hygienic, a `Let` can invalidate the expression
+    /// produced by `Identity` or `Sub` rewrites used later in the same scope.  In general, `Let`
+    /// should only be used inside a `Block`, and `Identity` and `Sub` rewrites should not be used
+    /// later in that block.
     Let(Vec<(String, Rewrite)>),
+    /// Single-variable `let` binding.  This has the same scoping issues as multi-variable `Let`;
+    /// because of this, `Let` should generally be used instead of multiple `Let1`s.
+    Let1(String, Box<Rewrite>),
 
     // Type builders
     /// Emit a complete pretty-printed type, discarding the original annotation.
@@ -191,6 +194,7 @@ impl Rewrite {
                 }
                 Let(new_vars)
             }
+            Let1(ref name, ref rw) => Let1(String::clone(name), try_subst(rw)?),
 
             Print(ref s) => Print(String::clone(s)),
             TyPtr(ref rw, mutbl) => TyPtr(try_subst(rw)?, mutbl),

--- a/c2rust-analyze/src/rewrite/shim.rs
+++ b/c2rust-analyze/src/rewrite/shim.rs
@@ -127,7 +127,12 @@ pub fn gen_shim_call_rewrites<'tcx>(
             Some(x) => x,
             None => continue,
         };
-        let hir_body_id = tcx.hir().body_owned_by(skip_def_id);
+        // When using --rewrite-paths, fns in extern blocks may show up here.  We can't do anything
+        // with these, since they don't have a HIR body, so skip them.
+        let hir_body_id = match tcx.hir().maybe_body_owned_by(skip_def_id) {
+            Some(x) => x,
+            None => continue,
+        };
         let hir = tcx.hir().body(hir_body_id);
         let typeck_results = tcx.typeck_body(hir_body_id);
         let mut v = ShimCallVisitor {

--- a/c2rust-analyze/src/rewrite/shim.rs
+++ b/c2rust-analyze/src/rewrite/shim.rs
@@ -1,6 +1,7 @@
 use crate::context::LTy;
 use crate::context::{FlagSet, GlobalAnalysisCtxt, GlobalAssignment};
 use crate::rewrite::expr::{self, CastBuilder};
+use crate::rewrite::ty;
 use crate::rewrite::Rewrite;
 use crate::type_desc::{self, TypeDesc};
 use rustc_hir::def::{DefKind, Res};
@@ -168,10 +169,19 @@ fn lty_to_desc_pair<'tcx>(
     Some((desc, fixed_desc))
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub enum ManualShimCasts {
+    No,
+    /// Emit `todo!("cast X from T1 to T2")` instead of panicking when a cast can't be generated.
+    /// The user can then implement the necessary casts manually.
+    Yes,
+}
+
 pub fn gen_shim_definition_rewrite<'tcx>(
     gacx: &GlobalAnalysisCtxt<'tcx>,
     gasn: &GlobalAssignment,
     def_id: DefId,
+    manual_casts: ManualShimCasts,
 ) -> (Span, Rewrite) {
     let tcx = gacx.tcx;
 
@@ -206,7 +216,20 @@ pub fn gen_shim_definition_rewrite<'tcx>(
             let mut cast_builder = CastBuilder::new(tcx, &gasn.perms, &gasn.flags, |rk| {
                 hir_rw = expr::convert_cast_rewrite(&rk, mem::take(&mut hir_rw));
             });
-            cast_builder.build_cast_desc_desc(fixed_desc, arg_desc);
+            match cast_builder.try_build_cast_desc_desc(fixed_desc, arg_desc) {
+                Ok(()) => {}
+                Err(e) => {
+                    if manual_casts == ManualShimCasts::Yes {
+                        hir_rw = Rewrite::Print(format!(
+                            r#"todo!("cast arg{i} from {} to {}")"#,
+                            ty::desc_to_ty(tcx, fixed_desc),
+                            ty::desc_to_ty(tcx, arg_desc),
+                        ));
+                    } else {
+                        panic!("error generating cast for {:?} arg{}: {}", def_id, i, e);
+                    }
+                }
+            }
         } else {
             // No-op.  `arg_lty` is a FIXED pointer, which doesn't need a cast; the shim argument
             // type is the same as the argument type of the wrapped function.
@@ -227,7 +250,20 @@ pub fn gen_shim_definition_rewrite<'tcx>(
         let mut cast_builder = CastBuilder::new(tcx, &gasn.perms, &gasn.flags, |rk| {
             result_rw = expr::convert_cast_rewrite(&rk, mem::take(&mut result_rw));
         });
-        cast_builder.build_cast_desc_desc(return_desc, fixed_desc);
+        match cast_builder.try_build_cast_desc_desc(return_desc, fixed_desc) {
+            Ok(()) => {}
+            Err(e) => {
+                if manual_casts == ManualShimCasts::Yes {
+                    result_rw = Rewrite::Print(format!(
+                        r#"todo!("cast safe_result from {} to {}")"#,
+                        ty::desc_to_ty(tcx, return_desc),
+                        ty::desc_to_ty(tcx, fixed_desc),
+                    ));
+                } else {
+                    panic!("error generating cast for {:?} result: {}", def_id, e);
+                }
+            }
+        }
     }
     stmts.push(Rewrite::Let1("result".into(), Box::new(result_rw)));
 

--- a/c2rust-analyze/tests/common/mod.rs
+++ b/c2rust-analyze/tests/common/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashSet,
     env,
+    ffi::OsString,
     fmt::{self, Display, Formatter},
     fs::{self, File},
     path::{Path, PathBuf},
@@ -56,6 +57,20 @@ struct AnalyzeArgs {
     /// this flag.
     #[arg(long)]
     catch_panics: bool,
+
+    /// Comma-separated list of paths to rewrite.  Any item whose path does not start with a prefix
+    /// from this list will be marked non-rewritable (`FIXED`).
+    #[clap(long)]
+    rewrite_paths: Option<OsString>,
+
+    /// Use `todo!()` placeholders in shims for casts that must be implemented manually.
+    ///
+    /// When a function requires a shim, and the shim requires a cast that can't be generated
+    /// automatically, the default is to cancel rewriting of the function.  With this option,
+    /// rewriting proceeds as normal, and shim generation emits `todo!()` in place of each
+    /// unsupported cast.
+    #[clap(long)]
+    use_manual_shims: bool,
 }
 
 impl AnalyzeArgs {
@@ -175,6 +190,12 @@ impl Analyze {
 
         if !args.catch_panics {
             cmd.env("C2RUST_ANALYZE_TEST_DONT_CATCH_PANIC", "1");
+        }
+        if args.use_manual_shims {
+            cmd.env("C2RUST_ANALYZE_USE_MANUAL_SHIMS", "1");
+        }
+        if let Some(ref rewrite_paths) = args.rewrite_paths {
+            cmd.env("C2RUST_ANALYZE_REWRITE_PATHS", rewrite_paths);
         }
         cmd.arg(&rs_path)
             .arg("-L")

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -60,6 +60,8 @@ define_tests! {
     pointee,
     ptrptr1,
     regions_fixed,
+    rewrite_paths,
+    rewrite_paths_manual_shim,
     statics,
     test_attrs,
     trivial,

--- a/c2rust-analyze/tests/filecheck/rewrite_paths.rs
+++ b/c2rust-analyze/tests/filecheck/rewrite_paths.rs
@@ -1,0 +1,29 @@
+//! --rewrite-paths good1,good2
+#![feature(register_tool)]
+#![register_tool(c2rust_analyze_test)]
+
+// CHECK-LABEL: fn good1<'h0>(x: &'h0 mut (i32))
+unsafe fn good1(x: *mut i32) -> i32 {
+    // CHECK: let y = &*(bad(core::ptr::addr_of_mut!(*(x)))).cast_const();
+    let y = bad(x);
+    *y
+}
+
+// CHECK-LABEL: fn bad(x: *mut i32) -> *mut i32
+// Since `bad` is not listed in --rewrite-paths, it will not be rewritten (aside from adding shim
+// calls).
+unsafe fn bad(x: *mut i32) -> *mut i32 {
+    // CHECK: good2_shim(x)
+    good2(x)
+}
+
+// CHECK-LABEL: fn good2<'h0,'h1>(x: &'h0 mut (i32)) -> &'h1 (i32)
+unsafe fn good2(x: *mut i32) -> *mut i32 {
+    *x = 1;
+    // CHECK: &*(x)
+    x
+}
+// CHECK-LABEL: unsafe fn good2_shim(arg0: *mut i32) -> *mut i32
+// CHECK: let safe_arg0 = &mut *arg0;
+// CHECK: let safe_result = good2(safe_arg0);
+// CHECK: let result = core::ptr::addr_of!(*safe_result).cast_mut();

--- a/c2rust-analyze/tests/filecheck/rewrite_paths.rs
+++ b/c2rust-analyze/tests/filecheck/rewrite_paths.rs
@@ -27,3 +27,9 @@ unsafe fn good2(x: *mut i32) -> *mut i32 {
 // CHECK: let safe_arg0 = &mut *arg0;
 // CHECK: let safe_result = good2(safe_arg0);
 // CHECK: let result = core::ptr::addr_of!(*safe_result).cast_mut();
+
+// Regression test for an issue where `gen_shim_call_rewrites` would panic upon encountering a
+// non-rewritten function that doesn't have a body.
+extern "C" {
+    fn memcpy(_: *mut u8, _: *const u8, _: usize) -> *mut u8;
+}

--- a/c2rust-analyze/tests/filecheck/rewrite_paths_manual_shim.rs
+++ b/c2rust-analyze/tests/filecheck/rewrite_paths_manual_shim.rs
@@ -1,0 +1,29 @@
+//! --rewrite-paths good1,good2 --use-manual-shims
+#![feature(register_tool)]
+#![register_tool(c2rust_analyze_test)]
+
+// CHECK-LABEL: fn good1<'h0>(x: &'h0 mut [(i32)])
+unsafe fn good1(x: *mut i32) -> i32 {
+    // CHECK: let y = &*(bad(core::ptr::addr_of_mut!(*&mut (x)[0]))).cast_const();
+    let y = bad(x);
+    *y
+}
+
+// CHECK-LABEL: fn bad(x: *mut i32) -> *mut i32
+// Since `bad` is not listed in --rewrite-paths, it will not be rewritten (aside from adding shim
+// calls).
+unsafe fn bad(x: *mut i32) -> *mut i32 {
+    // CHECK: good2_shim(x)
+    good2(x)
+}
+
+// CHECK-LABEL: fn good2<'h0,'h1>(x: &'h0 mut [(i32)]) -> &'h1 (i32)
+unsafe fn good2(x: *mut i32) -> *mut i32 {
+    *x.offset(1) = 1;
+    // CHECK: &*(x)
+    x
+}
+// CHECK-LABEL: unsafe fn good2_shim(arg0: *mut i32) -> *mut i32
+// CHECK: let safe_arg0 = todo!("cast arg0 from *mut i32 to &mut [i32]");
+// CHECK: let safe_result = good2(safe_arg0);
+// CHECK: let result = core::ptr::addr_of!(*safe_result).cast_mut();

--- a/c2rust-analyze/tests/filecheck/unrewritten_calls.rs
+++ b/c2rust-analyze/tests/filecheck/unrewritten_calls.rs
@@ -24,5 +24,7 @@ unsafe fn good2(x: *mut i32) -> *mut i32 {
     // CHECK: &*(x)
     x
 }
-// CHECK: unsafe fn good2_shim(arg0: *mut i32) -> *mut i32
-// CHECK: core::ptr::addr_of!(*good2(&mut *arg0)).cast_mut()
+// CHECK-LABEL: unsafe fn good2_shim(arg0: *mut i32) -> *mut i32
+// CHECK: let safe_arg0 = &mut *arg0;
+// CHECK: let safe_result = good2(safe_arg0);
+// CHECK: let result = core::ptr::addr_of!(*safe_result).cast_mut();


### PR DESCRIPTION
This exposes some configuration options that were previously controlled by environment variables as command-line options for the cargo wrapper, and also adds a few new options:

* `--rewrite-in-place`: Overwrite source files with the results of rewriting
* `--rewrite-paths`: Only rewrite defs whose paths start with a string from this list
* `--use-manual-shims`: When shims can't be generated, emit a `todo!()` placeholder for manual editing instead of failing
* `--fixed-defs-list`: Read a list of defs from this file and mark each one as `FIXED`