### PR TITLE
Release 0.19.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ marks.*.json
 inspect/
 *.analysis.txt
 analysis.txt
+polonius_cache/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "c2rust-build-paths",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-analysis-rt"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bincode",
  "crossbeam-queue",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-analyze"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -229,11 +229,11 @@ dependencies = [
 
 [[package]]
 name = "c2rust-asm-casts"
-version = "0.18.0"
+version = "0.19.0"
 
 [[package]]
 name = "c2rust-ast-builder"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-ast-exporter"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bindgen",
  "c2rust-build-paths",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-ast-printer"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "log",
  "prettyplease 0.1.25",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-bitfields"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "c2rust-bitfields-derive",
  "libc",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-bitfields-derive"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -283,14 +283,14 @@ dependencies = [
 
 [[package]]
 name = "c2rust-build-paths"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "print_bytes",
 ]
 
 [[package]]
 name = "c2rust-instrument"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-pdg"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bincode",
  "c2rust-analysis-rt",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-transpile"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "c2rust-ast-builder",
  "c2rust-ast-exporter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ exclude = [
 version = "0.19.0"
 authors = ["The C2Rust Project Developers <c2rust@immunant.com>"]
 edition = "2021"
+rust-version = "1.65"
 readme = "README.md"
 homepage = "https://c2rust.com/"
 repository = "https://github.com/immunant/c2rust/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "analysis/runtime",
     "c2rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.19.0"
 authors = ["The C2Rust Project Developers <c2rust@immunant.com>"]
 edition = "2021"
 readme = "README.md"

--- a/analysis/tests/lighttpd-minimal/Cargo.toml
+++ b/analysis/tests/lighttpd-minimal/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.18.0" }
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.19.0" }
 
 [features]
 miri = []

--- a/analysis/tests/lighttpd/Cargo.toml
+++ b/analysis/tests/lighttpd/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.18.0" }
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.19.0" }
 
 [features]
 miri = []

--- a/analysis/tests/minimal/Cargo.toml
+++ b/analysis/tests/minimal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.18.0" }
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.19.0" }
 
 [features]
 miri = []

--- a/analysis/tests/misc/Cargo.toml
+++ b/analysis/tests/misc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.18.0" }
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.19.0" }
 
 [features]
 miri = []

--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -32,11 +32,11 @@ toml_edit = "0.19.8"
 sha2 = "0.10.8"
 
 [build-dependencies]
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.18.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
 print_bytes = "1.1"
 
 [dev-dependencies]
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.18.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
 clap = { version = "4.1.9", features = ["derive"] }
 shlex = "1.3.0"
 

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -177,7 +177,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                                 self.facts,
                                 self.maps,
                                 &self.acx.gacx.adt_metadata,
