### PR TITLE
analyze: use a common namespace for all local and global PointerIds

### DIFF
--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -1162,8 +1162,11 @@ fn run(tcx: TyCtxt) {
                 let mut dynamic_non_null_ptrs = Vec::new();
                 for ptr in ptrs {
                     let static_non_null: bool = asn.perms()[ptr].contains(PermissionSet::NON_NULL);
-                    let ptr_is_global = ptr.index() < acx.local_ptr_base();
-                    let parent = if ptr_is_global { None } else { Some(ldid) };
+                    let parent = if acx.ptr_is_global(ptr) {
+                        None
+                    } else {
+                        Some(ldid)
+                    };
                     let dynamic_non_null: Option<bool> = observations
                         .get(&(parent, ptr))
                         .map(|&(saw_null, saw_non_null)| saw_non_null && !saw_null);
@@ -2178,7 +2181,7 @@ fn pdg_update_permissions_with_callback<'tcx>(
                 }
             };
 
-            let ptr_is_global = ptr.index() < acx.local_ptr_base();
+            let ptr_is_global = acx.ptr_is_global(ptr);
             callback(
                 &mut asn,
                 &mut updates_forbidden,

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -329,32 +329,6 @@ where
     }
 }
 
-pub(super) fn gather_foreign_sigs<'tcx>(gacx: &mut GlobalAnalysisCtxt<'tcx>, tcx: TyCtxt<'tcx>) {
-    for did in tcx
-        .hir_crate_items(())
-        .foreign_items()
-        .map(|item| item.def_id.to_def_id())
-        .filter(|did| matches!(tcx.def_kind(did), DefKind::Fn | DefKind::AssocFn))
-    {
-        let sig = tcx.erase_late_bound_regions(tcx.fn_sig(did));
-        let inputs = sig
-            .inputs()
-            .iter()
-            .map(|&ty| gacx.assign_pointer_ids_with_info(ty, PointerInfo::ANNOTATED))
-            .collect::<Vec<_>>();
-
-        let inputs = gacx.lcx.mk_slice(&inputs);
-        let output = gacx.assign_pointer_ids_with_info(sig.output(), PointerInfo::ANNOTATED);
-        let c_variadic = sig.c_variadic;
-        let lsig = LFnSig {
-            inputs,
-            output,
-            c_variadic,
-        };
-        gacx.fn_sigs.insert(did, lsig);
-    }
-}
-
 fn mark_foreign_fixed<'tcx>(
     gacx: &mut GlobalAnalysisCtxt<'tcx>,
     gasn: &mut GlobalAssignment,
@@ -599,57 +573,10 @@ fn run(tcx: TyCtxt) {
     populate_field_users(&mut gacx, &all_fn_ldids);
 
     // ----------------------------------
-    // Label all global types
+    // Label all global and local types
     // ----------------------------------
 
-    // Assign global `PointerId`s for all pointers that appear in function signatures.
-    for &ldid in &all_fn_ldids {
-        let sig = tcx.fn_sig(ldid.to_def_id());
-        let sig = tcx.erase_late_bound_regions(sig);
-
-        // All function signatures are fully annotated.
-        let inputs = sig
-            .inputs()
-            .iter()
-            .map(|&ty| gacx.assign_pointer_ids_with_info(ty, PointerInfo::ANNOTATED))
-            .collect::<Vec<_>>();
-        let inputs = gacx.lcx.mk_slice(&inputs);
-        let output = gacx.assign_pointer_ids_with_info(sig.output(), PointerInfo::ANNOTATED);
-        let c_variadic = sig.c_variadic;
-
-        let lsig = LFnSig {
-            inputs,
-            output,
-            c_variadic,
-        };
-        gacx.fn_sigs.insert(ldid.to_def_id(), lsig);
-    }
-
-    gather_foreign_sigs(&mut gacx, tcx);
-
-    // Collect all `static` items.
-    let all_static_dids = all_static_items(tcx);
-    debug!("statics:");
-    for &did in &all_static_dids {
-        debug!("  {:?}", did);
-    }
-
-    // Assign global `PointerId`s for types of `static` items.
-    assert!(gacx.static_tys.is_empty());
-    gacx.static_tys = HashMap::with_capacity(all_static_dids.len());
-    for &did in &all_static_dids {
-        gacx.assign_pointer_to_static(did);
-    }
-
-    // Label the field types of each struct.
-    for ldid in tcx.hir_crate_items(()).definitions() {
-        let did = ldid.to_def_id();
-        use DefKind::*;
-        if !matches!(tcx.def_kind(did), Struct | Enum | Union) {
-            continue;
-        }
-        gacx.assign_pointer_to_fields(did);
-    }
+    assign_pointer_ids(&mut gacx, &mut func_info, &all_fn_ldids);
 
     // Compute hypothetical region data for all ADTs and functions.  This can only be done after
     // all field types are labeled.
@@ -665,49 +592,15 @@ fn run(tcx: TyCtxt) {
         }
 
         let ldid_const = WithOptConstParam::unknown(ldid);
+        let info = func_info.get_mut(&ldid).unwrap();
         let mir = tcx.mir_built(ldid_const);
         let mir = mir.borrow();
-        let lsig = *gacx.fn_sigs.get(&ldid.to_def_id()).unwrap();
-
-        let mut acx = gacx.function_context(&mir);
+        let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
 
         let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
-            // Assign PointerIds to local types
-            assert!(acx.local_tys.is_empty());
-            acx.local_tys = IndexVec::with_capacity(mir.local_decls.len());
-            for (local, decl) in mir.local_decls.iter_enumerated() {
-                // TODO: set PointerInfo::ANNOTATED for the parts of the type with user annotations
-                let lty = match mir.local_kind(local) {
-                    LocalKind::Var | LocalKind::Temp => acx.assign_pointer_ids(decl.ty),
-                    LocalKind::Arg
-                        if lsig.c_variadic && local.as_usize() - 1 == lsig.inputs.len() =>
-                    {
-                        // This is the hidden VaList<'a> argument at the end
-                        // of the argument list of a variadic function. It does not
-                        // appear in lsig.inputs, so we handle it separately here.
-                        acx.assign_pointer_ids(decl.ty)
-                    }
-                    LocalKind::Arg => {
-                        debug_assert!(local.as_usize() >= 1 && local.as_usize() <= mir.arg_count);
-                        lsig.inputs[local.as_usize() - 1]
-                    }
-                    LocalKind::ReturnPointer => lsig.output,
-                };
-                let l = acx.local_tys.push(lty);
-                assert_eq!(local, l);
-
-                let ptr = acx.new_pointer(PointerInfo::ADDR_OF_LOCAL);
-                let l = acx.addr_of_local.push(ptr);
-                assert_eq!(local, l);
-            }
-
-            label_rvalue_tys(&mut acx, &mir);
-            update_pointer_info(&mut acx, &mir);
-
             pointee_type::generate_constraints(&acx, &mir)
         }));
 
-        let mut info = FuncInfo::default();
         let local_pointee_types = LocalPointerTable::new(0, acx.num_pointers());
         info.acx_data.set(acx.into_data());
 
@@ -717,12 +610,12 @@ fn run(tcx: TyCtxt) {
             }
             Err(pd) => {
                 gacx.mark_fn_failed(ldid.to_def_id(), DontRewriteFnReason::POINTEE_INVALID, pd);
+                assert!(gacx.fn_analysis_invalid(ldid.to_def_id()));
             }
         }
 
         info.local_pointee_types.set(local_pointee_types);
         info.recent_writes.set(RecentWrites::new(&mir));
-        func_info.insert(ldid, info);
     }
 
     // Iterate pointee constraints to a fixpoint.
@@ -1825,6 +1718,158 @@ fn run2<'tcx>(
             "saw permission errors in {} known fns",
             known_perm_error_fns.len()
         );
+    }
+}
+
+fn assign_pointer_ids<'tcx>(
+    gacx: &mut GlobalAnalysisCtxt<'tcx>,
+    func_info: &mut HashMap<LocalDefId, FuncInfo<'tcx>>,
+    all_fn_ldids: &[LocalDefId],
+) {
+    let tcx = gacx.tcx;
+
+    // Global items: functions
+
+    // Assign global `PointerId`s for all pointers that appear in function signatures.
+    for &ldid in all_fn_ldids {
+        let sig = tcx.fn_sig(ldid.to_def_id());
+        let sig = tcx.erase_late_bound_regions(sig);
+
+        // All function signatures are fully annotated.
+        let inputs = sig
+            .inputs()
+            .iter()
+            .map(|&ty| gacx.assign_pointer_ids_with_info(ty, PointerInfo::ANNOTATED))
+            .collect::<Vec<_>>();
+        let inputs = gacx.lcx.mk_slice(&inputs);
+        let output = gacx.assign_pointer_ids_with_info(sig.output(), PointerInfo::ANNOTATED);
+        let c_variadic = sig.c_variadic;
+
+        let lsig = LFnSig {
+            inputs,
+            output,
+            c_variadic,
+        };
+        gacx.fn_sigs.insert(ldid.to_def_id(), lsig);
+    }
+
+    // Foreign function signatures
+    for did in tcx
+        .hir_crate_items(())
+        .foreign_items()
+        .map(|item| item.def_id.to_def_id())
+        .filter(|did| matches!(tcx.def_kind(did), DefKind::Fn | DefKind::AssocFn))
+    {
+        let sig = tcx.erase_late_bound_regions(tcx.fn_sig(did));
+        let inputs = sig
+            .inputs()
+            .iter()
+            .map(|&ty| gacx.assign_pointer_ids_with_info(ty, PointerInfo::ANNOTATED))
+            .collect::<Vec<_>>();
+
+        let inputs = gacx.lcx.mk_slice(&inputs);
+        let output = gacx.assign_pointer_ids_with_info(sig.output(), PointerInfo::ANNOTATED);
+        let c_variadic = sig.c_variadic;
+
+        let lsig = LFnSig {
+            inputs,
+            output,
+            c_variadic,
+        };
+        gacx.fn_sigs.insert(did, lsig);
+    }
+
+    // Global items: statics
+
+    // Collect all `static` items.
+    let all_static_dids = all_static_items(tcx);
+    debug!("statics:");
+    for &did in &all_static_dids {
+        debug!("  {:?}", did);
+    }
+
+    // Assign global `PointerId`s for types of `static` items.
+    assert!(gacx.static_tys.is_empty());
+    gacx.static_tys = HashMap::with_capacity(all_static_dids.len());
+    for &did in &all_static_dids {
+        gacx.assign_pointer_to_static(did);
+    }
+
+    // Global items: ADTs
+
+    // Label the field types of each struct.
+    for ldid in tcx.hir_crate_items(()).definitions() {
+        let did = ldid.to_def_id();
+        use DefKind::*;
+        if !matches!(tcx.def_kind(did), Struct | Enum | Union) {
+            continue;
+        }
+        gacx.assign_pointer_to_fields(did);
+    }
+
+    // Local variables
+
+    for &ldid in all_fn_ldids {
+        if gacx.fn_analysis_invalid(ldid.to_def_id()) {
+            continue;
+        }
+
+        let ldid_const = WithOptConstParam::unknown(ldid);
+        let mir = tcx.mir_built(ldid_const);
+        let mir = mir.borrow();
+        let lsig = *gacx.fn_sigs.get(&ldid.to_def_id()).unwrap();
+
+        let mut acx = gacx.function_context(&mir);
+
+        let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
+            // Assign PointerIds to local types
+            assert!(acx.local_tys.is_empty());
+            acx.local_tys = IndexVec::with_capacity(mir.local_decls.len());
+            for (local, decl) in mir.local_decls.iter_enumerated() {
+                // TODO: set PointerInfo::ANNOTATED for the parts of the type with user annotations
+                let lty = match mir.local_kind(local) {
+                    LocalKind::Var | LocalKind::Temp => acx.assign_pointer_ids(decl.ty),
+                    LocalKind::Arg
+                        if lsig.c_variadic && local.as_usize() - 1 == lsig.inputs.len() =>
+                    {
+                        // This is the hidden VaList<'a> argument at the end
+                        // of the argument list of a variadic function. It does not
+                        // appear in lsig.inputs, so we handle it separately here.
+                        acx.assign_pointer_ids(decl.ty)
+                    }
+                    LocalKind::Arg => {
+                        debug_assert!(local.as_usize() >= 1 && local.as_usize() <= mir.arg_count);
+                        lsig.inputs[local.as_usize() - 1]
+                    }
+                    LocalKind::ReturnPointer => lsig.output,
+                };
+                let l = acx.local_tys.push(lty);
+                assert_eq!(local, l);
+
+                let ptr = acx.new_pointer(PointerInfo::ADDR_OF_LOCAL);
+                let l = acx.addr_of_local.push(ptr);
+                assert_eq!(local, l);
+            }
+
+            label_rvalue_tys(&mut acx, &mir);
+            update_pointer_info(&mut acx, &mir);
+        }));
+
+        let mut info = FuncInfo::default();
+        info.acx_data.set(acx.into_data());
+        func_info.insert(ldid, info);
+
+        match r {
+            Ok(()) => {}
+            Err(pd) => {
+                gacx.mark_fn_failed(
+                    ldid.to_def_id(),
+                    DontRewriteFnReason::MISC_ANALYSIS_INVALID,
+                    pd,
+                );
+                continue;
+            }
+        }
     }
 }
 

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -619,7 +619,8 @@ fn run(tcx: TyCtxt) {
     }
 
     // Iterate pointee constraints to a fixpoint.
