### PR TITLE
analyze: track reasons why functions are not rewritten

### DIFF
--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -2057,7 +2057,7 @@ fn process_new_dont_rewrite_items(gacx: &mut GlobalAnalysisCtxt, gasn: &mut Glob
             for &field_ldid in gacx.fn_fields_used.get(ldid) {
                 gacx.dont_rewrite_fields.add(
                     field_ldid.to_def_id(),
-                    DontRewriteFieldReason::NON_REWRITTEN_USER,
+                    DontRewriteFieldReason::NON_REWRITTEN_USE,
                 );
             }
 

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -995,7 +995,8 @@ fn run(tcx: TyCtxt) {
                     None => panic!("missing fn_sig for {:?}", ldid),
                 };
                 make_sig_fixed(&mut gasn, lsig);
-                gacx.set_dont_rewrite_fn(ldid.to_def_id(), DontRewriteFnReason::USER_REQUEST);
+                gacx.dont_rewrite_fns
+                    .add(ldid.to_def_id(), DontRewriteFnReason::USER_REQUEST);
             }
 
             DefKind::Struct | DefKind::Enum | DefKind::Union => {
@@ -1015,10 +1016,8 @@ fn run(tcx: TyCtxt) {
                             None => panic!("missing field_lty for {:?}", ldid),
                         };
                         make_ty_fixed(&mut gasn, lty);
-                        gacx.set_dont_rewrite_field(
-                            field.did,
-                            DontRewriteFieldReason::USER_REQUEST,
-                        );
+                        gacx.dont_rewrite_fields
+                            .add(field.did, DontRewriteFieldReason::USER_REQUEST);
                     }
                 }
             }
