### PR TITLE
ci: remove Slack integration for `c2rust-testsuites` CI workflow

### DIFF
--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -113,15 +113,6 @@ jobs:
         echo "PATH=$PATH"
         python3 testsuite/test.py curl json-c lua nginx zstd
 
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        fields: repo,message,commit,author,action,ref,job,took # selectable (default: repo,message)
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # optional
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
-      if: always() # Pick up events even if the job fails or is canceled.
-
     - uses: actions/upload-artifact@v4
       with:
         name: testsuite-build-artifacts


### PR DESCRIPTION
This is not very important, and it fails on external PRs, meaning we're unable to run `c2rust-testsuites` on them and catch potential errors.

* Fixes #1138.