### PR TITLE
analyze: run equiv pass before pointee

### DIFF
--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -77,6 +77,7 @@ impl<T> Default for MaybeUnset<T> {
 }
 
 impl<T> MaybeUnset<T> {
+    #[track_caller]
     pub fn set(&mut self, x: T) {
         if self.0.is_some() {
             panic!("value is already set");
@@ -84,6 +85,7 @@ impl<T> MaybeUnset<T> {
         self.0 = Some(x);
     }
 
+    #[track_caller]
     pub fn clear(&mut self) {
         if self.0.is_none() {
             panic!("value is already cleared");
@@ -91,14 +93,17 @@ impl<T> MaybeUnset<T> {
         self.0 = None;
     }
 
+    #[track_caller]
     pub fn get(&self) -> &T {
         self.0.as_ref().expect("value is not set")
     }
 
+    #[track_caller]
     pub fn get_mut(&mut self) -> &mut T {
         self.0.as_mut().expect("value is not set")
     }
 
+    #[track_caller]
     pub fn take(&mut self) -> T {
         self.0.take().expect("value is not set")
     }

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -590,88 +590,13 @@ fn run(tcx: TyCtxt) {
     // Infer pointee types
     // ----------------------------------
 
-    let mut pointee_vars = pointee_type::VarTable::default();
-
-    for &ldid in &all_fn_ldids {
-        if gacx.fn_analysis_invalid(ldid.to_def_id()) {
-            continue;
-        }
-
-        let ldid_const = WithOptConstParam::unknown(ldid);
-        let info = func_info.get_mut(&ldid).unwrap();
-        let mir = tcx.mir_built(ldid_const);
-        let mir = mir.borrow();
-        let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
-
-        let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
-            pointee_type::generate_constraints(&acx, &mir, &mut pointee_vars)
-        }));
-
-        let local_pointee_types = LocalPointerTable::new(acx.local_ptr_base(), acx.num_pointers());
-        info.acx_data.set(acx.into_data());
-
-        match r {
-            Ok(pointee_constraints) => {
-                info.pointee_constraints.set(pointee_constraints);
-            }
-            Err(pd) => {
-                gacx.mark_fn_failed(ldid.to_def_id(), DontRewriteFnReason::POINTEE_INVALID, pd);
-                assert!(gacx.fn_analysis_invalid(ldid.to_def_id()));
-            }
-        }
-
-        info.local_pointee_types.set(local_pointee_types);
-    }
-
-    // Iterate pointee constraints to a fixpoint.
-    let mut global_pointee_types =
-        GlobalPointerTable::<PointeeTypes>::new(gacx.num_global_pointers());
-    let mut loop_count = 0;
-    loop {
-        // Loop until the global assignment reaches a fixpoint.  The inner loop also runs until a
-        // fixpoint, but it only considers a single function at a time.  The inner loop for one
-        // function can affect other functions by updating `global_pointee_types`, so we also need
-        // the outer loop, which runs until the global type sets converge as well.
-        loop_count += 1;
-        // We shouldn't need more iterations than the longest acyclic path through the callgraph.
-        assert!(loop_count <= 1000);
-        let old_global_pointee_types = global_pointee_types.clone();
-
-        for &ldid in &all_fn_ldids {
-            if gacx.fn_analysis_invalid(ldid.to_def_id()) {
-                continue;
-            }
-
-            let info = func_info.get_mut(&ldid).unwrap();
-
-            let pointee_constraints = info.pointee_constraints.get();
-            let pointee_types = global_pointee_types.and_mut(info.local_pointee_types.get_mut());
-            pointee_type::solve_constraints(pointee_constraints, &pointee_vars, pointee_types);
-        }
-
-        if global_pointee_types == old_global_pointee_types {
-            break;
-        }
-    }
-
-    // Print results for debugging
-    for &ldid in &all_fn_ldids {
-        if gacx.fn_analysis_invalid(ldid.to_def_id()) {
-            continue;
-        }
-
-        let ldid_const = WithOptConstParam::unknown(ldid);
-        let info = func_info.get_mut(&ldid).unwrap();
-        let mir = tcx.mir_built(ldid_const);
-        let mir = mir.borrow();
-
-        let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
-        let name = tcx.item_name(ldid.to_def_id());
-        let pointee_types = global_pointee_types.and(info.local_pointee_types.get());
-        print_function_pointee_types(&acx, name, &mir, pointee_types);
-
-        info.acx_data.set(acx.into_data());
-    }
+    let mut global_pointee_types = do_pointee_type(&mut gacx, &mut func_info, &all_fn_ldids);
+    debug_print_pointee_types(
+        &mut gacx,
+        &mut func_info,
+        &all_fn_ldids,
+        &global_pointee_types,
+    );
 
     // ----------------------------------
     // Compute dataflow constraints
@@ -1945,6 +1870,109 @@ fn do_recent_writes<'tcx>(
 
         // This is very straightforward because it doesn't need an `AnalysisCtxt` and never fails.
         info.recent_writes.set(RecentWrites::new(&mir));
+    }
+}
+
+/// Run the `pointee_type` analysis, which tries to determine the actual type of data that each
+/// pointer can point to.  This is particularly important for `void*` pointers, which are typically
+/// cast to a different type before use.
+fn do_pointee_type<'tcx>(
+    gacx: &mut GlobalAnalysisCtxt<'tcx>,
+    func_info: &mut HashMap<LocalDefId, FuncInfo<'tcx>>,
+    all_fn_ldids: &[LocalDefId],
+) -> GlobalPointerTable<PointeeTypes<'tcx>> {
+    let tcx = gacx.tcx;
+    let mut global_pointee_types =
+        GlobalPointerTable::<PointeeTypes>::new(gacx.num_global_pointers());
+    let mut pointee_vars = pointee_type::VarTable::default();
+
+    for &ldid in all_fn_ldids {
+        if gacx.fn_analysis_invalid(ldid.to_def_id()) {
+            continue;
+        }
+
+        let ldid_const = WithOptConstParam::unknown(ldid);
+        let info = func_info.get_mut(&ldid).unwrap();
+        let mir = tcx.mir_built(ldid_const);
+        let mir = mir.borrow();
+        let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
+
+        let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
+            pointee_type::generate_constraints(&acx, &mir, &mut pointee_vars)
+        }));
+
+        let local_pointee_types = LocalPointerTable::new(acx.local_ptr_base(), acx.num_pointers());
+        info.acx_data.set(acx.into_data());
+
+        match r {
+            Ok(pointee_constraints) => {
+                info.pointee_constraints.set(pointee_constraints);
+            }
+            Err(pd) => {
+                gacx.mark_fn_failed(ldid.to_def_id(), DontRewriteFnReason::POINTEE_INVALID, pd);
+                assert!(gacx.fn_analysis_invalid(ldid.to_def_id()));
+            }
+        }
+
+        info.local_pointee_types.set(local_pointee_types);
+    }
+
+    // Iterate pointee constraints to a fixpoint.
+    let mut loop_count = 0;
+    loop {
+        // Loop until the global assignment reaches a fixpoint.  The inner loop also runs until a
+        // fixpoint, but it only considers a single function at a time.  The inner loop for one
+        // function can affect other functions by updating `global_pointee_types`, so we also need
+        // the outer loop, which runs until the global type sets converge as well.
+        loop_count += 1;
+        // We shouldn't need more iterations than the longest acyclic path through the callgraph.
+        assert!(loop_count <= 1000);
+        let old_global_pointee_types = global_pointee_types.clone();
+
+        for &ldid in all_fn_ldids {
+            if gacx.fn_analysis_invalid(ldid.to_def_id()) {
+                continue;
+            }
+
+            let info = func_info.get_mut(&ldid).unwrap();
+
+            let pointee_constraints = info.pointee_constraints.get();
+            let pointee_types = global_pointee_types.and_mut(info.local_pointee_types.get_mut());
+            pointee_type::solve_constraints(pointee_constraints, &pointee_vars, pointee_types);
+        }
+
+        if global_pointee_types == old_global_pointee_types {
+            break;
+        }
+    }
+
+    global_pointee_types
+}
+
+fn debug_print_pointee_types<'tcx>(
+    gacx: &mut GlobalAnalysisCtxt<'tcx>,
+    func_info: &mut HashMap<LocalDefId, FuncInfo<'tcx>>,
+    all_fn_ldids: &[LocalDefId],
+    global_pointee_types: &GlobalPointerTable<PointeeTypes<'tcx>>,
+) {
+    let tcx = gacx.tcx;
+    // Print results for debugging
+    for &ldid in all_fn_ldids {
+        if gacx.fn_analysis_invalid(ldid.to_def_id()) {
+            continue;
+        }
+
+        let ldid_const = WithOptConstParam::unknown(ldid);
+        let info = func_info.get_mut(&ldid).unwrap();
+        let mir = tcx.mir_built(ldid_const);
+        let mir = mir.borrow();
+
+        let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
+        let name = tcx.item_name(ldid.to_def_id());
+        let pointee_types = global_pointee_types.and(info.local_pointee_types.get());
+        print_function_pointee_types(&acx, name, &mir, pointee_types);
+
+        info.acx_data.set(acx.into_data());
     }
 }
 

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -581,6 +581,12 @@ fn run(tcx: TyCtxt) {
     gacx.construct_region_metadata();
 
     // ----------------------------------
+    // Run early analyses
+    // ----------------------------------
+
+    do_recent_writes(&gacx, &mut func_info, &all_fn_ldids);
+
+    // ----------------------------------
     // Infer pointee types
     // ----------------------------------
 
@@ -615,7 +621,6 @@ fn run(tcx: TyCtxt) {
         }
 
         info.local_pointee_types.set(local_pointee_types);
-        info.recent_writes.set(RecentWrites::new(&mir));
     }
 
     // Iterate pointee constraints to a fixpoint.
