### PR TITLE
analyze: allow pointee analysis to work interprocedurally

### DIFF
--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -627,12 +627,6 @@ fn run(tcx: TyCtxt) {
         assert!(loop_count <= 1000);
         let old_global_pointee_types = global_pointee_types.clone();
 
-        // Clear the `incomplete` flags for all global pointers.  See comment in
-        // `pointee_types::solve::solve_constraints`.
-        for (_, tys) in global_pointee_types.iter_mut() {
-            tys.incomplete = false;
-        }
-
         for &ldid in &all_fn_ldids {
             if gacx.fn_analysis_invalid(ldid.to_def_id()) {
                 continue;
@@ -2276,15 +2270,10 @@ fn print_function_pointee_types<'tcx>(
 
         for ptr in all_pointer_ids {
             let tys = &pointee_types[ptr];
-            if tys.ltys.is_empty() && !tys.incomplete {
+            if tys.tys.is_empty() {
                 continue;
             }
-            debug!(
-                "  pointer {:?}: {:?}{}",
-                ptr,
-                tys.ltys,
-                if tys.incomplete { " (INCOMPLETE)" } else { "" }
-            );
+            debug!("  pointer {:?}: {:?}", ptr, tys.tys,);
         }
     }
 }

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -2273,7 +2273,7 @@ fn print_function_pointee_types<'tcx>(
             if tys.tys.is_empty() {
                 continue;
             }
-            debug!("  pointer {:?}: {:?}", ptr, tys.tys,);
+            debug!("  pointer {:?}: {:?}", ptr, tys.tys);
         }
     }
 }

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -579,6 +579,8 @@ fn run(tcx: TyCtxt) {
     // Infer pointee types
     // ----------------------------------
 
+    let mut pointee_vars = pointee_type::VarTable::default();
+
     for &ldid in &all_fn_ldids {
         if gacx.fn_analysis_invalid(ldid.to_def_id()) {
             continue;
@@ -591,7 +593,7 @@ fn run(tcx: TyCtxt) {
         let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
 
         let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
-            pointee_type::generate_constraints(&acx, &mir)
+            pointee_type::generate_constraints(&acx, &mir, &mut pointee_vars)
         }));
 
         let local_pointee_types = LocalPointerTable::new(acx.local_ptr_base(), acx.num_pointers());
@@ -640,7 +642,7 @@ fn run(tcx: TyCtxt) {
 
             let pointee_constraints = info.pointee_constraints.get();
             let pointee_types = global_pointee_types.and_mut(info.local_pointee_types.get_mut());
-            pointee_type::solve_constraints(pointee_constraints, pointee_types);
+            pointee_type::solve_constraints(pointee_constraints, &pointee_vars, pointee_types);
         }
 
         if global_pointee_types == old_global_pointee_types {

--- a/c2rust-analyze/src/pointee_type/constraint_set.rs
+++ b/c2rust-analyze/src/pointee_type/constraint_set.rs
@@ -28,7 +28,6 @@ pub enum Constraint<'tcx> {
 pub struct ConstraintSet<'tcx> {
     pub constraints: Vec<Constraint<'tcx>>,
     constraint_dedup: HashSet<Constraint<'tcx>>,
-    pub var_table: VarTable<'tcx>,
 }
 
 impl<'tcx> ConstraintSet<'tcx> {
@@ -52,10 +51,6 @@ impl<'tcx> ConstraintSet<'tcx> {
 
     pub fn subset(&mut self, p: PointerId, q: PointerId) {
         self.add(Constraint::Subset(p, q));
-    }
-
-    pub fn fresh_var(&mut self) -> CTy<'tcx> {
-        self.var_table.fresh()
     }
 }
 

--- a/c2rust-analyze/src/pointee_type/mod.rs
+++ b/c2rust-analyze/src/pointee_type/mod.rs
@@ -7,14 +7,15 @@ mod constraint_set;
 mod solve;
 mod type_check;
 
-pub use self::constraint_set::{CTy, Constraint, ConstraintSet};
+pub use self::constraint_set::{CTy, Constraint, ConstraintSet, VarTable};
 pub use self::solve::{solve_constraints, PointeeTypes};
 
 pub fn generate_constraints<'tcx>(
     acx: &AnalysisCtxt<'_, 'tcx>,
     mir: &Body<'tcx>,
+    vars: &mut VarTable<'tcx>,
 ) -> ConstraintSet<'tcx> {
-    type_check::visit(acx, mir)
+    type_check::visit(acx, mir, vars)
 }
 
 pub fn remap_pointers_global<'tcx>(

--- a/c2rust-analyze/src/pointee_type/solve.rs
+++ b/c2rust-analyze/src/pointee_type/solve.rs
@@ -130,25 +130,42 @@ pub fn propagate_types<'tcx>(
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct PointeeTypes<'tcx> {
     /// The possible pointee types for this pointer.
