### PR TITLE
analyze: use println! instead of info! to print rewritten code

### DIFF
--- a/c2rust-analyze/src/rewrite/mod.rs
+++ b/c2rust-analyze/src/rewrite/mod.rs
@@ -23,7 +23,7 @@
 //! require us to update the `Span`s mentioned in the later rewrites to account for the changes in
 //! the source code produced by the earlier ones).
 
-use log::{debug, info, warn};
+use log::{debug, warn};
 use rustc_hir::Mutability;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{FileName, Span};
@@ -338,18 +338,18 @@ pub fn apply_rewrites(
     update_files: UpdateFiles,
 ) {
     let emit = |filename, src: String| {
-        info!("\n\n ===== BEGIN {:?} =====", filename);
+        println!("\n\n ===== BEGIN {:?} =====", filename);
         for line in src.lines() {
             // Omit filecheck directives from the debug output, as filecheck can get confused due
             // to directives matching themselves (e.g. `// CHECK: foo` will match the `foo` in the
             // line `// CHECK: foo`).
             if let Some((pre, _post)) = line.split_once("// CHECK") {
-                info!("{}// (FileCheck directive omitted)", pre);
+                println!("{}// (FileCheck directive omitted)", pre);
             } else {
-                info!("{}", line);
+                println!("{}", line);
             }
         }
-        info!(" ===== END {:?} =====", filename);
+        println!(" ===== END {:?} =====", filename);
 
         if !matches!(update_files, UpdateFiles::No) {
             let mut path_ok = false;


### PR DESCRIPTION
3271b3da22af95d1a02a7b5e115aca932155ee16 replaced all prints in c2rust-analyze with `info!` or other logging calls.  This generally makes it easier to filter the debug output.  However, using `info!` for printing the rewritten code adds a prefix to each line:

```
[INFO @ c2rust-analyze/src/rewrite/mod.rs:349 @ c2rust_analyze::rewrite]: extern crate libc;
[INFO @ c2rust-analyze/src/rewrite/mod.rs:349 @ c2rust_analyze::rewrite]: extern "C" {
[INFO @ c2rust-analyze/src/rewrite/mod.rs:349 @ c2rust_analyze::rewrite]:     fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
[INFO @ c2rust-analyze/src/rewrite/mod.rs:349 @ c2rust_analyze::rewrite]: }
```

This makes it hard to copy-paste the rewritten code into a separate .rs file for testing or debugging.

This branch changes the output of rewritten code from `info!` back to `println!`.