### PR TITLE
analyze: script for automatically fixing some compile errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,6 @@ marks.*.json
 # Outputs of `c2rust-analyze`
 inspect/
 *.analysis.txt
+*.rs.fixed
 analysis.txt
 polonius_cache/

--- a/c2rust-analyze/.gitignore
+++ b/c2rust-analyze/.gitignore
@@ -1,2 +1,3 @@
 /inspect/
 *.rlib
+/tests/auto_fix_errors/*.json

--- a/c2rust-analyze/scripts/auto_fix_errors.py
+++ b/c2rust-analyze/scripts/auto_fix_errors.py
@@ -1,5 +1,5 @@
 import argparse
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 import json
 import re
 import sys
@@ -231,13 +231,10 @@ def main():
         ))
 
     # Group fixes by file
-    fixes_by_file = {}
+    fixes_by_file = defaultdict(list)
     for fix in fixes:
-        file_fixes = fixes_by_file.get(fix.file_path)
-        if file_fixes is None:
-            fixes_by_file[fix.file_path] = [fix]
-        else:
-            file_fixes.append(fix)
+        fixes_by_file[fix.file_path].append(fix)
+    fixes_by_file = dict(fixes_by_file)
     for file_fixes in fixes_by_file.values():
         file_fixes.sort(key=lambda fix: fix.start_byte)
 

--- a/c2rust-analyze/scripts/auto_fix_errors.py
+++ b/c2rust-analyze/scripts/auto_fix_errors.py
@@ -1,5 +1,5 @@
 import argparse
-from dataclasses import dataclass
+from collections import namedtuple
 import json
 import re
 import sys
@@ -13,36 +13,43 @@ def parse_args() -> argparse.Namespace:
         help='output of `rustc --error-format json`')
     return parser.parse_args()
 
-@dataclass(frozen=True)
-class Fix:
-    file_path: str
-    line_number: int
-    start_byte: int
-    end_byte: int
-    new_text: str
-    message: str
+Fix = namedtuple('Fix', (
+    # Path to the file to modify.
+    'file_path',
+    # Line number where the fix will be applied.  This is used for debug output
+    # only.
+    'line_number',
+    # Start of the byte range to replace.
+    'start_byte',
+    # End (exclusive) of the byte range to replace.
+    'end_byte',
+    # Replacement text (as a `str`, not `bytes`).
+    'new_text',
+    # The original error message.  This is used for debug output only.
+    'message',
+))
 
-@dataclass(frozen=True)
-class LifetimeBound:
-    file_path: str
-    line_number: int
+LifetimeBound = namedtuple('LifetimeBound', (
+    'file_path',
+    'line_number',
     # Byte offset of the start of the lifetime parameter declaration.
-    start_byte: int
+    'start_byte',
     # Byte offset of the end of the lifetime parameter declaration.
-    end_byte: int
+    'end_byte',
     # The lifetime to use in the new bound.  If `'a: 'b` is the suggested
     # bound, then `start/end_byte` points to the declaration of `'a`, and
     # `bound_lifetime` is the string `"'b"`.
-    bound_lifetime: str
+    'bound_lifetime',
+))
 
-@dataclass(frozen=True)
-class RemoveDeriveCopy:
-    file_path: str
-    line_number: int
+RemoveDeriveCopy = namedtuple('RemoveDeriveCopy', (
+    'file_path',
+    'line_number',
     # Byte offset of the start of the token `Copy`.
-    start_byte: int
+    'start_byte',
     # Byte offset of the end of the token `Copy`.
-    end_byte: int
+    'end_byte',
+))
 
 MSG_LIFETIME_BOUND = 'lifetime may not live long enough'
 MSG_DERIVE_COPY = 'the trait `Copy` may not be implemented for this type'

--- a/c2rust-analyze/scripts/auto_fix_errors.py
+++ b/c2rust-analyze/scripts/auto_fix_errors.py
@@ -1,0 +1,113 @@
+import argparse
+from dataclasses import dataclass
+import json
+import sys
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='automatically apply rustc-suggested fixes for compile errors')
+    parser.add_argument('-n', '--dry-run', action='store_true',
+        help="print fixes that would be applied, but don't modify any files")
+    parser.add_argument('path', metavar='ERRORS.JSON',
+        help='output of `rustc --error-format json`')
+    return parser.parse_args()
+
+@dataclass(frozen=True)
+class Fix:
+    file_path: str
+    line_number: int
+    start_byte: int
+    end_byte: int
+    new_text: str
+    message: str
+
+def main():
+    args = parse_args()
+
+    fixes = []
+    def gather_fixes(j, message):
+        for span in j['spans']:
+            if span.get('suggestion_applicability') != 'MachineApplicable':
+                continue
+            fix = Fix(
+                file_path=span['file_name'],
+                line_number=span['line_start'],
+                start_byte=span['byte_start'],
+                end_byte=span['byte_end'],
+                new_text=span['suggested_replacement'],
+                message=message,
+            )
+            fixes.append(fix)
+
+        for child in j['children']:
+            gather_fixes(child, message)
+
+    with open(args.path, 'r') as f:
+        for line in f:
+            j = json.loads(line)
+
+            # Only process errors, not warnings.
+            level = j['level']
+            if level == 'error':
+                pass
+            elif level in ('warning', 'failure-note'):
+                continue
+            else:
+                # `help`, `note`, etc should not appear at top level.
+                assert False, 'unexpected `level` %r' % (level,)
+
+            gather_fixes(j, j['message'])
+
+    fixes_by_file = {}
+    for fix in fixes:
+        file_fixes = fixes_by_file.get(fix.file_path)
+        if file_fixes is None:
+            fixes_by_file[fix.file_path] = [fix]
+        else:
+            file_fixes.append(fix)
+    for file_fixes in fixes_by_file.values():
+        file_fixes.sort(key=lambda fix: fix.start_byte)
+
+    # Apply fixes
+    for file_path, file_fixes in sorted(fixes_by_file.items()):
+        content = open(file_path, 'rb').read()
+        chunks = []
+        pos = 0
+        prev_fix = None
+        for fix in file_fixes:
+            old_text = content[fix.start_byte : fix.end_byte].decode('utf-8')
+            desc = '%s:%d: %r -> %r (%s)' % (
+                file_path, fix.line_number, old_text, fix.new_text, fix.message)
+            if prev_fix is not None:
+                if fix.start_byte < prev_fix.end_byte:
+                    if fix.start_byte == prev_fix.start_byte \
+                            and fix.end_byte == prev_fix.end_byte \
+                            and fix.new_text == prev_fix.new_text:
+                        # `fix` and `prev_fix` suggest the same change, so we
+                        # don't need to apply `fix`.
+                        continue
+                    # We want to apply fix, but can't because it overlaps with
+                    # `prev_fix`.
+                    print('skipping due to overlap: %s' % desc)
+                    continue
+
+            prev_fix = fix
+
+            print(desc)
+            if fix.start_byte > pos:
+                chunks.append(content[pos : fix.start_byte])
+            chunks.append(fix.new_text.encode('utf-8'))
+            pos = fix.end_byte
+
+        if pos < len(content):
+            chunks.append(content[pos:])
+
+        new_content = b''.join(chunks)
+        if not args.dry_run:
+            open(file_path, 'wb').write(new_content)
+            print('wrote to %r' % file_path)
+        else:
+            print('would write to %r' % file_path)
+
+if __name__ == '__main__':
+    main()

--- a/c2rust-analyze/tests/auto_fix_errors.rs
+++ b/c2rust-analyze/tests/auto_fix_errors.rs
@@ -1,0 +1,82 @@
+pub mod common;
+
+use crate::common::{check_for_missing_tests_for, test_dir_for};
+use std::fs::{self, File};
+use std::process::Command;
+
+#[test]
+fn check_for_missing_tests() {
+    check_for_missing_tests_for(file!());
+}
+
+fn test(file_name: &str) {
+    let test_dir = test_dir_for(file!(), true);
+    let path = test_dir.join(file_name);
+    let fixed_path = path.with_extension("rs.fixed");
+    let json_path = path.with_extension("json");
+    let script_path = test_dir.join("../../scripts/auto_fix_errors.py");
+
+    fs::copy(&path, &fixed_path).unwrap();
+
+    // Run with `--error-format json` to produce JSON input for the script.
+    let mut cmd = Command::new("rustc");
+    cmd.arg("-A")
+        .arg("warnings")
+        .arg("--crate-name")
+        .arg(path.file_stem().unwrap())
+        .arg("--crate-type")
+        .arg("rlib")
+        .arg("--error-format")
+        .arg("json")
+        .arg(&fixed_path)
+        .stderr(File::create(&json_path).unwrap());
+    let status = cmd.status().unwrap();
+    assert_eq!(
+        status.code(),
+        Some(1),
+        "command {cmd:?} exited with code {status:?}"
+    );
+
+    // Run the script to fix errors.
+    let mut cmd = Command::new("python3");
+    cmd.arg(&script_path).arg(&json_path);
+    let status = cmd.status().unwrap();
+    assert!(
+        status.success(),
+        "command {cmd:?} exited with code {status:?}"
+    );
+
+    // There should be no more compile errors now.
+    let mut cmd = Command::new("rustc");
+    cmd.arg("-A")
+        .arg("warnings")
+        .arg("--crate-name")
+        .arg(path.file_stem().unwrap())
+        .arg("--crate-type")
+        .arg("rlib")
+        .arg(&fixed_path);
+    let status = cmd.status().unwrap();
+    assert!(
+        status.success(),
+        "command {cmd:?} exited with code {status:?}"
+    );
+}
+
+macro_rules! define_test {
+    ($name:ident) => {
+        #[test]
+        fn $name() {
+            test(concat!(stringify!($name), ".rs"));
+        }
+    };
+}
+
+macro_rules! define_tests {
+    ($($name:ident,)*) => {
+        $(define_test! { $name })*
+    }
+}
+
+define_tests! {
+    derive_copy,
+}

--- a/c2rust-analyze/tests/auto_fix_errors/derive_copy.rs
+++ b/c2rust-analyze/tests/auto_fix_errors/derive_copy.rs
@@ -1,0 +1,49 @@
+#[derive(Clone, Copy)]
+struct S1 {
+    x: Box<i32>,
+    y: &'static i32,
+}
+
+#[derive(Clone, Copy,)]
+struct S2 {
+    x: Box<i32>,
+    y: &'static i32,
+}
+
+
+#[derive(Copy, Clone)]
+struct S3 {
+    x: Box<i32>,
+    y: &'static i32,
+}
+
+
+#[derive(Copy, Clone,)]
+struct S4 {
+    x: Box<i32>,
+    y: &'static i32,
+}
+
+
+#[derive(Copy)]
+struct S5 {
+    x: Box<i32>,
+    y: &'static i32,
+}
+
+#[derive(Copy,)]
+struct S6 {
+    x: Box<i32>,
+    y: &'static i32,
+}
+
+
+#[derive(
+    Copy
+    ,
+    Clone
+)]
+struct S7 {
+    x: Box<i32>,
+    y: &'static i32,
+}


### PR DESCRIPTION
This branch adds a Python script that automatically fixes some kinds of compiler errors by processing the output of `rustc --error-format json`.  It applies all `MachineApplicable` suggestions, plus two other kinds of fixes that don't come with a `MachineApplicable` suggestion (in our current nightly) but are important for lighttpd `buffer`:

* "Lifetime may not live long enough": For each function, `c2rust-analyze` adds a lifetime parameter for each reference in the arguments and return type, but doesn't add any outlives bounds (e.g. `'a: 'b`) to relate those lifetimes.  On functions that return a borrowed reference into one of their arguments, this results in a borrow checker error.  The error comes with a human-readable suggestion like "consider adding the following bound: `'a: 'b`", and also marks the declaration of the first lifetime (`'a`); the auto-fix script parses this output and inserts the suggested `: 'b` bound after the declaration.
* "The trait `Copy` may not be implemented for this type": When `c2rust-analyze` converts a field from raw pointer type to `&mut T` or `Box<T>`, it doesn't remove `derive(Copy)` from the struct.  This causes a compile error because `&mut T` and `Box<T>` don't implement `Copy`.  The error marks the location of the `Copy` token in `#[derive(Copy)]`; the auto-fix script removes that token (and the subsequent comma, if necessary).  Note this can produce a trailing comma (`#[derive(Clone, Copy)]` -> `#[derive(Clone, )]`) or an empty `derive()` (`#[derive(Copy)]` -> `#[derive()]`), both of which are legal but unidiomatic.