### PR TITLE
`transpile`: allow expressions in compound literals for structs

### DIFF
--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -544,12 +544,6 @@ impl<'a> Translation<'a> {
                 Both(field_id, (field_name, _, bitfield_width, use_inner_type)) => {
                     let mut expr = self.convert_expr(ctx.used(), *field_id)?;
 
-                    if !expr.is_pure() {
-                        return Err(TranslationError::generic(
-                            "Expected no statements in field expression",
-                        ));
-                    }
-
                     if use_inner_type {
                         // See comment above
                         expr = expr.map(|fi| mk().anon_field_expr(fi, 0));

--- a/tests/structs/src/struct_with_exp.c
+++ b/tests/structs/src/struct_with_exp.c
@@ -1,0 +1,14 @@
+
+struct s { 
+    int i; 
+};
+
+void struct_with_exp(const unsigned int buffer_size, int buffer[const]){
+    if (buffer_size < 1) return;
+    
+    struct s *p;
+    int j = 42;
+    p = &((struct s){j++}); // Compound literal with address-of operator and post-increment operator
+
+    buffer[0] = p->i;
+}

--- a/tests/structs/src/test_struct_with_exp.rs
+++ b/tests/structs/src/test_struct_with_exp.rs
@@ -1,0 +1,23 @@
+use crate::struct_with_exp::rust_struct_with_exp;
+use libc::{c_int, c_uint, size_t};
+
+#[link(name = "test")]
+extern "C" {
+    fn struct_with_exp(_: c_uint, _: *mut c_int);
+}
+
+const BUFFER_SIZE: usize = 1;
+
+pub fn test_struct_with_exp() {
+  let mut buffer = [0; BUFFER_SIZE];
+  let mut rust_buffer = [0; BUFFER_SIZE];
+  let expected_buffer = [42];
+
+  unsafe {
+      struct_with_exp(BUFFER_SIZE as u32, buffer.as_mut_ptr());
+      rust_struct_with_exp(BUFFER_SIZE as u32, rust_buffer.as_mut_ptr());
+  }
+
+  assert_eq!(buffer, rust_buffer);
+  assert_eq!(buffer, expected_buffer);
+}


### PR DESCRIPTION
 This pull request resolves  ✅ [c2rust fails to handle increment or decrement operations within compound literals #1165](https://github.com/immunant/c2rust/issues/1165)

### Modification:

  - Suggested changes mentioned in [c2rust fails to handle increment or decrement operations within compound literals #1165](https://github.com/immunant/c2rust/issues/1165) were added in the `c2rust-transpile/src/translator/struct.rs` file.
  - Added relevant C program in `tests/structs/src/struct_with_exp.c`
  - Added relevant test code in `tests/structs/src/test_struct_with_exp.rs`

This test ensures that expressions, such as `j++`, are correctly evaluated during struct initialization using compound literals. The test has been integrated into the existing test suite and passed successfully, confirming the fix.

Please review the changes and provide feedback or approve the pull request. If further modifications are required, I am open to suggestions and will make the necessary adjustments.