### PR TITLE
analyze: support rewriting field projections on nullable pointers

### DIFF
--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -474,7 +474,7 @@ fn mutbl_from_bool(m: bool) -> hir::Mutability {
     }
 }
 
-fn apply_identity_adjustment<'tcx>(
+fn apply_adjustment<'tcx>(
     tcx: TyCtxt<'tcx>,
     adjustment: &Adjustment<'tcx>,
     rw: Rewrite,
@@ -517,19 +517,6 @@ fn materialize_adjustments<'tcx>(
 ) -> Rewrite {
     let adj_kinds: Vec<&_> = adjustments.iter().map(|a| &a.kind).collect();
     match (hir_rw, &adj_kinds[..]) {
-        (Rewrite::Identity, []) => Rewrite::Identity,
-        (Rewrite::Identity, _) => {
-            let mut hir_rw = Rewrite::Identity;
-            for (i, adj) in adjustments.iter().enumerate() {
-                hir_rw = apply_identity_adjustment(tcx, adj, hir_rw);
-                hir_rw = callback(i, hir_rw);
-            }
-            hir_rw
-        }
-        // TODO: ideally we should always materialize all adjustments (removing these special
-        // cases), and use `MirRewrite`s to eliminate any adjustments we no longer need.
-        (rw @ Rewrite::Ref(..), &[Adjust::Deref(..), Adjust::Borrow(..)]) => rw,
-        (rw @ Rewrite::MethodCall(..), &[Adjust::Deref(..), Adjust::Borrow(..)]) => rw,
         // The mut-to-const cast should be unneeded once the inner rewrite switches to a safe
         // reference type appropriate for the pointer's uses.  However, we still want to give
         // `callback` a chance to remove the cast itself so that if there's a `RemoveCast` rewrite
@@ -542,8 +529,14 @@ fn materialize_adjustments<'tcx>(
                 rw => rw,
             }
         }
-        (rw, &[]) => rw,
-        (rw, adjs) => panic!("rewrite {rw:?} and materializations {adjs:?} NYI"),
+        (rw, _) => {
+            let mut hir_rw = rw;
+            for (i, adj) in adjustments.iter().enumerate() {
+                hir_rw = apply_adjustment(tcx, adj, hir_rw);
+                hir_rw = callback(i, hir_rw);
+            }
+            hir_rw
+        }
     }
 }
 

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -448,12 +448,16 @@ impl<'tcx> Visitor<'tcx> for ConvertVisitor<'tcx> {
         }
 
         // Apply late rewrites.
-        assert!(mir_rws.iter().all(|mir_rw| {
-            matches!(
+        for mir_rw in mir_rws {
+            assert!(
+                matches!(
+                    mir_rw.desc,
+                    MirOriginDesc::StoreIntoLocal | MirOriginDesc::LoadFromTemp
+                ),
+                "bad desc {:?} for late rewrite: {mir_rw:?}",
                 mir_rw.desc,
-                MirOriginDesc::StoreIntoLocal | MirOriginDesc::LoadFromTemp
-            )
-        }));
+            );
+        }
         hir_rw = self.rewrite_from_mir_rws(Some(ex), mir_rws, hir_rw);
 
         if !matches!(hir_rw, Rewrite::Identity) {

--- a/c2rust-analyze/src/rewrite/expr/mod.rs
+++ b/c2rust-analyze/src/rewrite/expr/mod.rs
@@ -1,11 +1,15 @@
+use self::mir_op::MirRewrite;
+use self::unlower::{MirOrigin, PreciseLoc};
 use crate::context::{AnalysisCtxt, Assignment};
 use crate::pointee_type::PointeeTypes;
 use crate::pointer_id::PointerTable;
 use crate::rewrite::Rewrite;
 use rustc_hir::def_id::DefId;
 use rustc_hir::BodyId;
-use rustc_middle::mir::Body;
+use rustc_middle::mir::{Body, Location};
+use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
+use std::collections::{BTreeMap, HashMap};
 
 mod convert;
 mod distribute;
@@ -30,11 +34,83 @@ pub fn gen_expr_rewrites<'tcx>(
         acx.gacx.dont_rewrite_fns.add(def_id, errors);
     }
     let unlower_map = unlower::unlower(acx.tcx(), mir, hir_body_id);