@@ -1037,10 +1036,8 @@ fn run(tcx: TyCtxt) {
                 if !ptr.is_none() {
                     gasn.flags[ptr].insert(FlagSet::FIXED);
                 }
-                gacx.set_dont_rewrite_static(
-                    ldid.to_def_id(),
-                    DontRewriteStaticReason::USER_REQUEST,
-                );
+                gacx.dont_rewrite_statics
+                    .add(ldid.to_def_id(), DontRewriteStaticReason::USER_REQUEST);
             }
 
             _ => {}

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -1265,21 +1265,18 @@ fn run(tcx: TyCtxt) {
         all_rewrites.clear();
         eprintln!("\n--- start rewriting ---");
 
+        // Clear the list of newly non-rewritable fns.  After generating rewrites, if any functions
+        // became non-rewritable, we run another iteration.
+        let new_non_rewritable_fns = gacx.dont_rewrite_fns.take_new_keys();
+
         // Before generating rewrites, add the FIXED flag to the signatures of all functions where
         // rewriting will be skipped.
         //
         // The set of nonrewritten functions is monotonically nondecreasing throughout this loop,
         // so there's no need to worry about potentially removing `FIXED` from some functions.
-        for did in gacx.iter_fns_skip_rewrite() {
-            let lsig = gacx.fn_sigs[&did];
-            for sig_lty in lsig.inputs_and_output() {
-                for lty in sig_lty.iter() {
-                    let ptr = lty.label;
-                    if !ptr.is_none() {
-                        gasn.flags[ptr].insert(FlagSet::FIXED);
-                    }
-                }
-            }
+        for did in new_non_rewritable_fns {
+            let lsig = &gacx.fn_sigs[&did];
+            make_sig_fixed(&mut gasn, lsig);
         }
 
         for &ldid in &all_fn_ldids {
@@ -1343,7 +1340,6 @@ fn run(tcx: TyCtxt) {
         all_rewrites.extend(shim_call_rewrites);
 
         // Generate shims for functions that need them.
-        let mut any_failed = false;
         for def_id in shim_fn_def_ids {
             let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
                 all_rewrites.push(rewrite::gen_shim_definition_rewrite(
@@ -1357,13 +1353,13 @@ fn run(tcx: TyCtxt) {
                 Ok(()) => {}
                 Err(pd) => {
                     gacx.mark_fn_failed(def_id, DontRewriteFnReason::SHIM_GENERATION_FAILED, pd);
-                    any_failed = true;
                     continue;
                 }
             }
         }
 
-        if !any_failed {
+        // Exit the loop upon reaching a fixpoint.
+        if gacx.dont_rewrite_fns.new_keys().is_empty() {
             break;
         }
     }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -939,20 +939,15 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             .flat_map(|(fn_sig, known_fn)| known_fn.ptr_perms(fn_sig))
     }
 
+    /// Check whether the function with the given `def_id` has been marked as non-rewritable.
     pub fn dont_rewrite_fn(&self, def_id: DefId) -> bool {
         self.dont_rewrite_fns.contains(def_id)
     }
+    /// Check whether analysis failed for the function with the given `def_id`.
     pub fn fn_analysis_invalid(&self, def_id: DefId) -> bool {
         self.dont_rewrite_fns
             .get(def_id)
             .intersects(DontRewriteFnReason::ANALYSIS_INVALID_MASK)
-    }
-
-    pub fn dont_rewrite_static(&self, def_id: DefId) -> bool {
-        self.dont_rewrite_statics.contains(def_id)
-    }
-    pub fn dont_rewrite_field(&self, def_id: DefId) -> bool {
-        self.dont_rewrite_fields.contains(def_id)
     }
 }
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -241,8 +241,8 @@ bitflags! {
     pub struct DontRewriteStaticReason: u16 {
         /// The user requested that this static be left unchanged.
         const USER_REQUEST = 0x0001;
-        /// The field is used in a function that isn't being rewritten.
-        const NON_REWRITTEN_USER = 0x0002;
+        /// The static is used in a function that isn't being rewritten.
+        const NON_REWRITTEN_USE = 0x0002;
     }
 }
 
@@ -253,7 +253,7 @@ bitflags! {
         /// The user requested that this field be left unchanged.
         const USER_REQUEST = 0x0001;
         /// The field is used in a function that isn't being rewritten.
-        const NON_REWRITTEN_USER = 0x0002;
+        const NON_REWRITTEN_USE = 0x0002;
     }
 }
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -36,7 +36,9 @@ use rustc_middle::ty::TyKind;
 use rustc_type_ir::RegionKind::{ReEarlyBound, ReStatic};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Write as _};
-use std::ops::Index;
+use std::hash::Hash;
+use std::mem;
+use std::ops::{BitOr, Index};
 
 bitflags! {
     /// Permissions are created such that we allow dropping permissions in any assignment.
@@ -394,9 +396,9 @@ pub struct GlobalAnalysisCtxt<'tcx> {
     /// [`name`]: KnownFn::name
     known_fns: HashMap<&'static str, &'static KnownFn>,
 
-    dont_rewrite_fns: HashMap<DefId, DontRewriteFnReason>,
-    dont_rewrite_statics: HashMap<DefId, DontRewriteStaticReason>,
-    dont_rewrite_fields: HashMap<DefId, DontRewriteFieldReason>,
+    pub dont_rewrite_fns: FlagMap<DefId, DontRewriteFnReason>,
+    pub dont_rewrite_statics: FlagMap<DefId, DontRewriteStaticReason>,
+    pub dont_rewrite_fields: FlagMap<DefId, DontRewriteFieldReason>,
 
     /// `DefId`s of functions where analysis failed, and a [`PanicDetail`] explaining the reason
     /// for each failure.
@@ -769,9 +771,9 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
                 .iter()
                 .map(|known_fn| (known_fn.name, known_fn))
                 .collect(),
-            dont_rewrite_fns: HashMap::new(),
-            dont_rewrite_statics: HashMap::new(),
-            dont_rewrite_fields: HashMap::new(),
+            dont_rewrite_fns: FlagMap::new(),
+            dont_rewrite_statics: FlagMap::new(),
+            dont_rewrite_fields: FlagMap::new(),
             fns_failed: HashMap::new(),
             field_ltys: HashMap::new(),
             static_tys: HashMap::new(),
@@ -894,14 +896,14 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
     }
 
     pub fn mark_fn_failed(&mut self, did: DefId, reason: DontRewriteFnReason, detail: PanicDetail) {
-        self.set_dont_rewrite_fn(did, reason);
+        self.dont_rewrite_fns.add(did, reason);
         // Insert `detail` if there isn't yet an entry for this `DefId`.
         self.fns_failed.entry(did).or_insert(detail);
     }
 
     /// Iterate over the `DefId`s of all functions that should skip rewriting.
     pub fn iter_fns_skip_rewrite<'a>(&'a self) -> impl Iterator<Item = DefId> + 'a {
-        self.dont_rewrite_fns.keys().copied()
+        self.dont_rewrite_fns.keys()
     }
 
     pub fn known_fn(&self, def_id: DefId) -> Option<&'static KnownFn> {