@@ -1915,6 +1920,31 @@ impl<'tcx> AssignPointerIds<'tcx> for AnalysisCtxt<'_, 'tcx> {
 
     fn new_pointer(&mut self, info: PointerInfo) -> PointerId {
         self.new_pointer(info)
+    }
+}
+
+/// Run the `recent_writes` analysis, which computes the most recent write to each MIR local at
+/// each program point.  This can then be used to reconstruct the expression that's currently
+/// stored in the local.  For example, we use this to detect whether the size argument of `memcpy`
+/// is `mem::size_of::<T>()` for some `T`.
+fn do_recent_writes<'tcx>(
+    gacx: &GlobalAnalysisCtxt<'tcx>,
+    func_info: &mut HashMap<LocalDefId, FuncInfo<'tcx>>,
+    all_fn_ldids: &[LocalDefId],
+) {
+    let tcx = gacx.tcx;
+    for &ldid in all_fn_ldids {
+        if gacx.fn_analysis_invalid(ldid.to_def_id()) {
+            continue;
+        }
+
+        let ldid_const = WithOptConstParam::unknown(ldid);
+        let info = func_info.get_mut(&ldid).unwrap();
+        let mir = tcx.mir_built(ldid_const);
+        let mir = mir.borrow();
+
+        // This is very straightforward because it doesn't need an `AnalysisCtxt` and never fails.
+        info.recent_writes.set(RecentWrites::new(&mir));
     }
 }
 

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -1972,7 +1972,10 @@ fn build_dataflow_constraints<'tcx>(
 
         // Compute local equivalence classes and dataflow constraints.
         let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
