### PR TITLE
Use log crate for debugging output in c2rust-analyze

### DIFF
--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -25,9 +25,9 @@ use crate::type_desc::Ownership;
 use crate::util;
 use crate::util::Callee;
 use crate::util::TestAttr;
-use ::log::warn;
 use c2rust_pdg::graph::Graphs;
 use c2rust_pdg::info::NodeInfo;
+use log::{debug, info, warn};
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::CrateNum;
 use rustc_hir::def_id::DefId;
@@ -244,7 +244,7 @@ fn update_pointer_info<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>)
                 _ => continue,
             };
 
-            eprintln!(
+            debug!(
                 "update_pointer_info: visit assignment: {:?}[{}]: {:?}",
                 bb, i, stmt
             );
@@ -252,7 +252,7 @@ fn update_pointer_info<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>)
             if !pl.is_indirect() {
                 // This is a write directly to `pl.local`.
                 *write_count.entry(pl.local).or_insert(0) += 1;
-                eprintln!("  record write to LHS {:?}", pl);
+                debug!("  record write to LHS {:?}", pl);
             }
 
             let ref_pl = match *rv {
@@ -264,7 +264,7 @@ fn update_pointer_info<'tcx>(acx: &mut AnalysisCtxt<'_, 'tcx>, mir: &Body<'tcx>)
                 // For simplicity, we consider taking the address of a local to be a write.  We
                 // expect this not to happen for the sorts of temporary refs we're looking for.
                 if !ref_pl.is_indirect() {
-                    eprintln!("  record write to ref target {:?}", ref_pl);
+                    debug!("  record write to ref target {:?}", ref_pl);
                     *write_count.entry(ref_pl.local).or_insert(0) += 1;
                 }
 