@@ -931,56 +933,19 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
     }
 
     pub fn dont_rewrite_fn(&self, def_id: DefId) -> bool {
-        self.dont_rewrite_fns.contains_key(&def_id)
+        self.dont_rewrite_fns.contains(def_id)
     }
-
-    pub fn dont_rewrite_fn_reason(&self, def_id: DefId) -> DontRewriteFnReason {
-        self.dont_rewrite_fns
-            .get(&def_id)
-            .copied()
-            .unwrap_or_default()
-    }
-
-    pub fn set_dont_rewrite_fn(&mut self, def_id: DefId, reason: DontRewriteFnReason) {
-        assert_ne!(reason, DontRewriteFnReason::empty());
-        *self.dont_rewrite_fns.entry(def_id).or_default() |= reason;
-    }
-
     pub fn fn_analysis_invalid(&self, def_id: DefId) -> bool {
-        self.dont_rewrite_fn_reason(def_id)
+        self.dont_rewrite_fns
+            .get(def_id)
             .intersects(DontRewriteFnReason::ANALYSIS_INVALID_MASK)
     }
 
     pub fn dont_rewrite_static(&self, def_id: DefId) -> bool {
-        self.dont_rewrite_statics.contains_key(&def_id)
+        self.dont_rewrite_statics.contains(def_id)
     }
-
-    pub fn dont_rewrite_static_reason(&self, def_id: DefId) -> DontRewriteStaticReason {
-        self.dont_rewrite_statics
-            .get(&def_id)
-            .copied()
-            .unwrap_or_default()
-    }
-
-    pub fn set_dont_rewrite_static(&mut self, def_id: DefId, reason: DontRewriteStaticReason) {
-        assert_ne!(reason, DontRewriteStaticReason::empty());
-        *self.dont_rewrite_statics.entry(def_id).or_default() |= reason;
-    }
-
     pub fn dont_rewrite_field(&self, def_id: DefId) -> bool {
-        self.dont_rewrite_fields.contains_key(&def_id)
-    }
-
-    pub fn dont_rewrite_field_reason(&self, def_id: DefId) -> DontRewriteFieldReason {
-        self.dont_rewrite_fields
-            .get(&def_id)
-            .copied()
-            .unwrap_or_default()
-    }
-
-    pub fn set_dont_rewrite_field(&mut self, def_id: DefId, reason: DontRewriteFieldReason) {
-        assert_ne!(reason, DontRewriteFieldReason::empty());
-        *self.dont_rewrite_fields.entry(def_id).or_default() |= reason;
+        self.dont_rewrite_fields.contains(def_id)
     }
 }
 
