### PR TITLE
`rust-analyzer`: add `rust-analyzer` component to `rust-toolchain.toml` so that it is in sync with our pinned nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2022-08-08"
-components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri"]
+components = ["rustfmt-preview", "rustc-dev", "rust-src", "miri", "rust-analyzer"]


### PR DESCRIPTION
The latest `rust-analyzer` only supports `stable` and now breaks, so this pins it to the version on our `nightly`, which won't break on that version.