-            dataflow::generate_constraints(&acx, &mir, recent_writes, pointee_types)
+            (
+                dataflow::generate_constraints(&acx, &mir, recent_writes, pointee_types),
+                dataflow::generate_equiv_constraints(&acx, &mir, recent_writes),
+            )
         }));
         match r {
             Ok((dataflow, equiv_constraints)) => {

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -605,7 +605,8 @@ fn run(tcx: TyCtxt) {
     // Initial pass to assign local `PointerId`s and gather equivalence constraints, which state
     // that two pointer types must be converted to the same reference type.  Some additional data
     // computed during this the process is kept around for use in later passes.
-    let global_equiv = build_dataflow_constraints(
+    let global_equiv = build_equiv_constraints(&mut gacx, &mut func_info, &all_fn_ldids);
+    build_dataflow_constraints(
         &mut gacx,
         &mut func_info,
         &all_fn_ldids,
@@ -1937,15 +1938,12 @@ fn debug_print_pointee_types<'tcx>(
     }
 }
 
-/// Compute dataflow and equivalence constraints.  This doesn't try to solve the dataflow
-/// constraints yet.  This function returns only equivalence constraints because there are no
-/// global dataflow constraints; all dataflow constraints are function-local and are stored in that
-/// function's `FuncInfo`.
-fn build_dataflow_constraints<'tcx>(
+/// Compute equivalence constraints.  This builds local and global equivalence sets, which map each
+/// pointer to an equivalence-class representative.
+fn build_equiv_constraints<'tcx>(
     gacx: &mut GlobalAnalysisCtxt<'tcx>,
     func_info: &mut HashMap<LocalDefId, FuncInfo<'tcx>>,
     all_fn_ldids: &[LocalDefId],
-    global_pointee_types: &GlobalPointerTable<PointeeTypes<'tcx>>,
 ) -> GlobalEquivSet {
     let tcx = gacx.tcx;
 
@@ -1968,22 +1966,17 @@ fn build_dataflow_constraints<'tcx>(
 
         let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
         let recent_writes = info.recent_writes.get();
-        let pointee_types = global_pointee_types.and(info.local_pointee_types.get());
 
         // Compute local equivalence classes and dataflow constraints.
         let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
-            (
-                dataflow::generate_constraints(&acx, &mir, recent_writes, pointee_types),
-                dataflow::generate_equiv_constraints(&acx, &mir, recent_writes),
-            )
+            dataflow::generate_equiv_constraints(&acx, &mir, recent_writes)
         }));
         match r {
-            Ok((dataflow, equiv_constraints)) => {
+            Ok(equiv_constraints) => {
                 let mut equiv = global_equiv.and_mut(&mut local_equiv);
                 for (a, b) in equiv_constraints {
                     equiv.unify(a, b);
                 }
-                info.dataflow.set(dataflow);
             }
             Err(pd) => {
                 acx.gacx.mark_fn_failed(
@@ -1999,6 +1992,52 @@ fn build_dataflow_constraints<'tcx>(
     }
 
     global_equiv
+}
+
+/// Compute dataflow constraints.  This doesn't try to solve the dataflow constraints yet.  This
+/// function doesn't return anything because there are no global dataflow constraints; all dataflow
+/// constraints are function-local and are stored in that function's `FuncInfo`.
+fn build_dataflow_constraints<'tcx>(
+    gacx: &mut GlobalAnalysisCtxt<'tcx>,
+    func_info: &mut HashMap<LocalDefId, FuncInfo<'tcx>>,
+    all_fn_ldids: &[LocalDefId],
+    global_pointee_types: &GlobalPointerTable<PointeeTypes<'tcx>>,
+) {
+    let tcx = gacx.tcx;
+
+    for &ldid in all_fn_ldids {
+        if gacx.fn_analysis_invalid(ldid.to_def_id()) {
+            continue;
+        }
+
+        let ldid_const = WithOptConstParam::unknown(ldid);
+        let info = func_info.get_mut(&ldid).unwrap();
+        let mir = tcx.mir_built(ldid_const);
+        let mir = mir.borrow();
+
+        let acx = gacx.function_context_with_data(&mir, info.acx_data.take());
+        let recent_writes = info.recent_writes.get();
+        let pointee_types = global_pointee_types.and(info.local_pointee_types.get());
+
+        // Compute local equivalence classes and dataflow constraints.
+        let r = panic_detail::catch_unwind(AssertUnwindSafe(|| {
+            dataflow::generate_constraints(&acx, &mir, recent_writes, pointee_types)
+        }));
+        match r {
+            Ok(dataflow) => {
+                info.dataflow.set(dataflow);
+            }
+            Err(pd) => {
+                acx.gacx.mark_fn_failed(
+                    ldid.to_def_id(),
+                    DontRewriteFnReason::DATAFLOW_INVALID,
+                    pd,
+                );
+            }
+        };
+
+        info.acx_data.set(acx.into_data());
+    }
 }
 
 fn make_ty_fixed(asn: &mut Assignment, lty: LTy) {

--- a/c2rust-analyze/src/dataflow/mod.rs
+++ b/c2rust-analyze/src/dataflow/mod.rs
@@ -462,6 +462,14 @@ pub fn generate_constraints<'tcx>(
     mir: &Body<'tcx>,
     recent_writes: &RecentWrites,
     pointee_types: PointerTable<PointeeTypes<'tcx>>,
-) -> (DataflowConstraints, Vec<(PointerId, PointerId)>) {
+) -> DataflowConstraints {
     self::type_check::visit(acx, mir, recent_writes, pointee_types)
+}
+
+pub fn generate_equiv_constraints<'tcx>(
+    acx: &AnalysisCtxt<'_, 'tcx>,
+    mir: &Body<'tcx>,
+    recent_writes: &RecentWrites,
+) -> Vec<(PointerId, PointerId)> {
+    self::type_check::visit_equiv(acx, mir, recent_writes)
 }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -102,6 +102,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     }
 
     fn pointee_type(&self, ptr: PointerId) -> Option<LTy<'tcx>> {