-                                &self.acx.gacx.static_tys[&did],
+                                self.acx.gacx.static_tys[&did],
                             );
 
                             for l in lty.iter() {
@@ -585,7 +585,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                     }
                     Callee::Memcpy => {
                         let _pl_lty = self.visit_place(destination);
-                        let _rv_lty = assert_matches!(&args[..], [dest, src, _] => {
+                        assert_matches!(&args[..], [dest, src, _] => {
                             self.visit_operand(dest);
                             self.visit_operand(src);
                         });

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -1503,7 +1503,7 @@ pub fn print_ty_with_pointer_labels_into<L: Copy>(
         // Types with arguments
         Adt(adt_def, _substs) => {
             write!(dest, "{:?}", adt_def.did()).unwrap();
-            if lty.args.len() != 0 {
+            if !lty.args.is_empty() {
                 dest.push('<');
                 // TODO: region args
                 for (i, &arg_lty) in lty.args.iter().enumerate() {
@@ -1532,31 +1532,31 @@ pub fn print_ty_with_pointer_labels_into<L: Copy>(
                 dest.push_str("*mut ");
             }
             let s = f(lty.label);
-            if s.len() > 0 {
+            if !s.is_empty() {
                 dest.push_str(&s);
-                dest.push_str(" ");
+                dest.push(' ');
             }
             print_ty_with_pointer_labels_into(dest, lty.args[0], f);
         }
         &Ref(_rg, _ty, mutbl) => {
             let s = f(lty.label);
             if mutbl == Mutability::Not {
-                dest.push_str("&");
-                if s.len() > 0 {
+                dest.push('&');
+                if !s.is_empty() {
                     dest.push(' ');
                 }
             } else {
                 dest.push_str("&mut ");
             }
-            if s.len() > 0 {
+            if !s.is_empty() {
                 dest.push_str(&s);
-                dest.push_str(" ");
+                dest.push(' ');
             }
             print_ty_with_pointer_labels_into(dest, lty.args[0], f);
         }
         FnDef(def_id, _substs) => {
             write!(dest, "{:?}", def_id).unwrap();
-            if lty.args.len() != 0 {
+            if !lty.args.is_empty() {
                 dest.push('<');
                 // TODO: region args
                 for (i, &arg_lty) in lty.args.iter().enumerate() {
@@ -1581,14 +1581,14 @@ pub fn print_ty_with_pointer_labels_into<L: Copy>(
             print_ty_with_pointer_labels_into(dest, ret_lty, f);
         }
         Tuple(_) => {
-            dest.push_str("(");
+            dest.push('(');
             for (i, &arg_lty) in lty.args.iter().enumerate() {
                 if i > 0 {
                     dest.push_str(", ");
                 }
                 print_ty_with_pointer_labels_into(dest, arg_lty, f);
             }
-            dest.push_str(")");
+            dest.push(')');
         }
 
         // Types that aren't actually supported by this code yet

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -603,7 +603,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 self.visit_operand(&args[0]);
             }
             Callee::Null { .. } => {
-                assert!(args.len() == 0);
+                assert!(args.is_empty());
                 self.visit_place(destination, Mutability::Mut);
                 let pl_lty = self.acx.type_of(destination);
                 // We are assigning a null pointer to `destination`, so it must not have the

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -438,7 +438,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
             cmd.env("C2RUST_ANALYZE_FIXED_DEFS_LIST", fixed_defs_list);
         }
 
-        if rewrite_paths.len() > 0 {
+        if !rewrite_paths.is_empty() {
             let rewrite_paths = rewrite_paths.join(OsStr::new(","));
             cmd.env("C2RUST_ANALYZE_REWRITE_PATHS", rewrite_paths);
         }

--- a/c2rust-analyze/src/pointee_type/solve.rs
+++ b/c2rust-analyze/src/pointee_type/solve.rs
@@ -56,7 +56,7 @@ pub fn propagate_types<'tcx>(
             if new && !ty_sets[ptr1].is_subset(&ty_sets[ptr2]) {
                 let (tys1, tys2) = index_both(&mut ty_sets, ptr1, ptr2);
                 for cty in tys1.iter() {
-                    tys2.insert(cty.clone());
+                    tys2.insert(*cty);
                 }
                 // Since `ty_sets[ptr2]` was not a subset of `ty_sets[ptr1]`, we must have added at
                 // least one element to `ty_sets[ptr2]`.
@@ -75,7 +75,7 @@ pub fn propagate_types<'tcx>(
             if !ty_sets[ptr1].is_subset(&ty_sets[ptr2]) {
                 let (tys1, tys2) = index_both(&mut ty_sets, ptr1, ptr2);
                 for cty in tys1.iter() {
-                    tys2.insert(cty.clone());
+                    tys2.insert(*cty);
                 }
                 // Since `ty_sets[ptr2]` was not a subset of `ty_sets[ptr1]`, we must have added at
                 // least one element to `ty_sets[ptr2]`.

--- a/c2rust-analyze/src/pointee_type/type_check.rs
+++ b/c2rust-analyze/src/pointee_type/type_check.rs
@@ -76,7 +76,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 }
                 _ => {}
             }
-            lty = self.acx.projection_lty(lty, &proj);
+            lty = self.acx.projection_lty(lty, proj);
         }
         debug_assert_eq!(lty, self.acx.type_of(pl));
         lty

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -332,11 +332,11 @@ impl<'a, T> PointerTable<'a, T> {
     }
 
     pub fn global(&self) -> &'a GlobalPointerTable<T> {
-        &self.global
+        self.global
     }
 
     pub fn local(&self) -> &'a LocalPointerTable<T> {
-        &self.local
+        self.local
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (PointerId, &T)> {
@@ -386,19 +386,19 @@ impl<'a, T> PointerTableMut<'a, T> {
     }
 
     pub fn global(&self) -> &GlobalPointerTable<T> {
-        &self.global
+        self.global
     }
 
     pub fn global_mut(&mut self) -> &mut GlobalPointerTable<T> {
-        &mut self.global
+        self.global
     }
 
     pub fn local(&self) -> &LocalPointerTable<T> {
-        &self.local
+        self.local
     }
 
     pub fn local_mut(&mut self) -> &mut LocalPointerTable<T> {
-        &mut self.local
+        self.local
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (PointerId, &T)> {

--- a/c2rust-analyze/src/rewrite/expr/hir_only_casts.rs
+++ b/c2rust-analyze/src/rewrite/expr/hir_only_casts.rs
@@ -111,15 +111,15 @@ where
         if let hir::ExprKind::Cast(src_expr, _dest_ty) = ex.kind {
             let src_adjusts = self.typeck_results.expr_adjustments(src_expr);
             if let Some(last_adjust) = src_adjusts.last() {
-                if matches!(last_adjust.kind, Adjust::Pointer(_)) {
-                    if last_adjust.target == self.typeck_results.expr_ty(ex) {
-                        // `ex` has the form `x as T`, where `x` has a pointer adjustment and its
-                        // final adjusted type is identical to `T`.  In this case, rustc skips
-                        // generating MIR for this cast.
-                        if (self.filter)(src_expr) {
-                            self.rewrites
-                                .push((ex.span, Rewrite::Sub(0, src_expr.span)));
-                        }
+                if matches!(last_adjust.kind, Adjust::Pointer(_))
+                    && last_adjust.target == self.typeck_results.expr_ty(ex)
+                {
+                    // `ex` has the form `x as T`, where `x` has a pointer adjustment and its
+                    // final adjusted type is identical to `T`.  In this case, rustc skips
+                    // generating MIR for this cast.
+                    if (self.filter)(src_expr) {
+                        self.rewrites
+                            .push((ex.span, Rewrite::Sub(0, src_expr.span)));
                     }
                 }
             }

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -453,11 +453,11 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                                 dest_single,
                             });
 
-                            if !pl_ty.label.is_none() {
-                                if v.perms[pl_ty.label].intersects(PermissionSet::USED) {
-                                    let dest_lty = v.acx.type_of(&args[0]);
-                                    v.emit_cast_lty_lty(dest_lty, pl_ty);
-                                }
+                            if !pl_ty.label.is_none()
+                                && v.perms[pl_ty.label].intersects(PermissionSet::USED)
+                            {
+                                let dest_lty = v.acx.type_of(&args[0]);
+                                v.emit_cast_lty_lty(dest_lty, pl_ty);
                             }
                         });
                     }
@@ -499,11 +499,11 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                                 dest_single,
                             });
 
-                            if !pl_ty.label.is_none() {
-                                if v.perms[pl_ty.label].intersects(PermissionSet::USED) {
-                                    let dest_lty = v.acx.type_of(&args[0]);
-                                    v.emit_cast_lty_lty(dest_lty, pl_ty);
-                                }
+                            if !pl_ty.label.is_none()
+                                && v.perms[pl_ty.label].intersects(PermissionSet::USED)
+                            {
+                                let dest_lty = v.acx.type_of(&args[0]);
+                                v.emit_cast_lty_lty(dest_lty, pl_ty);
                             }
                         });
                     }
@@ -731,7 +731,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             None => return,
         };
 
-        debug_assert!(pl.projection.len() >= 1);
+        debug_assert!(!pl.projection.is_empty());
         // `LTy` of the base place, before the last projection.
         let base_lty = proj_ltys[pl.projection.len() - 1];
         // `LTy` resulting from applying `last_proj` to `base_lty`.
@@ -1136,18 +1136,18 @@ where
         Ok(match from.own {
             Ownership::Box => match to.own {
                 Ownership::Raw | Ownership::Imm => {
-                    return Err(format!("TODO: cast Box to Imm"));
+                    return Err("TODO: cast Box to Imm".to_string());
                     //Some(Ownership::Imm)
                 }
                 Ownership::RawMut | Ownership::Mut => {
-                    return Err(format!("TODO: cast Box to Mut"));
+                    return Err("TODO: cast Box to Mut".to_string());
                     //Some(Ownership::Mut)
                 }
                 _ => None,
             },
             Ownership::Rc => match to.own {
                 Ownership::Imm | Ownership::Raw | Ownership::RawMut => {
-                    return Err(format!("TODO: cast Rc to Imm"));
+                    return Err("TODO: cast Rc to Imm".to_string());
                     //Some(Ownership::Imm)
                 }
                 _ => None,

--- a/c2rust-analyze/src/rewrite/expr/mod.rs
+++ b/c2rust-analyze/src/rewrite/expr/mod.rs
@@ -76,7 +76,7 @@ fn debug_print_unlower_map<'tcx>(
             let sublocs = &k.sub;
             let ex = tcx.hir().expect_expr(v.hir_id);
             eprintln!("      {sublocs:?}: {:?}, {:?}", v.desc, ex.span);
-            for rw_kind in rewrites_by_subloc.remove(&sublocs).unwrap_or(Vec::new()) {
+            for rw_kind in rewrites_by_subloc.remove(&sublocs).unwrap_or_default() {
                 eprintln!("        {rw_kind:?}");
             }
         }

--- a/c2rust-analyze/src/rewrite/expr/unlower.rs
+++ b/c2rust-analyze/src/rewrite/expr/unlower.rs
@@ -295,7 +295,7 @@ impl<'a, 'tcx> UnlowerVisitor<'a, 'tcx> {
                     self.visit_expr_operand(arg, loc, sub_loc, mir_arg, &[]);
                 }
 
-                if extra_locs.len() > 0 {
+                if !extra_locs.is_empty() {
                     // Special case: if the receiver of a `MethodCall` has adjustments, they are
                     // emitted with the same span as the `MethodCall` itself, and thus show up as
                     // leftover `extra_locs` here.  We associate them with the child instead so all
@@ -528,7 +528,7 @@ impl<'a, 'tcx> UnlowerVisitor<'a, 'tcx> {
             ExprMir::Place(pl.as_ref()),
             extra_locs,
             loc,
-            sub_loc.to_owned(),
+            sub_loc,
         );
         self.walk_expr(ex, &mut cursor);
 
@@ -898,7 +898,7 @@ fn is_var(pl: mir::Place) -> bool {
 }
 
 fn is_temp_var(mir: &Body, pl: mir::PlaceRef) -> bool {
-    pl.projection.len() == 0 && mir.local_kind(pl.local) == mir::LocalKind::Temp
+    pl.projection.is_empty() && mir.local_kind(pl.local) == mir::LocalKind::Temp
 }
 
 fn is_temp_var_operand(mir: &Body, op: &mir::Operand) -> bool {
@@ -941,10 +941,8 @@ fn filter_stmt(stmt: &mir::Statement) -> bool {
 }
 
 /// Indicate whether a given MIR terminator should be considered when building the unlowering map.
-fn filter_term(term: &mir::Terminator) -> bool {
-    match term.kind {
-        _ => true,
-    }
+fn filter_term(_term: &mir::Terminator) -> bool {
+    true
 }
 
 fn build_span_index(mir: &Body<'_>) -> SpanIndex<Location> {
@@ -1063,7 +1061,7 @@ pub fn unlower<'tcx>(
     };
     visitor.visit_body(hir);
 
-    if visitor.append_extra_locations.len() > 0 {
+    if !visitor.append_extra_locations.is_empty() {
         for (&hir_id, locs) in &visitor.append_extra_locations {
             error!(
                 "leftover locations for {hir_id:?} = {:?}: locs = {locs:?}",

--- a/c2rust-analyze/src/rewrite/mod.rs
+++ b/c2rust-analyze/src/rewrite/mod.rs
@@ -367,13 +367,13 @@ pub fn apply_rewrites(
 
     let new_src = apply::apply_rewrites(tcx.sess.source_map(), rewrites);
     for (filename, file_rw) in new_src {
-        let annotations = annotations.remove(&filename).unwrap_or(Vec::new());
+        let annotations = annotations.remove(&filename).unwrap_or_default();
         let new_src = add_annotations(file_rw.new_src, Some(&file_rw.line_map), annotations);
         emit(filename, new_src);
     }
 
     // Also emit files that have annotations but no rewrites.
-    if annotations.len() > 0 {
+    if !annotations.is_empty() {
         let mut leftover_annotations = annotations.into_iter().collect::<Vec<_>>();
         leftover_annotations.sort();
         let sm = tcx.sess.source_map();

--- a/c2rust-ast-exporter/Cargo.toml
+++ b/c2rust-ast-exporter/Cargo.toml
@@ -23,7 +23,7 @@ bindgen = { version = "0.65", features = ["logging"] }
 clang-sys = "1.3"
 cmake = "0.1.49"
 env_logger = "0.10"
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.18.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
 
 [features]
 default = []

--- a/c2rust-bitfields/Cargo.toml
+++ b/c2rust-bitfields/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-c2rust-bitfields-derive = { version = "0.18.0", path = "../c2rust-bitfields-derive" }
+c2rust-bitfields-derive = { version = "0.19.0", path = "../c2rust-bitfields-derive" }
 
 [dev-dependencies]
 libc = "0.2"

--- a/c2rust-macros/Cargo.toml
+++ b/c2rust-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2rust-macros"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Stephen Crane <sjc@immunant.com>", "The C2Rust Project Developers <c2rust@immunant.com>"]
 edition = "2021"
 description = "Procedural macro support crate for C2Rust"

--- a/c2rust-refactor/Cargo.toml
+++ b/c2rust-refactor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2rust-refactor"
-version = "0.18.0"
+version = "0.19.0"
 authors = [
   "The C2Rust Project Developers <c2rust@immunant.com>",
   "Stuart Pernsteiner <spernsteiner@galois.com>",
@@ -17,18 +17,18 @@ json = "0.12"
 libc = "0.2"
 regex = "1.1"
 ena = "0.13"
-c2rust-ast-builder = { version = "0.18.0", path = "../c2rust-ast-builder" }
-c2rust-ast-printer = { version = "0.18.0", path = "../c2rust-ast-printer" }
+c2rust-ast-builder = { version = "0.19.0", path = "../c2rust-ast-builder" }
+c2rust-ast-printer = { version = "0.19.0", path = "../c2rust-ast-printer" }
 indexmap = { version = "1.0.1", features = ["serde-1"] }
 cargo = "0.44"
 clap = {version = "2.33", features = ["yaml"]}
-c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.18.0" }
+c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.19.0" }
 env_logger = "0.10"
 log = "0.4"
 rlua = "0.17"
 slotmap = {version = "0.4", features = ["unstable"]}
 derive_more = "0.99"
-c2rust-macros = { version = "0.18.0", path = "../c2rust-macros" }
+c2rust-macros = { version = "0.19.0", path = "../c2rust-macros" }
 flame = { version = "0.2.2", optional = true }
 flamer = { version = "0.4", optional = true }
 failure = "0.1"

--- a/c2rust-refactor/runtime/Cargo.toml
+++ b/c2rust-refactor/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2rust_runtime"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Stuart Pernsteiner <spernsteiner@galois.com>"]
 edition = "2021"
 

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -12,10 +12,10 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-c2rust-ast-builder = { version = "0.18.0", path = "../c2rust-ast-builder" }
-c2rust-ast-exporter = { version = "0.18.0", path = "../c2rust-ast-exporter" }
-c2rust-ast-printer = { version = "0.18.0", path = "../c2rust-ast-printer" }
-c2rust-bitfields = { version = "0.18.0", path = "../c2rust-bitfields" }
+c2rust-ast-builder = { version = "0.19.0", path = "../c2rust-ast-builder" }
+c2rust-ast-exporter = { version = "0.19.0", path = "../c2rust-ast-exporter" }
+c2rust-ast-printer = { version = "0.19.0", path = "../c2rust-ast-printer" }
+c2rust-bitfields = { version = "0.19.0", path = "../c2rust-bitfields" }
 colored = "2.0"
 dtoa = "1.0"
 failure = "0.1.5"

--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -214,8 +214,8 @@ fn immediate_stmt_children(kind: &CStmtKind) -> Vec<SomeId> {
             false_variant: opt_s,
         } => {
             let mut res = intos![e, s];
-            for &x in &opt_s {
-                res.push(x.into())
+            if let Some(x) = opt_s {
+                res.push(x.into());
             }
             res
         }
@@ -239,14 +239,14 @@ fn immediate_stmt_children(kind: &CStmtKind) -> Vec<SomeId> {
             body: d,
         } => {
             let mut res = vec![];
-            for &x in &a {
-                res.push(x.into())
+            if let Some(x) = a {
+                res.push(x.into());
             }
-            for &x in &b {
-                res.push(x.into())
+            if let Some(x) = b {
+                res.push(x.into());
             }
-            for &x in &c {
-                res.push(x.into())
+            if let Some(x) = c {
+                res.push(x.into());
             }
             res.push(d.into());
             res

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -263,7 +263,7 @@ pub fn transpile(tcfg: TranspilerConfig, cc_db: &Path, extra_clang_args: &[&str]
 
     let build_dir = get_build_dir(&tcfg, cc_db);
 
-    let lcmds = get_compile_commands(&cc_db, &tcfg.filter).unwrap_or_else(|_| {
+    let lcmds = get_compile_commands(cc_db, &tcfg.filter).unwrap_or_else(|_| {
         panic!(
             "Could not parse compile commands from {}",
             cc_db.to_string_lossy()
@@ -330,7 +330,7 @@ pub fn transpile(tcfg: TranspilerConfig, cc_db: &Path, extra_clang_args: &[&str]
                     cmd.abs_file(),
                     &ancestor_path,
                     &build_dir,
-                    &cc_db,
+                    cc_db,
                     &clang_args,
                 )
             })

--- a/c2rust-transpile/src/rust_ast/mod.rs
+++ b/c2rust-transpile/src/rust_ast/mod.rs
@@ -127,7 +127,7 @@ struct SpanRepr {
 /// But hopefully if such circumstances do befall us, we'll at least know what went wrong.
 ///
 /// On the plus side, the `fallback::Span` payload is a POD pair of two u32s, so that case is trivial.
-#[cfg_attr(tests, test)]
+#[cfg_attr(test, test)]
 fn validate_repr() {
     let repr: SpanRepr = unsafe { std::mem::transmute(Span::call_site()) };
     assert!(repr.compiler_or_fallback == 1);

--- a/c2rust/Cargo.toml
+++ b/c2rust/Cargo.toml
@@ -24,10 +24,10 @@ is_executable = "1.0"
 log = "0.4"
 regex = "1.3"
 shlex = "1.3"
-c2rust-transpile = { version = "0.18.0", path = "../c2rust-transpile" }
+c2rust-transpile = { version = "0.19.0", path = "../c2rust-transpile" }
 
 [build-dependencies]
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.18.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
 
 [features]
 # Force static linking of LLVM

--- a/dynamic_instrumentation/Cargo.toml
+++ b/dynamic_instrumentation/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 anyhow = "1.0"
 bincode = "1.0.1"
-c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.18.0" }
+c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.19.0" }
 indexmap = "1.9"
 itertools = "0.10"
 once_cell = "1.13"
@@ -29,7 +29,7 @@ env_logger = "0.10"
 tempfile = "3.3"
 
 [build-dependencies]
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.18.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
 
 [package.metadata.rust-analyzer] 
 rustc_private = true

--- a/examples/robotfindskitten/repo/rust/Cargo.toml
+++ b/examples/robotfindskitten/repo/rust/Cargo.toml
@@ -9,7 +9,7 @@ name = "robotfindskitten"
 path = "src/robotfindskitten.rs"
 
 [dependencies]
-c2rust_runtime = { path = "../../../../c2rust-refactor/runtime", version = "0.18.0" }
+c2rust_runtime = { path = "../../../../c2rust-refactor/runtime", version = "0.19.0" }
 rand = "0.5.5"
 pancurses = "0.16.0"
 libc = "0.2"

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 
 [dependencies]
 bincode = "1.0"
-c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.18.0" }
+c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.19.0" }
 indexed_vec = "1.2"
 indexmap = "1.8"
 serde = { version = "1.0", features = ["derive"] }
@@ -26,7 +26,7 @@ linked_hash_set = "0.1"
 clap = { version = "3.2", features = ["derive"] }
 
 [build-dependencies]
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.18.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
 
 [dev-dependencies]
 insta = "1.15"

--- a/tests/asm.aarch64/Cargo.toml
+++ b/tests/asm.aarch64/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-asm-casts = { path = "../../c2rust-asm-casts", version = "0.18.0" }
+c2rust-asm-casts = { path = "../../c2rust-asm-casts", version = "0.19.0" }

--- a/tests/asm.x86_64/Cargo.toml
+++ b/tests/asm.x86_64/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-asm-casts = { path = "../../c2rust-asm-casts", version = "0.18.0" }
+c2rust-asm-casts = { path = "../../c2rust-asm-casts", version = "0.19.0" }

--- a/tests/structs/Cargo.toml
+++ b/tests/structs/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-c2rust-bitfields = { path = "../../c2rust-bitfields", version = "0.18.0" }
+c2rust-bitfields = { path = "../../c2rust-bitfields", version = "0.19.0" }
 memoffset = "0.2"
 libc = "0.2"


### PR DESCRIPTION
This
* updates our version to `0.19.0`
* fixes `clippy` warnings
* fixes warnings on `stable` (`1.80.1`), including setting `resolver = "2"`
* sets `rust-version = "1.65"`, our pinned nightly

However, I'm unable to run `cargo update` since the resolver is still MSRV-unaware IIUC.  `cargo outdated` also fails:

```shell
> cargo outdated -R
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `/home/kkysen/.rustup/toolchains/nightly-2022-08-08-x86_64-unknown-linux-gnu/bin/rustc - --crate-name ___ --print=file-names -C link-arg=-fuse-ld=/home/kkysen/work/c++/mold/current/bin/mold --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg` (exit status: 1)
  --- stderr
  error: unknown print request `split-debuginfo`
```

Otherwise, this should be everything according to https://github.com/immunant/c2rust/wiki/Release-Process that needs to be checked in.