### PR TITLE
Fix noop deref warning

### DIFF
--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -2249,7 +2249,7 @@ impl Cfg<Label, StmtOrDecl> {
                     let cases: Vec<(String, Label)> = cases
                         .iter()
                         .map(|(pat, tgt)| -> (String, Label) {
-                            let pat: String = pprust::pat_to_string(pat.deref());
+                            let pat: String = pprust::pat_to_string(pat);
 
                             (pat, tgt.clone())
                         })


### PR DESCRIPTION
Without this change compiling shows a warning:

```
warning: call to `.deref()` on a reference in this situation does nothing
    --> c2rust-transpile/src/cfg/mod.rs:2252:72
     |
2252 | ...to_string(pat.deref());
     |                 ^^^^^^^^ help: remove this redundant call
     |
     = note: the type `syn::Pat` does not implement `Deref`, so calling `deref` on `&syn::Pat` copies the reference, which does not do anything and can be removed
     = note: `#[warn(noop_method_call)]` on by default
```