### PR TITLE
analyze: misc fixes for simple_buffer

### DIFF
--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -326,6 +326,26 @@ fn run_polonius<'tcx>(
         local_ltys.push(lty);
     }
 
+    // Assign origins to `rvalue_tys`.  We sort the keys first to ensure that we assign origins in
+    // a deterministic order.
+    let mut keys = acx.rvalue_tys.keys().collect::<Vec<_>>();
+    keys.sort();
+    let rvalue_ltys = keys
+        .into_iter()
+        .map(|&loc| {
+            let lty = acx.rvalue_tys[&loc];
+            let new_lty = assign_origins(
+                ltcx,
+                hypothesis,
+                &mut facts,
+                &mut maps,
+                &acx.gacx.adt_metadata,
+                lty,
+            );
+            (loc, new_lty)
+        })
+        .collect::<HashMap<_, _>>();
+
     // Gather field permissions
     let field_permissions = field_ltys
         .iter()
@@ -348,6 +368,7 @@ fn run_polonius<'tcx>(
         &mut maps,
         &mut loans,
         &local_ltys,
+        &rvalue_ltys,
         &field_permissions,
         hypothesis,
         mir,

--- a/c2rust-analyze/src/rewrite/apply.rs
+++ b/c2rust-analyze/src/rewrite/apply.rs
@@ -361,7 +361,7 @@ impl<S: Sink> Emitter<'_, S> {
                 })
             }
             Rewrite::MethodCall(ref method, ref receiver_rw, ref arg_rws) => {
-                self.emit(receiver_rw, 0)?;
+                self.emit(receiver_rw, 3)?;
                 self.emit_str(".")?;
                 self.emit_str(method)?;
                 self.emit_parenthesized(true, |slf| {

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -758,6 +758,11 @@ pub fn convert_cast_rewrite(kind: &mir_op::RewriteKind, hir_rw: Rewrite) -> Rewr
             Rewrite::Ref(Box::new(place), mutbl_from_bool(mutbl))
         }
 
+        mir_op::RewriteKind::Deref => {
+            // `p` -> `*p`
+            Rewrite::Deref(Box::new(hir_rw))
+        }
+
         mir_op::RewriteKind::OptionUnwrap => {
             // `p` -> `p.unwrap()`
             Rewrite::MethodCall("unwrap".to_string(), Box::new(hir_rw), vec![])

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -807,7 +807,10 @@ pub fn convert_cast_rewrite(kind: &mir_op::RewriteKind, hir_rw: Rewrite) -> Rewr
             // `p` -> `mem::replace(&mut p, Err(()))`
             Rewrite::Call(
                 "std::mem::replace".to_string(),
-                vec![hir_rw, Rewrite::Text("Err(())".into())],
+                vec![
+                    Rewrite::Ref(Box::new(hir_rw), hir::Mutability::Mut),
+                    Rewrite::Text("Err(())".into()),
+                ],
             )
         }
         mir_op::RewriteKind::DynOwnedWrap => {

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -802,10 +802,7 @@ pub fn convert_cast_rewrite(kind: &mir_op::RewriteKind, hir_rw: Rewrite) -> Rewr
             // `p` -> `mem::replace(&mut p, Err(()))`
             Rewrite::Call(
                 "std::mem::replace".to_string(),
-                vec![
-                    Rewrite::Ref(Box::new(hir_rw), hir::Mutability::Mut),
-                    Rewrite::Text("Err(())".into()),
-                ],
+                vec![hir_rw, Rewrite::Text("Err(())".into())],
             )
         }
         mir_op::RewriteKind::DynOwnedWrap => {

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -698,6 +698,7 @@ fn generate_zeroize_code(zero_ty: &ZeroizeType, lv: &str) -> String {
     match *zero_ty {
         ZeroizeType::Int => format!("{lv} = 0"),
         ZeroizeType::Bool => format!("{lv} = false"),
+        ZeroizeType::Option => format!("{lv} = None"),
         ZeroizeType::Array(ref elem_zero_ty) => format!(
             "
             {{
@@ -731,6 +732,7 @@ fn generate_zeroize_expr(zero_ty: &ZeroizeType) -> String {
     match *zero_ty {
         ZeroizeType::Int => format!("0"),
         ZeroizeType::Bool => format!("false"),
+        ZeroizeType::Option => format!("None"),
         ZeroizeType::Array(ref elem_zero_ty) => format!(
             "std::array::from_fn(|| {})",
             generate_zeroize_expr(elem_zero_ty)

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -448,7 +448,9 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                         // `visit_place` directly with the desired access.
                         v.enter_rvalue_operand(0, |v| {
                             v.enter_operand_place(|v| {
+                                eprintln!("BEGIN visit_place for ownership transfer");
                                 v.visit_place(rv_pl, PlaceAccess::Mut);
+                                eprintln!("END visit_place for ownership transfer");
                             });
                         });
                         // Obtain a reference to the place containing the `DynOwned` pointer.
@@ -458,8 +460,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                                 deref: false,
                             });
                             v.emit(RewriteKind::OptionMapBegin);
-                        } else {
-                            v.emit(RewriteKind::Ref { mutbl: true });
+                            v.emit(RewriteKind::Deref);
                         }
                         // Take the pointer out of that place.
                         v.emit(RewriteKind::DynOwnedTake);

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -66,6 +66,9 @@ pub enum RewriteKind {
     /// Replace &raw with & or &raw mut with &mut
     RawToRef { mutbl: bool },
 
+    /// Replace `ptr` with `*ptr`.
+    Deref,
+
     /// Replace `ptr.is_null()` with `ptr.is_none()`.
     IsNullToIsNone,
     /// Replace `ptr.is_null()` with the constant `false`.  We use this in cases where the rewritten

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -449,9 +449,20 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                             });
                         });
                         // Obtain a reference to the place containing the `DynOwned` pointer.
-                        v.emit(RewriteKind::Ref { mutbl: true });
+                        if v.is_nullable(rv_lty.label) {
+                            v.emit(RewriteKind::OptionDowngrade {
+                                mutbl: true,
+                                deref: false,
+                            });
+                            v.emit(RewriteKind::OptionMapBegin);
+                        } else {
+                            v.emit(RewriteKind::Ref { mutbl: true });
+                        }
                         // Take the pointer out of that place.
                         v.emit(RewriteKind::DynOwnedTake);
+                        if v.is_nullable(rv_lty.label) {
+                            v.emit(RewriteKind::OptionMapEnd);
+                        }
                         v.emit_cast_lty_lty(rv_lty, pl_lty);
                         return;
                     }

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -671,7 +671,10 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                             let pointee_lty = match dest_pointee {
                                 Some(x) => x,
                                 // TODO: emit void* cast before bailing out
-                                None => return,
+                                None => {
+                                    trace!("{callee:?}: no pointee type for dest");
+                                    return;
+                                }
                             };
 
                             let orig_pointee_ty = pointee_lty.ty;
@@ -687,7 +690,13 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                             let zero_ty = match ZeroizeType::from_ty(tcx, orig_pointee_ty) {
                                 Some(x) => x,
                                 // TODO: emit void* cast before bailing out
-                                None => return,
+                                None => {
+                                    trace!(
+                                        "{callee:?}: failed to compute ZeroizeType \
+                                        for {orig_pointee_ty:?}"
+                                    );
+                                    return;
+                                }
                             };
 
                             let rw = match *callee {
@@ -757,7 +766,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                         });
                     }
 
-                    Callee::Realloc => {
+                    ref callee @ Callee::Realloc => {
                         self.enter_rvalue(|v| {
                             let src_lty = v.acx.type_of(&args[0]);
                             let src_pointee = v.pointee_lty(src_lty);
@@ -767,7 +776,13 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                             let pointee_lty = match common_pointee {
                                 Some(x) => x,
                                 // TODO: emit void* cast before bailing out
-                                None => return,
+                                None => {
+                                    trace!(
+                                        "{callee:?}: no common pointee type \
+                                        between {src_pointee:?} and {dest_pointee:?}"
+                                    );
+                                    return;
+                                }
                             };
 
                             let orig_pointee_ty = pointee_lty.ty;
@@ -785,7 +800,13 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                             let zero_ty = match ZeroizeType::from_ty(tcx, orig_pointee_ty) {
                                 Some(x) => x,
                                 // TODO: emit void* cast before bailing out
-                                None => return,
+                                None => {
+                                    trace!(
+                                        "{callee:?}: failed to compute ZeroizeType \
+                                        for {orig_pointee_ty:?}"
+                                    );
+                                    return;
+                                }
                             };
 
                             // Cast input to either `Box<T>` or `Box<[T]>`, as in `free`.

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -135,7 +135,7 @@ pub enum RewriteKind {
 
     /// Extract the `T` from `DynOwned<T>`.
     DynOwnedUnwrap,
-    /// Move out of a `DynOwned<T>` and set the original location to empty / non-owned.
+    /// Move out of `&mut DynOwned<T>` and set the original location to empty / non-owned.
     DynOwnedTake,
     /// Wrap `T` in `Ok` to produce `DynOwned<T>`.
     DynOwnedWrap,
@@ -448,6 +448,9 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                                 v.visit_place(rv_pl, PlaceAccess::Mut);
                             });
                         });
+                        // Obtain a reference to the place containing the `DynOwned` pointer.
+                        v.emit(RewriteKind::Ref { mutbl: true });
+                        // Take the pointer out of that place.
                         v.emit(RewriteKind::DynOwnedTake);
                         v.emit_cast_lty_lty(rv_lty, pl_lty);
                         return;

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -1043,6 +1043,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
             PlaceElem::Deref => {
                 self.enter_place_deref_pointer(|v| {
                     v.visit_place_ref(base_pl, proj_ltys, access);
+                    let dyn_owned = v.is_dyn_owned(base_lty);
                     if v.is_nullable(base_lty.label) {
                         // If the pointer type is non-copy, downgrade (borrow) before calling
                         // `unwrap()`.
@@ -1054,12 +1055,15 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                         if !desc.own.is_copy() {
                             v.emit(RewriteKind::OptionDowngrade {
                                 mutbl: access == PlaceAccess::Mut,
-                                deref: true,
+                                deref: !dyn_owned,
                             });
                         }
                         v.emit(RewriteKind::OptionUnwrap);
+                        if dyn_owned {
+                            v.emit(RewriteKind::Deref);
+                        }
                     }
-                    if v.is_dyn_owned(base_lty) {
+                    if dyn_owned {
                         v.emit(RewriteKind::DynOwnedDowngrade {
                             mutbl: access == PlaceAccess::Mut,
                         });
@@ -1303,6 +1307,12 @@ where
             return Ok(());
         }
 
+        // To downgrade and unwrap a non-`dyn_owned` pointer, we call `p.as_deref().unwrap()`,
+        // which goes from `Option<Box<T>>` to `&T`.  To downgrade a `dyn_owned` pointer, we
+        // instead do `*p.as_ref().unwrap()`, which goes from `Option<DynOwned<T>>` to
+        // `DynOwned<T>`, with the latter being a read-only `Place` that can be further downgraded
+        // to eventually reach `&T`.
+        let mut deref_after_unwrap = false;
         if from.option && from.own != to.own {
             // Downgrade ownership before unwrapping the `Option` when possible.  This can avoid
             // moving/consuming the input.  For example, if the `from` type is `Option<Box<T>>` and
@@ -1315,15 +1325,17 @@ where
                     Ownership::Raw | Ownership::Imm => {
                         (self.emit)(RewriteKind::OptionDowngrade {
                             mutbl: false,
-                            deref: true,
+                            deref: !from.dyn_owned,
                         });
+                        deref_after_unwrap = from.dyn_owned;
                         from.own = Ownership::Imm;
                     }
                     Ownership::RawMut | Ownership::Cell | Ownership::Mut => {
                         (self.emit)(RewriteKind::OptionDowngrade {
                             mutbl: true,
-                            deref: true,
+                            deref: !from.dyn_owned,
                         });
+                        deref_after_unwrap = from.dyn_owned;
                         from.own = Ownership::Mut;
                     }
                     Ownership::Rc if from.own == Ownership::Rc => {
@@ -1346,6 +1358,9 @@ where
         if from.option && !to.option {
             // Unwrap first, then perform remaining casts.
             (self.emit)(RewriteKind::OptionUnwrap);
+            if deref_after_unwrap {
+                (self.emit)(RewriteKind::Deref);
+            }
             from.option = false;
         } else if from.option && to.option {
             trace!("try_build_cast_desc_desc: emit OptionMapBegin");
@@ -1363,6 +1378,9 @@ where
                 );
             }
             (self.emit)(RewriteKind::OptionMapBegin);
+            if deref_after_unwrap {
+                (self.emit)(RewriteKind::Deref);
+            }
             from.option = false;
             in_option_map = true;
         }

--- a/c2rust-analyze/tests/filecheck.rs
+++ b/c2rust-analyze/tests/filecheck.rs
@@ -63,6 +63,7 @@ define_tests! {
     pointee,
     ptrptr1,
     regions_fixed,
+    rewrite_nullable_box,
     rewrite_paths,
     rewrite_paths_manual_shim,
     statics,

--- a/c2rust-analyze/tests/filecheck/rewrite_nullable_box.rs
+++ b/c2rust-analyze/tests/filecheck/rewrite_nullable_box.rs
@@ -1,0 +1,35 @@
+//! Test cases for rewriting of nullable owned pointers.
+#![feature(rustc_private)]
+#![feature(register_tool)]
+#![register_tool(c2rust_analyze_test)]
+
+use std::mem;
+extern crate libc;
+
+extern "C" {
+    fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
+    fn free(__ptr: *mut libc::c_void);
+}
+
+#[c2rust_analyze_test::skip_borrowck]
+// CHECK-LABEL: fn test_is_null(
+pub unsafe fn test_is_null(cond: bool) {
+    // CHECK: let mut ptr: core::option::Option<core::result::Result<std::boxed::Box<(i32)>,()>> =
+    let mut ptr: *mut i32 = malloc(4) as *mut i32;
+    // This assignment exercises the option + dyn_owned case in `visit_place_ref`.
+    // CHECK: *(*(ptr).as_mut().unwrap()).as_deref_mut().unwrap() = 1;
+    *ptr = 1;
+    if cond {
+        ptr = 0 as *mut i32;
+    }
+    // This condition exercises the option + dyn_owned case in `try_build_cast_desc_desc`.
+    // CHECK: if !(ptr).as_ref().map(|__ptr| (*__ptr).as_deref().unwrap()).is_none() {
+    if !ptr.is_null() {
+        // CHECK: *(*(ptr).as_mut().unwrap()).as_deref_mut().unwrap() = 2;
+        *ptr = 2;
+    }
+    // This condition exercises the option + dyn_owned case in the `assignment_transfers_ownership`
+    // case of `visit_statement`.
+    // CHECK: std::mem::drop(((ptr).as_mut().map(|__ptr| std::mem::replace(&mut *__ptr,Err(()))).map(|__ptr| __ptr.unwrap())));
+    free(ptr as *mut libc::c_void);
+}


### PR DESCRIPTION
This branch has fixes for various minor issues uncovered while testing on `simple_buffer.c` (#1103).

* Fix borrowck handling of casts to `*mut my_struct` when `my_struct` has lifetimes
* Fix various cases of compile errors introduced by `DynOwned` rewrites
* Fix precedence of method calls when generating rewritten source code
* Treat `realloc(NULL, n)` like `malloc(n)`
* Support nullable pointers in the `ZeroizeTy` initializers used for `malloc`/`memset` rewrites