@@ -385,7 +385,7 @@ fn mark_foreign_fixed<'tcx>(
             let fields = adt_def.all_fields();
             for field in fields {
                 let field_lty = gacx.field_ltys[&field.did];
-                eprintln!(
+                debug!(
                     "adding FIXED permission for {adt_did:?} field {:?}",
                     field.did
                 );
@@ -573,9 +573,9 @@ struct FuncInfo<'tcx> {
 }
 
 fn run(tcx: TyCtxt) {
-    eprintln!("all defs:");
+    debug!("all defs:");
     for ldid in tcx.hir_crate_items(()).definitions() {
-        eprintln!("{:?}", ldid);
+        debug!("{:?}", ldid);
     }
 
     // Load the list of fixed defs early, so any errors are reported immediately.
@@ -591,9 +591,9 @@ fn run(tcx: TyCtxt) {
     // Follow a postorder traversal, so that callers are visited after their callees.  This means
     // callee signatures will usually be up to date when we visit the call site.
     let all_fn_ldids = fn_body_owners_postorder(tcx);
-    eprintln!("callgraph traversal order:");
+    debug!("callgraph traversal order:");
     for &ldid in &all_fn_ldids {
-        eprintln!("  {:?}", ldid);
+        debug!("  {:?}", ldid);
     }
 
     populate_field_users(&mut gacx, &all_fn_ldids);
@@ -629,9 +629,9 @@ fn run(tcx: TyCtxt) {
 
     // Collect all `static` items.
     let all_static_dids = all_static_items(tcx);
-    eprintln!("statics:");
+    debug!("statics:");
     for &did in &all_static_dids {
-        eprintln!("  {:?}", did);
+        debug!("  {:?}", did);
     }
 
     // Assign global `PointerId`s for types of `static` items.
@@ -834,7 +834,7 @@ fn run(tcx: TyCtxt) {
     // Remap pointers based on equivalence classes, so all members of an equivalence class now use
     // the same `PointerId`.
     let (global_counter, global_equiv_map) = global_equiv.renumber();
-    eprintln!("global_equiv_map = {global_equiv_map:?}");
+    debug!("global_equiv_map = {global_equiv_map:?}");
     pointee_type::remap_pointers_global(
         &mut global_pointee_types,
         &global_equiv_map,
@@ -849,7 +849,7 @@ fn run(tcx: TyCtxt) {
 
         let info = func_info.get_mut(&ldid).unwrap();
         let (local_counter, local_equiv_map) = info.local_equiv.renumber(&global_equiv_map);
-        eprintln!("local_equiv_map = {local_equiv_map:?}");
+        debug!("local_equiv_map = {local_equiv_map:?}");
         pointee_type::remap_pointers_local(
             &mut global_pointee_types,
             &mut info.local_pointee_types,
@@ -1043,8 +1043,8 @@ fn run(tcx: TyCtxt) {
         &mut g_updates_forbidden,
     );
 
-    eprintln!("=== ADT Metadata ===");
-    eprintln!("{:?}", gacx.adt_metadata);
+    debug!("=== ADT Metadata ===");
+    debug!("{:?}", gacx.adt_metadata);
 
     let mut loop_count = 0;
     loop {
@@ -1110,14 +1110,14 @@ fn run(tcx: TyCtxt) {
                 let added = new & !old;
                 let removed = old & !new;
                 let kept = old & new;
-                eprintln!(
+                debug!(
                     "changed {:?}: added {:?}, removed {:?}, kept {:?}",
                     ptr, added, removed, kept
                 );
                 num_changed += 1;
             }
         }
-        eprintln!(
+        debug!(
             "iteration {}: {} global pointers changed",
             loop_count, num_changed
         );
@@ -1126,7 +1126,7 @@ fn run(tcx: TyCtxt) {
             break;
         }
     }
-    eprintln!("reached fixpoint in {} iterations", loop_count);
+    info!("reached fixpoint in {} iterations", loop_count);
 
     // Do final processing on each function.
     for &ldid in &all_fn_ldids {
@@ -1404,7 +1404,7 @@ fn run2<'tcx>(
         assert!(i < 100);
         func_reports.clear();
         all_rewrites.clear();
-        eprintln!("\n--- start rewriting ---");
+        info!("--- start rewriting ---");
 
         // Update non-rewritten items first.  This has two purposes.  First, it clears the
         // `new_keys()` lists, which we check at the end of the loop to see whether we've reached a
@@ -1536,7 +1536,7 @@ fn run2<'tcx>(
     let mut adt_reports = HashMap::<DefId, String>::new();
     for &def_id in gacx.adt_metadata.table.keys() {
         if gacx.foreign_mentioned_tys.contains(&def_id) {
-            eprintln!("Avoiding rewrite for foreign-mentioned type: {def_id:?}");
+            debug!("Avoiding rewrite for foreign-mentioned type: {def_id:?}");
             continue;
         }
         if fixed_defs.contains(&def_id) {
@@ -1587,7 +1587,7 @@ fn run2<'tcx>(
 
         // Print labeling and rewrites for the current function.
 
-        eprintln!("\nfinal labeling for {:?}:", name);
+        debug!("\nfinal labeling for {:?}:", name);
         let lcx1 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
         let lcx2 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
         for (local, decl) in mir.local_decls.iter_enumerated() {
@@ -1602,12 +1602,11 @@ fn run2<'tcx>(
             );
         }
 
-        eprintln!("\ntype assignment for {:?}:", name);
+        debug!("\ntype assignment for {:?}:", name);
         rewrite::dump_rewritten_local_tys(&acx, &asn, pointee_types, &mir, describe_local);
 
-        eprintln!();
         if let Some(report) = func_reports.remove(&ldid) {
-            eprintln!("{}", report);
+            debug!("{}", report);
         }
 
         info.acx_data.set(acx.into_data());
@@ -1673,7 +1672,7 @@ fn run2<'tcx>(
     }
 
     // Print results for `static` items.
-    eprintln!("\nfinal labeling for static items:");
+    debug!("\nfinal labeling for static items:");
     let lcx1 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
     let lcx2 = crate::labeled_ty::LabeledTyCtxt::new(tcx);
     let mut static_dids = gacx.static_tys.keys().cloned().collect::<Vec<_>>();
@@ -1691,10 +1690,10 @@ fn run2<'tcx>(
             &gasn.flags,
         );
     }
-    eprintln!("\n{statics_report}");
+    debug!("\n{statics_report}");
 
     // Print results for ADTs and fields
-    eprintln!("\nfinal labeling for fields:");
+    debug!("\nfinal labeling for fields:");
     let mut field_dids = gacx.field_ltys.keys().cloned().collect::<Vec<_>>();
     field_dids.sort();
     for did in field_dids {
@@ -1704,7 +1703,7 @@ fn run2<'tcx>(
         if pid != PointerId::NONE {
             let ty_perms = gasn.perms[pid];
             let ty_flags = gasn.flags[pid];
-            eprintln!("{name:}: ({pid}) perms = {ty_perms:?}, flags = {ty_flags:?}");
+            debug!("{name:}: ({pid}) perms = {ty_perms:?}, flags = {ty_flags:?}");
         }
 
         // Emit annotations for fields
@@ -1739,7 +1738,7 @@ fn run2<'tcx>(
     adt_dids.sort();
     for did in adt_dids {
         if let Some(report) = adt_reports.remove(&did) {
-            eprintln!("\n{}", report);
+            debug!("\n{}", report);
         }
     }
 
@@ -1778,17 +1777,17 @@ fn run2<'tcx>(
     // ----------------------------------
 
     // Report errors that were caught previously
-    eprintln!("\nerror details:");
+    debug!("\nerror details:");
     for ldid in tcx.hir().body_owners() {
         if let Some(detail) = gacx.fns_failed.get(&ldid.to_def_id()) {
             if !detail.has_backtrace() {
                 continue;
             }
-            eprintln!("\nerror in {:?}:\n{}", ldid, detail.to_string_full());
+            debug!("\nerror in {:?}:{}", ldid, detail.to_string_full());
         }
     }
 
-    eprintln!("\nerror summary:");
+    debug!("\nerror summary:");
     fn sorted_def_ids(it: impl IntoIterator<Item = DefId>) -> Vec<DefId> {
         let mut v = it.into_iter().collect::<Vec<_>>();
         v.sort();
@@ -1802,27 +1801,27 @@ fn run2<'tcx>(
             Some(detail) => detail.to_string_short(),
             None => "(no panic)".into(),
         };
-        eprintln!("analysis of {def_id:?} failed: {flags:?}, {detail_str}");
+        debug!("analysis of {def_id:?} failed: {flags:?}, {detail_str}");
     }
 
     for def_id in sorted_def_ids(gacx.dont_rewrite_statics.keys()) {
         let flags = gacx.dont_rewrite_statics.get(def_id);
-        eprintln!("analysis of {def_id:?} failed: {flags:?}");
+        debug!("analysis of {def_id:?} failed: {flags:?}");
     }
 
     for def_id in sorted_def_ids(gacx.dont_rewrite_fields.keys()) {
         let flags = gacx.dont_rewrite_fields.get(def_id);
-        eprintln!("analysis of {def_id:?} failed: {flags:?}");
+        debug!("analysis of {def_id:?} failed: {flags:?}");
     }
 
-    eprintln!(
+    info!(
         "\nsaw errors in {} / {} functions",
         gacx.fns_failed.len(),
         all_fn_ldids.len()
     );
 
     if !known_perm_error_fns.is_empty() {
-        eprintln!(
+        info!(
             "saw permission errors in {} known fns",
             known_perm_error_fns.len()
         );
@@ -2184,7 +2183,7 @@ fn print_labeling_for_var<'tcx>(
             perms[lty.label]
         }
     });
-    eprintln!("{}: addr_of = {:?}, type = {:?}", desc, addr_of1, ty1);
+    debug!("{}: addr_of = {:?}, type = {:?}", desc, addr_of1, ty1);
 
     let addr_of2 = flags[addr_of_ptr];
     let ty2 = lcx2.relabel(lty, &mut |lty| {
@@ -2194,14 +2193,14 @@ fn print_labeling_for_var<'tcx>(
             flags[lty.label]
         }
     });
-    eprintln!(
+    debug!(
         "{}: addr_of flags = {:?}, type flags = {:?}",
         desc, addr_of2, ty2
     );
 
     let addr_of3 = addr_of_ptr;
     let ty3 = lty;
-    eprintln!("{}: addr_of = {:?}, type = {:?}", desc, addr_of3, ty3);
+    debug!("{}: addr_of = {:?}, type = {:?}", desc, addr_of3, ty3);
 }
 
 fn print_function_pointee_types<'tcx>(
@@ -2210,9 +2209,9 @@ fn print_function_pointee_types<'tcx>(
     mir: &Body<'tcx>,
     pointee_types: PointerTable<PointeeTypes<'tcx>>,
 ) {
-    eprintln!("\npointee types for {}", name);
+    debug!("\npointee types for {}", name);
     for (local, decl) in mir.local_decls.iter_enumerated() {
-        eprintln!(
+        debug!(
             "{:?} ({}): addr_of = {:?}, type = {:?}",
             local,
             describe_local(acx.tcx(), decl),
@@ -2235,7 +2234,7 @@ fn print_function_pointee_types<'tcx>(
             if tys.ltys.is_empty() && !tys.incomplete {
                 continue;
             }
-            eprintln!(
+            debug!(
                 "  pointer {:?}: {:?}{}",
                 ptr,
                 tys.ltys,

--- a/c2rust-analyze/src/borrowck/def_use.rs
+++ b/c2rust-analyze/src/borrowck/def_use.rs
@@ -1,4 +1,5 @@
 use crate::borrowck::atoms::{AllFacts, AtomMaps, Loan, Path, SubPoint};
+use log::debug;
 use rustc_middle::mir::visit::{
     MutatingUseContext, NonMutatingUseContext, NonUseContext, PlaceContext, Visitor,
 };
@@ -96,7 +97,7 @@ struct DefUseVisitor<'tcx, 'a> {
 impl<'tcx> Visitor<'tcx> for DefUseVisitor<'tcx, '_> {
     fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, location: Location) {
         self.super_place(place, context, location);
-        eprintln!(
+        debug!(
             "visit place {:?} with context {:?} = {:?} at {:?}",
             place,
             context,
@@ -132,7 +133,7 @@ impl<'tcx> Visitor<'tcx> for DefUseVisitor<'tcx, '_> {
     }
 
     fn visit_local(&mut self, local: Local, context: PlaceContext, location: Location) {
-        eprintln!(
+        debug!(
             "visit local {:?} with context {:?} = {:?} at {:?}",
             local,
             context,
@@ -157,7 +158,7 @@ impl<'tcx> Visitor<'tcx> for DefUseVisitor<'tcx, '_> {
 
     fn visit_statement(&mut self, stmt: &Statement<'tcx>, location: Location) {
         self.super_statement(stmt, location);
-        eprintln!("visit stmt {:?} at {:?}", stmt, location);
+        debug!("visit stmt {:?} at {:?}", stmt, location);
 
         if let StatementKind::StorageDead(local) = stmt.kind {
             // Observed: `StorageDead` emits `path_moved_at_base` at the `Mid` point.
@@ -194,7 +195,7 @@ impl<'tcx> LoanInvalidatedAtVisitor<'tcx, '_> {
         context: PlaceContext,
         location: Location,
     ) {
-        eprintln!(
+        debug!(
             "access loan {:?} (kind {:?}) at location {:?} (context {:?} = {:?})",
             loan,
             borrow_kind,
@@ -223,7 +224,7 @@ impl<'tcx> LoanInvalidatedAtVisitor<'tcx, '_> {
 impl<'tcx> Visitor<'tcx> for LoanInvalidatedAtVisitor<'tcx, '_> {
     fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, location: Location) {
         //self.super_place(place, context, location);
-        eprintln!(
+        debug!(
             "loan_invalidated_at: visit place {:?} with context {:?} = {:?} at {:?}",
             place,
             context,
@@ -260,7 +261,7 @@ impl<'tcx> Visitor<'tcx> for LoanInvalidatedAtVisitor<'tcx, '_> {
     }
 
     fn visit_local(&mut self, local: Local, context: PlaceContext, location: Location) {
-        eprintln!(
+        debug!(
             "loan_invalidated_at: visit local {:?} with context {:?} = {:?} at {:?}",
             local,
             context,

--- a/c2rust-analyze/src/dataflow/mod.rs
+++ b/c2rust-analyze/src/dataflow/mod.rs
@@ -4,6 +4,7 @@ use crate::context::{AnalysisCtxt, Assignment, FlagSet, PermissionSet, PointerId
 use crate::pointee_type::PointeeTypes;
 use crate::pointer_id::{OwnedPointerTable, PointerTable, PointerTableMut};
 use crate::recent_writes::RecentWrites;
+use log::debug;
 use rustc_middle::mir::Body;
 
 mod type_check;
@@ -65,14 +66,14 @@ impl DataflowConstraints {
         hypothesis: &mut PointerTableMut<PermissionSet>,
         updates_forbidden: &PointerTable<PermissionSet>,
     ) -> bool {
-        eprintln!("=== propagating ===");
-        eprintln!("constraints:");
+        debug!("=== propagating ===");
+        debug!("constraints:");
         for c in &self.constraints {
-            eprintln!("  {:?}", c);
+            debug!("  {:?}", c);
         }
-        eprintln!("hypothesis:");
+        debug!("hypothesis:");
         for (id, p) in hypothesis.iter() {
-            eprintln!("  {}: {:?}", id, p);
+            debug!("  {}: {:?}", id, p);
         }
 
         struct PropagatePerms;

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -216,7 +216,7 @@ impl Cargo {
         f(&mut cmd)?;
         let status = cmd.status()?;
         if !status.success() {
-            eprintln!("error ({status}) running: {cmd:?}");
+            ::log::error!("error ({status}) running: {cmd:?}");
             exit_with_status(status);
         }
         Ok(())

--- a/c2rust-analyze/src/pointee_type/type_check.rs
+++ b/c2rust-analyze/src/pointee_type/type_check.rs
@@ -219,7 +219,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     pub fn visit_call(&mut self, func: Ty<'tcx>, args: &[Operand<'tcx>], dest_lty: LTy<'tcx>) {
         let tcx = self.acx.tcx();
         let callee = ty_callee(tcx, func);
-        eprintln!("callee = {callee:?}");
+        debug!("callee = {callee:?}");
         match callee {
             Callee::Trivial => {}
             Callee::LocalDef { def_id, substs } => {
@@ -253,7 +253,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 // include information about expected/required pointee types
             }
             Callee::UnknownDef(_) => {
-                log::error!("TODO: visit Callee::{callee:?}");
+                error!("TODO: visit Callee::{callee:?}");
             }
 
             Callee::PtrOffset { .. } => {

--- a/c2rust-analyze/src/rewrite/apply.rs
+++ b/c2rust-analyze/src/rewrite/apply.rs
@@ -1,4 +1,5 @@
 use crate::rewrite::Rewrite;
+use log::warn;
 use rustc_hir::Mutability;
 use rustc_span::source_map::{FileName, SourceMap};
 use rustc_span::{BytePos, SourceFile, Span, SyntaxContext};
@@ -650,7 +651,7 @@ pub fn apply_rewrites(
 ) -> HashMap<FileName, FileRewrite> {
     let (rts, errs) = RewriteTree::build(rws);
     for (span, rw, err) in errs {
-        eprintln!(
+        warn!(
             "{:?}: warning: failed to apply rewrite {:?}: {:?}",
             span, rw, err
         );

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -108,7 +108,7 @@ impl<'tcx> ConvertVisitor<'tcx> {
         if let Some(child_span_rw) = self.rewrites.get(&sub_ex.hir_id) {
             let child_rw = &child_span_rw.1;
             if let Some(subst_rw) = child_rw.try_subst(&rw_sub) {
-                eprintln!(
+                debug!(
                     "get_subexpr: substituted {rw_sub:?} into {child_rw:?}, producing {subst_rw:?}"
                 );
                 self.subsumed_child_rewrites
@@ -603,7 +603,7 @@ impl<'tcx> Visitor<'tcx> for ConvertVisitor<'tcx> {
         hir_rw = self.rewrite_from_mir_rws(Some(ex), mir_rws, hir_rw);
 
         if !matches!(hir_rw, Rewrite::Identity) {
-            eprintln!(
+            debug!(
                 "rewrite {:?} at {:?} (materialize? {})",
                 hir_rw, callsite_span, self.materialize_adjustments
             );
@@ -710,7 +710,7 @@ fn generate_zeroize_code(zero_ty: &ZeroizeType, lv: &str) -> String {
             generate_zeroize_code(elem_zero_ty, "(*elem)")
         ),
         ZeroizeType::Struct(_, ref fields) => {
-            eprintln!("zeroize: {} fields on {lv}: {fields:?}", fields.len());
+            debug!("zeroize: {} fields on {lv}: {fields:?}", fields.len());
             let mut s = String::new();
             writeln!(s, "{{").unwrap();
             for (name, field_zero_ty) in fields {

--- a/c2rust-analyze/src/rewrite/expr/hir_only_casts.rs
+++ b/c2rust-analyze/src/rewrite/expr/hir_only_casts.rs
@@ -10,6 +10,7 @@
 //! path starts with rewrites on MIR and lifts them up to the HIR level.
 
 use crate::rewrite::Rewrite;
+use log::debug;
 use rustc_hir as hir;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_middle::hir::nested_filter;
@@ -88,7 +89,7 @@ where
     fn visit_expr(&mut self, ex: &'tcx hir::Expr<'tcx>) {
         // Check for the syntactic pattern of a two-part address-of.
         if let Some((ref_expr, mutbl)) = match_two_part_address_of(ex) {
-            eprintln!(
+            debug!(
                 "found two-part address-of pattern at {:?}, {:?}, {:?}",
                 ex.span, ref_expr.span, mutbl
             );
@@ -96,14 +97,14 @@ where
             if self.expr_has_address_of_adjustments(ref_expr, mutbl) {
                 if (self.filter)(ref_expr) {
                     // Emit a rewrite to remove the cast, leaving only the inner `&x`.
-                    eprintln!("  emit rewrite for expr at {:?}", ref_expr.span);
+                    debug!("  emit rewrite for expr at {:?}", ref_expr.span);
                     self.rewrites
                         .push((ex.span, Rewrite::Sub(0, ref_expr.span)));
                 } else {
-                    eprintln!("  filter rejected expr at {:?}", ref_expr.span);
+                    debug!("  filter rejected expr at {:?}", ref_expr.span);
                 }
             } else {
-                eprintln!("  missing adjustments for expr at {:?}", ref_expr.span);
+                debug!("  missing adjustments for expr at {:?}", ref_expr.span);
             }
         }
 

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -13,7 +13,7 @@ use crate::pointee_type::PointeeTypes;
 use crate::pointer_id::{PointerId, PointerTable};
 use crate::type_desc::{self, Ownership, Quantity, TypeDesc};
 use crate::util::{self, ty_callee, Callee};
-use log::{error, trace};
+use log::{debug, error, trace};
 use rustc_ast::Mutability;
 use rustc_middle::mir::{
     BasicBlock, Body, BorrowKind, Location, Operand, Place, PlaceElem, PlaceRef, Rvalue, Statement,
@@ -347,7 +347,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
 
     fn visit_statement(&mut self, stmt: &Statement<'tcx>, loc: Location) {
         let _g = panic_detail::set_current_span(stmt.source_info.span);
-        eprintln!(
+        debug!(
             "mir_op::visit_statement: {:?} @ {:?}: {:?}",
             loc, stmt.source_info.span, stmt
         );
@@ -880,7 +880,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     /// Visit an `Rvalue`.  If `expect_ty` is `Some`, also emit whatever casts are necessary to
     /// make the `Rvalue` produce a value of type `expect_ty`.
     fn visit_rvalue(&mut self, rv: &Rvalue<'tcx>, expect_ty: Option<LTy<'tcx>>) {
-        eprintln!("mir_op::visit_rvalue: {:?}, expect {:?}", rv, expect_ty);
+        debug!("mir_op::visit_rvalue: {:?}, expect {:?}", rv, expect_ty);
         match *rv {
             Rvalue::Use(ref op) => {
                 self.enter_rvalue_operand(0, |v| v.visit_operand(op, expect_ty));
@@ -965,7 +965,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                             self.perms[rv_lty.label],
                             self.flags[rv_lty.label],
                         );
-                        eprintln!("Cast with common pointee {:?}:\n  op_desc = {:?}\n  rv_desc = {:?}\n  matches? {}",
+                        debug!("Cast with common pointee {:?}:\n  op_desc = {:?}\n  rv_desc = {:?}\n  matches? {}",
                             pointee_lty, op_desc, rv_desc, op_desc == rv_desc);
                         if op_desc == rv_desc {
                             // After rewriting, the input and output types of the cast will be

--- a/c2rust-analyze/src/rewrite/expr/unlower.rs
+++ b/c2rust-analyze/src/rewrite/expr/unlower.rs
@@ -252,7 +252,7 @@ impl<'a, 'tcx> UnlowerVisitor<'a, 'tcx> {
                     Some(x @ (pl, _)) if is_var(pl) => x,
                     _ => {
                         warn("expected final Assign to store into var");
-                        eprintln!(
+                        debug!(
                             "visit_expr_inner: bail out: expr at {:?} isn't assigned to a var",
                             ex.span
                         );

--- a/c2rust-analyze/src/rewrite/mod.rs
+++ b/c2rust-analyze/src/rewrite/mod.rs
@@ -23,6 +23,7 @@
 //! require us to update the `Span`s mentioned in the later rewrites to account for the changes in
 //! the source code produced by the earlier ones).
 
+use log::{debug, info, warn};
 use rustc_hir::Mutability;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{FileName, Span};
@@ -327,18 +328,18 @@ pub fn apply_rewrites(
     update_files: UpdateFiles,
 ) {
     let emit = |filename, src: String| {
-        println!("\n\n ===== BEGIN {:?} =====", filename);
+        info!("\n\n ===== BEGIN {:?} =====", filename);
         for line in src.lines() {
             // Omit filecheck directives from the debug output, as filecheck can get confused due
             // to directives matching themselves (e.g. `// CHECK: foo` will match the `foo` in the
             // line `// CHECK: foo`).
             if let Some((pre, _post)) = line.split_once("// CHECK") {
-                println!("{}// (FileCheck directive omitted)", pre);
+                info!("{}// (FileCheck directive omitted)", pre);
             } else {
-                println!("{}", line);
+                info!("{}", line);
             }
         }
-        println!(" ===== END {:?} =====", filename);
+        info!(" ===== END {:?} =====", filename);
 
         if !matches!(update_files, UpdateFiles::No) {
             let mut path_ok = false;
@@ -350,7 +351,7 @@ pub fn apply_rewrites(
                         UpdateFiles::AlongsidePointwise(ref s) => {
                             let ext = format!("{}.rs", s);
                             let p = path.with_extension(&ext);
-                            eprintln!("writing to {:?}", p);
+                            debug!("writing to {:?}", p);
                             p
                         }
                         UpdateFiles::No => unreachable!(),
@@ -360,7 +361,7 @@ pub fn apply_rewrites(
                 }
             }
             if !path_ok {
-                log::warn!("couldn't write to non-real file {filename:?}");
+                warn!("couldn't write to non-real file {filename:?}");
             }
         }
     };

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -21,7 +21,7 @@ use crate::type_desc::{self, Ownership, PtrDesc, Quantity, TypeDesc};
 use hir::{
     FnRetTy, GenericParamKind, Generics, ItemKind, Path, PathSegment, VariantData, WherePredicate,
 };
-use log::warn;
+use log::{debug, warn};
 use rustc_ast::ast;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Namespace, Res};
@@ -255,9 +255,9 @@ fn deconstruct_hir_ty<'a, 'tcx>(
                 if type_args.len() < substs.types().count() {
                     // this situation occurs when there are hidden type arguments
                     // such as the allocator `std::alloc::Global` type argument in `Vec`
-                    eprintln!("warning: extra MIR type argument for {adt_def:?}:");
+                    debug!("warning: extra MIR type argument for {adt_def:?}:");
                     for mir_arg in substs.types().into_iter().skip(type_args.len()) {
-                        eprintln!("\t{:?}", mir_arg)
+                        debug!("\t{:?}", mir_arg)
                     }
                 } else if type_args.len() != substs.types().count() {
                     panic!("mismatched number of type arguments for {adt_def:?} and {hir_ty:?}")
@@ -278,7 +278,7 @@ fn deconstruct_hir_ty<'a, 'tcx>(
             Some(v)
         }
         (tk, hir_tk) => {
-            eprintln!("deconstruct_hir_ty: {tk:?} -- {hir_tk:?} not supported");
+            debug!("deconstruct_hir_ty: {tk:?} -- {hir_tk:?} not supported");
             None
         }
     }
@@ -946,7 +946,7 @@ pub fn dump_rewritten_local_tys<'tcx>(
             acx.gacx,
         );
         let ty = mk_rewritten_ty(rw_lcx, rw_lty);
-        eprintln!(
+        debug!(
             "{:?} ({}): {:?}",
             local,
             describe_local(acx.tcx(), decl),

--- a/c2rust-analyze/src/trivial.rs
+++ b/c2rust-analyze/src/trivial.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use rustc_middle::ty::{self, Binder, EarlyBinder, FnSig, GenSig, Subst, Ty, TyCtxt};
 
 pub trait IsTrivial<'tcx> {
@@ -60,7 +61,7 @@ impl<'tcx> IsTrivial<'tcx> for Ty<'tcx> {
     fn is_trivial(&self, tcx: TyCtxt<'tcx>) -> bool {
         let not_sure_yet = |is_trivial: bool| {
             let kind = self.kind();
-            eprintln!("assuming non-trivial for now as a safe backup (guessed {is_trivial:?}): ty.kind() = {kind:?}, ty = {self:?}");
+            debug!("assuming non-trivial for now as a safe backup (guessed {is_trivial:?}): ty.kind() = {kind:?}, ty = {self:?}");
             false
         };
 
@@ -84,7 +85,7 @@ impl<'tcx> IsTrivial<'tcx> for Ty<'tcx> {
 
             // don't know, as `dyn Trait` could be anything
             ty::Dynamic(trait_ty, _reg) => {
-                eprintln!("unsure how to check `dyn Trait` for accessible pointers, so assuming non-trivial: ty = {self:?}, trait_ty = {trait_ty:?}");
+                debug!("unsure how to check `dyn Trait` for accessible pointers, so assuming non-trivial: ty = {self:?}, trait_ty = {trait_ty:?}");
                 false
             }
 

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -1,5 +1,6 @@
 use crate::labeled_ty::LabeledTy;
 use crate::trivial::IsTrivial;
+use log::debug;
 use rustc_ast::ast::AttrKind;
 use rustc_const_eval::interpret::Scalar;
 use rustc_hir::def::DefKind;
@@ -201,7 +202,7 @@ pub enum Callee<'tcx> {
 pub fn ty_callee<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Callee<'tcx> {
     let is_trivial = || {
         let is_trivial = ty.fn_sig(tcx).is_trivial(tcx);
-        eprintln!("{ty:?} is trivial: {is_trivial}");
+        debug!("{ty:?} is trivial: {is_trivial}");
         is_trivial
     };
 
@@ -390,7 +391,7 @@ fn builtin_callee<'tcx>(tcx: TyCtxt<'tcx>, did: DefId, substs: SubstsRef<'tcx>) 
         }
 
         _ => {
-            eprintln!("name: {name:?}");
+            debug!("name: {name:?}");
             None
         }
     }

--- a/c2rust-analyze/tests/common/mod.rs
+++ b/c2rust-analyze/tests/common/mod.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use std::{
     collections::HashSet,
     env,
@@ -337,7 +338,7 @@ pub fn check_for_missing_tests_for(main_test_path: impl AsRef<Path>) {
         .collect::<Vec<_>>();
     for test_name in &missing_tests {
         let test_path = rel_test_dir.join(format!("{test_name}.rs"));
-        eprintln!("missing a `#[test] fn {test_name}` for {test_path:?}");
+        warn!("missing a `#[test] fn {test_name}` for {test_path:?}");
     }
     assert!(missing_tests.is_empty(), "see missing tests above");
 }


### PR DESCRIPTION
Replace all `eprintln!` macros with uses of the `log` crate for more efficient and fine-grained debugging output.