+    debug_print_unlower_map(acx.tcx(), mir, &unlower_map, &mir_rewrites);
     let rewrites_by_expr = distribute::distribute(acx.tcx(), unlower_map, mir_rewrites);
+
+    eprintln!("distributed rewrites:");
+    for (&hir_id, dist_rws) in &rewrites_by_expr {
+        let ex = acx.tcx().hir().expect_expr(hir_id);
+        eprintln!("  {:?}:", ex.span);
+        for rw in dist_rws {
+            eprintln!("    {rw:?}");
+        }
+    }
+
     let address_of_rewrites = hir_only_casts::remove_hir_only_casts(acx.tcx(), hir_body_id, |ex| {
         rewrites_by_expr.contains_key(&ex.hir_id)
     });
     let mut hir_rewrites = convert::convert_rewrites(acx.tcx(), hir_body_id, rewrites_by_expr);
     hir_rewrites.extend(address_of_rewrites);
     hir_rewrites
+}
+
+fn debug_print_unlower_map<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    mir: &Body<'tcx>,
+    unlower_map: &BTreeMap<PreciseLoc, MirOrigin>,
+    mir_rewrites: &HashMap<Location, Vec<MirRewrite>>,
+) {
+    let print_for_loc = |loc| {
+        let mut rewrites_by_subloc = HashMap::new();
+        for rw in mir_rewrites.get(&loc).map_or(&[] as &[_], |x| x) {
+            rewrites_by_subloc
+                .entry(&rw.sub_loc)
+                .or_insert(Vec::new())
+                .push(&rw.kind);
+        }
+
+        for (k, v) in unlower_map.range(&PreciseLoc { loc, sub: vec![] }..) {
+            if k.loc != loc {
+                break;
+            }
+            let sublocs = &k.sub;
+            let ex = tcx.hir().expect_expr(v.hir_id);
+            eprintln!("      {sublocs:?}: {:?}, {:?}", v.desc, ex.span);
+            for rw_kind in rewrites_by_subloc.remove(&sublocs).unwrap_or(Vec::new()) {
+                eprintln!("        {rw_kind:?}");
+            }
+        }
+
+        for (sublocs, rw_kinds) in rewrites_by_subloc {
+            eprintln!("      {sublocs:?} (missing unlowering)");
+            for rw_kind in rw_kinds {
+                eprintln!("        {rw_kind:?}");
+            }
+        }
+    };
+
+    eprintln!("unlowering for {:?}:", mir.source);
+    for (bb_id, bb) in mir.basic_blocks().iter_enumerated() {
+        eprintln!("  block {bb_id:?}:");
+        for (i, stmt) in bb.statements.iter().enumerate() {
+            let loc = Location {
+                block: bb_id,
+                statement_index: i,
+            };
+
+            eprintln!("    {loc:?}: {stmt:?}");
+            print_for_loc(loc);
+        }
+
+        {
+            let term = bb.terminator();
+            let loc = Location {
+                block: bb_id,
+                statement_index: bb.statements.len(),
+            };
+
+            eprintln!("    {loc:?}: {term:?}");
+            print_for_loc(loc);
+        }
+    }
 }

--- a/c2rust-analyze/src/rewrite/expr/unlower.rs
+++ b/c2rust-analyze/src/rewrite/expr/unlower.rs
@@ -1033,52 +1033,5 @@ pub fn unlower<'tcx>(
         }
     }
 
-    debug_print_unlower_map(tcx, mir, &visitor.unlower_map);
-
     visitor.unlower_map
