### PR TITLE
fix: clippy::not_unsafe_ptr_arg_deref

### DIFF
--- a/analysis/runtime/src/handlers.rs
+++ b/analysis/runtime/src/handlers.rs
@@ -161,8 +161,8 @@ pub fn addr_of_local(mir_loc: MirLocId, ptr: usize, local: u32, size: u32) {
     });
 }
 
-pub fn addr_of_sized<T: ?Sized>(mir_loc: MirLocId, ptr: *const T) {
-    let size = unsafe { core::mem::size_of_val(&*ptr) };
+pub unsafe fn addr_of_sized<T: ?Sized>(mir_loc: MirLocId, ptr: *const T) {
+    let size = core::mem::size_of_val(&*ptr);
     RUNTIME.send_event(Event {
         mir_loc,
         kind: EventKind::AddrOfSized {

--- a/analysis/runtime/src/handlers.rs
+++ b/analysis/runtime/src/handlers.rs
@@ -161,8 +161,10 @@ pub fn addr_of_local(mir_loc: MirLocId, ptr: usize, local: u32, size: u32) {
     });
 }
 
+/// # Safety
+/// `ptr` must be dereferenceable.
 pub unsafe fn addr_of_sized<T: ?Sized>(mir_loc: MirLocId, ptr: *const T) {
-    let size = core::mem::size_of_val(&*ptr);
+    let size = core::mem::size_of_val(unsafe { &*ptr });
     RUNTIME.send_event(Event {
         mir_loc,
         kind: EventKind::AddrOfSized {

--- a/analysis/runtime/src/handlers.rs
+++ b/analysis/runtime/src/handlers.rs
@@ -164,7 +164,7 @@ pub fn addr_of_local(mir_loc: MirLocId, ptr: usize, local: u32, size: u32) {
 /// # Safety
 /// `ptr` must be dereferenceable.
 pub unsafe fn addr_of_sized<T: ?Sized>(mir_loc: MirLocId, ptr: *const T) {
-    let size = core::mem::size_of_val(unsafe { &*ptr });
+    let size = core::mem::size_of_val(&*ptr);
     RUNTIME.send_event(Event {
         mir_loc,
         kind: EventKind::AddrOfSized {


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref