### PR TITLE
analyze: add --rewrite-mode pointwise

### DIFF
--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -525,7 +525,7 @@ fn run(tcx: TyCtxt) {
     /// the pointer analysis have a "global" part that's shared between all functions and a "local"
     /// part that's specific to the function being analyzed; this struct contains only the local
     /// parts.  The different fields are set, used, and cleared at various points below.
-    #[derive(Default)]
+    #[derive(Clone, Default)]
     struct FuncInfo<'tcx> {
         /// Local analysis context data, such as [`LTy`]s for all MIR locals.  Combine with the
         /// [`GlobalAnalysisCtxt`] to get a complete [`AnalysisCtxt`] for use within this function.

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -298,7 +298,7 @@ bitflags! {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct AdtMetadataTable<'tcx> {
     pub table: HashMap<DefId, AdtMetadata<'tcx>>,
     pub struct_dids: Vec<DefId>,
@@ -381,6 +381,7 @@ impl<'tcx> Debug for AdtMetadataTable<'tcx> {
     }
 }
 
+#[derive(Clone)]
 pub struct GlobalAnalysisCtxt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub lcx: LTyCtxt<'tcx>,
@@ -464,6 +465,7 @@ impl<'a, 'tcx> AnalysisCtxt<'_, 'tcx> {
     }
 }
 
+#[derive(Clone)]
 pub struct AnalysisCtxtData<'tcx> {
     ptr_info: LocalPointerTable<PointerInfo>,
     local_tys: IndexVec<Local, LTy<'tcx>>,
@@ -472,13 +474,14 @@ pub struct AnalysisCtxtData<'tcx> {
     string_literal_locs: Vec<Location>,
 }
 
+#[derive(Clone)]
 pub struct FnSigOrigins<'tcx> {
     pub origin_params: Vec<OriginParam>,
     pub inputs: Vec<LabeledTy<'tcx, &'tcx [OriginArg<'tcx>]>>,
     pub output: LabeledTy<'tcx, &'tcx [OriginArg<'tcx>]>,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct FnOriginMap<'tcx> {
     pub fn_info: HashMap<DefId, FnSigOrigins<'tcx>>,
 }
@@ -1420,6 +1423,7 @@ impl GlobalAssignment {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct LocalAssignment {
     pub perms: LocalPointerTable<PermissionSet>,
     pub flags: LocalPointerTable<FlagSet>,
@@ -1594,6 +1598,7 @@ pub fn print_ty_with_pointer_labels_into<L: Copy>(
 }
 
 /// Map for associating flags (such as `DontRewriteFnReason`) with keys (such as `DefId`).
+#[derive(Clone, Debug)]
 pub struct FlagMap<K, V> {
     /// Stores the current flags for each key.  If no flags are set, the entry is omitted; that is,
     /// for every entry `(k, v)`, it's always the case that `v != V::default()`.

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -131,6 +131,9 @@ enum RewriteMode {
     /// Save rewritten code to a separate file alongside each source file.
     #[value(name = "alongside")]
     Alongside,
+    /// Rewrite each function separately, and write the results for each to a separate file.
+    #[value(name = "pointwise")]
+    Pointwise,
 }
 
 fn exit_with_status(status: ExitStatus) {
@@ -445,6 +448,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
                 RewriteMode::None => "none",
                 RewriteMode::InPlace => "inplace",
                 RewriteMode::Alongside => "alongside",
+                RewriteMode::Pointwise => "pointwise",
             };
             cmd.env("C2RUST_ANALYZE_REWRITE_MODE", val);
         }

--- a/c2rust-analyze/src/pointee_type/constraint_set.rs
+++ b/c2rust-analyze/src/pointee_type/constraint_set.rs
@@ -24,7 +24,7 @@ pub enum Constraint<'tcx> {
     Subset(PointerId, PointerId),
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ConstraintSet<'tcx> {
     pub constraints: Vec<Constraint<'tcx>>,
     constraint_dedup: HashSet<Constraint<'tcx>>,
@@ -79,7 +79,7 @@ impl<'tcx> From<LTy<'tcx>> for CTy<'tcx> {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct VarTable<'tcx> {
     /// Equivalence class representative for each variable.  This can be either a known type
     /// (`CTy::Ty`) or an inference variable (`CTy::Var`).

--- a/c2rust-analyze/src/recent_writes.rs
+++ b/c2rust-analyze/src/recent_writes.rs
@@ -6,6 +6,7 @@ use rustc_middle::mir::{
 use std::collections::HashMap;
 
 /// Table for looking up the most recent write to a `Local` prior to a particular MIR statement.
+#[derive(Clone, Debug)]
 pub struct RecentWrites {
     blocks: IndexVec<BasicBlock, BlockWrites>,
     /// For each local, whether its address is taken anywhere within the current function.

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -114,7 +114,7 @@ fn create_rewrite_label<'tcx>(
     let mut pointee_ty = None;
     // For now, we only rewrite in cases where the inferred pointee has no arguments.
     // TODO: expand this to handle pointer-to-pointer cases and other complex inferred pointees
-    if !pointer_lty.label.is_none() {
+    if !pointer_lty.label.is_none() && !flags[pointer_lty.label].contains(FlagSet::FIXED) {
         if let Some(lty) = pointee_types[pointer_lty.label].get_sole_lty() {
             let ty = lty.ty;
             if lty.args.len() == 0 && !ty_has_adt_lifetime(ty, adt_metadata) {


### PR DESCRIPTION
This adds a new --rewrite-mode called "pointwise", which rewrites each function in isolation, with all other definitions marked `FIXED`.  The static analysis runs only once, then we run multiple rewriting passes using the same analysis results, making this much more efficient than running the whole `c2rust-analyze` tool multiple times.

The rewritten code is output to a separate file for each function.  For example, given `foo.rs` containing a function `bar`, this mode will write to `foo.bar.rs` the new code produced by rewriting only `bar`.

Pointwise mode is the basis for our new "pointwise success rate" metric.