-}
-
-fn debug_print_unlower_map<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    mir: &Body<'tcx>,
-    unlower_map: &BTreeMap<PreciseLoc, MirOrigin>,
-) {
-    eprintln!("unlowering for {:?}:", mir.source);
-    for (bb_id, bb) in mir.basic_blocks().iter_enumerated() {
-        eprintln!("  block {bb_id:?}:");
-        for (i, stmt) in bb.statements.iter().enumerate() {
-            let loc = Location {
-                block: bb_id,
-                statement_index: i,
-            };
-
-            eprintln!("    {loc:?}: {stmt:?}");
-            for (k, v) in unlower_map.range(&PreciseLoc { loc, sub: vec![] }..) {
-                if k.loc != loc {
-                    break;
-                }
-                let sublocs = &k.sub;
-                let ex = tcx.hir().expect_expr(v.hir_id);
-                eprintln!("      {sublocs:?}: {:?}, {:?}", v.desc, ex.span);
-            }
-        }
-
-        {
-            let term = bb.terminator();
-            let loc = Location {
-                block: bb_id,
-                statement_index: bb.statements.len(),
-            };
-
-            eprintln!("    {loc:?}: {term:?}");
-            for (k, v) in unlower_map.range(&PreciseLoc { loc, sub: vec![] }..) {
-                if k.loc != loc {
-                    break;
-                }
-                let sublocs = &k.sub;
-                let ex = tcx.hir().expect_expr(v.hir_id);
-                eprintln!("      {sublocs:?}: {:?}, {:?}", v.desc, ex.span);
-            }
-        }
-    }
 }

--- a/c2rust-analyze/src/rewrite/expr/unlower.rs
+++ b/c2rust-analyze/src/rewrite/expr/unlower.rs
@@ -540,6 +540,20 @@ impl<'a, 'tcx> UnlowerVisitor<'a, 'tcx> {
                         continue;
                     }
                 }
+                hir::ExprKind::AddrOf(kind, _mutbl, pl_ex) => match kind {
+                    hir::BorrowKind::Ref => {
+                        if let Some(_mir_mutbl) = cursor.peel_ref() {
+                            ex = pl_ex;
+                            continue;
+                        }
+                    }
+                    hir::BorrowKind::Raw => {
+                        if let Some(_mir_mutbl) = cursor.peel_address_of() {
+                            ex = pl_ex;
+                            continue;
+                        }
+                    }
+                },
                 _ => {}
             }
             // Keep looping only in cases that we specifically recognize.

--- a/c2rust-analyze/tests/filecheck/non_null_rewrites.rs
+++ b/c2rust-analyze/tests/filecheck/non_null_rewrites.rs
@@ -126,3 +126,18 @@ unsafe fn field_projection(cond: bool, mut p: *const S) -> i32 {
     let q: *const i32 = &(*p).x;
     *q
 }
+
+// CHECK-LABEL: unsafe fn local_field_projection{{[<(]}}
+unsafe fn local_field_projection(cond: bool) -> i32 {
+    let s = S { x: 1, y: 2 };
+
+    // Obtain a pointer to a field of a local.  This should produce `Some(&s.x)`.
+    // CHECK: let mut p: core::option::Option<&(i32)> = std::option::Option::Some(&*(&s.x));
+    let mut p: *const i32 = &s.x;
+
+    if cond {
+        // Ensure `p` is wrapped in `Option`.
+        p = ptr::null();
+    }
+    *p
+}

--- a/c2rust-analyze/tests/filecheck/non_null_rewrites.rs
+++ b/c2rust-analyze/tests/filecheck/non_null_rewrites.rs
@@ -146,3 +146,46 @@ unsafe fn local_field_projection(cond: bool) -> i32 {
     }
     *p
 }