@@ -1623,5 +1588,61 @@ pub fn print_ty_with_pointer_labels_into<L: Copy>(
         | Opaque(..) | Param(..) | Bound(..) | Placeholder(..) | Infer(..) | Error(..) => {
             write!(dest, "unknown:{:?}", lty.ty).unwrap();
         }
+    }
+}
+
+/// Map for associating flags (such as `DontRewriteFnReason`) with keys (such as `DefId`).
+pub struct FlagMap<K, V> {
+    /// Stores the current flags for each key.  If no flags are set, the entry is omitted; that is,
+    /// for every entry `(k, v)`, it's always the case that `v != V::default()`.
+    m: HashMap<K, V>,
+    /// Keys that were added to `m` since the last call to `take_new()`.  Specifically, this
+    /// includes every `k` for which `get(k)` was `V::default()` but `get(k)` now has a different,
+    /// non-default value.
+    new: Vec<K>,
+}
+
+impl<K, V> FlagMap<K, V>
+where
+    K: Copy + Hash + Eq,
+    V: Copy + Default + Eq + BitOr<Output = V>,
+{
+    pub fn new() -> FlagMap<K, V> {
+        FlagMap {
+            m: HashMap::new(),
+            new: Vec::new(),
+        }
+    }
+
+    pub fn add(&mut self, k: K, v: V) {
+        if v == V::default() {
+            return;
+        }
+        let cur = self.m.entry(k).or_default();
+        if *cur == V::default() {
+            self.new.push(k);
+        }
+        *cur = *cur | v;
+    }
+
+    /// Get the current flags for `k`.  Returns `V::default()` if no flags have been set.
+    pub fn get(&self, k: K) -> V {
+        self.m.get(&k).copied().unwrap_or_default()
+    }
+
+    pub fn contains(&self, k: K) -> bool {
+        self.m.contains_key(&k)
+    }
+
+    pub fn new_keys(&self) -> &[K] {
+        &self.new
+    }
+
+    pub fn take_new_keys(&mut self) -> Vec<K> {
+        mem::take(&mut self.new)
+    }
+
+    pub fn keys<'a>(&'a self) -> impl Iterator<Item = K> + 'a {
+        self.m.keys().copied()
     }
 }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -186,6 +186,59 @@ bitflags! {
     }
 }
 
+bitflags! {
+    /// Flags indicating reasons why a function isn't being rewritten.
+    #[derive(Default)]
+    pub struct DontRewriteFnReason: u16 {
+        /// The user requested that this function be left unchanged.
+        const USER_REQUEST = 0x0001;
+        /// The function contains an unsupported int-to-pointer cast.
+        const INT_TO_PTR_CAST = 0x0002;
+        /// The function calls an extern function that has no safe rewrite.
+        const EXTERN_CALL = 0x0004;
+        /// The function calls another local function that isn't being rewritten.
+        const NON_REWRITTEN_CALLEE = 0x0008;
+        /// The function uses `Cell` pointers whose types are too complex for the current rewrite
+        /// rules.
+        const COMPLEX_CELL = 0x0010;
+        /// The function contains a pointer-to-pointer cast that isn't covered by rewrite rules.
+        const PTR_TO_PTR_CAST = 0x0020;
+        /// The function dereferences a pointer that would remain raw after rewriting.
+        const RAW_PTR_DEREF = 0x0040;
+
+        /// Dataflow analysis failed on this function.
+        const DATAFLOW_FAILED = 0x0080;
+        /// Borrowcheck/Polonius analysis failed on this function.
+        const BORROWCK_FAILED = 0x0100;
+        /// MIR rewrite generation failed on this function.
+        const MIR_REWRITE_FAILED = 0x0200;
+        /// HIR/AST rewrite generation failed on this function.
+        const HIR_REWRITE_FAILED = 0x0200;
+    }
+}
+
+bitflags! {
+    /// Flags indicating reasons why a static isn't being rewritten.
+    #[derive(Default)]
+    pub struct DontRewriteStaticReason: u16 {
+        /// The user requested that this static be left unchanged.
+        const USER_REQUEST = 0x0001;
+        /// The field is used in a function that isn't being rewritten.
+        const NON_REWRITTEN_USER = 0x0002;
+    }
+}
+
+bitflags! {
+    /// Flags indicating reasons why an ADT field isn't being rewritten.
+    #[derive(Default)]
+    pub struct DontRewriteFieldReason: u16 {
+        /// The user requested that this field be left unchanged.
+        const USER_REQUEST = 0x0001;
+        /// The field is used in a function that isn't being rewritten.
+        const NON_REWRITTEN_USER = 0x0002;
+    }
+}
+
 pub use crate::pointer_id::PointerId;
 
 pub type LTy<'tcx> = LabeledTy<'tcx, PointerId>;
