### PR TITLE
analyze: initial implementation of NON_NULL static analysis

### DIFF
--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -603,7 +603,9 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         });
                     }
                     Callee::Null { .. } => {
-                        // TODO: do we need to do anything here?
+                        // Just visit the place.  The null pointer returned here has no origin, so
+                        // there's no need to call `do_assign` to set up subset relations.
+                        let _pl_lty = self.visit_place(destination);
                     }
                 }
             }

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -602,6 +602,9 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                             self.visit_operand(p)
                         });
                     }
+                    Callee::Null { .. } => {
+                        // TODO: do we need to do anything here?
+                    }
                 }
             }
             // TODO(spernsteiner): handle other `TerminatorKind`s

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -166,7 +166,7 @@ impl PermissionSet {
 
     /// The permissions for a (byte-)string literal.
     //
-    // `.union` is used here since it's a `const fn`, unlike `BitOr::bitor`.
+    // `union_all` is used here since it's a `const fn`, unlike `BitOr::bitor`.
     pub const STRING_LITERAL: Self = Self::union_all([Self::READ, Self::OFFSET_ADD]);
 }
 
@@ -456,10 +456,11 @@ impl<'a, 'tcx> AnalysisCtxt<'_, 'tcx> {
             let ptr = lty.label;
             let expected_perms = PermissionSet::STRING_LITERAL;
             let mut actual_perms = asn.perms()[ptr];
-            // Ignore `UNIQUE` as it gets automatically added to all permissions
-            // and then removed later if it can't apply.
-            // We don't care about `UNIQUE` for const refs, so just unset it here.
+            // Ignore `UNIQUE` and `NON_NULL` as they get automatically added to all permissions
+            // and then removed later if it can't apply.  We don't care about `UNIQUE` or
+            // `NON_NULL` for const refs, so just unset it here.
             actual_perms.set(PermissionSet::UNIQUE, false);
+            actual_perms.set(PermissionSet::NON_NULL, false);
             assert_eq!(expected_perms, actual_perms);
         }
     }

--- a/c2rust-analyze/src/dataflow/mod.rs
+++ b/c2rust-analyze/src/dataflow/mod.rs
@@ -40,8 +40,7 @@ impl DataflowConstraints {
         self.constraints.push(Constraint::AllPerms(ptr, perms));
     }
 
-    #[allow(dead_code)]
-    fn _add_no_perms(&mut self, ptr: PointerId, perms: PermissionSet) {
+    fn add_no_perms(&mut self, ptr: PointerId, perms: PermissionSet) {
         self.constraints.push(Constraint::NoPerms(ptr, perms));
     }
 

--- a/c2rust-analyze/src/dataflow/mod.rs
+++ b/c2rust-analyze/src/dataflow/mod.rs
@@ -86,7 +86,7 @@ impl DataflowConstraints {
                 // Permissions that should be propagated "down": if the superset (`b`)
                 // doesn't have it, then the subset (`a`) should have it removed.
                 #[allow(bad_style)]
-                let PROPAGATE_DOWN = PermissionSet::UNIQUE;
+                let PROPAGATE_DOWN = PermissionSet::UNIQUE | PermissionSet::NON_NULL;
                 // Permissions that should be propagated "up": if the subset (`a`) has it,
                 // then the superset (`b`) should be given it.
                 #[allow(bad_style)]

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -599,6 +599,15 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 assert!(args.len() == 1);
                 self.visit_operand(&args[0]);
             }
+            Callee::Null { .. } => {
+                assert!(args.len() == 0);
+                self.visit_place(destination, Mutability::Mut);
+                let pl_lty = self.acx.type_of(destination);
+                // We are assigning a null pointer to `destination`, so it must not have the
+                // `NON_NULL` flag.
+                self.constraints
+                    .add_no_perms(pl_lty.label, PermissionSet::NON_NULL);
+            }
         }
     }
 

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -123,6 +123,9 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 if !op.constant().copied().map(is_null_const).unwrap_or(false) {
                     panic!("Creating non-null pointers from exposed addresses not supported");
                 }
