### PR TITLE
analyze: uncomment line in scripts/run_pointwise_metrics.sh

### DIFF
--- a/c2rust-analyze/scripts/run_pointwise_metrics.sh
+++ b/c2rust-analyze/scripts/run_pointwise_metrics.sh
@@ -55,7 +55,7 @@ case "$project" in
         ;;
 
     cfs_*)
-        : cargo run --bin c2rust-analyze --release -- \
+        cargo run --bin c2rust-analyze --release -- \
             --rewrite-mode pointwise --use-manual-shims -- \
             build --manifest-path "$MODULE_DIR/Cargo.toml" \
             |& tee pointwise-cfs-analyze-$now.log \


### PR DESCRIPTION
In #1074, I had commented out a line to speed up testing, and accidentally left it that way when I merged the branch.