@@ -325,6 +378,10 @@ pub struct GlobalAnalysisCtxt<'tcx> {
     ///
     /// [`name`]: KnownFn::name
     known_fns: HashMap<&'static str, &'static KnownFn>,
+
+    dont_rewrite_fns: HashMap<DefId, DontRewriteFnReason>,
+    dont_rewrite_statics: HashMap<DefId, DontRewriteStaticReason>,
+    dont_rewrite_fields: HashMap<DefId, DontRewriteFieldReason>,
 
     /// `DefId`s of functions where analysis failed, and a [`PanicDetail`] explaining the reason
     /// for each failure.
@@ -700,6 +757,9 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
                 .iter()
                 .map(|known_fn| (known_fn.name, known_fn))
                 .collect(),
+            dont_rewrite_fns: HashMap::new(),
+            dont_rewrite_statics: HashMap::new(),
+            dont_rewrite_fields: HashMap::new(),
             fns_failed: HashMap::new(),
             fns_fixed: HashSet::new(),
             field_ltys: HashMap::new(),
@@ -762,6 +822,9 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             ref mut ptr_info,
             ref mut fn_sigs,
             known_fns: _,
+            dont_rewrite_fns: _,
+            dont_rewrite_statics: _,
+            dont_rewrite_fields: _,
             fns_failed: _,
             fns_fixed: _,
             ref mut field_ltys,
@@ -879,6 +942,54 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             })
             .filter_map(|(&def_id, fn_sig)| Some((fn_sig, self.known_fn(def_id)?)))
             .flat_map(|(fn_sig, known_fn)| known_fn.ptr_perms(fn_sig))
