### PR TITLE
analyze: static/dynamic comparison mode for NON_NULL

### DIFF
--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -932,13 +932,6 @@ fn run(tcx: TyCtxt) {
     }
 
     // Load permission info from PDG
-    let mut func_def_path_hash_to_ldid = HashMap::new();
-    for &ldid in &all_fn_ldids {
-        let def_path_hash: (u64, u64) = tcx.def_path_hash(ldid.to_def_id()).0.as_value();
-        eprintln!("def_path_hash {:?} = {:?}", def_path_hash, ldid);
-        func_def_path_hash_to_ldid.insert(def_path_hash, ldid);
-    }
-
     if let Some(pdg_file_path) = std::env::var_os("PDG_FILE") {
         let f = std::fs::File::open(pdg_file_path).unwrap();
         let graphs: Graphs = bincode::deserialize_from(f).unwrap();
@@ -961,6 +954,13 @@ fn run(tcx: TyCtxt) {
                     known_nulls.insert((n.function.id, dest));
                 }
             }
+        }
+
+        let mut func_def_path_hash_to_ldid = HashMap::new();
+        for &ldid in &all_fn_ldids {
+            let def_path_hash: (u64, u64) = tcx.def_path_hash(ldid.to_def_id()).0.as_value();
+            eprintln!("def_path_hash {:?} = {:?}", def_path_hash, ldid);
+            func_def_path_hash_to_ldid.insert(def_path_hash, ldid);
         }
 
         let allow_unsound =

--- a/scripts/pdg.sh
+++ b/scripts/pdg.sh
@@ -2,17 +2,15 @@
 
 set -euox pipefail
 
-CWD="${PWD}"
-SCRIPT_PATH="${0}"
-SCRIPT_DIR="${CWD}/$(dirname "${SCRIPT_PATH}")"
+SCRIPT_PATH="$(realpath ${0})"
+SCRIPT_DIR="$(dirname "${SCRIPT_PATH}")"
+C2RUST_DIR="$(dirname "${SCRIPT_DIR}")"
+
+source ${SCRIPT_DIR}/pdg_setup.sh
 
 # Usage: `./pdg.sh <test crate dir> <test binary args...>`
 # 
-# Environment Variables:
-# * `PROFILE` (default `release`):
-#       a `cargo` profile as in `target/$PROFILE`
-# * `NO_USE_PDG` (default empty):
-#       if non-empty, do not use the PDG as a starting point for analysis
+# Environment Variables: see `scripts/pdg_functions.sh` for a full list.
 # 
 # Instrument and run a test crate, create its PDG, and then run analysis on it.
 # 
@@ -27,80 +25,18 @@ SCRIPT_DIR="${CWD}/$(dirname "${SCRIPT_PATH}")"
 #    A machine-readable PDG is saved to `pdg.bc` in the same directory.
 # 5. Using the `pdg.bc` file as an initial state for analysis, run static
 #    analysis using `c2rust-analyze`.
+
 main() {
-    local test_dir="${1}"
-    local args=("${@:2}")
+    CARGO_INSTRUMENT_COMMAND=run
 
-    local profile_dir_name="${PROFILE:-release}"
-
-    local profile_dir="target/${profile_dir_name}"
-    local profile="${profile_dir_name}"
-    if [[ "${profile}" == "debug" ]]; then
-        profile=dev
-    fi
-    local profile_args=(--profile "${profile}")
-
-    local metadata="${test_dir}/metadata.bc"
-    local pdg="${test_dir}/pdg.bc"
-    local event_log="${test_dir}/log.bc"
-    local runtime="analysis/runtime"
-
+    # set the environment variables for instrumentation
+    c2rust-set-instrument-vars "${@}"
     # build and run a test with instrumentation
-    (
-        unset RUSTFLAGS # transpiled code has tons of warnings; don't allow `-D warnings`
-        export RUST_BACKTRACE=1
-        export INSTRUMENT_RUNTIME=bg
-        export INSTRUMENT_BACKEND=log
-        export INSTRUMENT_OUTPUT="${event_log}"
-        export INSTRUMENT_OUTPUT_APPEND=false
-        export METADATA_FILE="${metadata}"
-
-        cargo run \
-            --bin c2rust-instrument \
-            "${profile_args[@]}" \
-            -- \
-            --metadata "${metadata}" \
-            --set-runtime \
-            --runtime-path "${runtime}" \
-            -- run \
-            --manifest-path "${test_dir}/Cargo.toml" \
-            "${profile_args[@]}" \
-            -- "${args[@]}"
-    )
+    c2rust-instrument "${@}"
     # construct pdg from log events
-    (
-        export RUST_BACKTRACE=full # print sources w/ color-eyre
-        export RUST_LOG=error
-        cargo run \
-            --bin c2rust-pdg \
-            "${profile_args[@]}" \
-            -- \
-            --event-log "${event_log}" \
-            --metadata "${metadata}" \
-            --print graphs \
-            --print write-permissions \
-            --print counts \
-            --output "${pdg}" \
-        > "${test_dir}/pdg.log"
-    )
+    c2rust-pdg "${@}"
     # use pdg in analysis
-    (
-        export RUST_BACKTRACE=full # print sources w/ color-eyre
-        export RUST_LOG=error
-        if [[ "${NO_USE_PDG:-}" == "" ]]; then
-            # cargo runs this from a different pwd, so make path absolute
-            export PDG_FILE="$(realpath ${pdg})"
-        fi
-        cargo run \
-            --bin c2rust-analyze \
-            "${profile_args[@]}" \
-            -- \
-            build \
-            -- \
-            "${profile_args[@]}" \
-            --features=c2rust-analysis-rt \
-            --manifest-path "${test_dir}/Cargo.toml"
-    )
+    c2rust-analyze-with-pdg "${@}"
 }
 
 main "${@}"