+        assert!(!ptr.is_none());
         self.pointee_types
             .as_ref()
             .and_then(|pointee_types| pointee_types[ptr].get_sole_lty())

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -32,16 +32,27 @@ use rustc_middle::ty::{SubstsRef, Ty, TyKind};
 ///   and destination.  This is necessary because we generally can't change the inner pointer type
 ///   when performing a cast (for example, it's possible to convert `&[&[T]]` to `&&[T]` - take the
 ///   address of the first element - but not to `&[&T]]`).
+///
+///
+/// # Optional fields
+///
+/// Several fields of this visitor are wrapped in `Option`.  These are accessed using helper
+/// methods that do nothing when the field is `None`.  We use this to run the visitor in two
+/// different modes, one for computing equivalence constraints and the other for computing all
+/// other dataflow constraints.  The two kinds of constraints are closely related, and it's easiest
+/// to implement them both in a single visitor.  But we compute them in two separate passes because
+/// equivalence constraints can be used to improve the quality of the `pointee_type` analysis, and
+/// pointee results are needed to compute the dataflow constraints.
 struct TypeChecker<'tcx, 'a> {
     acx: &'a AnalysisCtxt<'a, 'tcx>,
     mir: &'a Body<'tcx>,
     recent_writes: &'a RecentWrites,
-    pointee_types: PointerTable<'a, PointeeTypes<'tcx>>,
+    pointee_types: Option<PointerTable<'a, PointeeTypes<'tcx>>>,
     /// Subset constraints on pointer permissions.  For example, this contains constraints like
     /// "the `PermissionSet` assigned to `PointerId` `l1` must be a subset of the `PermissionSet`
     /// assigned to `l2`".  See `dataflow::Constraint` for a full description of supported
     /// constraints.
-    constraints: DataflowConstraints,
+    constraints: Option<DataflowConstraints>,
     /// Equivalence constraints on pointer permissions and flags.  An entry `(l1, l2)` in this list
     /// means that `PointerId`s `l1` and `l2` should be assigned exactly the same permissions and
     /// flags.  This ensures that the two pointers will be rewritten to the same safe type.
@@ -49,39 +60,51 @@ struct TypeChecker<'tcx, 'a> {
     /// Higher-level code eventually feeds the constraints recorded here into the union-find data
     /// structure defined in `crate::equiv`, so adding a constraint here has the effect of unifying
     /// the equivalence classes of the two `PointerId`s.
-    equiv_constraints: Vec<(PointerId, PointerId)>,
+    equiv_constraints: Option<Vec<(PointerId, PointerId)>>,
 }
 
 impl<'tcx> TypeChecker<'tcx, '_> {
     fn add_edge(&mut self, src: PointerId, dest: PointerId) {
         // Copying `src` to `dest` can discard permissions, but can't add new ones.
-        self.constraints.add_subset(dest, src);
+        if let Some(ref mut constraints) = self.constraints {
+            constraints.add_subset(dest, src);
+        }
     }
 
     fn add_edge_except(&mut self, src: PointerId, dest: PointerId, except: PermissionSet) {
         // Copying `src` to `dest` can discard permissions, but can't add new ones,
         // except for the specified exceptions.
-        self.constraints.add_subset_except(dest, src, except);
+        if let Some(ref mut constraints) = self.constraints {
+            constraints.add_subset_except(dest, src, except);
+        }
     }
 
     /// Add `Constraint::AllPerms`, which requires `ptr` to have all of the permissions listed in
     /// `perms`.
     fn add_all_perms(&mut self, ptr: PointerId, perms: PermissionSet) {
-        self.constraints.add_all_perms(ptr, perms);
+        if let Some(ref mut constraints) = self.constraints {
+            constraints.add_all_perms(ptr, perms);
+        }
     }
 
     /// Add `Constraint::NoPerms`, which requires `ptr` to have none of the permissions listed in
     /// `perms`.
     fn add_no_perms(&mut self, ptr: PointerId, perms: PermissionSet) {
-        self.constraints.add_no_perms(ptr, perms);
+        if let Some(ref mut constraints) = self.constraints {
+            constraints.add_no_perms(ptr, perms);
+        }
     }
 
     fn add_equiv(&mut self, a: PointerId, b: PointerId) {
-        self.equiv_constraints.push((a, b));
+        if let Some(ref mut equiv_constraints) = self.equiv_constraints {
+            equiv_constraints.push((a, b));
+        }
     }
 
     fn pointee_type(&self, ptr: PointerId) -> Option<LTy<'tcx>> {
-        self.pointee_types[ptr].get_sole_lty()
+        self.pointee_types
+            .as_ref()
+            .and_then(|pointee_types| pointee_types[ptr].get_sole_lty())
     }
 
     fn record_access(&mut self, ptr: PointerId, mutbl: Mutability) {
@@ -728,26 +751,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
     }
 }
 