-    let mut global_pointee_types = GlobalPointerTable::<PointeeTypes>::new(gacx.num_pointers());
+    let mut global_pointee_types =
+        GlobalPointerTable::<PointeeTypes>::new(gacx.num_global_pointers());
     let mut loop_count = 0;
     loop {
         // Loop until the global assignment reaches a fixpoint.  The inner loop also runs until a
@@ -680,7 +681,7 @@ fn run(tcx: TyCtxt) {
     // Initial pass to assign local `PointerId`s and gather equivalence constraints, which state
     // that two pointer types must be converted to the same reference type.  Some additional data
     // computed during this the process is kept around for use in later passes.
-    let mut global_equiv = GlobalEquivSet::new(gacx.num_pointers());
+    let mut global_equiv = GlobalEquivSet::new(gacx.num_global_pointers());
     for &ldid in &all_fn_ldids {
         let info = func_info.get_mut(&ldid).unwrap();
         let mut local_equiv =
@@ -804,8 +805,8 @@ fn run(tcx: TyCtxt) {
     ]);
     const INITIAL_FLAGS: FlagSet = FlagSet::empty();
 
-    let mut gasn = GlobalAssignment::new(gacx.num_pointers(), INITIAL_PERMS, INITIAL_FLAGS);
-    let mut g_updates_forbidden = GlobalPointerTable::new(gacx.num_pointers());
+    let mut gasn = GlobalAssignment::new(gacx.num_global_pointers(), INITIAL_PERMS, INITIAL_FLAGS);
+    let mut g_updates_forbidden = GlobalPointerTable::new(gacx.num_global_pointers());
 
     for (ptr, &info) in gacx.ptr_info().iter() {
         if should_make_fixed(info) {

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -682,11 +682,16 @@ fn run(tcx: TyCtxt) {
     // computed during this the process is kept around for use in later passes.
     let mut global_equiv = GlobalEquivSet::new(gacx.num_pointers());
     for &ldid in &all_fn_ldids {
+        let info = func_info.get_mut(&ldid).unwrap();
+        let mut local_equiv = LocalEquivSet::new(0, info.acx_data.num_pointers());
+
         if gacx.fn_analysis_invalid(ldid.to_def_id()) {
+            // Even on failure, we set a blank `local_equiv`.  This is necessary because we apply
+            // renumbering to all functions, even those where analysis has failed.
+            info.local_equiv.set(local_equiv);
             continue;
         }
 
-        let info = func_info.get_mut(&ldid).unwrap();
         let ldid_const = WithOptConstParam::unknown(ldid);
         let mir = tcx.mir_built(ldid_const);
         let mir = mir.borrow();
@@ -695,28 +700,28 @@ fn run(tcx: TyCtxt) {
         let recent_writes = info.recent_writes.get();
         let pointee_types = global_pointee_types.and(info.local_pointee_types.get());
 
+        // Compute local equivalence classes and dataflow constraints.
         let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
             dataflow::generate_constraints(&acx, &mir, recent_writes, pointee_types)
         }));
-
-        let (dataflow, equiv_constraints) = match r {
-            Ok(x) => x,
+        match r {
+            Ok((dataflow, equiv_constraints)) => {
+                let mut equiv = global_equiv.and_mut(&mut local_equiv);
+                for (a, b) in equiv_constraints {
+                    equiv.unify(a, b);
+                }
+                info.dataflow.set(dataflow);
+            }
             Err(pd) => {
-                info.acx_data.set(acx.into_data());
-                gacx.mark_fn_failed(ldid.to_def_id(), DontRewriteFnReason::DATAFLOW_INVALID, pd);
-                continue;
+                acx.gacx.mark_fn_failed(
+                    ldid.to_def_id(),
+                    DontRewriteFnReason::DATAFLOW_INVALID,
+                    pd,
+                );
             }
         };
 
-        // Compute local equivalence classes and dataflow constraints.
-        let mut local_equiv = LocalEquivSet::new(0, acx.num_pointers());
-        let mut equiv = global_equiv.and_mut(&mut local_equiv);
-        for (a, b) in equiv_constraints {
-            equiv.unify(a, b);
-        }
-
         info.acx_data.set(acx.into_data());
-        info.dataflow.set(dataflow);
         info.local_equiv.set(local_equiv);
     }
 
@@ -736,26 +741,28 @@ fn run(tcx: TyCtxt) {
     gacx.remap_pointers(&global_equiv_map, global_counter);
 
     for &ldid in &all_fn_ldids {
-        if gacx.fn_analysis_invalid(ldid.to_def_id()) {
-            continue;
-        }
+        // Note that we apply this `PointerId` remapping even for failed functions.
 
         let info = func_info.get_mut(&ldid).unwrap();
         let (local_counter, local_equiv_map) = info.local_equiv.renumber(&global_equiv_map);
         debug!("local_equiv_map = {local_equiv_map:?}");
-        pointee_type::remap_pointers_local(
-            &mut global_pointee_types,
-            &mut info.local_pointee_types,
-            global_equiv_map.and(&local_equiv_map),
-            &local_counter,
-        );
+        if info.local_pointee_types.is_set() {
+            pointee_type::remap_pointers_local(
+                &mut global_pointee_types,
+                &mut info.local_pointee_types,
+                global_equiv_map.and(&local_equiv_map),
+                &local_counter,
+            );
+        }
         info.acx_data.remap_pointers(
             &mut gacx,
             global_equiv_map.and(&local_equiv_map),
             local_counter,
         );
-        info.dataflow
-            .remap_pointers(global_equiv_map.and(&local_equiv_map));
+        if info.dataflow.is_set() {
+            info.dataflow
+                .remap_pointers(global_equiv_map.and(&local_equiv_map));
+        }
         info.local_equiv.clear();
     }
 

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -2,8 +2,8 @@ use crate::annotate::AnnotationBuffer;
 use crate::borrowck;
 use crate::context::{
     self, AnalysisCtxt, AnalysisCtxtData, Assignment, DontRewriteFieldReason, DontRewriteFnReason,
-    DontRewriteStaticReason, FlagSet, GlobalAnalysisCtxt, GlobalAssignment, LFnSig, LTy, LTyCtxt,
-    LocalAssignment, PermissionSet, PointerId, PointerInfo,
+    DontRewriteStaticReason, FlagSet, GlobalAnalysisCtxt, LFnSig, LTy, LTyCtxt, PermissionSet,
+    PointerId, PointerInfo,
 };
 use crate::dataflow;
 use crate::dataflow::DataflowConstraints;
@@ -17,7 +17,6 @@ use crate::pointee_type::PointeeTypes;
 use crate::pointer_id::GlobalPointerTable;
 use crate::pointer_id::LocalPointerTable;
 use crate::pointer_id::PointerTable;
-use crate::pointer_id::PointerTableMut;
 use crate::recent_writes::RecentWrites;
 use crate::rewrite;
 use crate::type_desc;
@@ -331,24 +330,24 @@ where
 
 fn mark_foreign_fixed<'tcx>(
     gacx: &mut GlobalAnalysisCtxt<'tcx>,
-    gasn: &mut GlobalAssignment,
+    asn: &mut Assignment,
     tcx: TyCtxt<'tcx>,
 ) {
     // FIX the inputs and outputs of function declarations in extern blocks
     for (did, lsig) in gacx.fn_sigs.iter() {
         if tcx.is_foreign_item(did) {
-            make_sig_fixed(gasn, lsig);
+            make_sig_fixed(asn, lsig);
         }
     }
 
     // FIX the types of static declarations in extern blocks
     for (did, lty) in gacx.static_tys.iter() {
         if tcx.is_foreign_item(did) {
-            make_ty_fixed(gasn, lty);
+            make_ty_fixed(asn, lty);
 
             // Also fix the `addr_of_static` permissions.
             let ptr = gacx.addr_of_static[did];
-            gasn.flags[ptr].insert(FlagSet::FIXED);
+            asn.flags[ptr].insert(FlagSet::FIXED);
         }
     }
 
@@ -363,25 +362,25 @@ fn mark_foreign_fixed<'tcx>(
                     "adding FIXED permission for {adt_did:?} field {:?}",
                     field.did
                 );
-                make_ty_fixed(gasn, field_lty);
+                make_ty_fixed(asn, field_lty);
             }
         }
     }
 }
 
