### PR TITLE
analyze: borrowck performance improvements

### DIFF
--- a/c2rust-analyze/src/borrowck/dump.rs
+++ b/c2rust-analyze/src/borrowck/dump.rs
@@ -1,7 +1,7 @@
+//! Copied partly from rustc `compiler/rustc_borrowck/src/facts.rs`, which is dual-licensed MIT and
+//! Apache 2.0.
 use crate::borrowck::atoms::{AllFacts, AtomMaps, Loan, Origin, Output, Path, Point, Variable};
 use rustc_hash::{FxHashMap, FxHashSet};
-/// Copied partly from rustc `compiler/rustc_borrowck/src/facts.rs`, which is dual-licensed MIT and
-/// Apache 2.0.
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt::Write as _;

--- a/c2rust-analyze/src/borrowck/dump.rs
+++ b/c2rust-analyze/src/borrowck/dump.rs
@@ -3,6 +3,7 @@
 use crate::borrowck::atoms::{AllFacts, AtomMaps, Loan, Origin, Output, Path, Point, Variable};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::{BTreeMap, BTreeSet};
+use std::env;
 use std::error::Error;
 use std::fmt::Write as _;
 use std::fs::{self, File};
@@ -10,11 +11,20 @@ use std::hash::Hash;
 use std::io::{BufWriter, Write};
 use std::path;
 
+thread_local! {
+    static DUMP_FACTS: bool = {
+        env::var("C2RUST_ANALYZE_DUMP_POLONIUS_FACTS").map_or(false, |val| &val == "1")
+    };
+}
+
 pub fn dump_facts_to_dir(
     facts: &AllFacts,
     maps: &AtomMaps,
     dir: impl AsRef<path::Path>,
 ) -> Result<(), Box<dyn Error>> {
+    if !DUMP_FACTS.with(|&flag| flag) {
+        return Ok(());
+    }
     let dir: &path::Path = dir.as_ref();
     fs::create_dir_all(dir)?;
     let wr = FactWriter { maps, dir };
@@ -60,6 +70,9 @@ pub fn dump_output_to_dir(
     maps: &AtomMaps,
     dir: impl AsRef<path::Path>,
 ) -> Result<(), Box<dyn Error>> {
+    if !DUMP_FACTS.with(|&flag| flag) {
+        return Ok(());
+    }
     let dir: &path::Path = dir.as_ref();
     fs::create_dir_all(dir)?;
     let wr = FactWriter { maps, dir };

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Formatter, Write as _};
 use std::fs::{self, File};
 use std::hash::{Hash, Hasher};
+use std::io::{BufReader, BufWriter};
 
 mod atoms;
 mod def_use;
@@ -383,7 +384,7 @@ fn run_polonius<'tcx>(
 fn try_load_cached_output(facts_hash: &str) -> Option<Output> {
     let path = format!("polonius_cache/{}.output", facts_hash);
 
-    let f = File::open(&path).ok()?;
+    let f = BufReader::new(File::open(&path).ok()?);
     let raw = match bincode::deserialize_from(f) {
         Ok(x) => x,
         Err(e) => {
@@ -492,7 +493,7 @@ fn save_cached_output(facts_hash: &str, output: &Output) -> Result<(), bincode::
         ),
     );
 
-    let f = File::create(path)?;
+    let f = BufWriter::new(File::create(path)?);
     bincode::serialize_into(f, &raw)
 }
 


### PR DESCRIPTION
I found some easy borrowck/Polonius performance improvements while investigating a performance regression on a development branch.

1. Use `BufReader`/`BufWriter` when loading/saving from the `polonius_cache`.  Otherwise `bincode` reads/writes each 8-byte field individually.
2. Don't dump Polonius facts to `inspect/FUNC/*.facts` unless requested with `C2RUST_ANALYZE_DUMP_POLONIUS_FACTS=1`.  This takes a nontrivial amount of time for big functions and is only needed when debugging certain borrowck issues.

Improvements compared to master (all measurements taken on the second run, after populating `polonius_cache/`):
* `cargo test algo_md5`: 25s -> 4.6s
* `cargo test --release algo_md5`: 16s -> 2.1s