-pub fn visit<'tcx>(
-    acx: &AnalysisCtxt<'_, 'tcx>,
-    mir: &Body<'tcx>,
-    recent_writes: &RecentWrites,
-    pointee_types: PointerTable<PointeeTypes<'tcx>>,
-) -> (DataflowConstraints, Vec<(PointerId, PointerId)>) {
-    let mut tc = TypeChecker {
-        acx,
-        mir,
-        recent_writes,
-        pointee_types,
-        constraints: DataflowConstraints::default(),
-        equiv_constraints: Vec::new(),
-    };
-
-    for (ptr, perms, neg_perms) in acx.string_literal_perms() {
-        tc.constraints.add_all_perms(ptr, perms);
-        tc.constraints.add_no_perms(ptr, neg_perms);
-    }
-
+fn visit_common<'tcx>(tc: &mut TypeChecker<'tcx, '_>, mir: &Body<'tcx>) {
     for (bb, bb_data) in mir.basic_blocks().iter_enumerated() {
         for (i, stmt) in bb_data.statements.iter().enumerate() {
             tc.visit_statement(
@@ -766,6 +770,48 @@ pub fn visit<'tcx>(
             },
         );
     }
+}
 
-    (tc.constraints, tc.equiv_constraints)
+/// Process a MIR body to compute dataflow constraints.
+pub fn visit<'tcx>(
+    acx: &AnalysisCtxt<'_, 'tcx>,
+    mir: &Body<'tcx>,
+    recent_writes: &RecentWrites,
+    pointee_types: PointerTable<PointeeTypes<'tcx>>,
+) -> DataflowConstraints {
+    let mut tc = TypeChecker {
+        acx,
+        mir,
+        recent_writes,
+        pointee_types: Some(pointee_types),
+        constraints: Some(DataflowConstraints::default()),
+        equiv_constraints: None,
+    };
+
+    for (ptr, perms, neg_perms) in acx.string_literal_perms() {
+        tc.add_all_perms(ptr, perms);
+        tc.add_no_perms(ptr, neg_perms);
+    }
+
+    visit_common(&mut tc, mir);
+    tc.constraints.unwrap()
+}
+
+/// Process a MIR body to compute equivalence constraints.
+pub fn visit_equiv<'tcx>(
+    acx: &AnalysisCtxt<'_, 'tcx>,
+    mir: &Body<'tcx>,
+    recent_writes: &RecentWrites,
+) -> Vec<(PointerId, PointerId)> {
+    let mut tc = TypeChecker {
+        acx,
+        mir,
+        recent_writes,
+        pointee_types: None,
+        constraints: None,
+        equiv_constraints: Some(Vec::new()),
+    };
+
+    visit_common(&mut tc, mir);
+    tc.equiv_constraints.unwrap()
 }