+                // The target type of the cast must not have `NON_NULL` permission.
+                self.constraints
+                    .add_no_perms(to_lty.label, PermissionSet::NON_NULL);
             }
             CastKind::PointerExposeAddress => {
                 // Allow, as [`CastKind::PointerFromExposedAddress`] is the dangerous one,

--- a/c2rust-analyze/src/pointee_type/type_check.rs
+++ b/c2rust-analyze/src/pointee_type/type_check.rs
@@ -332,6 +332,9 @@ impl<'tcx> TypeChecker<'tcx, '_> {
             Callee::IsNull => {
                 // No constraints.
             }
+            Callee::Null { .. } => {
+                // No constraints.
+            }
         }
     }
 }

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -346,7 +346,7 @@ fn builtin_callee<'tcx>(tcx: TyCtxt<'tcx>, did: DefId, substs: SubstsRef<'tcx>) 
         }
 
         "null" | "null_mut" => {
-            // The `core::mem::size_of` function.
+            // The `core::ptr::null/null_mut` function.
             let parent_did = tcx.parent(did);
             if tcx.def_kind(parent_did) != DefKind::Mod {
                 return None;

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -55,6 +55,7 @@ define_tests! {
     insertion_sort_driver,
     insertion_sort_rewrites,
     known_fn,
+    non_null,
     offset1,
     offset2,
     pointee,

--- a/c2rust-analyze/tests/filecheck/alias1.rs
+++ b/c2rust-analyze/tests/filecheck/alias1.rs
@@ -2,23 +2,23 @@ use std::ptr;
 
 // CHECK-LABEL: final labeling for "alias1_good"
 pub unsafe fn alias1_good() {
-    // CHECK-DAG: ([[@LINE+1]]: mut x): addr_of = READ | WRITE | UNIQUE,
+    // CHECK-DAG: ([[@LINE+1]]: mut x): addr_of = READ | WRITE | UNIQUE | NON_NULL,
     let mut x = 0;
-    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE | NON_NULL#
     let p = ptr::addr_of_mut!(x);
-    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE | NON_NULL#
     let q = ptr::addr_of_mut!(x);
     *q = 1;
 }
 
 // CHECK-LABEL: final labeling for "alias1_bad"
 pub unsafe fn alias1_bad() {
-    // CHECK-DAG: ([[@LINE+2]]: mut x): addr_of = READ | WRITE,
+    // CHECK-DAG: ([[@LINE+2]]: mut x): addr_of = READ | WRITE | NON_NULL,
     // CHECK-DAG: ([[@LINE+1]]: mut x): addr_of flags = CELL,
     let mut x = 0;
-    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE | NON_NULL#
     let p = ptr::addr_of_mut!(x);
-    // CHECK-DAG: ([[@LINE+2]]: q): {{.*}}type = (empty)#
+    // CHECK-DAG: ([[@LINE+2]]: q): {{.*}}type = NON_NULL#
     // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type flags = CELL#
     let q = ptr::addr_of_mut!(x);
     *p = 1;

--- a/c2rust-analyze/tests/filecheck/alias2.rs
+++ b/c2rust-analyze/tests/filecheck/alias2.rs
@@ -1,43 +1,43 @@
 use std::ptr;
 
 // CHECK-LABEL: final labeling for "alias2_copy_good"
-// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE | NON_NULL#
 pub unsafe fn alias2_copy_good(x: *mut i32) {
-    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE | NON_NULL#
     let p = x;
-    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE | NON_NULL#
     let q = x;
     *q = 1;
 }
 
 // CHECK-LABEL: final labeling for "alias2_addr_of_good"
-// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE | NON_NULL#
 pub unsafe fn alias2_addr_of_good(x: *mut i32) {
-    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE | NON_NULL#
     let p = ptr::addr_of_mut!(*x);
-    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE | NON_NULL#
     let q = ptr::addr_of_mut!(*x);
     *q = 1;
 }
 
 // CHECK-LABEL: final labeling for "alias2_copy_bad"
-// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE#
+// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE | NON_NULL#
 // CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type flags = CELL#
 pub unsafe fn alias2_copy_bad(x: *mut i32) {
-    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE | NON_NULL#
     let p = x;
-    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = (empty)#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = NON_NULL#
     let q = x;
     *p = 1;
 }
 
 // CHECK-LABEL: final labeling for "alias2_addr_of_bad"
-// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE#
+// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE | NON_NULL#
 // CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type flags = CELL#
 pub unsafe fn alias2_addr_of_bad(x: *mut i32) {
-    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE | NON_NULL#
     let p = ptr::addr_of_mut!(*x);
-    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = (empty)#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = NON_NULL#
     let q = ptr::addr_of_mut!(*x);
     *p = 1;
 }

--- a/c2rust-analyze/tests/filecheck/alias3.rs
+++ b/c2rust-analyze/tests/filecheck/alias3.rs
@@ -1,26 +1,26 @@
 use std::ptr;
 
 // CHECK-LABEL: final labeling for "alias3_copy_bad1"
-// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE#
+// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE | NON_NULL#
 // CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type flags = CELL#
 pub unsafe fn alias3_copy_bad1(x: *mut i32) {
-    // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ#
+    // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | NON_NULL#
     // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type flags = CELL#
     let p = x;
-    // CHECK-DAG: ([[@LINE+2]]: q): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+2]]: q): {{.*}}type = READ | WRITE | NON_NULL#
     // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type flags = CELL#
     let q = x;
     *q = *p;
 }
 
 // CHECK-LABEL: final labeling for "alias3_copy_bad2"
-// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE#
+// CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE | NON_NULL#
 // CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type flags = CELL#
 pub unsafe fn alias3_copy_bad2(x: *mut i32) {
-    // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | WRITE | NON_NULL#
     // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type flags = CELL#
     let p = x;
-    // CHECK-DAG: ([[@LINE+2]]: q): {{.*}}type = READ#
+    // CHECK-DAG: ([[@LINE+2]]: q): {{.*}}type = READ | NON_NULL#
     // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type flags = CELL#
     let q = x;
     *p = *q;

--- a/c2rust-analyze/tests/filecheck/alloc.rs
+++ b/c2rust-analyze/tests/filecheck/alloc.rs
@@ -38,7 +38,7 @@ unsafe extern "C" fn calloc1() -> *mut i32 {
 
 // CHECK-LABEL: final labeling for "malloc1"
 pub unsafe extern "C" fn malloc1(mut cnt: libc::c_int) -> *mut i32 {
-    // CHECK-DAG: ([[@LINE+1]]: i): addr_of = UNIQUE, type = READ
+    // CHECK-DAG: ([[@LINE+1]]: i): addr_of = UNIQUE | NON_NULL, type = READ | NON_NULL
     let i = malloc(::std::mem::size_of::<i32>() as libc::c_ulong) as *mut i32;
     let x = *i;
     return i;
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn malloc1(mut cnt: libc::c_int) -> *mut i32 {
 
 // CHECK-LABEL: final labeling for "free1"
 unsafe extern "C" fn free1(mut i: *mut i32) {
-    // CHECK-DAG: ([[@LINE+1]]: i{{.*}}): {{.*}}type = UNIQUE | FREE#
+    // CHECK-DAG: ([[@LINE+1]]: i{{.*}}): {{.*}}type = UNIQUE | FREE | NON_NULL#
     free(i as *mut libc::c_void);
 }
 
@@ -54,12 +54,12 @@ unsafe extern "C" fn free1(mut i: *mut i32) {
 unsafe extern "C" fn realloc1(mut i: *mut i32, len: libc::c_ulong) {
     let mut capacity = 1;
     let mut x = 1;
-    // CHECK-DAG: ([[@LINE+1]]: mut elem): addr_of = UNIQUE, type = READ | WRITE | OFFSET_ADD | OFFSET_SUB
+    // CHECK-DAG: ([[@LINE+1]]: mut elem): addr_of = UNIQUE | NON_NULL, type = READ | WRITE | OFFSET_ADD | OFFSET_SUB | NON_NULL
     let mut elem = i;
     loop {
         if x == capacity {
             capacity *= 2;
-            // CHECK-DAG: ([[@LINE+2]]: i{{.*}}): addr_of = UNIQUE, type = FREE
+            // CHECK-DAG: ([[@LINE+2]]: i{{.*}}): addr_of = UNIQUE | NON_NULL, type = FREE | NON_NULL
             i = realloc(
                 i as *mut libc::c_void,
                 4 as libc::c_ulong,
@@ -76,22 +76,22 @@ unsafe extern "C" fn realloc1(mut i: *mut i32, len: libc::c_ulong) {
 
 // CHECK-LABEL: final labeling for "alloc_and_free1"
 pub unsafe extern "C" fn alloc_and_free1(mut cnt: libc::c_int) {
-    // CHECK-DAG: ([[@LINE+1]]: i): addr_of = UNIQUE, type = UNIQUE | FREE#
+    // CHECK-DAG: ([[@LINE+1]]: i): addr_of = UNIQUE | NON_NULL, type = UNIQUE | FREE | NON_NULL#
     let i = malloc(::std::mem::size_of::<i32>() as libc::c_ulong) as *mut i32;
-    // CHECK-DAG: ([[@LINE+1]]: i{{.*}}): {{.*}}type = UNIQUE | FREE#
+    // CHECK-DAG: ([[@LINE+1]]: i{{.*}}): {{.*}}type = UNIQUE | FREE | NON_NULL#
     free(i as *mut libc::c_void);
 }
 
 
 // CHECK-LABEL: final labeling for "alloc_and_free2"
 pub unsafe extern "C" fn alloc_and_free2(mut cnt: libc::c_int) {
-    // CHECK-DAG: ([[@LINE+1]]: i): addr_of = UNIQUE, type = READ | WRITE | UNIQUE | FREE#
+    // CHECK-DAG: ([[@LINE+1]]: i): addr_of = UNIQUE | NON_NULL, type = READ | WRITE | UNIQUE | FREE | NON_NULL#
     let i = malloc(::std::mem::size_of::<i32>() as libc::c_ulong) as *mut i32;
     if !i.is_null() {
-        // CHECK-DAG: ([[@LINE+1]]: mut b): addr_of = UNIQUE, type = READ | WRITE | UNIQUE#
+        // CHECK-DAG: ([[@LINE+1]]: mut b): addr_of = UNIQUE | NON_NULL, type = READ | WRITE | UNIQUE | NON_NULL#
         let mut b = i;
         *b = 2;
-        // CHECK-DAG: ([[@LINE+1]]: i): {{.*}}type = UNIQUE | FREE#
+        // CHECK-DAG: ([[@LINE+1]]: i): {{.*}}type = UNIQUE | FREE | NON_NULL#
         free(i as *mut libc::c_void);
     }
 }

--- a/c2rust-analyze/tests/filecheck/cast.rs
+++ b/c2rust-analyze/tests/filecheck/cast.rs
@@ -10,7 +10,7 @@ struct S {
 
 // CHECK-LABEL: final labeling for "null_ptr"
 pub unsafe fn null_ptr() {
-    // CHECK-DAG: ([[@LINE+3]]: s): addr_of = UNIQUE | NON_NULL, type = READ | WRITE | UNIQUE | NON_NULL#
+    // CHECK-DAG: ([[@LINE+3]]: s): addr_of = UNIQUE | NON_NULL, type = READ | WRITE | UNIQUE#
     // CHECK-LABEL: type assignment for "null_ptr":
     // CHECK-DAG: ([[@LINE+1]]: s): &mut S
     let s = 0 as *mut S;

--- a/c2rust-analyze/tests/filecheck/cast.rs
+++ b/c2rust-analyze/tests/filecheck/cast.rs
@@ -10,7 +10,7 @@ struct S {
 
 // CHECK-LABEL: final labeling for "null_ptr"
 pub unsafe fn null_ptr() {
-    // CHECK-DAG: ([[@LINE+3]]: s): addr_of = UNIQUE, type = READ | WRITE | UNIQUE#
+    // CHECK-DAG: ([[@LINE+3]]: s): addr_of = UNIQUE | NON_NULL, type = READ | WRITE | UNIQUE | NON_NULL#
     // CHECK-LABEL: type assignment for "null_ptr":
     // CHECK-DAG: ([[@LINE+1]]: s): &mut S
     let s = 0 as *mut S;

--- a/c2rust-analyze/tests/filecheck/fields.rs
+++ b/c2rust-analyze/tests/filecheck/fields.rs
@@ -60,15 +60,15 @@ struct HypoWrapper {
 // CHECK-DAG: assign Label { origin: Some(Origin([[P_REF_A_ORIGIN]]))
 
 // CHECK-LABEL: final labeling for "_field_access"
-// CHECK-DAG: ([[@LINE+3]]: ppd): addr_of = UNIQUE, type = READ | WRITE | UNIQUE
+// CHECK-DAG: ([[@LINE+3]]: ppd): addr_of = UNIQUE | NON_NULL, type = READ | WRITE | UNIQUE | NON_NULL
 // CHECK-DAG: ([[@LINE+2]]: ra): &'d mut A<'d>
 // CHECK-DAG: ([[@LINE+1]]: ppd): &mut &mut Data
 unsafe fn _field_access<'d, 'a: 'd, T: Clone + Copy>(ra: &'d mut A<'d>, ppd: *mut *mut Data<'d>) {
-    // CHECK-DAG: ([[@LINE+2]]: rd): addr_of = UNIQUE, type = READ | UNIQUE
+    // CHECK-DAG: ([[@LINE+2]]: rd): addr_of = UNIQUE | NON_NULL, type = READ | UNIQUE | NON_NULL
     // CHECK-DAG: ([[@LINE+1]]: rd): &Data
     let rd = (*(**ppd).a.pra).rd;
 
-    // CHECK-DAG: ([[@LINE+2]]: pi): addr_of = UNIQUE, type = READ | WRITE | UNIQUE
+    // CHECK-DAG: ([[@LINE+2]]: pi): addr_of = UNIQUE | NON_NULL, type = READ | WRITE | UNIQUE | NON_NULL
     // CHECK-DAG: ([[@LINE+1]]: pi): &mut i32
     let pi = rd.pi;
     *pi = 3;

--- a/c2rust-analyze/tests/filecheck/foreign.rs
+++ b/c2rust-analyze/tests/filecheck/foreign.rs
@@ -4,10 +4,10 @@ extern "C" {
 
 type Alias = Bar;
 
-// CHECK-DAG: br: ({{.*}}) perms = UNIQUE, flags = FIXED
-// CHECK-DAG: bz: ({{.*}}) perms = UNIQUE, flags = FIXED
-// CHECK-DAG: x: ({{.*}}) perms = UNIQUE, flags = FIXED
-// CHECK-DAG: y: ({{.*}}) perms = UNIQUE, flags = FIXED
+// CHECK-DAG: br: ({{.*}}) perms = UNIQUE | NON_NULL, flags = FIXED
+// CHECK-DAG: bz: ({{.*}}) perms = UNIQUE | NON_NULL, flags = FIXED
+// CHECK-DAG: x: ({{.*}}) perms = UNIQUE | NON_NULL, flags = FIXED
+// CHECK-DAG: y: ({{.*}}) perms = UNIQUE | NON_NULL, flags = FIXED
 // CHECK-DAG: "s": addr_of flags = FIXED
 // CHECK-DAG: "STATIC_PTR": addr_of flags = FIXED, type flags = FIXED#{{.*}}
 

--- a/c2rust-analyze/tests/filecheck/insertion_sort.rs
+++ b/c2rust-analyze/tests/filecheck/insertion_sort.rs
@@ -6,26 +6,26 @@ extern crate libc;
 
 #[no_mangle]
 // CHECK-LABEL: final labeling for "insertion_sort"
-// CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
 pub unsafe extern "C" fn insertion_sort(n: libc::c_int, p: *mut libc::c_int) {
     let mut i: libc::c_int = 1 as libc::c_int;
     while i < n {
-        // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-        // CHECK-DAG: ([[@LINE+1]]: p.offset(i as isize)): {{.*}}type = READ | UNIQUE#
+        // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+        // CHECK-DAG: ([[@LINE+1]]: p.offset(i as isize)): {{.*}}type = READ | UNIQUE | NON_NULL#
         let tmp: libc::c_int = *p.offset(i as isize);
         let mut j: libc::c_int = i;
-        // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-        // CHECK-DAG: ([[@LINE+1]]: p.offset{{.*}}): {{.*}}type = READ | UNIQUE#
+        // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+        // CHECK-DAG: ([[@LINE+1]]: p.offset{{.*}}): {{.*}}type = READ | UNIQUE | NON_NULL#
         while j > 0 as libc::c_int && *p.offset((j - 1 as libc::c_int) as isize) > tmp {
-            // CHECK-DAG: ([[@LINE+4]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-            // CHECK-DAG: ([[@LINE+3]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-            // CHECK-DAG: ([[@LINE+2]]: p.offset((j {{.*}}): {{.*}}type = READ | UNIQUE#
-            // CHECK-DAG: ([[@LINE+1]]: p.offset(j {{.*}}): {{.*}}type = READ | WRITE | UNIQUE#
+            // CHECK-DAG: ([[@LINE+4]]: p): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+            // CHECK-DAG: ([[@LINE+3]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+            // CHECK-DAG: ([[@LINE+2]]: p.offset((j {{.*}}): {{.*}}type = READ | UNIQUE | NON_NULL#
+            // CHECK-DAG: ([[@LINE+1]]: p.offset(j {{.*}}): {{.*}}type = READ | WRITE | UNIQUE | NON_NULL#
             *p.offset(j as isize) = *p.offset((j - 1 as libc::c_int) as isize);
             j -= 1
         }
-        // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-        // CHECK-DAG: ([[@LINE+1]]: p.offset(j {{.*}}): {{.*}}type = READ | WRITE | UNIQUE#
+        // CHECK-DAG: ([[@LINE+2]]: p): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+        // CHECK-DAG: ([[@LINE+1]]: p.offset(j {{.*}}): {{.*}}type = READ | WRITE | UNIQUE | NON_NULL#
         *p.offset(j as isize) = tmp;
         i += 1
     }

--- a/c2rust-analyze/tests/filecheck/known_fn.rs
+++ b/c2rust-analyze/tests/filecheck/known_fn.rs
@@ -9,7 +9,7 @@ extern "C" {
 
 // CHECK-LABEL: final labeling for "known_fn"
 pub fn known_fn() {
-    // CHECK-DAG: ([[@LINE+3]]: path): addr_of = UNIQUE, type = READ | UNIQUE | OFFSET_ADD#
+    // CHECK-DAG: ([[@LINE+3]]: path): addr_of = UNIQUE | NON_NULL, type = READ | UNIQUE | OFFSET_ADD | NON_NULL#
     // CHECK-LABEL: type assignment for "known_fn":
     // CHECK-DAG: ([[@LINE+1]]: path): &[i8]
     let path = b".\0" as *const u8 as *const c_char;

--- a/c2rust-analyze/tests/filecheck/non_null.rs
+++ b/c2rust-analyze/tests/filecheck/non_null.rs
@@ -1,0 +1,34 @@
+use std::ptr;
+
+// CHECK-LABEL: final labeling for "f"
+fn f(cond: bool) {
+    let x = 1_i32;
+    // CHECK: ([[@LINE+1]]: mut y): {{.*}}, type = UNIQUE#
+    let mut y = ptr::addr_of!(x);
+    if cond {
+        y = ptr::null();
+    }
+}
+
+// CHECK-LABEL: final labeling for "g"
+fn g(cond: bool) {
+    let x = 1_i32;
+    // CHECK: ([[@LINE+1]]: y): {{.*}}, type = UNIQUE | NON_NULL#
+    let y = ptr::addr_of!(x);
+    if cond {
+        let z = ptr::null::<i32>();
+    }
+}
+
+// CHECK-LABEL: final labeling for "h"
+fn h(cond: bool) {
+    let x = 1_i32;
+    // CHECK: ([[@LINE+1]]: y): {{.*}}, type = UNIQUE | NON_NULL#
+    let y = ptr::addr_of!(x);
+    // CHECK: ([[@LINE+1]]: z): {{.*}}, type = UNIQUE#
+    let z = if cond {
+        y
+    } else {
+        ptr::null()
+    };
+}

--- a/c2rust-analyze/tests/filecheck/non_null.rs
+++ b/c2rust-analyze/tests/filecheck/non_null.rs
@@ -32,3 +32,15 @@ fn h(cond: bool) {
         ptr::null()
     };
 }
+
+
+// Like `f`, but uses `0 as *const _` instead of `ptr::null()`.
+// CHECK-LABEL: final labeling for "f_zero"
+fn f_zero(cond: bool) {
+    let x = 1_i32;
+    // CHECK: ([[@LINE+1]]: mut y): {{.*}}, type = UNIQUE#
+    let mut y = ptr::addr_of!(x);
+    if cond {
+        y = 0 as *const _;
+    }
+}

--- a/c2rust-analyze/tests/filecheck/offset1.rs
+++ b/c2rust-analyze/tests/filecheck/offset1.rs
@@ -1,18 +1,18 @@
 use std::ptr;
 
 // CHECK-LABEL: final labeling for "offset1_const"
-// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
 pub unsafe fn offset1_const(x: *mut i32) -> i32 {
-    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[@LINE+1]]: x.offset(1)): {{.*}}type = READ | UNIQUE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+    // CHECK-DAG: ([[@LINE+1]]: x.offset(1)): {{.*}}type = READ | UNIQUE | NON_NULL#
     *x.offset(1)
 }
 
 // CHECK-LABEL: final labeling for "offset1_unknown"
-// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
 pub unsafe fn offset1_unknown(x: *mut i32, off: isize) -> i32 {
-    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[@LINE+1]]: x.offset(off)): {{.*}}type = READ | UNIQUE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+    // CHECK-DAG: ([[@LINE+1]]: x.offset(off)): {{.*}}type = READ | UNIQUE | NON_NULL#
     *x.offset(off)
 }
 
@@ -23,18 +23,18 @@ pub unsafe fn offset1_usize(x: *mut i32, off: usize) -> i32 {
 */
 
 // CHECK-LABEL: final labeling for "offset1_immut"
-// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
 pub unsafe fn offset1_immut(x: *const i32, off: isize) -> i32 {
-    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[@LINE+1]]: x.offset(off)): {{.*}}type = READ | UNIQUE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+    // CHECK-DAG: ([[@LINE+1]]: x.offset(off)): {{.*}}type = READ | UNIQUE | NON_NULL#
     *x.offset(off)
 }
 
 // CHECK-LABEL: final labeling for "offset1_double"
-// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
 pub unsafe fn offset1_double(x: *mut i32, off: isize) -> i32 {
-    // CHECK-DAG: ([[@LINE+3]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[@LINE+2]]: x.offset(off)): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[@LINE+1]]: x.offset{{.*}}...{{.*}}): {{.*}}type = READ | UNIQUE#
+    // CHECK-DAG: ([[@LINE+3]]: x): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+    // CHECK-DAG: ([[@LINE+2]]: x.offset(off)): {{.*}}type = READ | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+    // CHECK-DAG: ([[@LINE+1]]: x.offset{{.*}}...{{.*}}): {{.*}}type = READ | UNIQUE | NON_NULL#
     *x.offset(off).offset(off)
 }

--- a/c2rust-analyze/tests/filecheck/offset2.rs
+++ b/c2rust-analyze/tests/filecheck/offset2.rs
@@ -1,25 +1,25 @@
 use std::ptr;
 
 // CHECK-LABEL: final labeling for "offset2_good"
-// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
 pub unsafe fn offset2_good(x: *mut i32, off: isize) {
-    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = UNIQUE | NON_NULL#
     let p = x.offset(off);
-    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = READ | WRITE | UNIQUE | NON_NULL#
     let q = x.offset(off);
     *q = 1;
 }
 
 // CHECK-LABEL: final labeling for "offset2_bad"
-// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | OFFSET_ADD | OFFSET_SUB#
+// CHECK-DAG: ([[@LINE+1]]: x): {{.*}}type = READ | WRITE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
 pub unsafe fn offset2_bad(x: *mut i32, off: isize) {
-    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE | OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = READ | WRITE | OFFSET_ADD | OFFSET_SUB | NON_NULL#
+    // CHECK-DAG: ([[@LINE+1]]: p): {{.*}}type = READ | WRITE | NON_NULL#
     let p = x.offset(off);
-    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = OFFSET_ADD | OFFSET_SUB#
-    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = (empty)#
+    // CHECK-DAG: ([[@LINE+2]]: x): {{.*}}type = OFFSET_ADD | OFFSET_SUB | NON_NULL#
+    // CHECK-DAG: ([[@LINE+1]]: q): {{.*}}type = NON_NULL#
     let q = x.offset(off);
     *p = 1;
 }


### PR DESCRIPTION
This adds a very basic static analysis for `NON_NULL` within the current `dataflow` framework.  It starts by optimistically assuming that all pointers are `NON_NULL`, and removes the permission from pointers into which a `ptr::null()` or equivalent might flow.  This branch just implements the static analysis, not rewriting.

I'm actually not a huge fan of this design - I think we'd probably get much better results with a path-sensitive analysis that can handle common patterns from C like `if !p.is_null() { let q = (&p).field; /* use q... */ }` by detecting null checks in the CFG.  But the simple path-insensitive version is sufficient for now, and gives us somewhere to plug in the dynamic analysis results.