+
+// CHECK-LABEL: unsafe fn null_ptr_special_cases{{[<(]}}
+unsafe fn null_ptr_special_cases(cond: bool, p: *const i32, i: isize) -> *const i32 {
+    // In C, `*NULL` is usually undefined behavior, even in cases like `sizeof(*(char*)0)` that
+    // don't involve an actual memory access.  However, there are two special cases in the
+    // standard:
+    //
+    // 1. `&*p == p` for all `p`, even if `p == NULL`.
+    // 2. `&p[i] == p + i` for all `p`, even if `p == NULL`.  Note that `NULL + 0 == NULL`, but
+    //    `NULL + i` with nonzero `i` is undefined.
+    //
+    // Here we test these two cases to see if rewriting introduces a panic even in cases where the
+    // C operation is valid.
+
+    // Make `p` nullable.
+    let mut p = p;
+    if cond {
+        p = ptr::null();
+    }
+
+    // Currently, `&*p` rewrites to `Some(&*p.unwrap())`, which panics when `p` is null.
+    //
+    // CHECK: Some(&(*(p).unwrap()));
+    let q = ptr::addr_of!(*p);
+
+    // `offset(i)` rewrites to `map`, which passes null/`None` through unchanged.
+    //
+    // CHECK: let (arr, idx, ) = ((q), (0) as usize, );
+    // CHECK-NEXT: arr.map(|arr| &arr[idx ..])
+    let r = q.offset(0);
+
+    // Because we use `Option::map` for this rewrite, it returns `None` if `p` is `None`, even when
+    // `i != 0`.  This is different from the concrete behavior of most C compilers, where `NULL + i
+    // != NULL`.  Adding `NULL + i` (with nonzero `i`) is undefined behavior in C, so it's legal
+    // for us to define it this way, though it may produce surprising results in some cases like
+    // handrolled `offsetof` macros.
+    //
+    // CHECK: let (arr, idx, ) = ((r), (i) as usize, );
+    // CHECK-NEXT: arr.map(|arr| &arr[idx ..])
+    let s = r.offset(i);
+
+    s
+}

--- a/c2rust-analyze/tests/filecheck/non_null_rewrites.rs
+++ b/c2rust-analyze/tests/filecheck/non_null_rewrites.rs
@@ -106,3 +106,23 @@ unsafe fn downgrade_mut_to_imm_on_deref(cond: bool, mut p: *mut i32) -> i32 {
     *p = 2;
     x
 }
+
+struct S {
+    x: i32,
+    y: i32,
+}
+
+// CHECK-LABEL: unsafe fn field_projection{{[<(]}}
+// CHECK-SAME: p: core::option::Option<&{{('[^ ]* )?}}(S)>
+unsafe fn field_projection(cond: bool, mut p: *const S) -> i32 {
+    if cond {
+        // Ensure `p` is wrapped in `Option`.
+        p = ptr::null();
+    }
+    // Do a field projection.  This should become a `.map()` call.
+    // TODO: Currently, we generate an incorrect rewrite for such projections
+    // CHECK: let q: core::option::Option<&(i32)> =
+    // CHECK-SAME: &(*(p).unwrap()).x
+    let q: *const i32 = &(*p).x;
+    *q
+}


### PR DESCRIPTION
This adds support for rewriting field projections like `&(*p).x` when `p` is a nullable pointer.  The result looks like `Some(&(*p.unwrap()).x)`.

I initially tried to avoid a panic when `p` is null by implementing a rewrite using `Option::map`: `p.map(|ptr| &ptr.x)`.  However, implementing this correctly wound up being quite complex.  It's undefined behavior in C to do `&p->x` when `p == NULL`, so it seems reasonable to introduce a panic in that case.

The `mir_op` changes for this are relatively straightforward, but `unlower`, `distribute`, and `convert` needed some work.  In particular, `unlower` now has a new variant `MirOriginDesc::LoadFromTempForAdjustment(i)`, which disambiguates cases like this:
```Rust
// Rust:
f(&(*p).x)

// MIR:
// Evaluate the main expression:
_tmp1 = &(*_p).x;
// unlower_map entries for &(*p).x:
// * Expr
// * StoreIntoLocal

// Adjustments inserted to coerce `&T` to `*const T`:
_tmp2 = addr_of!(*_tmp1);
// * LoadFromTempForAdjustment(0) (load of _tmp1)
// * Adjustment(0) (deref)
// * Adjustment(1) (addr-of)
// * StoreIntoLocal

// The actual function call:
_result = f(_tmp2);
// * LoadFromTemp (load final result of &(*p).x from _tmp2)
```
Previously, the `LoadFromTempForAdjustment` would be recorded as `LoadFromTemp`, meaning there would be two `LoadFromTemp` entries in the unlower_map for the expression `&(*p).x`.  Rewrites attached to the first `LoadFromTemp` (in this case, the use of `_tmp1` in the second statement) would be wrongly applied at the site of the last `LoadFromTemp`.  This caused `unwrap()` and `Some(_)` rewrites to be applied in the wrong order, causing type errors in the rewritten code.