-    pub ltys: HashSet<LTy<'tcx>>,
-    /// If set, `ltys` is incomplete - the analysis identified pointee types that couldn't be
-    /// exported into global scope.
-    pub incomplete: bool,
+    pub tys: HashSet<CTy<'tcx>>,
 }
 
 impl<'tcx> PointeeTypes<'tcx> {
     /// Get the sole `LTy` in this set, if there is exactly one.
     pub fn get_sole_lty(&self) -> Option<LTy<'tcx>> {
-        if self.incomplete || self.ltys.len() != 1 {
+        if self.tys.len() != 1 {
             return None;
         }
-        let lty = *self.ltys.iter().next().unwrap();
-        Some(lty)
+        match self.tys.iter().copied().next()? {
+            CTy::Var(_) => None,
+            CTy::Ty(lty) => Some(lty),
+        }
     }
 
     pub fn merge(&mut self, other: PointeeTypes<'tcx>) {
-        self.ltys.extend(other.ltys);
-        self.incomplete |= other.incomplete;
+        self.tys.extend(other.tys);
+    }
+
+    pub fn simplify(&mut self, vars: &VarTable<'tcx>) {
+        let mut add = Vec::new();
+        let mut remove = Vec::new();
+        for &cty in &self.tys {
+            let rep = vars.cty_rep(cty);
+            if rep != cty {
+                remove.push(cty);
+                add.push(rep);
+            }
+        }
+
+        for cty in remove {
+            self.tys.remove(&cty);
+        }
+        for cty in add {
+            self.tys.insert(cty);
+        }
     }
 }
 
@@ -159,9 +176,7 @@ fn import<'tcx>(
 ) {
     for (ptr, tys) in pointee_tys.iter() {
         let ty_set = &mut ty_sets[ptr];
-        for &lty in &tys.ltys {
-            ty_set.insert(CTy::Ty(lty));
-        }
+        ty_set.extend(tys.tys.iter().copied());
     }
 }
 
@@ -171,25 +186,10 @@ fn export<'tcx>(
     ty_sets: PointerTable<HashSet<CTy<'tcx>>>,
     mut pointee_tys: PointerTableMut<PointeeTypes<'tcx>>,
 ) {
-    let local_ptr_range = pointee_tys.local().range();
     for (ptr, ctys) in ty_sets.iter() {
         let out = &mut pointee_tys[ptr];
-        for &cty in ctys {
-            if let CTy::Ty(lty) = var_table.cty_rep(cty) {
-                let mut ok = true;
-                lty.for_each_label(&mut |p| {
-                    if local_ptr_range.contains(p) {
-                        ok = false;
-                    }
-                });
-                if ok {
-                    out.ltys.insert(lty);
-                    continue;
-                }
-            }
-            // If we failed to export this `CTy`, mark the `PointeeTypes` incomplete.
-            out.incomplete = true;
-        }
+        out.tys.extend(ctys.iter().copied());
+        out.simplify(var_table);
     }
 }
 
@@ -198,12 +198,6 @@ pub fn solve_constraints<'tcx>(
     vars: &VarTable<'tcx>,
     mut pointee_tys: PointerTableMut<PointeeTypes<'tcx>>,
 ) {
-    // Clear the `incomplete` flags for all local pointers.  If there are still non-exportable
-    // types for those pointers, the flag will be set again in `export()`.
-    for (_, tys) in pointee_tys.local_mut().iter_mut() {
-        tys.incomplete = false;
-    }
-
     let mut ty_sets = OwnedPointerTable::with_len_of(&pointee_tys.borrow());
     import(pointee_tys.borrow(), ty_sets.borrow_mut());
     init_type_sets(cset, ty_sets.borrow_mut());

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -268,14 +268,6 @@ impl<T> LocalPointerTable<T> {
         ptr.index().wrapping_sub(self.base) < self.len() as u32
     }
 
-    /// Helper for performing `contains` checks while `self` is mutably borrowed.
-    pub fn range(&self) -> PointerRange {
-        PointerRange {
-            base: self.base,
-            len: self.len() as u32,
-        }
-    }
-
     pub fn iter(&self) -> impl Iterator<Item = (PointerId, &T)> {
         let base = self.base;
         self.table
@@ -408,22 +400,6 @@ impl<T> Index<PointerId> for GlobalPointerTable<T> {
 impl<T> IndexMut<PointerId> for GlobalPointerTable<T> {
     fn index_mut(&mut self, id: PointerId) -> &mut T {
         &mut self.0[id.index()]
-    }
-}
-
-pub struct PointerRange {
-    base: u32,
-    len: u32,
-}
-
-impl PointerRange {
-    pub fn contains(&self, ptr: PointerId) -> bool {
-        // If `ptr.index() < self.base`, the subtraction will wrap to a large number in excess of
-        // `self.len()`.
-        //
-        // Note that `base + len` can't overflow `u32::MAX` due to checks in `LocalPointerTable`
-        // above.
-        ptr.index().wrapping_sub(self.base) < self.len
     }
 }
 


### PR DESCRIPTION
This branch modifies the pointee-type analysis to use a single global `VarTable` for all functions, which allows pointee inference variables produced in one function to be resolved in another.  This is necessary for lighttpd's `buffer` module, which allocates a `buffer` object in one function (producing an inference variable for the `malloc`) and initializes it in a different function (where the inference variable can now be resolved).

The pointee analysis previously involved an "export" operation that ran after processing each function to convert the analysis results to a form that makes sense in other functions.  This meant that the results couldn't contain any inference variables or mention any local `PointerId`s.  Any entries in the results that violated these constraints would be erased, and the result set would be marked "incomplete".  With this branch, both constraints are lifted, as both inference variables and local `PointerId`s are representable in the global scope.