+    }
+
+    pub fn dont_rewrite_fn(&self, def_id: DefId) -> bool {
+        self.dont_rewrite_fns.contains_key(&def_id)
+    }
+
+    pub fn dont_rewrite_fn_reason(&self, def_id: DefId) -> DontRewriteFnReason {
+        self.dont_rewrite_fns
+            .get(&def_id)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    pub fn set_dont_rewrite_fn(&mut self, def_id: DefId, reason: DontRewriteFnReason) {
+        assert_ne!(reason, DontRewriteFnReason::empty());
+        *self.dont_rewrite_fns.entry(def_id).or_default() |= reason;
+    }
+
+    pub fn dont_rewrite_static(&self, def_id: DefId) -> bool {
+        self.dont_rewrite_statics.contains_key(&def_id)
+    }
+
+    pub fn dont_rewrite_static_reason(&self, def_id: DefId) -> DontRewriteStaticReason {
+        self.dont_rewrite_statics
+            .get(&def_id)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    pub fn set_dont_rewrite_static(&mut self, def_id: DefId, reason: DontRewriteStaticReason) {
+        assert_ne!(reason, DontRewriteStaticReason::empty());
+        *self.dont_rewrite_statics.entry(def_id).or_default() |= reason;
+    }
+
+    pub fn dont_rewrite_field(&self, def_id: DefId) -> bool {
+        self.dont_rewrite_fields.contains_key(&def_id)
+    }
+
+    pub fn dont_rewrite_field_reason(&self, def_id: DefId) -> DontRewriteFieldReason {
+        self.dont_rewrite_fields
+            .get(&def_id)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    pub fn set_dont_rewrite_field(&mut self, def_id: DefId, reason: DontRewriteFieldReason) {
+        assert_ne!(reason, DontRewriteFieldReason::empty());
+        *self.dont_rewrite_fields.entry(def_id).or_default() |= reason;
     }
 }
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -34,11 +34,12 @@ use rustc_middle::ty::Ty;
 use rustc_middle::ty::TyCtxt;
 use rustc_middle::ty::TyKind;
 use rustc_type_ir::RegionKind::{ReEarlyBound, ReStatic};
-use std::collections::{HashMap, HashSet};
+use std::collections::hash_map::{Entry, HashMap};
+use std::collections::HashSet;
 use std::fmt::{Debug, Write as _};
 use std::hash::Hash;
 use std::mem;
-use std::ops::{BitOr, Index};
+use std::ops::{BitOr, Index, Range};
 
 bitflags! {
     /// Permissions are created such that we allow dropping permissions in any assignment.
@@ -387,6 +388,7 @@ pub struct GlobalAnalysisCtxt<'tcx> {
     ptr_info: GlobalPointerTable<PointerInfo>,
 
     pub fn_sigs: HashMap<DefId, LFnSig<'tcx>>,
+    pub fn_fields_used: MultiMap<LocalDefId, LocalDefId>,
 
     /// A map of all [`KnownFn`]s as determined by [`all_known_fns`].
     ///
@@ -405,6 +407,7 @@ pub struct GlobalAnalysisCtxt<'tcx> {
     pub fns_failed: HashMap<DefId, PanicDetail>,
 
     pub field_ltys: HashMap<DefId, LTy<'tcx>>,
+    pub field_users: MultiMap<LocalDefId, LocalDefId>,
 
     pub static_tys: HashMap<DefId, LTy<'tcx>>,
     pub addr_of_static: HashMap<DefId, PointerId>,
@@ -767,6 +770,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             lcx: LabeledTyCtxt::new(tcx),
             ptr_info: GlobalPointerTable::empty(),
             fn_sigs: HashMap::new(),
+            fn_fields_used: MultiMap::new(),
             known_fns: all_known_fns()
                 .iter()
                 .map(|known_fn| (known_fn.name, known_fn))
@@ -776,6 +780,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             dont_rewrite_fields: FlagMap::new(),
             fns_failed: HashMap::new(),
             field_ltys: HashMap::new(),
+            field_users: MultiMap::new(),
             static_tys: HashMap::new(),
             addr_of_static: HashMap::new(),
             adt_metadata: AdtMetadataTable::default(),
@@ -834,12 +839,14 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             lcx,
             ref mut ptr_info,
             ref mut fn_sigs,
+            fn_fields_used: _,
             known_fns: _,
             dont_rewrite_fns: _,
             dont_rewrite_statics: _,
             dont_rewrite_fields: _,
             fns_failed: _,
             ref mut field_ltys,
+            field_users: _,
             ref mut static_tys,
             ref mut addr_of_static,
             adt_metadata: _,
@@ -1644,5 +1651,43 @@ where
 
     pub fn keys<'a>(&'a self) -> impl Iterator<Item = K> + 'a {
         self.m.keys().copied()
+    }
+}
+
+/// A map from keys to lists of values, with a compact representation.
+#[derive(Clone, Debug)]
+pub struct MultiMap<K, V> {
+    defs: HashMap<K, Range<usize>>,
+    users: Vec<V>,
+}
+
+impl<K, V> MultiMap<K, V>
+where
+    K: Copy + Hash + Eq + Debug,
+{
+    pub fn new() -> MultiMap<K, V> {
+        MultiMap {
+            defs: HashMap::new(),
+            users: Vec::new(),
+        }
+    }
+
+    pub fn insert(&mut self, def: K, users: impl IntoIterator<Item = V>) {
+        let e = match self.defs.entry(def) {
+            Entry::Vacant(e) => e,
+            Entry::Occupied(_) => panic!("duplicate entry for {def:?}"),
+        };
+        let start = self.users.len();
+        self.users.extend(users);
+        let end = self.users.len();
+        e.insert(start..end);
+    }
+
+    pub fn get(&self, def: K) -> &[V] {
+        let range = match self.defs.get(&def) {
+            Some(x) => x,
+            None => return &[],
+        };
+        &self.users[range.clone()]
     }
 }

