### PR TITLE
`transpile`: emit zeroed array expressions as `[0; N]`

### DIFF
--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -190,6 +190,14 @@ impl<'c> Translation<'c> {
                 if is_string {
                     let v = ids.first().unwrap();
                     self.convert_expr(ctx.used(), *v)
+                } else if ids.len() == 0 {
+                    // this was likely a C array of the form `int x[16] = {}`,
+                    // we'll emit that as [0; 16].
+                    let len = mk().lit_expr(mk().int_unsuffixed_lit(n as u128));
+                    self.implicit_default_expr(ty, ctx.is_static)?
+                        .and_then(|default_value| {
+                            Ok(WithStmts::new_val(mk().repeat_expr(default_value, len)))
+                        })
                 } else {
                     Ok(ids
                         .iter()

--- a/tests/arrays/src/arrays.c
+++ b/tests/arrays/src/arrays.c
@@ -6,8 +6,13 @@ static char *foo = "mystring";
 void entry(const unsigned buffer_size, int buffer[const])
 {
     int arr[1][1] = { 1 };
-
     arr[0][0] += 9;
+
+    int arr2[16] = {};
+    arr2[15] += 9;
+
+    struct {char* x; int y;} arr3[1] = {};
+    arr3[0].y += 9;
 
     int i = 0;
 


### PR DESCRIPTION
an input like 

```c
int foo() {
    int x[16] = {};
    return 0;
}
```

was emitted as

```rust
    let mut bar: [libc::c_int; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
```

but now emits

```rust
    let mut bar: [libc::c_int; 16] = [0; 16];
```

The current version only supports floating and integral types: in more recent rust versions it would be easy to make this work for e.g. structs: just use a `const { ... }` block. But c2rust targets older versions, and there (without introducing extra constants) the expression's type must be copy, and I could not find a convenient way to tell whether a `CTypeId` will derive/implement `Copy`.

this came up when working with the output of `creduce`, which loves zeroing arrays.