--- a/c2rust-analyze/src/dataflow/type_check.rs
+++ b/c2rust-analyze/src/dataflow/type_check.rs
@@ -68,6 +68,10 @@ impl<'tcx> TypeChecker<'tcx, '_> {
         self.equiv_constraints.push((a, b));
     }
 
+    fn pointee_type(&self, ptr: PointerId) -> Option<LTy<'tcx>> {
+        self.pointee_types[ptr].get_sole_lty()
+    }
+
     fn record_access(&mut self, ptr: PointerId, mutbl: Mutability) {
         debug!("record_access({:?}, {:?})", ptr, mutbl);
         if ptr == PointerId::NONE {
@@ -545,7 +549,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 // Figure out whether we're copying one element or (possibly) several.
                 let mut maybe_offset_perm = PermissionSet::OFFSET_ADD;
                 let rv_ptr = rv_lty.label;
-                if let Some(pointee_lty) = self.pointee_types[rv_ptr].get_sole_lty() {
+                if let Some(pointee_lty) = self.pointee_type(rv_ptr) {
                     if self.operand_is_size_of_t(loc, &args[2], pointee_lty.ty) {
                         // The size is exactly the (original) size of the pointee type, so this
                         // `memset` is operating on a single element only.
@@ -589,7 +593,7 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                 // Figure out whether we're writing to one element or (possibly) several.
                 let mut maybe_offset_perm = PermissionSet::OFFSET_ADD;
                 let rv_ptr = rv_lty.label;
-                if let Some(pointee_lty) = self.pointee_types[rv_ptr].get_sole_lty() {
+                if let Some(pointee_lty) = self.pointee_type(rv_ptr) {
                     if self.operand_is_size_of_t(loc, &args[2], pointee_lty.ty) {
                         // The size is exactly the (original) size of the pointee type, so this
                         // `memset` is operating on a single element only.

--- a/c2rust-analyze/src/pointee_type/mod.rs
+++ b/c2rust-analyze/src/pointee_type/mod.rs
@@ -1,7 +1,5 @@
 use crate::context::AnalysisCtxt;
-use crate::pointer_id::{GlobalPointerTable, LocalPointerTable, PointerId, PointerTable};
 use rustc_middle::mir::Body;
-use std::mem;
 
 mod constraint_set;
 mod solve;
@@ -16,35 +14,4 @@ pub fn generate_constraints<'tcx>(
     vars: &mut VarTable<'tcx>,
 ) -> ConstraintSet<'tcx> {
     type_check::visit(acx, mir, vars)
-}
-
-pub fn remap_pointers_global<'tcx>(
-    pointee_types: &mut GlobalPointerTable<PointeeTypes<'tcx>>,
-    map: &GlobalPointerTable<PointerId>,
-    count: usize,
-) {
-    let mut old = mem::replace(pointee_types, GlobalPointerTable::new(count));
-    let new = pointee_types;
-    for (old_ptr, old_val) in old.iter_mut() {
-        // If there are multiple old pointers that map to the same new pointer, merge their sets.
-        new[map[old_ptr]].merge(mem::take(old_val));
-    }
-}
-
-pub fn remap_pointers_local<'tcx>(
-    global_pointee_types: &mut GlobalPointerTable<PointeeTypes<'tcx>>,
-    local_pointee_types: &mut LocalPointerTable<PointeeTypes<'tcx>>,
-    map: PointerTable<PointerId>,
-    local_base: u32,
-    local_count: usize,
-) {
-    let mut old = mem::replace(
-        local_pointee_types,
-        LocalPointerTable::new(local_base, local_count),
-    );
-    let mut new = global_pointee_types.and_mut(local_pointee_types);
-    for (old_ptr, old_val) in old.iter_mut() {
-        // If there are multiple old pointers that map to the same new pointer, merge their sets.
-        new[map[old_ptr]].merge(mem::take(old_val));
-    }
 }

--- a/c2rust-analyze/src/pointee_type/solve.rs
+++ b/c2rust-analyze/src/pointee_type/solve.rs
@@ -145,10 +145,6 @@ impl<'tcx> PointeeTypes<'tcx> {
         }
     }
 
-    pub fn merge(&mut self, other: PointeeTypes<'tcx>) {
-        self.tys.extend(other.tys);
-    }
-
     pub fn simplify(&mut self, vars: &VarTable<'tcx>) {
         let mut add = Vec::new();
         let mut remove = Vec::new();

--- a/c2rust-analyze/tests/filecheck/pointee.rs
+++ b/c2rust-analyze/tests/filecheck/pointee.rs
@@ -1,4 +1,10 @@
+#![feature(rustc_private)]
 use std::ptr;
+
+extern crate libc;
+extern "C" {
+    fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
+}
 
 // CHECK-LABEL: fn memcpy1
 unsafe fn memcpy1(dest: *mut (), src: *const ()) {
@@ -21,4 +27,26 @@ unsafe fn remove_cast() {
     // CHECK: let dest_ptr = ((&mut *(&mut dest)));
     let dest_ptr = &mut dest as *mut u8 as *mut ();
     memcpy1(dest_ptr, src_ptr);
+}
+
+
+// CHECK-LABEL: fn malloc_fresh
+unsafe fn malloc_fresh() {
+    let mut p = 0 as *mut libc::c_void;
+    let fresh = &mut p;
+    // CHECK: malloc(4)
+    let q = malloc(4);
+    *fresh = q;
+    *(p as *mut i32) = 1;
+}
+
+// CHECK-LABEL: fn malloc_no_fresh
+unsafe fn malloc_no_fresh() {
+    let mut p = 0 as *mut libc::c_void;
+    // CHECK-NOT: malloc(4)
+    // CHECK: Box::new
+    // CHECK-NOT: malloc(4)
+    let q = malloc(4);
+    p = q;
+    *(p as *mut i32) = 1;
 }

--- a/c2rust-analyze/tests/filecheck/pointee.rs
+++ b/c2rust-analyze/tests/filecheck/pointee.rs
@@ -34,7 +34,9 @@ unsafe fn remove_cast() {
 unsafe fn malloc_fresh() {
     let mut p = 0 as *mut libc::c_void;
     let fresh = &mut p;
-    // CHECK: malloc(4)
+    // CHECK-NOT: malloc(4)
+    // CHECK: Box::new
+    // CHECK-NOT: malloc(4)
     let q = malloc(4);
     *fresh = q;
     *(p as *mut i32) = 1;


### PR DESCRIPTION
This branch changes the order of analysis passes to run the equivalence class analysis and `PointerId` renumbering before running the pointee type analysis.  In particular, this improves the pointee results in cases involving `fresh` references, such as this new test case:

```Rust
let mut p = 0 as *mut libc::c_void;
let fresh = &mut p;
*fresh = malloc(4);
```

Most of the changes here are refactorings to move specific analysis passes from `run()` into helper functions, which makes them easier to reorder.