--- a/scripts/pdg_setup.sh
+++ b/scripts/pdg_setup.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# This script can be source'd to provide a few useful
+# shell functions for analysis using the PDG.
+#
+# Environment Variables:
+# * `RUST_PROFILE` (default `release`):
+#       a `cargo` profile as in `target/$RUST_PROFILE`
+# * `NO_USE_PDG` (default empty):
+#       if non-empty, do not use the PDG as a starting point for analysis
+# * `CARGO_INSTRUMENT_COMMAND` (default `build`):
+#       the `cargo` command to run for instrumentation, e.g., `run` or `build`
+# * `INSTRUMENT_OUTPUT_APPEND` (default `false`):
+#       set to `true` to append instrumentation events to the log instead
+#       of replacing the existing log on every invocation of the instrumented
+#       binary
+
+# Variables that are computed when the script is sourced
+SCRIPT_PATH="$(realpath ${BASH_SOURCE[0]})"
+SCRIPT_DIR="$(dirname "${SCRIPT_PATH}")"
+
+# Variables that are exported to the functions below
+export C2RUST_DIR="$(dirname "${SCRIPT_DIR}")"
+
+_c2rust_prepare_vars() {
+    test_dir="$(realpath ${1})"
+    args=("${@:2}")
+
+    profile_dir_name="${RUST_PROFILE:-release}"
+
+    profile_dir="target/${profile_dir_name}"
+    profile="${profile_dir_name}"
+    if [[ "${profile}" == "debug" ]]; then
+        profile=dev
+    fi
+    profile_args=(--profile "${profile}")
+
+    metadata="${test_dir}/metadata.bc"
+    pdg="${test_dir}/pdg.bc"
+    event_log="${test_dir}/log.bc"
+    runtime="${C2RUST_DIR}/analysis/runtime"
+}
+
+c2rust-set-instrument-vars() {
+    _c2rust_prepare_vars "${@}"
+
+    # We need these variables to have exactly these values
+    export INSTRUMENT_RUNTIME=bg
+    export INSTRUMENT_BACKEND=log
+    export INSTRUMENT_OUTPUT="${event_log}"
+    export METADATA_FILE="${metadata}"
+
+    # These variables can be overridden by the user
+    export INSTRUMENT_OUTPUT_APPEND=${INSTRUMENT_OUTPUT_APPEND:-false}
+}
+
+c2rust-instrument() (
+    _c2rust_prepare_vars "${@}"
+
+    unset RUSTFLAGS # transpiled code has tons of warnings; don't allow `-D warnings`
+    export RUST_BACKTRACE=full
+
+    cd "${C2RUST_DIR}"
+    cargo run \
+        --bin c2rust-instrument \
+        "${profile_args[@]}" \
+        -- \
+        --metadata "${metadata}" \
+        --set-runtime \
+        --runtime-path "${runtime}" \
+        -- "${CARGO_INSTRUMENT_COMMAND:-build}" \
+        --manifest-path "${test_dir}/Cargo.toml" \
+        "${profile_args[@]}" \
+        -- "${args[@]}"
+)
+
+c2rust-pdg() (
+    _c2rust_prepare_vars "${@}"
+
+    export RUST_BACKTRACE=full # print sources w/ color-eyre
+    export RUST_LOG=error
+
+    cd "${C2RUST_DIR}"
+    cargo run \
+        --bin c2rust-pdg \
+        "${profile_args[@]}" \
+        -- \
+        --event-log "${event_log}" \
+        --metadata "${metadata}" \
+        --print graphs \
+        --print write-permissions \
+        --print counts \
+        --output "${pdg}" \
+        > "${test_dir}/pdg.log"
+)
+
+c2rust-analyze-with-pdg() (
+    _c2rust_prepare_vars "${@}"
+
+    export RUST_BACKTRACE=full # print sources w/ color-eyre
+    export RUST_LOG=error
+    if [[ "${NO_USE_PDG:-}" == "" ]]; then
+        # cargo runs this from a different pwd, so make path absolute
+        export PDG_FILE="${pdg}"
+    fi
+
+    cd "${C2RUST_DIR}"
+    cargo run \
+        --bin c2rust-analyze \
+        "${profile_args[@]}" \
+        -- \
+        build \
+        -- \
+        "${profile_args[@]}" \
+        --features=c2rust-analysis-rt \
+        --manifest-path "${test_dir}/Cargo.toml"
+)


### PR DESCRIPTION
This adds a mode for comparing static analysis results to the dynamic results from the PDG.  Comparison mode is enabled by setting the env var `C2RUST_ANALYZE_COMPARE_PDG=1`.  When this mode is enabled, c2rust-analyze skips normal rewriting and instead prints a copy of the input code with annotation comments indicating places where static and dynamic NON_NULL results disagree.  Specifically, it annotates cases where either the static analysis computed NON_NULL but the PDG includes at least one observation where the pointer is null, or the dynamic analysis marked the pointer nullable but the PDG contains observations that are all non-null.

In support of the main change, this branch also includes a refactor of the PDG processing code.