-fn mark_all_statics_fixed<'tcx>(gacx: &mut GlobalAnalysisCtxt<'tcx>, gasn: &mut GlobalAssignment) {
+fn mark_all_statics_fixed<'tcx>(gacx: &mut GlobalAnalysisCtxt<'tcx>, asn: &mut Assignment) {
     for (did, lty) in gacx.static_tys.iter() {
-        make_ty_fixed(gasn, lty);
+        make_ty_fixed(asn, lty);
 
         // Also fix the `addr_of_static` permissions.
         let ptr = gacx.addr_of_static[did];
-        gasn.flags[ptr].insert(FlagSet::FIXED);
+        asn.flags[ptr].insert(FlagSet::FIXED);
     }
 }
 
 fn mark_all_structs_fixed<'tcx>(
     gacx: &mut GlobalAnalysisCtxt<'tcx>,
-    gasn: &mut GlobalAssignment,
+    asn: &mut Assignment,
     tcx: TyCtxt<'tcx>,
 ) {
     for adt_did in &gacx.adt_metadata.struct_dids {
@@ -389,7 +388,7 @@ fn mark_all_structs_fixed<'tcx>(
         let fields = adt_def.all_fields();
         for field in fields {
             let field_lty = gacx.field_ltys[&field.did];
-            make_ty_fixed(gasn, field_lty);
+            make_ty_fixed(asn, field_lty);
         }
     }
 }
@@ -532,12 +531,6 @@ struct FuncInfo<'tcx> {
     /// complete [`EquivSet`], which assigns an equivalence class to each [`PointerId`] that
     /// appears in the function.  Used for renumbering [`PointerId`]s.
     local_equiv: MaybeUnset<LocalEquivSet>,
-    /// Local part of the permission/flag assignment.  Combine with the [`GlobalAssignment`] to
-    /// get a complete [`Assignment`] for this function, which maps every [`PointerId`] in this
-    /// function to a [`PermissionSet`] and [`FlagSet`].
-    lasn: MaybeUnset<LocalAssignment>,
-    /// Local part of the `updates_forbidden` mask.
-    l_updates_forbidden: MaybeUnset<LocalPointerTable<PermissionSet>>,
     /// Constraints on pointee types gathered from the body of this function.
     pointee_constraints: MaybeUnset<pointee_type::ConstraintSet<'tcx>>,
     /// Local part of pointee type sets.
@@ -805,55 +798,47 @@ fn run(tcx: TyCtxt) {
     ]);
     const INITIAL_FLAGS: FlagSet = FlagSet::empty();
 
-    let mut gasn = GlobalAssignment::new(gacx.num_global_pointers(), INITIAL_PERMS, INITIAL_FLAGS);
-    let mut g_updates_forbidden = GlobalPointerTable::new(gacx.num_global_pointers());
+    let mut asn = Assignment::new(gacx.num_total_pointers(), INITIAL_PERMS, INITIAL_FLAGS);
+    let mut updates_forbidden = GlobalPointerTable::new(gacx.num_total_pointers());
 
     for (ptr, &info) in gacx.ptr_info().iter() {
         if should_make_fixed(info) {
-            gasn.flags[ptr].insert(FlagSet::FIXED);
+            asn.flags[ptr].insert(FlagSet::FIXED);
         }
         if info.contains(PointerInfo::ADDR_OF_LOCAL) {
             // `addr_of_local` is always a stack pointer, though it should be rare for the
             // `ADDR_OF_LOCAL` flag to appear on a global `PointerId`.
-            gasn.perms[ptr].remove(PermissionSet::HEAP);
+            asn.perms[ptr].remove(PermissionSet::HEAP);
         }
     }
 
-    mark_foreign_fixed(&mut gacx, &mut gasn, tcx);
+    mark_foreign_fixed(&mut gacx, &mut asn, tcx);
 
     if rewrite_pointwise {
         // In pointwise mode, we restrict rewriting to a single fn at a time.  All statics and
         // struct fields are marked `FIXED` so they won't be rewritten.
-        mark_all_statics_fixed(&mut gacx, &mut gasn);
-        mark_all_structs_fixed(&mut gacx, &mut gasn, tcx);
+        mark_all_statics_fixed(&mut gacx, &mut asn);
+        mark_all_structs_fixed(&mut gacx, &mut asn, tcx);
     }
 
     for (ptr, perms) in gacx.known_fn_ptr_perms() {
-        let existing_perms = &mut gasn.perms[ptr];
+        let existing_perms = &mut asn.perms[ptr];
         existing_perms.remove(INITIAL_PERMS);
         assert_eq!(*existing_perms, PermissionSet::empty());
         *existing_perms = perms;
     }
 
     for info in func_info.values_mut() {
-        let num_pointers = info.acx_data.num_pointers();
-        let base = info.acx_data.local_ptr_base();
-        let mut lasn = LocalAssignment::new(base, num_pointers, INITIAL_PERMS, INITIAL_FLAGS);
-        let l_updates_forbidden = LocalPointerTable::new(base, num_pointers);
-
         for (ptr, &info) in info.acx_data.local_ptr_info().iter() {
             if should_make_fixed(info) {
-                lasn.flags[ptr].insert(FlagSet::FIXED);
+                asn.flags[ptr].insert(FlagSet::FIXED);
             }
             if info.contains(PointerInfo::ADDR_OF_LOCAL) {
                 // `addr_of_local` is always a stack pointer.  This will be propagated
                 // automatically through dataflow whenever the address of the local is taken.
-                lasn.perms[ptr].remove(PermissionSet::HEAP);
+                asn.perms[ptr].remove(PermissionSet::HEAP);
             }
         }
-
-        info.lasn.set(lasn);
-        info.l_updates_forbidden.set(l_updates_forbidden);
     }
 
     // Load permission info from PDG
@@ -865,8 +850,8 @@ fn run(tcx: TyCtxt) {
                 &mut gacx,
                 &all_fn_ldids,
                 &mut func_info,
-                &mut gasn,
-                &mut g_updates_forbidden,
+                &mut asn,
+                &mut updates_forbidden,
                 pdg_file_path,
             );
         }
@@ -888,7 +873,7 @@ fn run(tcx: TyCtxt) {
                     Some(x) => x,
                     None => panic!("missing fn_sig for {:?}", ldid),
                 };
-                make_sig_fixed(&mut gasn, lsig);
+                make_sig_fixed(&mut asn, lsig);
                 gacx.dont_rewrite_fns
                     .add(ldid.to_def_id(), DontRewriteFnReason::USER_REQUEST);
             }
@@ -909,7 +894,7 @@ fn run(tcx: TyCtxt) {
                             Some(&x) => x,
                             None => panic!("missing field_lty for {:?}", ldid),
                         };
-                        make_ty_fixed(&mut gasn, lty);
+                        make_ty_fixed(&mut asn, lty);
                         gacx.dont_rewrite_fields
                             .add(field.did, DontRewriteFieldReason::USER_REQUEST);
                     }
@@ -921,14 +906,14 @@ fn run(tcx: TyCtxt) {
                     Some(&x) => x,
                     None => panic!("missing static_ty for {:?}", ldid),
                 };
-                make_ty_fixed(&mut gasn, lty);
+                make_ty_fixed(&mut asn, lty);
 
                 let ptr = match gacx.addr_of_static.get(&ldid.to_def_id()) {
                     Some(&x) => x,
                     None => panic!("missing addr_of_static for {:?}", ldid),
                 };
                 if !ptr.is_none() {
-                    gasn.flags[ptr].insert(FlagSet::FIXED);
+                    asn.flags[ptr].insert(FlagSet::FIXED);
                 }
                 gacx.dont_rewrite_statics
                     .add(ldid.to_def_id(), DontRewriteStaticReason::USER_REQUEST);
