### PR TITLE
`c2rust transpile`: Allow any integral types in init lists, not just `char` and `int`

### DIFF
--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -249,7 +249,7 @@ impl<'c> Translation<'c> {
             CTypeKind::Vector(CQualTypeId { ctype, .. }, len) => {
                 self.vector_list_initializer(ctx, ids, ctype, len)
             }
-            CTypeKind::Char | CTypeKind::Int => {
+            ref kind if kind.is_integral_type() => {
                 let id = ids.first().unwrap();
                 self.convert_expr(ctx.used(), *id)
             }


### PR DESCRIPTION
* Fixes #1009.

This also fixes these errors in transpiling [`nasa/cFS`](https://github.com/nasa/cFS).