### PR TITLE
Fix c2rust-analyze panic for variadic functions

### DIFF
--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -266,6 +266,7 @@ pub type LTyCtxt<'tcx> = LabeledTyCtxt<'tcx, PointerId>;
 pub struct LFnSig<'tcx> {
     pub inputs: &'tcx [LTy<'tcx>],
     pub output: LTy<'tcx>,
+    pub c_variadic: bool,
 }
 
 impl<'tcx> LFnSig<'tcx> {


### PR DESCRIPTION
Add support for variadic functions in the "Infer pointee types" phase of c2rust-analyze.