@@ -943,13 +928,7 @@ fn run(tcx: TyCtxt) {
     // ----------------------------------
 
     apply_test_attr_fail_before_analysis(&mut gacx, &all_fn_ldids);
-    apply_test_attr_force_non_null_args(
-        &mut gacx,
-        &all_fn_ldids,
-        &mut func_info,
-        &mut gasn,
-        &mut g_updates_forbidden,
-    );
+    apply_test_attr_force_non_null_args(&mut gacx, &all_fn_ldids, &mut asn, &mut updates_forbidden);
 
     debug!("=== ADT Metadata ===");
     debug!("{:?}", gacx.adt_metadata);
@@ -958,10 +937,10 @@ fn run(tcx: TyCtxt) {
     loop {
         // Loop until the global assignment reaches a fixpoint.  The inner loop also runs until a
         // fixpoint, but it only considers a single function at a time.  The inner loop for one
-        // function can affect other functions by updating the `GlobalAssignment`, so we also need
-        // the outer loop, which runs until the `GlobalAssignment` converges as well.
+        // function can affect other functions by updating the `Assignment`, so we also need the
+        // outer loop, which runs until the `Assignment` converges as well.
         loop_count += 1;
-        let old_gasn = gasn.clone();
+        let old_gasn = asn.perms.as_slice()[..gacx.num_global_pointers()].to_owned();
 
         for &ldid in &all_fn_ldids {
             if gacx.fn_analysis_invalid(ldid.to_def_id()) {
@@ -976,14 +955,11 @@ fn run(tcx: TyCtxt) {
 
             let field_ltys = gacx.field_ltys.clone();
             let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
-            let mut asn = gasn.and(&mut info.lasn);
-            let updates_forbidden = g_updates_forbidden.and(&info.l_updates_forbidden);
 
             let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
                 // `dataflow.propagate` and `borrowck_mir` both run until the assignment converges
                 // on a fixpoint, so there's no need to do multiple iterations here.
-                info.dataflow
-                    .propagate(&mut asn.perms_mut(), &updates_forbidden);
+                info.dataflow.propagate(&mut asn.perms, &updates_forbidden);
 
                 borrowck::borrowck_mir(
                     &acx,
@@ -1012,8 +988,9 @@ fn run(tcx: TyCtxt) {
         }
 
         let mut num_changed = 0;
-        for (ptr, &old) in old_gasn.perms.iter() {
-            let new = gasn.perms[ptr];
+        for (i, &old) in old_gasn.iter().enumerate() {
+            let ptr = PointerId::global(i as u32);
+            let new = asn.perms[ptr];
             if old != new {
                 let added = new & !old;
                 let removed = old & !new;
@@ -1030,7 +1007,7 @@ fn run(tcx: TyCtxt) {
             loop_count, num_changed
         );
 
-        if gasn == old_gasn {
+        if &asn.perms.as_slice()[..gacx.num_global_pointers()] == &old_gasn {
             break;
         }
     }
@@ -1047,7 +1024,6 @@ fn run(tcx: TyCtxt) {
         let mir = tcx.mir_built(ldid_const);
         let mir = mir.borrow();
         let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
-        let mut asn = gasn.and(&mut info.lasn);
 
         let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
             // Add the CELL permission to pointers that need it.
@@ -1074,11 +1050,11 @@ fn run(tcx: TyCtxt) {
     // Check that these perms haven't changed.
     let mut known_perm_error_ptrs = HashSet::new();
     for (ptr, perms) in gacx.known_fn_ptr_perms() {
-        if gasn.perms[ptr] != perms {
+        if asn.perms[ptr] != perms {
             known_perm_error_ptrs.insert(ptr);
             warn!(
                 "known permissions changed for PointerId {ptr:?}: {perms:?} -> {:?}",
-                gasn.perms[ptr]
+                asn.perms[ptr]
             );
         }
     }
@@ -1112,8 +1088,8 @@ fn run(tcx: TyCtxt) {
             &mut gacx,
             &all_fn_ldids,
             &mut func_info,
-            &mut gasn,
-            &mut g_updates_forbidden,
+            &mut asn,
+            &mut updates_forbidden,
             pdg_file_path,
             |_asn, _updates_forbidden, ldid, ptr, ptr_is_global, _node_info, node_is_non_null| {
                 let parent = if ptr_is_global { None } else { Some(ldid) };
@@ -1144,7 +1120,6 @@ fn run(tcx: TyCtxt) {
             let mir = tcx.mir_built(ldid_const);
             let mir = mir.borrow();
             let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
-            let asn = gasn.and(&mut info.lasn);
 
             // Generate inline annotations for pointer-typed locals
             for (local, decl) in mir.local_decls.iter_enumerated() {
@@ -1212,7 +1187,7 @@ fn run(tcx: TyCtxt) {
             None,
             tcx,
             gacx,
-            gasn,
+            asn,
             &global_pointee_types,
             func_info,
             &all_fn_ldids,
@@ -1225,7 +1200,7 @@ fn run(tcx: TyCtxt) {
                 Some(ldid),
                 tcx,
                 gacx.clone(),
-                gasn.clone(),
+                asn.clone(),
                 &global_pointee_types,
                 func_info.clone(),
                 &all_fn_ldids,
@@ -1240,7 +1215,7 @@ fn run2<'tcx>(
     pointwise_fn_ldid: Option<LocalDefId>,
     tcx: TyCtxt<'tcx>,
     mut gacx: GlobalAnalysisCtxt<'tcx>,
-    mut gasn: GlobalAssignment,
+    mut asn: Assignment,
     global_pointee_types: &GlobalPointerTable<PointeeTypes<'tcx>>,
     mut func_info: HashMap<LocalDefId, FuncInfo<'tcx>>,
     all_fn_ldids: &Vec<LocalDefId>,
@@ -1258,11 +1233,11 @@ fn run2<'tcx>(
         if ptr.is_none() {
             return false;
         }
-        let flags = gasn.flags[ptr];
+        let flags = asn.flags[ptr];
         if flags.contains(FlagSet::FIXED) {
             return false;
         }
-        let perms = gasn.perms[ptr];
+        let perms = asn.perms[ptr];
         let desc = type_desc::perms_to_desc(lty.ty, perms, flags);
         match desc.own {
             Ownership::Imm | Ownership::Cell | Ownership::Mut => true,
@@ -1322,7 +1297,7 @@ fn run2<'tcx>(
         // `new_keys()` lists, which we check at the end of the loop to see whether we've reached a
         // fixpoint.  Second, doing this adds the `FIXED` flag to pointers that we shouldn't
         // rewrite, such as pointers in the signatures of non-rewritten functions.
-        process_new_dont_rewrite_items(&mut gacx, &mut gasn);
+        process_new_dont_rewrite_items(&mut gacx, &mut asn);
 
         for &ldid in all_fn_ldids {
             if gacx.dont_rewrite_fn(ldid.to_def_id()) {
@@ -1335,7 +1310,6 @@ fn run2<'tcx>(
             let mir = tcx.mir_built(ldid_const);
             let mir = mir.borrow();
             let mut acx = gacx.function_context_with_data(&mir, info.acx_data.take());
-            let asn = gasn.and(&mut info.lasn);
             let pointee_types = global_pointee_types.and(info.local_pointee_types.get());
 
             let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
@@ -1387,7 +1361,7 @@ fn run2<'tcx>(
 
         // This call never panics, which is important because this is the fallback if the more
         // sophisticated analysis and rewriting above did panic.
-        let (shim_call_rewrites, shim_fn_def_ids) = rewrite::gen_shim_call_rewrites(&gacx, &gasn);
+        let (shim_call_rewrites, shim_fn_def_ids) = rewrite::gen_shim_call_rewrites(&gacx, &asn);
         all_rewrites.extend(shim_call_rewrites);
 
         // Generate shims for functions that need them.
@@ -1395,7 +1369,7 @@ fn run2<'tcx>(
             let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
                 all_rewrites.push(rewrite::gen_shim_definition_rewrite(
                     &gacx,
-                    &gasn,
+                    &asn,
                     def_id,
                     manual_shim_casts,
                 ));
@@ -1424,7 +1398,7 @@ fn run2<'tcx>(
         if fixed_defs.contains(&def_id) {
             continue;
         }
-        static_rewrites.extend(rewrite::gen_static_rewrites(tcx, &gasn, def_id, ptr));
+        static_rewrites.extend(rewrite::gen_static_rewrites(tcx, &asn, def_id, ptr));
     }
     let mut statics_report = String::new();
     writeln!(
@@ -1455,7 +1429,7 @@ fn run2<'tcx>(
             continue;
         }
 
-        let adt_rewrites = rewrite::gen_adt_ty_rewrites(&gacx, &gasn, global_pointee_types, def_id);
+        let adt_rewrites = rewrite::gen_adt_ty_rewrites(&gacx, &asn, global_pointee_types, def_id);
         let report = adt_reports.entry(def_id).or_default();
         writeln!(
             report,
@@ -1494,7 +1468,6 @@ fn run2<'tcx>(
         let mir = tcx.mir_built(ldid_const);
         let mir = mir.borrow();
         let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
-        let asn = gasn.and(&mut info.lasn);
         let pointee_types = global_pointee_types.and(info.local_pointee_types.get());
 
         // Print labeling and rewrites for the current function.
@@ -1509,8 +1482,8 @@ fn run2<'tcx>(
                 format_args!("{:?} ({})", local, describe_local(tcx, decl)),
                 acx.addr_of_local[local],
                 acx.local_tys[local],
-                &asn.perms(),
-                &asn.flags(),
+                asn.perms(),
+                asn.flags(),
             );
         }
 
@@ -1540,7 +1513,6 @@ fn run2<'tcx>(
         let mir = tcx.mir_built(ldid_const);
         let mir = mir.borrow();
         let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
-        let asn = gasn.and(&mut info.lasn);
 
         let mut emit_lty_annotations = |span, lty: LTy, desc: &str| {
             let mut ptrs = Vec::new();
@@ -1598,8 +1570,8 @@ fn run2<'tcx>(
             format_args!("{name:?}"),
             gacx.addr_of_static[&did],
             lty,
-            &gasn.perms,
-            &gasn.flags,
+            &asn.perms,
+            &asn.flags,
         );
     }
     debug!("\n{statics_report}");
@@ -1613,8 +1585,8 @@ fn run2<'tcx>(
         let name = tcx.item_name(did);
         let pid = field_lty.label;
         if pid != PointerId::NONE {
-            let ty_perms = gasn.perms[pid];
-            let ty_flags = gasn.flags[pid];
+            let ty_perms = asn.perms[pid];
+            let ty_flags = asn.flags[pid];
             debug!("{name:}: ({pid}) perms = {ty_perms:?}, flags = {ty_flags:?}");
         }
 
@@ -1641,7 +1613,7 @@ fn run2<'tcx>(
         for ptr in ptrs {
             ann.emit(
                 span,
-                format_args!("  {} = {:?}, {:?}", ptr, gasn.perms[ptr], gasn.flags[ptr]),
+                format_args!("  {} = {:?}, {:?}", ptr, asn.perms[ptr], asn.flags[ptr]),
             );
         }
     }
@@ -1899,6 +1871,8 @@ fn assign_pointer_ids<'tcx>(
             }
         }
     }
+
+    gacx.set_num_total_pointers(next_base as usize);
 }
 
 pub trait AssignPointerIds<'tcx> {
@@ -1943,18 +1917,18 @@ impl<'tcx> AssignPointerIds<'tcx> for AnalysisCtxt<'_, 'tcx> {
     }
 }
 
-fn make_ty_fixed(gasn: &mut GlobalAssignment, lty: LTy) {
+fn make_ty_fixed(asn: &mut Assignment, lty: LTy) {
     for lty in lty.iter() {
         let ptr = lty.label;
         if !ptr.is_none() {
-            gasn.flags[ptr].insert(FlagSet::FIXED);
+            asn.flags[ptr].insert(FlagSet::FIXED);
         }
     }
 }
 
-fn make_sig_fixed(gasn: &mut GlobalAssignment, lsig: &LFnSig) {
+fn make_sig_fixed(asn: &mut Assignment, lsig: &LFnSig) {
     for lty in lsig.inputs.iter().copied().chain(iter::once(lsig.output)) {
-        make_ty_fixed(gasn, lty);
+        make_ty_fixed(asn, lty);
     }
 }
 
@@ -1982,19 +1956,14 @@ fn apply_test_attr_fail_before_analysis(
 fn apply_test_attr_force_non_null_args(
     gacx: &mut GlobalAnalysisCtxt,
     all_fn_ldids: &[LocalDefId],
-    func_info: &mut HashMap<LocalDefId, FuncInfo>,
-    gasn: &mut GlobalAssignment,
-    g_updates_forbidden: &mut GlobalPointerTable<PermissionSet>,
+    asn: &mut Assignment,
+    updates_forbidden: &mut GlobalPointerTable<PermissionSet>,
 ) {
     let tcx = gacx.tcx;
     for &ldid in all_fn_ldids {
         if !util::has_test_attr(tcx, ldid, TestAttr::ForceNonNullArgs) {
             continue;
         }
-
-        let info = func_info.get_mut(&ldid).unwrap();
-        let mut asn = gasn.and(&mut info.lasn);
-        let mut updates_forbidden = g_updates_forbidden.and_mut(&mut info.l_updates_forbidden);
 
         let lsig = &gacx.fn_sigs[&ldid.to_def_id()];
         for arg_lty in lsig.inputs {
@@ -2013,8 +1982,8 @@ fn pdg_update_permissions<'tcx>(
     gacx: &mut GlobalAnalysisCtxt<'tcx>,
     all_fn_ldids: &[LocalDefId],
     func_info: &mut HashMap<LocalDefId, FuncInfo<'tcx>>,
-    gasn: &mut GlobalAssignment,
-    g_updates_forbidden: &mut GlobalPointerTable<PermissionSet>,
+    asn: &mut Assignment,
+    updates_forbidden: &mut GlobalPointerTable<PermissionSet>,
     pdg_file_path: impl AsRef<Path>,
 ) {
     let allow_unsound =
@@ -2024,8 +1993,8 @@ fn pdg_update_permissions<'tcx>(
         gacx,
         all_fn_ldids,
         func_info,
-        gasn,
-        g_updates_forbidden,
+        asn,
+        updates_forbidden,
         pdg_file_path,
         |asn, updates_forbidden, _ldid, ptr, _ptr_is_global, node_info, node_is_non_null| {
             let old_perms = asn.perms()[ptr];
@@ -2082,12 +2051,12 @@ fn pdg_update_permissions_with_callback<'tcx>(
     gacx: &mut GlobalAnalysisCtxt<'tcx>,
     all_fn_ldids: &[LocalDefId],
     func_info: &mut HashMap<LocalDefId, FuncInfo<'tcx>>,
-    gasn: &mut GlobalAssignment,
-    g_updates_forbidden: &mut GlobalPointerTable<PermissionSet>,
+    asn: &mut Assignment,
+    updates_forbidden: &mut GlobalPointerTable<PermissionSet>,
     pdg_file_path: impl AsRef<Path>,
     mut callback: impl FnMut(
         &mut Assignment,
-        &mut PointerTableMut<PermissionSet>,
+        &mut GlobalPointerTable<PermissionSet>,
         LocalDefId,
         PointerId,
         bool,
@@ -2145,8 +2114,6 @@ fn pdg_update_permissions_with_callback<'tcx>(
             let mir = tcx.mir_built(ldid_const);
             let mir = mir.borrow();
             let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
-            let mut asn = gasn.and(&mut info.lasn);
-            let mut updates_forbidden = g_updates_forbidden.and_mut(&mut info.l_updates_forbidden);
 
             let dest_pl = match n.dest.as_ref() {
                 Some(x) => x,
@@ -2184,8 +2151,8 @@ fn pdg_update_permissions_with_callback<'tcx>(
 
             let ptr_is_global = acx.ptr_is_global(ptr);
             callback(
-                &mut asn,
-                &mut updates_forbidden,
+                asn,
+                updates_forbidden,
                 ldid,
                 ptr,
                 ptr_is_global,
@@ -2517,7 +2484,7 @@ fn populate_field_users(gacx: &mut GlobalAnalysisCtxt, fn_ldids: &[LocalDefId]) 
 /// Call `take_new_keys()` on `gacx.dont_rewrite_{fns,statics,fields}` and process the results.
 /// This involves adding `FIXED` to some pointers and maybe propagating `DontRewrite` flags to
 /// other items.
-fn process_new_dont_rewrite_items(gacx: &mut GlobalAnalysisCtxt, gasn: &mut GlobalAssignment) {
+fn process_new_dont_rewrite_items(gacx: &mut GlobalAnalysisCtxt, asn: &mut Assignment) {
     for i in 0.. {
         assert!(i < 20);
         let mut found_any = false;
@@ -2525,7 +2492,7 @@ fn process_new_dont_rewrite_items(gacx: &mut GlobalAnalysisCtxt, gasn: &mut Glob
         for did in gacx.dont_rewrite_fns.take_new_keys() {
             found_any = true;
             let lsig = &gacx.fn_sigs[&did];
-            make_sig_fixed(gasn, lsig);
+            make_sig_fixed(asn, lsig);
 
             let ldid = match did.as_local() {
                 Some(x) => x,
@@ -2545,13 +2512,13 @@ fn process_new_dont_rewrite_items(gacx: &mut GlobalAnalysisCtxt, gasn: &mut Glob
         for did in gacx.dont_rewrite_statics.take_new_keys() {
             found_any = true;
             let lty = gacx.static_tys[&did];
-            make_ty_fixed(gasn, lty);
+            make_ty_fixed(asn, lty);
         }
 
         for did in gacx.dont_rewrite_fields.take_new_keys() {
             found_any = true;
             let lty = gacx.field_ltys[&did];
-            make_ty_fixed(gasn, lty);
+            make_ty_fixed(asn, lty);
         }
 
         // The previous steps can cause more items to become non-rewritten.  Keep going until

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -708,7 +708,7 @@ fn run(tcx: TyCtxt) {
         }));
 
         let mut info = FuncInfo::default();
-        let local_pointee_types = LocalPointerTable::new(acx.num_pointers());
+        let local_pointee_types = LocalPointerTable::new(0, acx.num_pointers());
         info.acx_data.set(acx.into_data());
 
         match r {
@@ -816,7 +816,7 @@ fn run(tcx: TyCtxt) {
         };
 
         // Compute local equivalence classes and dataflow constraints.
-        let mut local_equiv = LocalEquivSet::new(acx.num_pointers());
+        let mut local_equiv = LocalEquivSet::new(0, acx.num_pointers());
         let mut equiv = global_equiv.and_mut(&mut local_equiv);
         for (a, b) in equiv_constraints {
             equiv.unify(a, b);
@@ -930,8 +930,8 @@ fn run(tcx: TyCtxt) {
 
     for info in func_info.values_mut() {
         let num_pointers = info.acx_data.num_pointers();
-        let mut lasn = LocalAssignment::new(num_pointers, INITIAL_PERMS, INITIAL_FLAGS);
-        let l_updates_forbidden = LocalPointerTable::new(num_pointers);
+        let mut lasn = LocalAssignment::new(0, num_pointers, INITIAL_PERMS, INITIAL_FLAGS);
+        let l_updates_forbidden = LocalPointerTable::new(0, num_pointers);
 
         for (ptr, &info) in info.acx_data.local_ptr_info().iter() {
             if should_make_fixed(info) {

--- a/c2rust-analyze/src/borrowck/mod.rs
+++ b/c2rust-analyze/src/borrowck/mod.rs
@@ -4,7 +4,7 @@ use crate::context::AdtMetadataTable;
 use crate::context::{AnalysisCtxt, PermissionSet};
 use crate::dataflow::DataflowConstraints;
 use crate::labeled_ty::{LabeledTy, LabeledTyCtxt};
-use crate::pointer_id::{PointerTable, PointerTableMut};
+use crate::pointer_id::GlobalPointerTable;
 use crate::util::{describe_rvalue, RvalueDesc};
 use indexmap::{IndexMap, IndexSet};
 use log::{debug, info, warn};
@@ -121,8 +121,8 @@ impl std::fmt::Debug for OriginParam {
 pub fn borrowck_mir<'tcx>(
     acx: &AnalysisCtxt<'_, 'tcx>,
     dataflow: &DataflowConstraints,
-    hypothesis: &mut PointerTableMut<PermissionSet>,
-    updates_forbidden: &PointerTable<PermissionSet>,
+    hypothesis: &mut GlobalPointerTable<PermissionSet>,
+    updates_forbidden: &GlobalPointerTable<PermissionSet>,
     name: &str,
     mir: &Body<'tcx>,
     field_ltys: HashMap<DefId, context::LTy<'tcx>>,
@@ -201,7 +201,7 @@ pub fn borrowck_mir<'tcx>(
 
 fn run_polonius<'tcx>(
     acx: &AnalysisCtxt<'_, 'tcx>,
-    hypothesis: &PointerTableMut<PermissionSet>,
+    hypothesis: &GlobalPointerTable<PermissionSet>,
     name: &str,
     mir: &Body<'tcx>,
     field_ltys: &HashMap<DefId, context::LTy<'tcx>>,
@@ -617,7 +617,7 @@ fn construct_adt_origins<'tcx>(
 
 fn assign_origins<'tcx>(
     ltcx: LTyCtxt<'tcx>,
-    hypothesis: &PointerTableMut<PermissionSet>,
+    hypothesis: &GlobalPointerTable<PermissionSet>,
     _facts: &mut AllFacts,
     maps: &mut AtomMaps<'tcx>,
     adt_metadata: &AdtMetadataTable<'tcx>,

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -3,7 +3,7 @@ use crate::borrowck::{assign_origins, construct_adt_origins, LTy, LTyCtxt, Label
 use crate::context::{const_alloc_id, find_static_for_alloc};
 use crate::context::{AnalysisCtxt, PermissionSet};
 use crate::panic_detail;
-use crate::pointer_id::PointerTableMut;
+use crate::pointer_id::GlobalPointerTable;
 use crate::util::{self, ty_callee, Callee};
 use assert_matches::assert_matches;
 use indexmap::IndexMap;
@@ -29,7 +29,7 @@ struct TypeChecker<'tcx, 'a> {
     local_ltys: &'a [LTy<'tcx>],
     rvalue_ltys: &'a HashMap<Location, LTy<'tcx>>,
     field_permissions: &'a HashMap<DefId, PermissionSet>,
-    hypothesis: &'a PointerTableMut<'a, PermissionSet>,
+    hypothesis: &'a GlobalPointerTable<PermissionSet>,
     local_decls: &'a IndexVec<Local, LocalDecl<'tcx>>,
     current_location: Location,
     static_origin: Origin,
@@ -628,7 +628,7 @@ pub fn visit_body<'tcx>(
     local_ltys: &[LTy<'tcx>],
     rvalue_ltys: &HashMap<Location, LTy<'tcx>>,
     field_permissions: &HashMap<DefId, PermissionSet>,
-    hypothesis: &PointerTableMut<PermissionSet>,
+    hypothesis: &GlobalPointerTable<PermissionSet>,
     mir: &Body<'tcx>,
     static_origin: Origin,
 ) {

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -978,6 +978,10 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             .get(def_id)
             .intersects(DontRewriteFnReason::ANALYSIS_INVALID_MASK)
     }
+
+    pub fn ptr_is_global(&self, ptr: PointerId) -> bool {
+        self.ptr_info.contains(ptr)
+    }
 }
 
 impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
@@ -1060,6 +1064,10 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
 
     pub fn local_ptr_base(&self) -> u32 {
         self.ptr_info.base()
+    }
+
+    pub fn ptr_is_global(&self, ptr: PointerId) -> bool {
+        self.gacx.ptr_is_global(ptr)
     }
 
     pub fn type_of<T: TypeOf<'tcx>>(&self, x: T) -> LTy<'tcx> {
@@ -1309,7 +1317,7 @@ fn remap_local_ptr_info(
     let mut new_local_ptr_info = LocalPointerTable::<PointerInfo>::new(base, count);
     let mut new_ptr_info = new_global_ptr_info.and_mut(&mut new_local_ptr_info);
     for (old, &new) in map.iter() {
-        if old.index() < old_local_ptr_info.base() {
+        if !old_local_ptr_info.contains(old) {
             // If `old` is global then `new` is also global, and this remapping was handled already
             // by `remap_global_ptr_info`.
             continue;

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -406,6 +406,8 @@ pub struct GlobalAnalysisCtxt<'tcx> {
     pub lcx: LTyCtxt<'tcx>,
 
     ptr_info: GlobalPointerTable<PointerInfo>,
+    /// Total number of global and local pointers across all functions.
+    num_total_pointers: usize,
 
     pub fn_sigs: HashMap<DefId, LFnSig<'tcx>>,
     pub fn_fields_used: MultiMap<LocalDefId, LocalDefId>,
@@ -798,6 +800,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             tcx,
             lcx: LabeledTyCtxt::new(tcx),
             ptr_info: GlobalPointerTable::empty(),
+            num_total_pointers: 0,
             fn_sigs: HashMap::new(),
             fn_fields_used: MultiMap::new(),
             known_fns: all_known_fns()
@@ -855,6 +858,18 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         self.ptr_info.len()
     }
 
+    pub fn num_total_pointers(&self) -> usize {
+        self.num_total_pointers
+    }
+
+    pub fn set_num_total_pointers(&mut self, n: usize) {
+        assert_eq!(
+            self.num_total_pointers, 0,
+            "num_total_pointers has already been set"
+        );
+        self.num_total_pointers = n;
+    }
+
     pub fn ptr_info(&self) -> &GlobalPointerTable<PointerInfo> {
         &self.ptr_info
     }
@@ -867,6 +882,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             tcx: _,
             lcx,
             ref mut ptr_info,
+            num_total_pointers: _,
             ref mut fn_sigs,
             fn_fields_used: _,
             known_fns: _,
@@ -1443,79 +1459,33 @@ pub fn label_no_pointers<'tcx>(acx: &AnalysisCtxt<'_, 'tcx>, ty: Ty<'tcx>) -> LT
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct GlobalAssignment {
+pub struct Assignment {
     pub perms: GlobalPointerTable<PermissionSet>,
     pub flags: GlobalPointerTable<FlagSet>,
 }
 
-impl GlobalAssignment {
-    pub fn new(
-        len: usize,
-        default_perms: PermissionSet,
-        default_flags: FlagSet,
-    ) -> GlobalAssignment {
-        GlobalAssignment {
+impl Assignment {
+    pub fn new(len: usize, default_perms: PermissionSet, default_flags: FlagSet) -> Assignment {
+        Assignment {
             perms: GlobalPointerTable::from_raw(vec![default_perms; len]),
             flags: GlobalPointerTable::from_raw(vec![default_flags; len]),
         }
     }
 
-    pub fn and<'a>(&'a mut self, local: &'a mut LocalAssignment) -> Assignment<'a> {
-        Assignment {
-            global: self,
-            local,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct LocalAssignment {
-    pub perms: LocalPointerTable<PermissionSet>,
-    pub flags: LocalPointerTable<FlagSet>,
-}
-
-impl LocalAssignment {
-    pub fn new(
-        base: u32,
-        len: usize,
-        default_perms: PermissionSet,
-        default_flags: FlagSet,
-    ) -> LocalAssignment {
-        LocalAssignment {
-            perms: LocalPointerTable::from_raw(base, vec![default_perms; len]),
-            flags: LocalPointerTable::from_raw(base, vec![default_flags; len]),
-        }
-    }
-}
-
-pub struct Assignment<'a> {
-    pub global: &'a mut GlobalAssignment,
-    local: &'a mut LocalAssignment,
-}
-
-impl Assignment<'_> {
-    pub fn perms(&self) -> PointerTable<PermissionSet> {
-        self.global.perms.and(&self.local.perms)
+    pub fn perms(&self) -> &GlobalPointerTable<PermissionSet> {
+        &self.perms
     }
 
-    pub fn perms_mut(&mut self) -> PointerTableMut<PermissionSet> {
-        self.global.perms.and_mut(&mut self.local.perms)
+    pub fn perms_mut(&mut self) -> &mut GlobalPointerTable<PermissionSet> {
+        &mut self.perms
     }
 
-    pub fn flags(&self) -> PointerTable<FlagSet> {
-        self.global.flags.and(&self.local.flags)
+    pub fn flags(&self) -> &GlobalPointerTable<FlagSet> {
+        &self.flags
     }
 
-    #[allow(dead_code)]
-    pub fn _flags_mut(&mut self) -> PointerTableMut<FlagSet> {
-        self.global.flags.and_mut(&mut self.local.flags)
-    }
-
-    pub fn all_mut(&mut self) -> (PointerTableMut<PermissionSet>, PointerTableMut<FlagSet>) {
-        (
-            self.global.perms.and_mut(&mut self.local.perms),
-            self.global.flags.and_mut(&mut self.local.flags),
-        )
+    pub fn _flags_mut(&mut self) -> &mut GlobalPointerTable<FlagSet> {
+        &mut self.flags
     }
 }
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -837,9 +837,9 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
     pub fn function_context<'a>(
         &'a mut self,
         mir: &'a Body<'tcx>,
-        base: u32,
+        local_ptr_base: u32,
     ) -> AnalysisCtxt<'a, 'tcx> {
-        AnalysisCtxt::new(self, mir, base)
+        AnalysisCtxt::new(self, mir, local_ptr_base)
     }
 
     pub fn function_context_with_data<'a>(
@@ -1004,11 +1004,11 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
     pub fn new(
         gacx: &'a mut GlobalAnalysisCtxt<'tcx>,
         mir: &'a Body<'tcx>,
-        base: u32,
+        local_ptr_base: u32,
     ) -> AnalysisCtxt<'a, 'tcx> {
         AnalysisCtxt {
             gacx,
-            ptr_info: LocalPointerTable::empty(base),
+            ptr_info: LocalPointerTable::empty(local_ptr_base),
             local_decls: &mir.local_decls,
             local_tys: IndexVec::new(),
             addr_of_local: IndexVec::new(),

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -1309,7 +1309,7 @@ fn remap_local_ptr_info(
     let mut new_local_ptr_info = LocalPointerTable::<PointerInfo>::new(base, count);
     let mut new_ptr_info = new_global_ptr_info.and_mut(&mut new_local_ptr_info);
     for (old, &new) in map.iter() {
-        if old.is_global() {
+        if old.index() < old_local_ptr_info.base() {
             // If `old` is global then `new` is also global, and this remapping was handled already
             // by `remap_global_ptr_info`.
             continue;

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -834,8 +834,12 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         self.fn_origins = fn_origin_args_params(self.tcx, &self.adt_metadata);
     }
 
-    pub fn function_context<'a>(&'a mut self, mir: &'a Body<'tcx>) -> AnalysisCtxt<'a, 'tcx> {
-        AnalysisCtxt::new(self, mir)
+    pub fn function_context<'a>(
+        &'a mut self,
+        mir: &'a Body<'tcx>,
+        base: u32,
+    ) -> AnalysisCtxt<'a, 'tcx> {
+        AnalysisCtxt::new(self, mir, base)
     }
 
     pub fn function_context_with_data<'a>(
@@ -987,10 +991,11 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
     pub fn new(
         gacx: &'a mut GlobalAnalysisCtxt<'tcx>,
         mir: &'a Body<'tcx>,
+        base: u32,
     ) -> AnalysisCtxt<'a, 'tcx> {
         AnalysisCtxt {
             gacx,
-            ptr_info: LocalPointerTable::empty(0),
+            ptr_info: LocalPointerTable::empty(base),
             local_decls: &mir.local_decls,
             local_tys: IndexVec::new(),
             addr_of_local: IndexVec::new(),
@@ -1056,8 +1061,12 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
         self.gacx.ptr_info.and_mut(&mut self.ptr_info)
     }
 
-    pub fn _local_ptr_info(&self) -> &LocalPointerTable<PointerInfo> {
+    pub fn local_ptr_info(&self) -> &LocalPointerTable<PointerInfo> {
         &self.ptr_info
+    }
+
+    pub fn local_ptr_base(&self) -> u32 {
+        self.ptr_info.base()
     }
 
     pub fn type_of<T: TypeOf<'tcx>>(&self, x: T) -> LTy<'tcx> {
@@ -1257,6 +1266,10 @@ impl<'tcx> AnalysisCtxtData<'tcx> {
 
     pub fn num_pointers(&self) -> usize {
         self.ptr_info.len()
+    }
+
+    pub fn local_ptr_base(&self) -> u32 {
+        self.ptr_info.base()
     }
 }
 

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -990,7 +990,7 @@ impl<'a, 'tcx> AnalysisCtxt<'a, 'tcx> {
     ) -> AnalysisCtxt<'a, 'tcx> {
         AnalysisCtxt {
             gacx,
-            ptr_info: LocalPointerTable::empty(),
+            ptr_info: LocalPointerTable::empty(0),
             local_decls: &mir.local_decls,
             local_tys: IndexVec::new(),
             addr_of_local: IndexVec::new(),
@@ -1298,7 +1298,7 @@ fn remap_local_ptr_info(
     map: &PointerTable<PointerId>,
     num_pointers: usize,
 ) -> LocalPointerTable<PointerInfo> {
-    let mut new_local_ptr_info = LocalPointerTable::<PointerInfo>::new(num_pointers);
+    let mut new_local_ptr_info = LocalPointerTable::<PointerInfo>::new(0, num_pointers);
     let mut new_ptr_info = new_global_ptr_info.and_mut(&mut new_local_ptr_info);
     for (old, &new) in map.iter() {
         if old.is_global() {
@@ -1460,13 +1460,14 @@ pub struct LocalAssignment {
 
 impl LocalAssignment {
     pub fn new(
+        base: u32,
         len: usize,
         default_perms: PermissionSet,
         default_flags: FlagSet,
     ) -> LocalAssignment {
         LocalAssignment {
-            perms: LocalPointerTable::from_raw(vec![default_perms; len]),
-            flags: LocalPointerTable::from_raw(vec![default_flags; len]),
+            perms: LocalPointerTable::from_raw(base, vec![default_perms; len]),
+            flags: LocalPointerTable::from_raw(base, vec![default_flags; len]),
         }
     }
 }

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -851,7 +851,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
         self.ptr_info.push(info)
     }
 
-    pub fn num_pointers(&self) -> usize {
+    pub fn num_global_pointers(&self) -> usize {
         self.ptr_info.len()
     }
 

--- a/c2rust-analyze/src/equiv.rs
+++ b/c2rust-analyze/src/equiv.rs
@@ -114,7 +114,8 @@ impl LocalEquivSet {
         global_map: &GlobalPointerTable<PointerId>,
     ) -> (NextLocalPointerId, LocalPointerTable<PointerId>) {
         let mut counter = NextLocalPointerId::new();
-        let mut map = LocalPointerTable::from_raw(0, vec![PointerId::NONE; self.0.len()]);
+        let mut map =
+            LocalPointerTable::from_raw(self.0.base(), vec![PointerId::NONE; self.0.len()]);
 
         for old_id in self.0.iter().map(|(x, _)| x) {
             let rep = self.rep(old_id);

--- a/c2rust-analyze/src/equiv.rs
+++ b/c2rust-analyze/src/equiv.rs
@@ -107,13 +107,14 @@ impl LocalEquivSet {
     }
 
     /// Assign new `PointerId`s for the pointers in this set, with one ID per equivalence class.
-    /// Returns the next-ID counter for the new numbering and a map from old `PointerId`s to new
-    /// ones.
+    /// Returns the base, the number of pointers after remapping, and a map from old `PointerId`s
+    /// to new ones.
     pub fn renumber(
         &self,
         global_map: &GlobalPointerTable<PointerId>,
-    ) -> (NextLocalPointerId, LocalPointerTable<PointerId>) {
-        let mut counter = NextLocalPointerId::new();
+        counter: &mut NextLocalPointerId,
+    ) -> (u32, usize, LocalPointerTable<PointerId>) {
+        let base = counter.value();
         let mut map =
             LocalPointerTable::from_raw(self.0.base(), vec![PointerId::NONE; self.0.len()]);
 
@@ -131,7 +132,8 @@ impl LocalEquivSet {
             };
         }
 
-        (counter, map)
+        let count = (counter.value() - base) as usize;
+        (base, count, map)
     }
 }
 

--- a/c2rust-analyze/src/equiv.rs
+++ b/c2rust-analyze/src/equiv.rs
@@ -143,9 +143,9 @@ impl<'g> EquivSet<'g> {
 
     fn set_parent(&self, x: PointerId, parent: PointerId) {
         // Local items can point to global ones, but not vice versa.
-        //if x.is_global() {
-        //    debug_assert!(parent.is_global());
-        //}
+        if self.0.ptr_is_global(x) {
+            debug_assert!(self.0.ptr_is_global(parent));
+        }
 
         self.0[x].set(parent);
     }

--- a/c2rust-analyze/src/equiv.rs
+++ b/c2rust-analyze/src/equiv.rs
@@ -83,7 +83,7 @@ impl LocalEquivSet {
 
     fn set_parent(&self, x: PointerId, parent: PointerId) {
         // `x` must be a local ID; its parent can be either local or global.
-        debug_assert!(x.index() >= self.0.base());
+        debug_assert!(self.0.contains(x));
         self.0[x].set(parent);
     }
 
@@ -96,7 +96,7 @@ impl LocalEquivSet {
     /// method.
     fn rep(&self, x: PointerId) -> PointerId {
         let parent = self.parent(x);
-        if parent == x || parent.index() < self.0.base() || self.parent(parent) == parent {
+        if parent == x || !self.0.contains(parent) || self.parent(parent) == parent {
             return parent;
         }
 
@@ -120,7 +120,7 @@ impl LocalEquivSet {
         for old_id in self.0.iter().map(|(x, _)| x) {
             let rep = self.rep(old_id);
 
-            if rep.index() < self.0.base() {
+            if global_map.contains(rep) {
                 map[old_id] = global_map[rep];
             } else if !map[rep].is_none() {
                 map[old_id] = map[rep];
@@ -128,7 +128,7 @@ impl LocalEquivSet {
                 let new_id = counter.next();
                 map[old_id] = new_id;
                 map[rep] = new_id;
-            };
+            }
         }
 
         let count = (counter.value() - base) as usize;

--- a/c2rust-analyze/src/equiv.rs
+++ b/c2rust-analyze/src/equiv.rs
@@ -71,11 +71,11 @@ impl GlobalEquivSet {
 }
 
 impl LocalEquivSet {
-    pub fn new(len: usize) -> LocalEquivSet {
+    pub fn new(base: u32, len: usize) -> LocalEquivSet {
         let raw = (0..len as u32)
-            .map(|x| Cell::new(PointerId::local(x)))
+            .map(|x| Cell::new(PointerId::local(base + x)))
             .collect();
-        LocalEquivSet(LocalPointerTable::from_raw(raw))
+        LocalEquivSet(LocalPointerTable::from_raw(base, raw))
     }
 
     fn parent(&self, x: PointerId) -> PointerId {
@@ -114,7 +114,7 @@ impl LocalEquivSet {
         global_map: &GlobalPointerTable<PointerId>,
     ) -> (NextLocalPointerId, LocalPointerTable<PointerId>) {
         let mut counter = NextLocalPointerId::new();
-        let mut map = LocalPointerTable::from_raw(vec![PointerId::NONE; self.0.len()]);
+        let mut map = LocalPointerTable::from_raw(0, vec![PointerId::NONE; self.0.len()]);
 
         for old_id in self.0.iter().map(|(x, _)| x) {
             let rep = self.rep(old_id);

--- a/c2rust-analyze/src/pointee_type/mod.rs
+++ b/c2rust-analyze/src/pointee_type/mod.rs
@@ -1,8 +1,5 @@
 use crate::context::AnalysisCtxt;
-use crate::pointer_id::{
-    GlobalPointerTable, LocalPointerTable, NextGlobalPointerId, NextLocalPointerId, PointerId,
-    PointerTable,
-};
+use crate::pointer_id::{GlobalPointerTable, LocalPointerTable, PointerId, PointerTable};
 use rustc_middle::mir::Body;
 use std::mem;
 
@@ -23,12 +20,9 @@ pub fn generate_constraints<'tcx>(
 pub fn remap_pointers_global<'tcx>(
     pointee_types: &mut GlobalPointerTable<PointeeTypes<'tcx>>,
     map: &GlobalPointerTable<PointerId>,
-    counter: &NextGlobalPointerId,
+    count: usize,
 ) {
-    let mut old = mem::replace(
-        pointee_types,
-        GlobalPointerTable::new(counter.num_pointers()),
-    );
+    let mut old = mem::replace(pointee_types, GlobalPointerTable::new(count));
     let new = pointee_types;
     for (old_ptr, old_val) in old.iter_mut() {
         // If there are multiple old pointers that map to the same new pointer, merge their sets.
@@ -40,11 +34,12 @@ pub fn remap_pointers_local<'tcx>(
     global_pointee_types: &mut GlobalPointerTable<PointeeTypes<'tcx>>,
     local_pointee_types: &mut LocalPointerTable<PointeeTypes<'tcx>>,
     map: PointerTable<PointerId>,
-    counter: &NextLocalPointerId,
+    local_base: u32,
+    local_count: usize,
 ) {
     let mut old = mem::replace(
         local_pointee_types,
-        LocalPointerTable::new(0, counter.num_pointers()),
+        LocalPointerTable::new(local_base, local_count),
     );
     let mut new = global_pointee_types.and_mut(local_pointee_types);
     for (old_ptr, old_val) in old.iter_mut() {

--- a/c2rust-analyze/src/pointee_type/mod.rs
+++ b/c2rust-analyze/src/pointee_type/mod.rs
@@ -44,7 +44,7 @@ pub fn remap_pointers_local<'tcx>(
 ) {
     let mut old = mem::replace(
         local_pointee_types,
-        LocalPointerTable::new(counter.num_pointers()),
+        LocalPointerTable::new(0, counter.num_pointers()),
     );
     let mut new = global_pointee_types.and_mut(local_pointee_types);
     for (old_ptr, old_val) in old.iter_mut() {

--- a/c2rust-analyze/src/pointee_type/solve.rs
+++ b/c2rust-analyze/src/pointee_type/solve.rs
@@ -170,14 +170,14 @@ fn export<'tcx>(
     ty_sets: PointerTable<HashSet<CTy<'tcx>>>,
     mut pointee_tys: PointerTableMut<PointeeTypes<'tcx>>,
 ) {
-    let local_ptr_base = pointee_tys.local().base();
+    let local_ptr_range = pointee_tys.local().range();
     for (ptr, ctys) in ty_sets.iter() {
         let out = &mut pointee_tys[ptr];
         for &cty in ctys {
             if let CTy::Ty(lty) = var_table.cty_rep(cty) {
                 let mut ok = true;
                 lty.for_each_label(&mut |p| {
-                    if !p.is_none() && p.index() >= local_ptr_base {
+                    if local_ptr_range.contains(p) {
                         ok = false;
                     }
                 });

--- a/c2rust-analyze/src/pointee_type/solve.rs
+++ b/c2rust-analyze/src/pointee_type/solve.rs
@@ -170,13 +170,14 @@ fn export<'tcx>(
     ty_sets: PointerTable<HashSet<CTy<'tcx>>>,
     mut pointee_tys: PointerTableMut<PointeeTypes<'tcx>>,
 ) {
+    let local_ptr_base = pointee_tys.local().base();
     for (ptr, ctys) in ty_sets.iter() {
         let out = &mut pointee_tys[ptr];
         for &cty in ctys {
             if let CTy::Ty(lty) = var_table.cty_rep(cty) {
                 let mut ok = true;
                 lty.for_each_label(&mut |p| {
-                    if p.is_local() {
+                    if !p.is_none() && p.index() >= local_ptr_base {
                         ok = false;
                     }
                 });

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -321,12 +321,23 @@ impl<T> GlobalPointerTable<T> {
         GlobalPointerTable(PointerTableInner::new(len))
     }
 
+    pub fn with_len_of<U>(table: &GlobalPointerTable<U>) -> GlobalPointerTable<T>
+    where
+        T: Default,
+    {
+        GlobalPointerTable::new(table.len())
+    }
+
     pub fn from_raw(raw: Vec<T>) -> GlobalPointerTable<T> {
         GlobalPointerTable(PointerTableInner::from_raw(raw))
     }
 
     pub fn into_raw(self) -> Vec<T> {
         self.0.into_raw()
+    }
+
+    pub fn as_slice(&self) -> &[T] {
+        &self.0 .0
     }
 
     pub fn len(&self) -> usize {

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -101,7 +101,10 @@ impl NextGlobalPointerId {
 #[derive(Clone, PartialEq, Eq, Debug)]
 struct PointerTableInner<T>(Vec<T>);
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct LocalPointerTable<T>(PointerTableInner<T>);
+pub struct LocalPointerTable<T> {
+    table: PointerTableInner<T>,
+    base: u32,
+}
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GlobalPointerTable<T>(PointerTableInner<T>);
 pub struct PointerTable<'a, T> {
@@ -161,55 +164,75 @@ impl<T> IndexMut<u32> for PointerTableInner<T> {
 
 #[allow(dead_code)]
 impl<T> LocalPointerTable<T> {
-    pub fn empty() -> LocalPointerTable<T> {
-        LocalPointerTable(PointerTableInner::empty())
+    pub fn empty(base: u32) -> LocalPointerTable<T> {
+        LocalPointerTable {
+            table: PointerTableInner::empty(),
+            base,
+        }
     }
 
-    pub fn new(len: usize) -> LocalPointerTable<T>
+    pub fn new(base: u32, len: usize) -> LocalPointerTable<T>
     where
         T: Default,
     {
-        LocalPointerTable(PointerTableInner::new(len))
+        // `base + len` must not exceed `u32::MAX`.
+        let len_u32 = u32::try_from(len).unwrap();
+        assert!(base.checked_add(len_u32).is_some());
+
+        LocalPointerTable {
+            table: PointerTableInner::new(len),
+            base,
+        }
     }
 
-    pub fn from_raw(raw: Vec<T>) -> LocalPointerTable<T> {
-        LocalPointerTable(PointerTableInner::from_raw(raw))
+    pub fn from_raw(base: u32, raw: Vec<T>) -> LocalPointerTable<T> {
+        // `base + len` must not exceed `u32::MAX`.
+        let len = u32::try_from(raw.len()).unwrap();
+        assert!(base.checked_add(len).is_some());
+
+        LocalPointerTable {
+            table: PointerTableInner::from_raw(raw),
+            base,
+        }
     }
 
-    pub fn into_raw(self) -> Vec<T> {
-        self.0.into_raw()
+    pub fn into_raw(self) -> (u32, Vec<T>) {
+        (self.base, self.table.into_raw())
     }
 
     pub fn len(&self) -> usize {
-        self.0 .0.len()
+        self.table.0.len()
     }
 
     pub fn fill(&mut self, x: T)
     where
         T: Clone,
     {
-        self.0 .0.fill(x);
+        self.table.0.fill(x);
     }
 
     pub fn push(&mut self, x: T) -> PointerId {
-        let raw = self.0.push(x);
-        PointerId::local(raw)
+        assert!(self.base + (self.len() as u32) < u32::MAX);
+        let raw = self.table.push(x);
+        PointerId::local(raw + self.base)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (PointerId, &T)> {
-        self.0
-             .0
+        let base = self.base;
+        self.table
+            .0
             .iter()
             .enumerate()
-            .map(|(i, x)| (PointerId::local(i as u32), x))
+            .map(move |(i, x)| (PointerId::local(i as u32 + base), x))
     }
 
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (PointerId, &mut T)> {
-        self.0
-             .0
+        let base = self.base;
+        self.table
+            .0
             .iter_mut()
             .enumerate()
-            .map(|(i, x)| (PointerId::local(i as u32), x))
+            .map(move |(i, x)| (PointerId::local(i as u32 + base), x))
     }
 }
 
@@ -217,14 +240,14 @@ impl<T> Index<PointerId> for LocalPointerTable<T> {
     type Output = T;
     fn index(&self, id: PointerId) -> &T {
         assert!(id.is_local());
-        &self.0[id.index()]
+        &self.table[id.index() - self.base]
     }
 }
 
 impl<T> IndexMut<PointerId> for LocalPointerTable<T> {
     fn index_mut(&mut self, id: PointerId) -> &mut T {
         assert!(id.is_local());
-        &mut self.0[id.index()]
+        &mut self.table[id.index() - self.base]
     }
 }
 
@@ -453,7 +476,7 @@ impl<T> OwnedPointerTable<T> {
     {
         OwnedPointerTable::new(
             GlobalPointerTable::new(table.global.len()),
-            LocalPointerTable::new(table.local.len()),
+            LocalPointerTable::new(table.local.base, table.local.len()),
         )
     }
 

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -64,7 +64,7 @@ impl fmt::Debug for PointerId {
 pub struct NextLocalPointerId(u32);
 
 impl NextLocalPointerId {
-    pub fn new() -> NextLocalPointerId {
+    pub fn _new() -> NextLocalPointerId {
         NextLocalPointerId(0)
     }
 
@@ -74,7 +74,11 @@ impl NextLocalPointerId {
         PointerId::local(x)
     }
 
-    pub fn num_pointers(&self) -> usize {
+    pub fn value(&self) -> u32 {
+        self.0
+    }
+
+    pub fn _num_pointers(&self) -> usize {
         self.0 as usize
     }
 }
@@ -95,6 +99,10 @@ impl NextGlobalPointerId {
 
     pub fn num_pointers(&self) -> usize {
         self.0 as usize
+    }
+
+    pub fn into_local(self) -> NextLocalPointerId {
+        NextLocalPointerId(self.0)
     }
 }
 

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -420,6 +420,9 @@ impl PointerRange {
     pub fn contains(&self, ptr: PointerId) -> bool {
         // If `ptr.index() < self.base`, the subtraction will wrap to a large number in excess of
         // `self.len()`.
+        //
+        // Note that `base + len` can't overflow `u32::MAX` due to checks in `LocalPointerTable`
+        // above.
         ptr.index().wrapping_sub(self.base) < self.len
     }
 }

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -70,7 +70,7 @@ impl NextLocalPointerId {
 
     pub fn next(&mut self) -> PointerId {
         let x = self.0;
-        self.0 += 1;
+        self.0 = self.0.checked_add(1).unwrap();
         PointerId::local(x)
     }
 
@@ -89,7 +89,7 @@ impl NextGlobalPointerId {
 
     pub fn next(&mut self) -> PointerId {
         let x = self.0;
-        self.0 += 1;
+        self.0 = self.0.checked_add(1).unwrap();
         PointerId::global(x)
     }
 

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -200,8 +200,16 @@ impl<T> LocalPointerTable<T> {
         (self.base, self.table.into_raw())
     }
 
+    pub fn base(&self) -> u32 {
+        self.base
+    }
+
     pub fn len(&self) -> usize {
         self.table.0.len()
+    }
+
+    pub fn next_index(&self) -> u32 {
+        self.base + self.len() as u32
     }
 
     pub fn fill(&mut self, x: T)
@@ -274,6 +282,10 @@ impl<T> GlobalPointerTable<T> {
 
     pub fn len(&self) -> usize {
         self.0 .0.len()
+    }
+
+    pub fn next_index(&self) -> u32 {
+        self.len() as u32
     }
 
     pub fn push(&mut self, x: T) -> PointerId {

--- a/c2rust-analyze/src/rewrite/statics.rs
+++ b/c2rust-analyze/src/rewrite/statics.rs
@@ -1,4 +1,4 @@
-use crate::context::GlobalAssignment;
+use crate::context::Assignment;
 use crate::context::{FlagSet, PermissionSet};
 use crate::pointer_id::PointerId;
 use crate::rewrite::Rewrite;
@@ -11,13 +11,13 @@ use rustc_span::Span;
 /// changing the declaration to match observed/analyzed usage.
 pub fn gen_static_rewrites<'tcx>(
     tcx: TyCtxt<'tcx>,
-    gasn: &GlobalAssignment,
+    asn: &Assignment,
     def_id: DefId,
     ptr: PointerId,
 ) -> Option<(Span, Rewrite)> {
     // If the `addr_of_static` `PointerId` is `FIXED`, then we're forbidden from emitting this
     // rewrite.
-    let flags = gasn.flags[ptr];
+    let flags = asn.flags[ptr];
     if flags.contains(FlagSet::FIXED) {
         return None;
     }
@@ -33,7 +33,7 @@ pub fn gen_static_rewrites<'tcx>(
         ItemKind::Static(_ty, mutbl, _body_id) => mutbl == Mutability::Mut,
         _ => panic!("expected item {:?} to be a `static`", item),
     };
-    let perms = gasn.perms[ptr];
+    let perms = asn.perms[ptr];
     let written_to = perms.contains(PermissionSet::WRITE);
     if written_to != is_mutable {
         let ident = tcx

--- a/c2rust-analyze/src/rewrite/ty.rs
+++ b/c2rust-analyze/src/rewrite/ty.rs
@@ -10,8 +10,7 @@ use std::ops::Index;
 use crate::borrowck::{OriginArg, OriginParam};
 use crate::context::AdtMetadataTable;
 use crate::context::{
-    AnalysisCtxt, Assignment, FlagSet, FnSigOrigins, GlobalAnalysisCtxt, GlobalAssignment, LTy,
-    PermissionSet,
+    AnalysisCtxt, Assignment, FlagSet, FnSigOrigins, GlobalAnalysisCtxt, LTy, PermissionSet,
 };
 use crate::labeled_ty::{LabeledTy, LabeledTyCtxt};
 use crate::pointee_type::PointeeTypes;
@@ -480,7 +479,7 @@ pub fn desc_to_ty<'tcx>(tcx: TyCtxt<'tcx>, desc: TypeDesc<'tcx>) -> Ty<'tcx> {
 }
 
 struct HirTyVisitor<'a, 'tcx> {
-    asn: &'a Assignment<'a>,
+    asn: &'a Assignment,
     pointee_types: PointerTable<'a, PointeeTypes<'tcx>>,
     acx: &'a AnalysisCtxt<'a, 'tcx>,
     rw_lcx: LabeledTyCtxt<'tcx, RewriteLabel<'tcx>>,
@@ -669,8 +668,8 @@ impl<'tcx, 'a> intravisit::Visitor<'tcx> for HirTyVisitor<'a, 'tcx> {
                     assert_eq!(mir_local_decl.source_info.span, hir_local.pat.span);
                     let lty = self.acx.local_tys[*mir_local];
                     let rw_lty = relabel_rewrites(
-                        &self.asn.perms(),
-                        &self.asn.flags(),
+                        self.asn.perms(),
+                        self.asn.flags(),
                         &self.pointee_types,
                         self.rw_lcx,
                         lty,
@@ -739,8 +738,8 @@ pub fn gen_ty_rewrites<'tcx>(
                 create_rewrite_label(
                     pointer_lty,
                     args,
-                    &asn.perms(),
-                    &asn.flags(),
+                    asn.perms(),
+                    asn.flags(),
                     &pointee_types,
                     lifetime_lty.label,
                     &acx.gacx.adt_metadata,
@@ -758,8 +757,8 @@ pub fn gen_ty_rewrites<'tcx>(
                 create_rewrite_label(
                     pointer_lty,
                     args,
-                    &asn.perms(),
-                    &asn.flags(),
+                    asn.perms(),
+                    asn.flags(),
                     &pointee_types,
                     lifetime_lty.label,
                     &acx.gacx.adt_metadata,
@@ -859,7 +858,7 @@ pub fn gen_generics_rws<'p, 'tcx>(
 
 pub fn gen_adt_ty_rewrites<'tcx>(
     gacx: &GlobalAnalysisCtxt<'tcx>,
-    gasn: &GlobalAssignment,
+    asn: &Assignment,
     pointee_types: &GlobalPointerTable<PointeeTypes<'tcx>>,
     did: DefId,
 ) -> Vec<(Span, Rewrite)> {
@@ -903,8 +902,8 @@ pub fn gen_adt_ty_rewrites<'tcx>(
                 create_rewrite_label(
                     pointer_lty,
                     args,
-                    &gasn.perms,
-                    &gasn.flags,
+                    &asn.perms,
+                    &asn.flags,
                     pointee_types,
                     lifetime_lty.label,
                     &gacx.adt_metadata,
@@ -938,8 +937,8 @@ pub fn dump_rewritten_local_tys<'tcx>(
     for (local, decl) in mir.local_decls.iter_enumerated() {
         // TODO: apply `Cell` if `addr_of_local` indicates it's needed
         let rw_lty = relabel_rewrites(
-            &asn.perms(),
-            &asn.flags(),
+            asn.perms(),
+            asn.flags(),
             &pointee_types,
             rw_lcx,
             acx.local_tys[local],


### PR DESCRIPTION
Currently, each function has its own namespace for local `PointerId`s: `PointerId::local(3)` in function `f` is distinct from `PointerId::local(3)` in function `g`.  This creates some problems for pointee type inference*.  This branch puts all functions' local `PointerId`s into a common namespace, with each function occupying a different range in that space.  This means each `PointerId` is now globally unique, and code that is analyzing one function can mention `PointerId`s from a different function without ambiguity.

Most analyses still only look at a single function; these use a sparse `PointerTable` that has entries only for global `PointerId`s (that is, `PointerId`s in the range allocated for globals) and for the local `PointerId`s of the current function.  Any analyses that need to consider cross-function local `PointerId`s can use a single large `GlobalPointerTable` instead.

---

\* The specific issue is this: the allocation in lighttpd's `buffer_init` is not initialized inside that function, so correctly inferring the type requires unifying type variables interprocedurally.  The type variables for the pointee analysis are tracked in a `VarTable`, which contains `LTy`s.  We'd like to track variables from all functions in one big `VarTable`, so that we can unify variables that originated in different functions.  However, `LTy`s may contain local `PointerId`s, so a shared `VarTable` could mix up local `PointerId`s from different functions/namespaces, producing nonsensical results.  The fix being applied here is to put all `PointerId`s into a single namespace, so all type variables can be tracked in a common `VarTable`, and there is no longer an obstacle to unifying type variables from different functions.