--- a/c2rust-analyze/src/rewrite/expr/mod.rs
+++ b/c2rust-analyze/src/rewrite/expr/mod.rs
@@ -2,6 +2,7 @@ use crate::context::{AnalysisCtxt, Assignment};
 use crate::pointee_type::PointeeTypes;
 use crate::pointer_id::PointerTable;
 use crate::rewrite::Rewrite;
+use rustc_hir::def_id::DefId;
 use rustc_hir::BodyId;
 use rustc_middle::mir::Body;
 use rustc_span::Span;
@@ -17,13 +18,17 @@ pub use self::convert::convert_cast_rewrite;
 pub use self::mir_op::CastBuilder;
 
 pub fn gen_expr_rewrites<'tcx>(
-    acx: &AnalysisCtxt<'_, 'tcx>,
+    acx: &mut AnalysisCtxt<'_, 'tcx>,
     asn: &Assignment,
     pointee_types: PointerTable<PointeeTypes<'tcx>>,
+    def_id: DefId,
     mir: &Body<'tcx>,
     hir_body_id: BodyId,
 ) -> Vec<(Span, Rewrite)> {
-    let mir_rewrites = mir_op::gen_mir_rewrites(acx, asn, pointee_types, mir);
+    let (mir_rewrites, errors) = mir_op::gen_mir_rewrites(acx, asn, pointee_types, mir);
+    if !errors.is_empty() {
+        acx.gacx.dont_rewrite_fns.add(def_id, errors);
+    }
     let unlower_map = unlower::unlower(acx.tcx(), mir, hir_body_id);
     let rewrites_by_expr = distribute::distribute(acx.tcx(), unlower_map, mir_rewrites);
     let address_of_rewrites = hir_only_casts::remove_hir_only_casts(acx.tcx(), hir_body_id, |ex| {

--- a/c2rust-analyze/tests/filecheck/test_attrs.rs
+++ b/c2rust-analyze/tests/filecheck/test_attrs.rs
@@ -17,13 +17,13 @@ fn g(x: *mut i32) -> *mut i32 {
     x
 }
 
-// CHECK: analysis of DefId({{.*}} ~ test_attrs[{{.*}}]::h) failed: [unknown]: explicit fail_before_analysis for testing
+// CHECK: analysis of DefId({{.*}} ~ test_attrs[{{.*}}]::h) failed: FAKE_INVALID_FOR_TESTING, [unknown]: explicit fail_before_analysis for testing
 #[c2rust_analyze_test::fail_before_analysis]
 fn h(x: *mut i32) -> *mut i32 {
     x
 }
 
-// CHECK: analysis of DefId({{.*}} ~ test_attrs[{{.*}}]::i) failed: [unknown]: explicit fail_before_rewriting for testing
+// CHECK: analysis of DefId({{.*}} ~ test_attrs[{{.*}}]::i) failed: FAKE_INVALID_FOR_TESTING, [unknown]: explicit fail_before_rewriting for testing
 #[c2rust_analyze_test::fail_before_rewriting]
 fn i(x: *mut i32) -> *mut i32 {
     x


### PR DESCRIPTION
This branch replaces most of the existing `fns_failed`/`fns_fixed` machinery with a new strategy for marking items with a  "don't rewrite" flag.  This makes it easier to integrate new, stricter checks for unsupported code patterns, with the goal of reducing compile errors in the rewritten code.  Some of these checks are also implemented in this branch, such as a check for complex (and currently unsupported) `Cell` rewrites.

When an item is marked as don't-rewrite, we also record a reason flag.  This is helpful for debugging, and will also make it easy in the future to disable specific checks (by ignoring the corresponding reason flag) for debugging/testing purposes or by user request.