### PR TITLE
analyze: implement Box<T> rewrites

### DIFF
--- a/c2rust-analyze/src/dataflow/mod.rs
+++ b/c2rust-analyze/src/dataflow/mod.rs
@@ -11,6 +11,18 @@ mod type_check;
 #[derive(Clone, Debug)]
 enum Constraint {
     /// Pointer `.0` must have a subset of the permissions of pointer `.1`.
+    ///
+    /// `Subset` and `SubsetExcept` have a special case involving `FREE` and `OFFSET` permissions.
+    /// The rewriter can't produce a cast that converts `Box<[T]>` to `Box<T>`; to avoid needing
+    /// such casts, we forbid assignment operations from discarding the `OFFSET` permission while
+    /// keeping `FREE`.  We implement this restriction by adding an additional requirement to the
+    /// definition of `Subset(L, R)`: if `L` contains `FREE` and `R` contains `OFFSET`, then `L`
+    /// must also contain `OFFSET`.  This is sufficient because all assignments and
+    /// pseudo-assignments generate `Subset` constraints.
+    ///
+    /// If `L` does not contain `FREE`, then no additional requirement applies, even if `R` does
+    /// contain `OFFSET`.  We allow discarding both `FREE` and `OFFSET` simultaneously during an
+    /// assignment.
     Subset(PointerId, PointerId),
     /// Pointer `.0` must have a subset of permissions of pointer `.1`, except
     /// for the provided permission set.
@@ -102,10 +114,25 @@ impl DataflowConstraints {
                     | PermissionSet::OFFSET_SUB
                     | PermissionSet::FREE;
 
-                (
-                    old_a & !(!old_b & (PROPAGATE_DOWN & !except)),
-                    old_b | (old_a & (PROPAGATE_UP & !except)),
-                )
+                let remove_a = !old_b & PROPAGATE_DOWN & !except;
+                let add_b = old_a & PROPAGATE_UP & !except;
+
+                // Special case: as documented on `Constraint::Subset`, if the subset has `FREE`,
+                // we propagate `OFFSET` in the opposite direction.  Specifically, if the superset
+                // has `OFFSET`, we add it to the subset, propagating "down".  (Propagating "up"
+                // here could allow `OFFSET` and `!OFFSET` to propagated up into the same
+                // `PointerId` through two different constraints, creating a conflict.)
+                let add_a = if old_a.contains(PermissionSet::FREE) {
+                    #[allow(bad_style)]
+                    let PROPAGATE_DOWN_WHEN_FREE =
+                        PermissionSet::OFFSET_ADD | PermissionSet::OFFSET_SUB;
+                    old_b & PROPAGATE_DOWN_WHEN_FREE & !except
+                } else {
+                    PermissionSet::empty()
+                };
+                debug_assert_eq!(add_a & remove_a, PermissionSet::empty());
+
+                ((old_a | add_a) & !remove_a, old_b | add_b)
             }
 
             fn all_perms(

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -576,7 +576,7 @@ fn generate_zeroize_code(zero_ty: &ZeroizeType, lv: &str) -> String {
         ",
             generate_zeroize_code(elem_zero_ty, "(*elem)")
         ),
-        ZeroizeType::Struct(ref fields) => {
+        ZeroizeType::Struct(_, ref fields) => {
             eprintln!("zeroize: {} fields on {lv}: {fields:?}", fields.len());
             let mut s = String::new();
             writeln!(s, "{{").unwrap();

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -661,15 +661,18 @@ pub fn convert_cast_rewrite(kind: &mir_op::RewriteKind, hir_rw: Rewrite) -> Rewr
             Rewrite::MethodCall(ref_method, Box::new(hir_rw), vec![])
         }
 
-        mir_op::RewriteKind::DynOwnedTakeUnwrap => {
-            let hir_rw = Rewrite::Call(
+        mir_op::RewriteKind::DynOwnedUnwrap => {
+            Rewrite::MethodCall("unwrap".to_string(), Box::new(hir_rw), vec![])
+        }
+        mir_op::RewriteKind::DynOwnedTake => {
+            // `p` -> `mem::replace(&mut p, Err(()))`
+            Rewrite::Call(
                 "std::mem::replace".to_string(),
                 vec![
                     Rewrite::Ref(Box::new(hir_rw), hir::Mutability::Mut),
                     Rewrite::Text("Err(())".into()),
                 ],
-            );
-            Rewrite::MethodCall("unwrap".to_string(), Box::new(hir_rw), vec![])
+            )
         }
         mir_op::RewriteKind::DynOwnedWrap => {
             Rewrite::Call("std::result::Result::<_, ()>::Ok".to_string(), vec![hir_rw])

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -566,7 +566,7 @@ fn generate_zeroize_code(zero_ty: &ZeroizeType, lv: &str) -> String {
     match *zero_ty {
         ZeroizeType::Int => format!("{lv} = 0"),
         ZeroizeType::Bool => format!("{lv} = false"),
-        ZeroizeType::Iterable(ref elem_zero_ty) => format!(
+        ZeroizeType::Array(ref elem_zero_ty) => format!(
             "
             {{
                 for elem in {lv}.iter_mut() {{

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -324,6 +324,65 @@ impl<'tcx> ConvertVisitor<'tcx> {
                 Rewrite::Call("std::mem::drop".to_string(), vec![self.get_subexpr(ex, 0)])
             }
 
+            mir_op::RewriteKind::ReallocSafe {
+                ref zero_ty,
+                elem_size,
+                src_single,
+                dest_single,
+            } => {
+                // `realloc(p, n)` -> `Box::new(...)`
+                assert!(matches!(hir_rw, Rewrite::Identity));
+                let zeroize_expr = generate_zeroize_expr(zero_ty);
+                let mut stmts = vec![
+                    Rewrite::Let(vec![
+                        ("src_ptr".into(), self.get_subexpr(ex, 0)),
+                        ("dest_byte_len".into(), self.get_subexpr(ex, 1)),
+                    ]),
+                    Rewrite::Let1(
+                        "dest_n".into(),
+                        Box::new(format_rewrite!("dest_byte_len as usize / {elem_size}")),
+                    ),
+                ];
+                if dest_single {
+                    stmts.push(Rewrite::Text("assert_eq!(dest_n, 1)".into()));
+                }
+                let expr = match (src_single, dest_single) {
+                    (false, false) => {
+                        stmts.push(Rewrite::Let1(
+                            "mut dest_ptr".into(),
+                            Box::new(Rewrite::Text("Vec::from(src_ptr)".into())),
+                        ));
+                        stmts.push(format_rewrite!(
+                            "dest_ptr.resize_with(dest_n, || {})",
+                            zeroize_expr,
+                        ));
+                        Rewrite::Text("dest_ptr.into_boxed_slice()".into())
+                    }
+                    (false, true) => {
+                        format_rewrite!(
+                            "src_ptr.into_iter().next().unwrap_or_else(|| {})",
+                            zeroize_expr
+                        )
+                    }
+                    (true, false) => {
+                        stmts.push(Rewrite::Let1(
+                            "mut dest_ptr".into(),
+                            Box::new(Rewrite::Text("Vec::with_capacity(dest_n)".into())),
+                        ));
+                        stmts.push(Rewrite::Text(
+                            "if dest_n >= 1 { dest_ptr.push(*src_ptr); }".into(),
+                        ));
+                        stmts.push(format_rewrite!(
+                            "dest_ptr.resize_with(dest_n, || {})",
+                            zeroize_expr,
+                        ));
+                        Rewrite::Text("dest_ptr.into_boxed_slice()".into())
+                    }
+                    (true, true) => Rewrite::Text("src_ptr".into()),
+                };
+                Rewrite::Block(stmts, Some(Box::new(expr)))
+            }
+
             mir_op::RewriteKind::CellGet => {
                 // `*x` to `Cell::get(x)`
                 assert!(matches!(hir_rw, Rewrite::Identity));

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -290,17 +290,33 @@ impl<'tcx> ConvertVisitor<'tcx> {
                 ref zero_ty,
                 elem_size,
                 single,
+            }
+            | mir_op::RewriteKind::CallocSafe {
+                ref zero_ty,
+                elem_size,
+                single,
             } => {
                 // `malloc(n)` -> `Box::new(z)` or similar
                 assert!(matches!(hir_rw, Rewrite::Identity));
                 let zeroize_expr = generate_zeroize_expr(zero_ty);
-                let mut stmts = vec![
-                    Rewrite::Let(vec![("byte_len".into(), self.get_subexpr(ex, 0))]),
-                    Rewrite::Let1(
-                        "n".into(),
-                        Box::new(format_rewrite!("byte_len as usize / {elem_size}")),
-                    ),
-                ];
+                let mut stmts = match *rw {
+                    mir_op::RewriteKind::MallocSafe { .. } => vec![
+                        Rewrite::Let(vec![("byte_len".into(), self.get_subexpr(ex, 0))]),
+                        Rewrite::Let1(
+                            "n".into(),
+                            Box::new(format_rewrite!("byte_len as usize / {elem_size}")),
+                        ),
+                    ],
+                    mir_op::RewriteKind::CallocSafe { .. } => vec![
+                        Rewrite::Let(vec![
+                            ("count".into(), self.get_subexpr(ex, 0)),
+                            ("size".into(), self.get_subexpr(ex, 1)),
+                        ]),
+                        format_rewrite!("assert_eq!(size, {elem_size})"),
+                        Rewrite::Let1("n".into(), Box::new(format_rewrite!("count as usize"))),
+                    ],
+                    _ => unreachable!(),
+                };
                 let expr = if single {
                     stmts.push(Rewrite::Text("assert_eq!(n, 1)".into()));
                     format_rewrite!("Box::new({})", zeroize_expr)

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -318,6 +318,12 @@ impl<'tcx> ConvertVisitor<'tcx> {
                 Rewrite::Block(stmts, Some(Box::new(expr)))
             }
 
+            mir_op::RewriteKind::FreeSafe { single: _ } => {
+                // `free(p)` -> `drop(p)`
+                assert!(matches!(hir_rw, Rewrite::Identity));
+                Rewrite::Call("std::mem::drop".to_string(), vec![self.get_subexpr(ex, 0)])
+            }
+
             mir_op::RewriteKind::CellGet => {
                 // `*x` to `Cell::get(x)`
                 assert!(matches!(hir_rw, Rewrite::Identity));

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -661,6 +661,30 @@ pub fn convert_cast_rewrite(kind: &mir_op::RewriteKind, hir_rw: Rewrite) -> Rewr
             Rewrite::MethodCall(ref_method, Box::new(hir_rw), vec![])
         }
 
+        mir_op::RewriteKind::DynOwnedTakeUnwrap => {
+            let hir_rw = Rewrite::Call(
+                "std::mem::replace".to_string(),
+                vec![
+                    Rewrite::Ref(Box::new(hir_rw), hir::Mutability::Mut),
+                    Rewrite::Text("Err(())".into()),
+                ],
+            );
+            Rewrite::MethodCall("unwrap".to_string(), Box::new(hir_rw), vec![])
+        }
+        mir_op::RewriteKind::DynOwnedWrap => {
+            Rewrite::Call("std::result::Result::<_, ()>::Ok".to_string(), vec![hir_rw])
+        }
+
+        mir_op::RewriteKind::DynOwnedDowngrade { mutbl } => {
+            let ref_method = if mutbl {
+                "as_deref_mut".into()
+            } else {
+                "as_deref".into()
+            };
+            let hir_rw = Rewrite::MethodCall(ref_method, Box::new(hir_rw), vec![]);
+            Rewrite::MethodCall("unwrap".into(), Box::new(hir_rw), vec![])
+        }
+
         mir_op::RewriteKind::CastRefToRaw { mutbl } => {
             // `addr_of!(*p)` is cleaner than `p as *const _`; we don't know the pointee
             // type here, so we can't emit `p as *const T`.

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -614,14 +614,14 @@ pub fn convert_cast_rewrite(kind: &mir_op::RewriteKind, hir_rw: Rewrite) -> Rewr
             Rewrite::Ref(Box::new(elem), mutbl_from_bool(mutbl))
         }
 
-        mir_op::RewriteKind::MutToImm => {
-            // `p` -> `&*p`
+        mir_op::RewriteKind::Reborrow { mutbl } => {
+            // `p` -> `&*p` / `&mut *p`
             let hir_rw = match fold_mut_to_imm(hir_rw) {
                 Ok(folded_rw) => return folded_rw,
                 Err(rw) => rw,
             };
             let place = Rewrite::Deref(Box::new(hir_rw));
-            Rewrite::Ref(Box::new(place), hir::Mutability::Not)
+            Rewrite::Ref(Box::new(place), mutbl_from_bool(mutbl))
         }
 
         mir_op::RewriteKind::OptionUnwrap => {

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -671,7 +671,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                             // from that type to the required output type.
                             v.emit_cast_adjust_lty(
                                 |desc| TypeDesc {
-                                    own: desc.own,
+                                    own: Ownership::Box,
                                     qty: if single {
                                         Quantity::Single
                                     } else {
@@ -703,7 +703,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                             // ownership.
                             v.enter_call_arg(0, |v| {
                                 v.emit_cast_lty_adjust(src_lty, |desc| TypeDesc {
-                                    own: desc.own,
+                                    own: Ownership::Box,
                                     qty: if single {
                                         Quantity::Single
                                     } else {

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -162,6 +162,30 @@ pub struct MirRewrite {
     pub sub_loc: Vec<SubLoc>,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+enum PlaceAccess {
+    Imm,
+    Mut,
+    Move,
+}
+
+impl PlaceAccess {
+    pub fn from_bool(mutbl: bool) -> PlaceAccess {
+        if mutbl {
+            PlaceAccess::Mut
+        } else {
+            PlaceAccess::Imm
+        }
+    }
+
+    pub fn from_mutbl(mutbl: Mutability) -> PlaceAccess {
+        match mutbl {
+            Mutability::Not => PlaceAccess::Imm,
+            Mutability::Mut => PlaceAccess::Mut,
+        }
+    }
+}
+
 struct ExprRewriteVisitor<'a, 'tcx> {
     acx: &'a AnalysisCtxt<'a, 'tcx>,
     perms: PointerTable<'a, PermissionSet>,
@@ -354,7 +378,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 self.enter_rvalue(|v| v.visit_rvalue(rv, Some(rv_lty)));
                 // The cast from `rv_lty` to `pl_lty` should be applied to the RHS.
                 self.enter_rvalue(|v| v.emit_cast_lty_lty(rv_lty, pl_lty));
-                self.enter_dest(|v| v.visit_place(pl, true));
+                self.enter_dest(|v| v.visit_place(pl, PlaceAccess::Mut));
             }
             StatementKind::FakeRead(..) => {}
             StatementKind::SetDiscriminant { .. } => todo!("statement {:?}", stmt),
@@ -571,7 +595,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                     BorrowKind::Mut { .. } => true,
                     BorrowKind::Shared | BorrowKind::Shallow | BorrowKind::Unique => false,
                 };
-                self.enter_rvalue_place(0, |v| v.visit_place(pl, mutbl));
+                self.enter_rvalue_place(0, |v| v.visit_place(pl, PlaceAccess::from_bool(mutbl)));
 
                 if let Some(expect_ty) = expect_ty {
                     if self.is_nullable(expect_ty.label) {
@@ -585,7 +609,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 // TODO
             }
             Rvalue::AddressOf(mutbl, pl) => {
-                self.enter_rvalue_place(0, |v| v.visit_place(pl, mutbl == Mutability::Mut));
+                self.enter_rvalue_place(0, |v| v.visit_place(pl, PlaceAccess::from_mutbl(mutbl)));
                 if let Some(expect_ty) = expect_ty {
                     let desc = type_desc::perms_to_desc_with_pointee(
                         self.acx.tcx(),
@@ -607,7 +631,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 }
             }
             Rvalue::Len(pl) => {
-                self.enter_rvalue_place(0, |v| v.visit_place(pl, false));
+                self.enter_rvalue_place(0, |v| v.visit_place(pl, PlaceAccess::Imm));
             }
             Rvalue::Cast(_kind, ref op, ty) => {
                 if util::is_null_const_operand(op) && ty.is_unsafe_ptr() {
@@ -666,7 +690,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 self.enter_rvalue_operand(0, |v| v.visit_operand(op, None));
             }
             Rvalue::Discriminant(pl) => {
-                self.enter_rvalue_place(0, |v| v.visit_place(pl, false));
+                self.enter_rvalue_place(0, |v| v.visit_place(pl, PlaceAccess::Imm));
             }
             Rvalue::Aggregate(ref _kind, ref ops) => {
                 for (i, op) in ops.iter().enumerate() {
@@ -677,7 +701,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 self.enter_rvalue_operand(0, |v| v.visit_operand(op, None));
             }
             Rvalue::CopyForDeref(pl) => {
-                self.enter_rvalue_place(0, |v| v.visit_place(pl, false));
+                self.enter_rvalue_place(0, |v| v.visit_place(pl, PlaceAccess::Imm));
             }
         }
     }
@@ -687,7 +711,8 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     fn visit_operand(&mut self, op: &Operand<'tcx>, expect_ty: Option<LTy<'tcx>>) {
         match *op {
             Operand::Copy(pl) | Operand::Move(pl) => {
-                self.enter_operand_place(|v| v.visit_place(pl, false));
+                // TODO: should this be Move, Imm, or dependent on the type?
+                self.enter_operand_place(|v| v.visit_place(pl, PlaceAccess::Move));
 
                 if let Some(expect_ty) = expect_ty {
                     let ptr_lty = self.acx.type_of(pl);
@@ -704,7 +729,8 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
     fn visit_operand_desc(&mut self, op: &Operand<'tcx>, expect_desc: TypeDesc<'tcx>) {
         match *op {
             Operand::Copy(pl) | Operand::Move(pl) => {
-                self.visit_place(pl, false);
+                // TODO: should this be Move, Imm, or dependent on the type?
+                self.visit_place(pl, PlaceAccess::Move);
 
                 let ptr_lty = self.acx.type_of(pl);
                 if !ptr_lty.label.is_none() {
@@ -715,24 +741,24 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         }
     }
 
-    fn visit_place(&mut self, pl: Place<'tcx>, in_mutable_context: bool) {
+    fn visit_place(&mut self, pl: Place<'tcx>, access: PlaceAccess) {
         let mut ltys = Vec::with_capacity(1 + pl.projection.len());
         ltys.push(self.acx.type_of(pl.local));
         for proj in pl.projection {
             let prev_lty = ltys.last().copied().unwrap();
             ltys.push(self.acx.projection_lty(prev_lty, &proj));
         }
-        self.visit_place_ref(pl.as_ref(), &ltys, in_mutable_context);
+        self.visit_place_ref(pl.as_ref(), &ltys, access);
     }
 
     /// Generate rewrites for a `Place` represented as a `PlaceRef`.  `proj_ltys` gives the `LTy`
-    /// for the `Local` and after each projection.  `in_mutable_context` is `true` if the `Place`
-    /// is in a mutable context, such as the LHS of an assignment.
+    /// for the `Local` and after each projection.  `access` describes how the place is being used:
+    /// immutably, mutably, or being moved out of.
     fn visit_place_ref(
         &mut self,
         pl: PlaceRef<'tcx>,
         proj_ltys: &[LTy<'tcx>],
-        in_mutable_context: bool,
+        access: PlaceAccess,
     ) {
         let (&last_proj, rest) = match pl.projection.split_last() {
             Some(x) => x,
@@ -752,7 +778,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         match last_proj {
             PlaceElem::Deref => {
                 self.enter_place_deref_pointer(|v| {
-                    v.visit_place_ref(base_pl, proj_ltys, in_mutable_context);
+                    v.visit_place_ref(base_pl, proj_ltys, access);
                     if v.is_nullable(base_lty.label) {
                         // If the pointer type is non-copy, downgrade (borrow) before calling
                         // `unwrap()`.
@@ -763,7 +789,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                         );
                         if !desc.own.is_copy() {
                             v.emit(RewriteKind::OptionDowngrade {
-                                mutbl: in_mutable_context,
+                                mutbl: access == PlaceAccess::Mut,
                                 deref: true,
                             });
                         }
@@ -772,14 +798,10 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 });
             }
             PlaceElem::Field(_idx, _ty) => {
-                self.enter_place_field_base(|v| {
-                    v.visit_place_ref(base_pl, proj_ltys, in_mutable_context)
-                });
+                self.enter_place_field_base(|v| v.visit_place_ref(base_pl, proj_ltys, access));
             }
             PlaceElem::Index(_) | PlaceElem::ConstantIndex { .. } | PlaceElem::Subslice { .. } => {
-                self.enter_place_index_array(|v| {
-                    v.visit_place_ref(base_pl, proj_ltys, in_mutable_context)
-                });
+                self.enter_place_index_array(|v| v.visit_place_ref(base_pl, proj_ltys, access));
             }
             PlaceElem::Downcast(_, _) => {}
         }

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -153,7 +153,7 @@ pub enum ZeroizeType {
     /// Zeroize by storing the literal `false`.
     Bool,
     /// Iterate over `x.iter_mut()` and zeroize each element.
-    Iterable(Box<ZeroizeType>),
+    Array(Box<ZeroizeType>),
     /// Zeroize each named field.
     Struct(Vec<(String, ZeroizeType)>),
 }
@@ -999,7 +999,7 @@ impl ZeroizeType {
             }
             TyKind::Array(elem_ty, _) => {
                 let elem_zero = ZeroizeType::from_ty(tcx, elem_ty)?;
-                ZeroizeType::Iterable(Box::new(elem_zero))
+                ZeroizeType::Array(Box::new(elem_zero))
             }
             _ => return None,
         })

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -114,7 +114,9 @@ pub enum RewriteKind {
     OptionDowngrade { mutbl: bool, deref: bool },
 
     /// Extract the `T` from `DynOwned<T>`.
-    DynOwnedTakeUnwrap,
+    DynOwnedUnwrap,
+    /// Move out of a `DynOwned<T>` and set the original location to empty / non-owned.
+    DynOwnedTake,
     /// Wrap `T` in `Ok` to produce `DynOwned<T>`.
     DynOwnedWrap,
     /// Downgrade ownership of a `DynOwned<T>` to `&T` or `&mut T` by calling
@@ -164,8 +166,11 @@ pub struct MirRewrite {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 enum PlaceAccess {
+    /// Enclosing context intends to read from the place.
     Imm,
+    /// Enclosing context intends to write to the place.
     Mut,
+    /// Enclosing context intends to move out of the place.
     Move,
 }
 
@@ -298,6 +303,22 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             && !self.flags[ptr].contains(FlagSet::FIXED)
     }
 
+    fn is_dyn_owned(&self, lty: LTy) -> bool {
+        if !matches!(lty.kind(), TyKind::Ref(..) | TyKind::RawPtr(..)) {
+            return false;
+        }
+        if lty.label.is_none() {
+            return false;
+        }
+        let perms = self.perms[lty.label];
+        let flags = self.flags[lty.label];
+        if flags.contains(FlagSet::FIXED) {
+            return false;
+        }
+        let desc = type_desc::perms_to_desc(lty.ty, perms, flags);
+        desc.dyn_owned
+    }
+
     fn visit_statement(&mut self, stmt: &Statement<'tcx>, loc: Location) {
         let _g = panic_detail::set_current_span(stmt.source_info.span);
         eprintln!(
@@ -375,9 +396,47 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 };
 
                 let rv_lty = self.acx.type_of_rvalue(rv, loc);
-                self.enter_rvalue(|v| v.visit_rvalue(rv, Some(rv_lty)));
                 // The cast from `rv_lty` to `pl_lty` should be applied to the RHS.
-                self.enter_rvalue(|v| v.emit_cast_lty_lty(rv_lty, pl_lty));
+                self.enter_rvalue(|v| {
+                    // Special case: when reading from a `DynOwned` place to another `DynOwned`
+                    // place, visit the RHS place mutably and `mem::take` out of it to avoid a
+                    // static ownership transfer.
+
+                    // Check whether this assignment transfers ownership of its RHS.  If so, return
+                    // the RHS `Place`.
+                    let assignment_transfers_ownership = || {
+                        if !v.is_dyn_owned(v.acx.type_of(pl)) {
+                            return None;
+                        }
+                        let op = match rv {
+                            Rvalue::Use(ref x) => x,
+                            _ => return None,
+                        };
+                        let rv_pl = op.place()?;
+                        if !v.is_dyn_owned(v.acx.type_of(rv_pl)) {
+                            return None;
+                        }
+                        Some(rv_pl)
+                    };
+                    if let Some(rv_pl) = assignment_transfers_ownership() {
+                        // Obtain mutable access to `pl`, so we can `mem::take(&mut pl)`.
+                        // Normally, `Operand::Move` would ask for `PlaceAccess::Move`; we
+                        // instead bypass `visit_rvalue` and `visit_operand` so we can call
+                        // `visit_place` directly with the desired access.
+                        v.enter_rvalue_operand(0, |v| {
+                            v.enter_operand_place(|v| {
+                                v.visit_place(rv_pl, PlaceAccess::Mut);
+                            });
+                        });
+                        v.emit(RewriteKind::DynOwnedTake);
+                        v.emit_cast_lty_lty(rv_lty, pl_lty);
+                        return;
+                    }
+
+                    // Normal case: just `visit_rvalue` and emit a cast if needed.
+                    v.visit_rvalue(rv, Some(rv_lty));
+                    v.emit_cast_lty_lty(rv_lty, pl_lty)
+                });
                 self.enter_dest(|v| v.visit_place(pl, PlaceAccess::Mut));
             }
             StatementKind::FakeRead(..) => {}
@@ -765,7 +824,9 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             None => return,
         };
 
-        debug_assert!(!pl.projection.is_empty());
+        // TODO: downgrade Move to Imm if the new type is Copy
+
+        debug_assert!(pl.projection.len() >= 1);
         // `LTy` of the base place, before the last projection.
         let base_lty = proj_ltys[pl.projection.len() - 1];
         // `LTy` resulting from applying `last_proj` to `base_lty`.
@@ -794,6 +855,11 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                             });
                         }
                         v.emit(RewriteKind::OptionUnwrap);
+                    }
+                    if v.is_dyn_owned(base_lty) {
+                        v.emit(RewriteKind::DynOwnedDowngrade {
+                            mutbl: access == PlaceAccess::Mut,
+                        });
                     }
                 });
             }
@@ -1074,7 +1140,7 @@ where
                     (self.emit)(RewriteKind::DynOwnedDowngrade { mutbl: true });
                 }
                 Ownership::Rc | Ownership::Box => {
-                    (self.emit)(RewriteKind::DynOwnedTakeUnwrap);
+                    (self.emit)(RewriteKind::DynOwnedUnwrap);
                 }
             }
             from.dyn_owned = false;

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -667,20 +667,20 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
 
                             // `MallocSafe` produces either `Box<T>` or `Box<[T]>`.  Emit a cast
                             // from that type to the required output type.
-                            let desc = TypeDesc {
-                                own: Ownership::Box,
-                                qty: if single {
-                                    Quantity::Single
-                                } else {
-                                    Quantity::Slice
+                            v.emit_cast_adjust_lty(
+                                |desc| TypeDesc {
+                                    own: desc.own,
+                                    qty: if single {
+                                        Quantity::Single
+                                    } else {
+                                        Quantity::Slice
+                                    },
+                                    dyn_owned: false,
+                                    option: false,
+                                    pointee_ty: desc.pointee_ty,
                                 },
-                                dyn_owned: false,
-                                option: false,
-                                // Use the non-rewritten pointee type rather than `dest_pointee`,
-                                // since the former is what `emit_cast_*` will expect.
-                                pointee_ty: dest_lty.args[0].ty,
-                            };
-                            v.emit_cast_desc_lty(desc, dest_lty);
+                                dest_lty,
+                            );
                         });
                     }
 
@@ -1033,6 +1033,32 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         let flags = self.flags;
         let mut builder = CastBuilder::new(self.acx.tcx(), &perms, &flags, |rk| self.emit(rk));
         builder.build_cast_lty_lty(from_lty, to_lty);
+    }
+
+    /// Cast `from_lty` to an adjusted version of itself.  If `from_desc` is the `TypeDesc`
+    /// corresponding to `from_lty`, this emits a cast from `from_desc` to `to_adjust(from_desc)`.
+    fn emit_cast_lty_adjust(
+        &mut self,
+        from_lty: LTy<'tcx>,
+        to_adjust: impl FnOnce(TypeDesc<'tcx>) -> TypeDesc<'tcx>,
+    ) {
+        let perms = self.perms;
+        let flags = self.flags;
+        let mut builder = CastBuilder::new(self.acx.tcx(), &perms, &flags, |rk| self.emit(rk));
+        builder.build_cast_lty_adjust(from_lty, to_adjust);
+    }
+
+    /// Cast an adjusted version of `to_lty` to `to_lty` itself.  If `to_desc` is the `TypeDesc`
+    /// corresponding to `to_lty`, this emits a cast from `from_adjust(to_desc)` to `to_desc`.
+    fn emit_cast_adjust_lty(
+        &mut self,
+        from_adjust: impl FnOnce(TypeDesc<'tcx>) -> TypeDesc<'tcx>,
+        to_lty: LTy<'tcx>,
+    ) {
+        let perms = self.perms;
+        let flags = self.flags;
+        let mut builder = CastBuilder::new(self.acx.tcx(), &perms, &flags, |rk| self.emit(rk));
+        builder.build_cast_adjust_lty(from_adjust, to_lty);
     }
 }
 
@@ -1419,9 +1445,11 @@ where
         self.build_cast_desc_desc(from, to);
     }
 
-    pub fn build_cast_lty_lty(&mut self, from_lty: LTy<'tcx>, to_lty: LTy<'tcx>) {
-        let Self { perms, flags, .. } = *self;
+    fn lty_to_desc(&self, lty: LTy<'tcx>) -> TypeDesc<'tcx> {
+        type_desc::perms_to_desc(lty.ty, self.perms[lty.label], self.flags[lty.label])
+    }
 
+    pub fn build_cast_lty_lty(&mut self, from_lty: LTy<'tcx>, to_lty: LTy<'tcx>) {
         if from_lty.label.is_none() && to_lty.label.is_none() {
             // Input and output are both non-pointers.
             return;
@@ -1434,26 +1462,23 @@ where
             return;
         }
 
-        let from_fixed = flags[from_lty.label].contains(FlagSet::FIXED);
-        let to_fixed = flags[to_lty.label].contains(FlagSet::FIXED);
-
-        let lty_to_desc =
-            |lty: LTy<'tcx>| type_desc::perms_to_desc(lty.ty, perms[lty.label], flags[lty.label]);
+        let from_fixed = self.flags[from_lty.label].contains(FlagSet::FIXED);
+        let to_fixed = self.flags[to_lty.label].contains(FlagSet::FIXED);
 
         match (from_fixed, to_fixed) {
             (false, false) => {
-                let from = lty_to_desc(from_lty);
-                let to = lty_to_desc(to_lty);
+                let from = self.lty_to_desc(from_lty);
+                let to = self.lty_to_desc(to_lty);
                 self.build_cast_desc_desc(from, to);
             }
 
             (false, true) => {
-                let from = lty_to_desc(from_lty);
+                let from = self.lty_to_desc(from_lty);
                 self.build_cast_desc_lty(from, to_lty);
             }
 
             (true, false) => {
-                let to = lty_to_desc(to_lty);
+                let to = self.lty_to_desc(to_lty);
                 self.build_cast_lty_desc(from_lty, to);
             }
 
@@ -1461,6 +1486,50 @@ where
                 // No-op.  Both sides are `FIXED`, so we assume the existing code is already valid.
             }
         }
+    }
+
+    pub fn build_cast_lty_adjust(
+        &mut self,
+        from_lty: LTy<'tcx>,
+        to_adjust: impl FnOnce(TypeDesc<'tcx>) -> TypeDesc<'tcx>,
+    ) {
+        if from_lty.label.is_none() {
+            // Input and output are both non-pointers.
+            return;
+        }
+        if !matches!(from_lty.ty.kind(), TyKind::RawPtr(..)) {
+            // TODO: hack to work around issues with already-safe code
+            return;
+        }
+        if self.flags[from_lty.label].contains(FlagSet::FIXED) {
+            return;
+        }
+
+        let from = self.lty_to_desc(from_lty);
+        let to = to_adjust(from);
+        self.build_cast_desc_desc(from, to);
+    }
+
+    pub fn build_cast_adjust_lty(
+        &mut self,
+        from_adjust: impl FnOnce(TypeDesc<'tcx>) -> TypeDesc<'tcx>,
+        to_lty: LTy<'tcx>,
+    ) {
+        if to_lty.label.is_none() {
+            // Input and output are both non-pointers.
+            return;
+        }
+        if !matches!(to_lty.ty.kind(), TyKind::RawPtr(..)) {
+            // TODO: hack to work around issues with already-safe code
+            return;
+        }
+        if self.flags[to_lty.label].contains(FlagSet::FIXED) {
+            return;
+        }
+
+        let to = self.lty_to_desc(to_lty);
+        let from = from_adjust(to);
+        self.build_cast_desc_desc(from, to);
     }
 }
 

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -110,8 +110,16 @@ pub enum RewriteKind {
     /// but passes through `None` unchanged instead of panicking.
     OptionMapEnd,
     /// Downgrade ownership of an `Option` to `Option<&_>` or `Option<&mut _>` by calling
-    /// `as_ref()`/`as_mut()` and optionally `as_deref()`/`as_deref_mut()`.
+    /// `as_ref()`/`as_mut()` or `as_deref()`/`as_deref_mut()`.
     OptionDowngrade { mutbl: bool, deref: bool },
+
+    /// Extract the `T` from `DynOwned<T>`.
+    DynOwnedTakeUnwrap,
+    /// Wrap `T` in `Ok` to produce `DynOwned<T>`.
+    DynOwnedWrap,
+    /// Downgrade ownership of a `DynOwned<T>` to `&T` or `&mut T` by calling
+    /// `as_deref()`/`as_deref_mut()` and `unwrap`.
+    DynOwnedDowngrade { mutbl: bool },
 
     /// Cast `&T` to `*const T` or `&mut T` to `*mut T`.
     CastRefToRaw { mutbl: bool },
@@ -791,6 +799,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                 Quantity::OffsetPtr => Quantity::OffsetPtr,
                 Quantity::Array => unreachable!("perms_to_desc should not return Quantity::Array"),
             },
+            dyn_owned: result_desc.dyn_owned,
             option: result_desc.option,
             pointee_ty: result_desc.pointee_ty,
         };
@@ -1034,6 +1043,21 @@ where
             in_option_map = true;
         }
 
+        if from.dyn_owned {
+            match to.own {
+                Ownership::Raw | Ownership::Imm => {
+                    (self.emit)(RewriteKind::DynOwnedDowngrade { mutbl: false });
+                }
+                Ownership::RawMut | Ownership::Cell | Ownership::Mut => {
+                    (self.emit)(RewriteKind::DynOwnedDowngrade { mutbl: true });
+                }
+                Ownership::Rc | Ownership::Box => {
+                    (self.emit)(RewriteKind::DynOwnedTakeUnwrap);
+                }
+            }
+            from.dyn_owned = false;
+        }
+
         // Early `Ownership` casts.  We do certain casts here in hopes of reaching an `Ownership`
         // on which we can safely adjust `Quantity`.
         from.own = self.cast_ownership(from, to, true)?;
@@ -1087,6 +1111,11 @@ where
 
         // Late `Ownership` casts.
         from.own = self.cast_ownership(from, to, false)?;
+
+        if to.dyn_owned {
+            (self.emit)(RewriteKind::DynOwnedWrap);
+            from.dyn_owned = true;
+        }
 
         if in_option_map {
             assert!(!from.option);

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -19,8 +19,7 @@ use rustc_middle::mir::{
     BasicBlock, Body, BorrowKind, Location, Operand, Place, PlaceElem, PlaceRef, Rvalue, Statement,
     StatementKind, Terminator, TerminatorKind,
 };
-use rustc_middle::ty::print::FmtPrinter;
-use rustc_middle::ty::print::Print;
+use rustc_middle::ty::print::{FmtPrinter, PrettyPrinter, Print};
 use rustc_middle::ty::{ParamEnv, Ty, TyCtxt, TyKind};
 use std::collections::HashMap;
 use std::ops::Index;
@@ -155,7 +154,7 @@ pub enum ZeroizeType {
     /// Iterate over `x.iter_mut()` and zeroize each element.
     Array(Box<ZeroizeType>),
     /// Zeroize each named field.
-    Struct(Vec<(String, ZeroizeType)>),
+    Struct(String, Vec<(String, ZeroizeType)>),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -995,7 +994,14 @@ impl ZeroizeType {
                     let zero = ZeroizeType::from_ty(tcx, ty)?;
                     fields.push((name, zero));
                 }
-                ZeroizeType::Struct(fields)
+
+                let name_printer = FmtPrinter::new(tcx, Namespace::ValueNS);
+                let name = name_printer
+                    .print_value_path(adt_def.did(), &[])
+                    .unwrap()
+                    .into_buffer();
+
+                ZeroizeType::Struct(name, fields)
             }
             TyKind::Array(elem_ty, _) => {
                 let elem_zero = ZeroizeType::from_ty(tcx, elem_ty)?;

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -58,8 +58,8 @@ pub enum RewriteKind {
     OptionMapOffsetSlice { mutbl: bool },
     /// Replace `slice` with `&slice[0]`.
     SliceFirst { mutbl: bool },
-    /// Replace `ptr` with `&*ptr`, converting `&mut T` to `&T`.
-    MutToImm,
+    /// Replace `ptr` with `&*ptr` or `&mut *ptr`, converting `ptr` to `&T` or `&mut T`.
+    Reborrow { mutbl: bool },
     /// Remove a call to `as_ptr` or `as_mut_ptr`.
     RemoveAsPtr,
     /// Remove a cast, changing `x as T` to just `x`.
@@ -1154,7 +1154,7 @@ where
             },
             Ownership::Mut => match to.own {
                 Ownership::Imm | Ownership::Raw => {
-                    (self.emit)(RewriteKind::MutToImm);
+                    (self.emit)(RewriteKind::Reborrow { mutbl: false });
                     Some(Ownership::Imm)
                 }
                 Ownership::Cell => {

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -1136,12 +1136,12 @@ where
         Ok(match from.own {
             Ownership::Box => match to.own {
                 Ownership::Raw | Ownership::Imm => {
-                    return Err("TODO: cast Box to Imm".to_string());
-                    //Some(Ownership::Imm)
+                    (self.emit)(RewriteKind::Reborrow { mutbl: false });
+                    Some(Ownership::Imm)
                 }
-                Ownership::RawMut | Ownership::Mut => {
-                    return Err("TODO: cast Box to Mut".to_string());
-                    //Some(Ownership::Mut)
+                Ownership::RawMut | Ownership::Mut | Ownership::Cell => {
+                    (self.emit)(RewriteKind::Reborrow { mutbl: true });
+                    Some(Ownership::Mut)
                 }
                 _ => None,
             },

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -592,6 +592,12 @@ fn rewrite_ty<'tcx>(
             };
 
             if dyn_owned {
+                // Ideally, we would use a custom `DynOwned<T>` type here to make the meaning
+                // clear.  However, we don't currently have a run-time support library for
+                // c2rust-analyze where we could define such a type.  As an alternative, for now we
+                // use `Result<T, ()>`, which has roughly the same semantics (equivalent to
+                // `Option<T>`).  We don't use `Option<T>` because it would result in confusing
+                // `Option<Option<T>>` types for pointers that are both owned and nullable.
                 rw = Rewrite::TyCtor(
                     "core::result::Result".into(),
                     vec![rw, Rewrite::Print("()".into())],

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -561,7 +561,7 @@ fn rewrite_ty<'tcx>(
                 Ownership::Cell => Rewrite::TyRef(lifetime_type, Box::new(rw), Mutability::Not),
                 Ownership::Mut => Rewrite::TyRef(lifetime_type, Box::new(rw), Mutability::Mut),
                 Ownership::Rc => todo!(),
-                Ownership::Box => todo!(),
+                Ownership::Box => Rewrite::TyCtor("alloc::boxed::Box".into(), vec![rw]),
             };
 
             if option {

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -588,7 +588,7 @@ fn rewrite_ty<'tcx>(
                 Ownership::Cell => Rewrite::TyRef(lifetime_type, Box::new(rw), Mutability::Not),
                 Ownership::Mut => Rewrite::TyRef(lifetime_type, Box::new(rw), Mutability::Mut),
                 Ownership::Rc => todo!(),
-                Ownership::Box => Rewrite::TyCtor("alloc::boxed::Box".into(), vec![rw]),
+                Ownership::Box => Rewrite::TyCtor("std::boxed::Box".into(), vec![rw]),
             };
 
             if dyn_owned {

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -333,7 +333,11 @@ impl Convert<hir::Mutability> for mir::Mutability {
     }
 }
 
-fn mk_adt_with_arg<'tcx>(tcx: TyCtxt<'tcx>, path: &str, arg_ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
+fn mk_adt_with_generic_args<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    path: &str,
+    args: impl IntoIterator<Item = GenericArg<'tcx>>,
+) -> ty::Ty<'tcx> {
     let mut path_parts_iter = path.split("::");
     let crate_name = path_parts_iter
         .next()
@@ -364,8 +368,12 @@ fn mk_adt_with_arg<'tcx>(tcx: TyCtxt<'tcx>, path: &str, arg_ty: ty::Ty<'tcx>) ->
     }
 
     let adt = tcx.adt_def(cur_did);
-    let substs = tcx.mk_substs([GenericArg::from(arg_ty)].into_iter());
+    let substs = tcx.mk_substs(args.into_iter());
     tcx.mk_adt(adt, substs)
+}
+
+fn mk_adt_with_arg<'tcx>(tcx: TyCtxt<'tcx>, path: &str, arg_ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
+    mk_adt_with_generic_args(tcx, path, [GenericArg::from(arg_ty)])
 }
 
 fn mk_cell<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
@@ -374,6 +382,11 @@ fn mk_cell<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
 
 fn mk_option<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
     mk_adt_with_arg(tcx, "core::option::Option", ty)
+}
+
+fn mk_dyn_owned<'tcx>(tcx: TyCtxt<'tcx>, ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
+    let args = [GenericArg::from(ty), GenericArg::from(tcx.mk_unit())];
+    mk_adt_with_generic_args(tcx, "core::result::Result", args)
 }
 
 /// Produce a `Ty` reflecting the rewrites indicated by the labels in `rw_lty`.
@@ -422,7 +435,12 @@ pub fn desc_parts_to_ty<'tcx>(
     pointee_ty: Ty<'tcx>,
 ) -> Ty<'tcx> {
     let mut ty = pointee_ty;
-    let PtrDesc { own, qty, option } = ptr_desc;
+    let PtrDesc {
+        own,
+        qty,
+        dyn_owned,
+        option,
+    } = ptr_desc;
 
     if own == Ownership::Cell {
         ty = mk_cell(tcx, ty);
@@ -445,6 +463,10 @@ pub fn desc_parts_to_ty<'tcx>(
         Ownership::Rc => todo!(),
         Ownership::Box => tcx.mk_box(ty),
     };
+
+    if dyn_owned {
+        ty = mk_dyn_owned(tcx, ty);
+    }
 
     if option {
         ty = mk_option(tcx, ty);
@@ -539,7 +561,12 @@ fn rewrite_ty<'tcx>(
 
         if let Some(ptr_desc) = rw_lty.label.ty_desc {
             assert_eq!(hir_args.len(), 1);
-            let PtrDesc { own, qty, option } = ptr_desc;
+            let PtrDesc {
+                own,
+                qty,
+                dyn_owned,
+                option,
+            } = ptr_desc;
 
             if own == Ownership::Cell {
                 rw = Rewrite::TyCtor("core::cell::Cell".into(), vec![rw]);
@@ -563,6 +590,13 @@ fn rewrite_ty<'tcx>(
                 Ownership::Rc => todo!(),
                 Ownership::Box => Rewrite::TyCtor("alloc::boxed::Box".into(), vec![rw]),
             };
+
+            if dyn_owned {
+                rw = Rewrite::TyCtor(
+                    "core::result::Result".into(),
+                    vec![rw, Rewrite::Print("()".into())],
+                );
+            }
 
             if option {
                 rw = Rewrite::TyCtor("core::option::Option".into(), vec![rw]);

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -84,7 +84,9 @@ impl Ownership {
 }
 
 fn perms_to_ptr_desc(perms: PermissionSet, flags: FlagSet) -> PtrDesc {
-    let own = if perms.contains(PermissionSet::UNIQUE | PermissionSet::WRITE) {
+    let own = if perms.contains(PermissionSet::FREE) {
+        Ownership::Box
+    } else if perms.contains(PermissionSet::UNIQUE | PermissionSet::WRITE) {
         Ownership::Mut
     } else if flags.contains(FlagSet::CELL) {
         Ownership::Cell

--- a/c2rust-analyze/tests/filecheck/alloc.rs
+++ b/c2rust-analyze/tests/filecheck/alloc.rs
@@ -59,7 +59,7 @@ unsafe extern "C" fn realloc1(mut i: *mut i32, len: libc::c_ulong) {
     loop {
         if x == capacity {
             capacity *= 2;
-            // CHECK-DAG: ([[@LINE+2]]: i{{.*}}): addr_of = UNIQUE | NON_NULL, type = FREE | NON_NULL
+            // CHECK-DAG: ([[@LINE+2]]: i{{.*}}): addr_of = UNIQUE | NON_NULL, type = OFFSET_ADD | OFFSET_SUB | FREE | NON_NULL
             i = realloc(
                 i as *mut libc::c_void,
                 4 as libc::c_ulong,

--- a/c2rust-analyze/tests/filecheck/alloc.rs
+++ b/c2rust-analyze/tests/filecheck/alloc.rs
@@ -53,10 +53,10 @@ unsafe extern "C" fn free1(mut i: *mut i32) {
 // CHECK-LABEL: final labeling for "realloc1"
 unsafe extern "C" fn realloc1(n: libc::c_ulong) {
     // CHECK-DAG: ([[@LINE+1]]: mut buf): addr_of = UNIQUE | NON_NULL, type = READ | WRITE | UNIQUE | OFFSET_ADD | OFFSET_SUB | FREE | NON_NULL
-    let mut buf: *mut i32 = malloc(2 * mem::size_of::<i32>() as libc::c_ulong) as *mut i32;
+    let mut buf: *mut i32 = malloc(2 * std::mem::size_of::<i32>() as libc::c_ulong) as *mut i32;
     let mut len = 0;
     let mut capacity = 2;
-    memset(buf as *mut libc::c_void, 0, 2 * mem::size_of::<i32>() as usize);
+    memset(buf as *mut libc::c_void, 0, 2 * std::mem::size_of::<i32>() as usize);
 
     let mut i = 0;
     while i < n {
@@ -65,10 +65,12 @@ unsafe extern "C" fn realloc1(n: libc::c_ulong) {
             // CHECK-DAG: ([[@LINE+2]]: buf{{.*}}): addr_of = UNIQUE | NON_NULL, type = UNIQUE | OFFSET_ADD | OFFSET_SUB | FREE | NON_NULL
             buf = realloc(
                 buf as *mut libc::c_void,
-                capacity as libc::c_ulong,
+                (capacity * std::mem::size_of::<i32>()) as libc::c_ulong,
             ) as *mut i32;
         }
         *buf.offset(i as isize) = i as i32;
+        len += 1;
+        i += 1;
     }
 
     free(buf as *mut libc::c_void);

--- a/c2rust-analyze/tests/filecheck/alloc.rs
+++ b/c2rust-analyze/tests/filecheck/alloc.rs
@@ -95,3 +95,14 @@ pub unsafe extern "C" fn alloc_and_free2(mut cnt: libc::c_int) {
         free(i as *mut libc::c_void);
     }
 }
+
+// CHECK-LABEL: final labeling for "alloc_and_free3"
+pub unsafe extern "C" fn alloc_and_free3(mut cnt: libc::c_int) {
+    // CHECK-DAG: ([[@LINE+1]]: mut i): addr_of = UNIQUE | NON_NULL, type = READ | WRITE | UNIQUE | FREE | NON_NULL#
+    let mut i: *mut i32 = malloc(::std::mem::size_of::<i32>() as libc::c_ulong) as *mut i32;
+    // CHECK-DAG: ([[@LINE+1]]: mut b): addr_of = UNIQUE | NON_NULL, type = READ | WRITE | UNIQUE | FREE | NON_NULL#
+    let mut b: *mut i32 = i;
+    *b = 2;
+    // CHECK-DAG: ([[@LINE+1]]: b): {{.*}}type = UNIQUE | FREE | NON_NULL#
+    free(b as *mut libc::c_void);
+}

--- a/c2rust-analyze/tests/filecheck/field_temp.rs
+++ b/c2rust-analyze/tests/filecheck/field_temp.rs
@@ -7,7 +7,7 @@ pub struct MyList {
 
 // CHECK-LABEL: final labeling for "list_get"
 pub unsafe fn list_get(l: *const MyList, i: usize) -> i32 {
-    // The temporary `(*l).data` requires a MIR `MutToImm` rewrite.
+    // The temporary `(*l).data` requires a MIR `Reborrow` rewrite.
     // CHECK: ([[@LINE+2]]: (*l).data): &[i32]
     // CHECK: [[@LINE+1]]: (*l).data.offse ... size): &(&(&*$0)[($1 as usize) ..])[0]
     *(*l).data.offset(i as isize)


### PR DESCRIPTION
This branch adds rewrites to convert pointers with the `FREE` permission into `Box<T>`.  This follows the dynamic ownership tracking proposal in #1097.

Specific changes:
* Adds a new `dyn_owned: bool` field to `TypeDesc`, which indicates that the pointer type should be wrapped in a dynamic ownership wrapper.
* Extends `ZeroizeType` handling to support zero-initializing some pointer types (necessary to allow `malloc`/`calloc` of structs that contain pointers).
* Adds support for `Box` and `dyn_owned` related casts in `mir_op` and `rewrite::expr::convert`.
* Adds custom rewrite rules for `malloc`, `calloc`, `free`, and `realloc`.