### PR TITLE
analyze: add option to skip borrowck

### DIFF
--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -877,6 +877,8 @@ fn run(tcx: TyCtxt) {
     debug!("=== ADT Metadata ===");
     debug!("{:?}", gacx.adt_metadata);
 
+    let skip_borrowck_everywhere = env::var("C2RUST_ANALYZE_SKIP_BORROWCK").as_deref() == Ok("1");
+
     let mut loop_count = 0;
     loop {
         // Loop until the global assignment reaches a fixpoint.  The inner loop also runs until a
@@ -891,7 +893,8 @@ fn run(tcx: TyCtxt) {
                 continue;
             }
 
-            let skip_borrowck = util::has_test_attr(tcx, ldid, TestAttr::SkipBorrowck);
+            let skip_borrowck =
+                skip_borrowck_everywhere || util::has_test_attr(tcx, ldid, TestAttr::SkipBorrowck);
 
             let info = func_info.get_mut(&ldid).unwrap();
             let ldid_const = WithOptConstParam::unknown(ldid);

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -941,6 +941,11 @@ fn run(tcx: TyCtxt) {
         let mut num_changed = 0;
         for (i, &old) in old_gasn.iter().enumerate() {
             let ptr = PointerId::global(i as u32);
+
+            if skip_borrowck_everywhere {
+                asn.perms[ptr].insert(PermissionSet::UNIQUE);
+            }
+
             let new = asn.perms[ptr];
             if old != new {
                 let added = new & !old;
@@ -2276,7 +2281,7 @@ fn pdg_update_permissions<'tcx>(
                     perms.insert(PermissionSet::OFFSET_SUB);
                 }
                 if !node_info.unique {
-                    perms.remove(PermissionSet::UNIQUE);
+                    //perms.remove(PermissionSet::UNIQUE);
                 }
             }
 

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -891,6 +891,8 @@ fn run(tcx: TyCtxt) {
                 continue;
             }
 
+            let skip_borrowck = util::has_test_attr(tcx, ldid, TestAttr::SkipBorrowck);
+
             let info = func_info.get_mut(&ldid).unwrap();
             let ldid_const = WithOptConstParam::unknown(ldid);
             let name = tcx.item_name(ldid.to_def_id());
@@ -905,15 +907,17 @@ fn run(tcx: TyCtxt) {
                 // on a fixpoint, so there's no need to do multiple iterations here.
                 info.dataflow.propagate(&mut asn.perms, &updates_forbidden);
 
-                borrowck::borrowck_mir(
-                    &acx,
-                    &info.dataflow,
-                    &mut asn.perms_mut(),
-                    &updates_forbidden,
-                    name.as_str(),
-                    &mir,
-                    field_ltys,
-                );
+                if !skip_borrowck {
+                    borrowck::borrowck_mir(
+                        &acx,
+                        &info.dataflow,
+                        &mut asn.perms_mut(),
+                        &updates_forbidden,
+                        name.as_str(),
+                        &mir,
+                        field_ltys,
+                    );
+                }
             }));
 
             info.acx_data.set(acx.into_data());

--- a/c2rust-analyze/src/main.rs
+++ b/c2rust-analyze/src/main.rs
@@ -104,6 +104,11 @@ struct Args {
     #[clap(long)]
     annotate_def_spans: bool,
 
+    /// Completely disable the `borrowck` pass.  All pointers will be given the `UNIQUE`
+    /// permission; none will be wrapped in `Cell`.
+    #[clap(long)]
+    skip_borrowck: bool,
+
     /// Read a list of defs that should be marked non-rewritable (`FIXED`) from this file path.
     /// Run `c2rust-analyze` without this option and check the debug output for a full list of defs
     /// in the crate being analyzed; the file passed to this option should list a subset of those
@@ -408,6 +413,7 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
         rewrite_in_place,
         use_manual_shims,
         annotate_def_spans,
+        skip_borrowck,
         fixed_defs_list,
         force_rewrite_defs_list,
         skip_pointee_defs_list,
@@ -487,6 +493,10 @@ fn cargo_wrapper(rustc_wrapper: &Path) -> anyhow::Result<()> {
 
         if annotate_def_spans {
             cmd.env("C2RUST_ANALYZE_ANNOTATE_DEF_SPANS", "1");
+        }
+
+        if skip_borrowck {
+            cmd.env("C2RUST_ANALYZE_SKIP_BORROWCK", "1");
         }
 
         Ok(())

--- a/c2rust-analyze/src/util.rs
+++ b/c2rust-analyze/src/util.rs
@@ -552,6 +552,9 @@ pub enum TestAttr {
     /// `#[c2rust_analyze_test::force_non_null_args]`: Mark arguments as `NON_NULL` and don't allow
     /// that flag to be changed during dataflow analysis.
     ForceNonNullArgs,
+    /// `#[c2rust_analyze_test::skip_borrowck]`: Don't run borrowck for this function.  The
+    /// `UNIQUE` permission won't be removed from pointers.
+    SkipBorrowck,
 }
 
 impl TestAttr {
@@ -562,6 +565,7 @@ impl TestAttr {
             TestAttr::FailBeforeRewriting => "fail_before_rewriting",
             TestAttr::SkipRewrite => "skip_rewrite",
             TestAttr::ForceNonNullArgs => "force_non_null_args",
+            TestAttr::SkipBorrowck => "skip_borrowck",
         }
     }
 }


### PR DESCRIPTION
This adds a new command-line option `--skip-borrowck` that completely disables the borrowck pass.  All pointers are given the `UNIQUE` permission, allowing them to be rewritten to `&mut T` instead of `&Cell<T>`.  This is useful when the code uses language features that aren't supported by borrowck and it's known (or assumed) that it doesn't require any `Cell` rewrites.