### PR TITLE
transpile: Make cast from `bool` to pointer compile through `size_t`

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4282,6 +4282,13 @@ impl<'c> Translation<'c> {
                             target_ty,
                         )))
                     })
+                } else if target_ty_ctype.is_pointer() && source_ty_kind.is_bool() {
+                    val.and_then(|x| {
+                        Ok(WithStmts::new_val(mk().cast_expr(
+                            mk().cast_expr(x, mk().path_ty(vec!["libc", "size_t"])),
+                            target_ty,
+                        )))
+                    })
                 } else {
                     // Other numeric casts translate to Rust `as` casts,
                     // unless the cast is to a function pointer then use `transmute`.

--- a/tests/casts/src/casts.c
+++ b/tests/casts/src/casts.c
@@ -30,4 +30,5 @@ void cast_stuff(void) {
 
         bool b = true;
         float x15 = b;
+        void* x16 = (void*)b;
 }


### PR DESCRIPTION
* Similar to #1030.

* Fixes #1077.