### PR TITLE
analyze: more def list options

### DIFF
--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -435,7 +435,7 @@ fn parse_def_id(s: &str) -> Result<DefId, String> {
     Ok(def_id)
 }
 
-fn read_fixed_defs_list(fixed_defs: &mut HashSet<DefId>, path: &str) -> io::Result<()> {
+fn read_defs_list(defs: &mut HashSet<DefId>, path: &str) -> io::Result<()> {
     let f = BufReader::new(File::open(path)?);
     for (i, line) in f.lines().enumerate() {
         let line = line?;
@@ -447,7 +447,7 @@ fn read_fixed_defs_list(fixed_defs: &mut HashSet<DefId>, path: &str) -> io::Resu
         let def_id = parse_def_id(line).unwrap_or_else(|e| {
             panic!("failed to parse {} line {}: {}", path, i + 1, e);
         });
-        fixed_defs.insert(def_id);
+        defs.insert(def_id);
     }
     Ok(())
 }
@@ -512,7 +512,7 @@ fn check_rewrite_path_prefixes(tcx: TyCtxt, fixed_defs: &mut HashSet<DefId>, pre
 fn get_fixed_defs(tcx: TyCtxt) -> io::Result<HashSet<DefId>> {
     let mut fixed_defs = HashSet::new();
     if let Ok(path) = env::var("C2RUST_ANALYZE_FIXED_DEFS_LIST") {
-        read_fixed_defs_list(&mut fixed_defs, &path)?;
+        read_defs_list(&mut fixed_defs, &path)?;
     }
     if let Ok(prefixes) = env::var("C2RUST_ANALYZE_REWRITE_PATHS") {
         check_rewrite_path_prefixes(tcx, &mut fixed_defs, &prefixes);

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -555,7 +555,14 @@ struct FuncInfo<'tcx> {
 fn run(tcx: TyCtxt) {
     debug!("all defs:");
     for ldid in tcx.hir_crate_items(()).definitions() {
+        //debug!("{:?} @ {:?}", ldid, tcx.source_span(ldid));
         debug!("{:?}", ldid);
+        if tcx.def_kind(ldid) == DefKind::Struct {
+            let adt_def = tcx.adt_def(ldid);
+            for field in &adt_def.non_enum_variant().fields {
+                debug!("{:?}", field.did);
+            }
+        }
     }
 
     // Load the list of fixed defs early, so any errors are reported immediately.

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -425,7 +425,7 @@ fn parse_def_id(s: &str) -> Result<DefId, String> {
     };
 
     let rendered = format!("{:?}", def_id);
-    if &rendered != s {
+    if &rendered != orig_s {
         return Err(format!(
             "path mismatch: after parsing input {}, obtained a different path {:?}",
             orig_s, def_id

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -423,6 +423,9 @@ pub struct GlobalAnalysisCtxt<'tcx> {
     pub dont_rewrite_fns: FlagMap<DefId, DontRewriteFnReason>,
     pub dont_rewrite_statics: FlagMap<DefId, DontRewriteStaticReason>,
     pub dont_rewrite_fields: FlagMap<DefId, DontRewriteFieldReason>,
+    /// Never mark these defs as `FIXED`, regardless of what `DontRewriteReason`s they might
+    /// acquire.
+    pub force_rewrite: HashSet<DefId>,
 
     /// `DefId`s of functions where analysis failed, and a [`PanicDetail`] explaining the reason
     /// for each failure.
@@ -810,6 +813,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             dont_rewrite_fns: FlagMap::new(),
             dont_rewrite_statics: FlagMap::new(),
             dont_rewrite_fields: FlagMap::new(),
+            force_rewrite: HashSet::new(),
             fns_failed: HashMap::new(),
             field_ltys: HashMap::new(),
             field_users: MultiMap::new(),
@@ -889,6 +893,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
             dont_rewrite_fns: _,
             dont_rewrite_statics: _,
             dont_rewrite_fields: _,
+            force_rewrite: _,
             fns_failed: _,
             ref mut field_ltys,
             field_users: _,

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -110,6 +110,10 @@ struct Args {
     #[clap(long)]
     force_rewrite_defs_list: Option<PathBuf>,
 
+    /// Read a list of defs on which the pointee type analysis should be skipped.
+    #[clap(long)]
+    skip_pointee_defs_list: Option<PathBuf>,
+
     /// `cargo` args.
     cargo_args: Vec<OsString>,
 }
@@ -398,6 +402,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
         use_manual_shims,
         fixed_defs_list,
         force_rewrite_defs_list,
+        skip_pointee_defs_list,
         cargo_args,
     } = Args::parse();
 
@@ -447,6 +452,10 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
 
         if let Some(ref force_rewrite_defs_list) = force_rewrite_defs_list {
             cmd.env("C2RUST_ANALYZE_FORCE_REWRITE_LIST", force_rewrite_defs_list);
+        }
+
+        if let Some(ref skip_pointee_defs_list) = skip_pointee_defs_list {
+            cmd.env("C2RUST_ANALYZE_SKIP_POINTEE_LIST", skip_pointee_defs_list);
         }
 
         if !rewrite_paths.is_empty() {

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -104,6 +104,12 @@ struct Args {
     #[clap(long)]
     fixed_defs_list: Option<PathBuf>,
 
+    /// Read a list of defs that should always be rewritable (not `FIXED`) from this file path.
+    /// This suppresses the rewriter's default behavior of skipping over defs that encounter
+    /// analysis or rewriting errors.
+    #[clap(long)]
+    force_rewrite_defs_list: Option<PathBuf>,
+
     /// `cargo` args.
     cargo_args: Vec<OsString>,
 }
@@ -391,6 +397,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
         rewrite_in_place,
         use_manual_shims,
         fixed_defs_list,
+        force_rewrite_defs_list,
         cargo_args,
     } = Args::parse();
 
@@ -436,6 +443,10 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
 
         if let Some(ref fixed_defs_list) = fixed_defs_list {
             cmd.env("C2RUST_ANALYZE_FIXED_DEFS_LIST", fixed_defs_list);
+        }
+
+        if let Some(ref force_rewrite_defs_list) = force_rewrite_defs_list {
+            cmd.env("C2RUST_ANALYZE_FORCE_REWRITE_LIST", force_rewrite_defs_list);
         }
 
         if !rewrite_paths.is_empty() {


### PR DESCRIPTION
This adds more command line options for controlling which defs get rewritten.  Specifically, it adds two new options:

* `--force-rewrite-defs-list FILE`: Reads from `FILE` a list of `DefId`s that should always be rewritten, even if related defs encounter analysis or rewriting errors.
* `--skip-pointee-defs-list FILE`: Reads from `FILE` a list of `DefId`s for which pointee analysis should be skipped.

Both options take input in the same format as the existing `--fixed-defs-list FILE` option.

These options were useful for getting the `buffer` module to rewrite successfully while running `c2rust-analyze` against the entire lighttpd codebase.

This PR also fixes a bug that caused `DefId`s to be erroneously rejected when parsing the `--fixed-defs-list` file.