### PR TITLE
transpile: remove `git-testament` dependency (for now) to remove `time` dependency to build on 1.80.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,12 +181,10 @@ dependencies = [
  "c2rust-transpile",
  "clap 3.2.25",
  "env_logger",
- "git-testament",
  "is_executable",
  "log",
  "regex",
  "shlex",
- "time-macros",
 ]
 
 [[package]]
@@ -750,29 +748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
-name = "git-testament"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986bf57c808270f3a0a0652c3bfce0f5d667aa5f5b465616dc697c7f390834b1"
-dependencies = [
- "git-testament-derive",
- "no-std-compat",
-]
-
-[[package]]
-name = "git-testament-derive"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a782db5866c7ab75f3552dda4cbf34e3e257cc64c963c6ed5af1e12818e8ae6"
-dependencies = [
- "log",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "time",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,12 +990,6 @@ checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
-
-[[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "nom"
@@ -1480,33 +1449,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af0097eaf301d576d0b2aead7a59facab6d53cc636340f0291fab8446a2e8613"
-dependencies = [
- "itoa",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
-
-[[package]]
-name = "time-macros"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
-dependencies = [
- "time-core",
 ]
 
 [[package]]

--- a/c2rust/Cargo.toml
+++ b/c2rust/Cargo.toml
@@ -20,14 +20,11 @@ azure-devops = { project = "immunant/c2rust", pipeline = "immunant.c2rust", buil
 anyhow = "1.0"
 clap = { version = "3.2.22", features = ["yaml", "cargo", "derive"] }
 env_logger = "0.10"
-git-testament = "0.2.1"
 is_executable = "1.0"
 log = "0.4"
 regex = "1.3"
 shlex = "1.3"
 c2rust-transpile = { version = "0.18.0", path = "../c2rust-transpile" }
-# Required to avoid too-new version (dep of git-testament) which our rustc cannot compile
-time-macros = "=0.2.6"
 
 [build-dependencies]
 c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.18.0" }

--- a/c2rust/src/main.rs
+++ b/c2rust/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::anyhow;
 use clap::{crate_authors, App, AppSettings, Arg};
-use git_testament::{git_testament, render_testament};
 use is_executable::IsExecutable;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -10,8 +9,6 @@ use std::path::PathBuf;
 use std::process;
 use std::process::Command;
 use std::str;
-
-git_testament!(TESTAMENT);
 
 /// A `c2rust` sub-command.
 struct SubCommand {
@@ -124,7 +121,7 @@ fn main() -> anyhow::Result<()> {
 
     // If we didn't get a subcommand, then use `clap` for parsing and error/help messages.
     let matches = App::new("C2Rust")
-        .version(&*render_testament!(TESTAMENT))
+        .version(env!("CARGO_PKG_VERSION"))
         .author(crate_authors!(", "))
         .settings(&[AppSettings::SubcommandRequiredElseHelp])
         .subcommands(sub_commands.keys().map(|name| {


### PR DESCRIPTION
* Fixes #1109.

Our old nightly (1.65) pins `time-macros` to an old version, which requires `time` to stay on an old version. But since 1.80 broke `time` (due to https://github.com/time-rs/time/issues/693 and https://github.com/rust-lang/rust/issues/127343), we need to update `time`.  Doing this requires `time-macros` to be upgraded, which requires at least rust 1.67. There's an old PR, #811, for this, but it needs rebasing. So for now, removing `git-testament` and its `time` dependency is simpler, and we can add it back later once we update to a newer nightly.

With this fix, both `cargo build -p c2rust` (the pinned nightly) and `cargo +stable build -p c2rust` (1.80.1) now work.

If this is good, and once we merge this, we'll release a new version with the fix.