### PR TITLE
Update CI workflow to use upload-artifacts@v4 action

### DIFF
--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -122,7 +122,7 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
       if: always() # Pick up events even if the job fails or is canceled.
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: testsuite-build-artifacts
         path: |


### PR DESCRIPTION
The old version is deprecated and now raises an error