### PR TITLE
[WIP] analyze: refactor mir_op to explicitly track per-subloc info

### DIFF
--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -2028,7 +2028,7 @@ where
     }
 }
 
-pub trait IsLocal {
+trait IsLocal {
     fn is_local(&self) -> bool;
 }
 

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -28,7 +28,7 @@ use std::ops::Index;
 
 use rustc_hir::def::Namespace;
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum SubLoc {
     /// The LHS of an assignment or call.  `StatementKind::Assign/TerminatorKind::Call -> Place`
     Dest,

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -208,7 +208,7 @@ pub struct MirRewrite {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
-enum PlaceAccess {
+pub enum PlaceAccess {
     /// Enclosing context intends to read from the place.
     Imm,
     /// Enclosing context intends to write to the place.
@@ -2028,7 +2028,7 @@ where
     }
 }
 
-trait IsLocal {
+pub trait IsLocal {
     fn is_local(&self) -> bool;
 }
 

--- a/c2rust-analyze/src/rewrite/expr/mod.rs
+++ b/c2rust-analyze/src/rewrite/expr/mod.rs
@@ -38,7 +38,8 @@ pub fn gen_expr_rewrites<'tcx>(
     let subloc_info = subloc_info::typecheck_subloc_info(acx, &subloc_globals, subloc_info, mir);
     debug_print_subloc_info_map(acx.tcx(), mir, &subloc_info);
 
-    let (mir_rewrites, errors) = mir_op::gen_mir_rewrites(acx, asn, pointee_types, last_use, mir);
+    //let (mir_rewrites, errors) = mir_op::gen_mir_rewrites(acx, asn, pointee_types, last_use, mir);
+    let (mir_rewrites, errors) = mir_op::gen_mir_rewrites(acx, &subloc_info, mir);
     if !errors.is_empty() {
         acx.gacx.dont_rewrite_fns.add(def_id, errors);
     }

--- a/c2rust-analyze/src/rewrite/expr/subloc_info.rs
+++ b/c2rust-analyze/src/rewrite/expr/subloc_info.rs
@@ -1,0 +1,731 @@
+use crate::context::{AnalysisCtxt, Assignment, DontRewriteFnReason, FlagSet, LTy, PermissionSet};
+use crate::last_use::{self, LastUse};
+use crate::panic_detail;
+use crate::pointee_type::PointeeTypes;
+use crate::pointer_id::{GlobalPointerTable, PointerId, PointerTable};
+use crate::rewrite;
+use crate::type_desc::{self, Ownership, Quantity, TypeDesc};
+use crate::util::{self, ty_callee, Callee};
+use log::{error, trace};
+use rustc_ast::Mutability;
+use rustc_middle::mir::{
+    BasicBlock, Body, BorrowKind, Location, Operand, Place, PlaceElem, PlaceRef, Rvalue, Statement,
+    StatementKind, Terminator, TerminatorKind,
+};
+use rustc_middle::ty::print::{FmtPrinter, PrettyPrinter, Print};
+use rustc_middle::ty::{AdtDef, Ty, TyCtxt, TyKind};
+use std::collections::HashMap;
+use std::ops::Index;
+use super::mir_op::{SubLoc, PlaceAccess, IsLocal};
+
+#[derive(Clone, Debug)]
+pub struct SublocInfo<'tcx> {
+    /// The type of this node in the original MIR.
+    pub old_ty: SublocType<'tcx>,
+    /// The type this node would have after rewriting, if the MIR was unchanged.  For example, if
+    /// this node is an `Operand` that reads from a `Local`, this would give the rewritten type of
+    /// that `Local`.
+    pub new_ty: SublocType<'tcx>,
+    /// The type required by the surrounding context.  For example, in `StatementKind::Assign`, the
+    /// `expect_ty` fields of the `Place` and `Rvalue` will match, reflecting the fact that the LHS
+    /// and RHS must have the same type.  If `new_ty != expect_ty`, then a cast must be inserted at
+    /// this node.
+    ///
+    /// This is set to `new_ty` by the initial pass, but in a later pass may be updated to fix type
+    /// errors that would be introduced by naïve rewriting.
+    pub expect_ty: SublocType<'tcx>,
+    /// If set, casts applied to this subloc can move the value if needed.  Otherwise, casts may
+    /// only borrow the value.
+    pub can_move: bool,
+    /// If set, casts applied to this subloc can borrow the value mutably if needed.  Otherwise,
+    /// casts may only borrow the value immutably (or move it, if `can_move` is set).
+    pub can_mutate: bool,
+    /// Indicates the type of access the surrounding context will perform on this subloc.  This is
+    /// mainly relevant for `Place`s.
+    pub access: PlaceAccess,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum SublocType<'tcx> {
+    Ptr(TypeDesc<'tcx>),
+    Other(Ty<'tcx>),
+}
+
+
+struct CollectInfoVisitor<'a, 'tcx> {
+    acx: &'a AnalysisCtxt<'a, 'tcx>,
+    perms: &'a GlobalPointerTable<PermissionSet>,
+    flags: &'a GlobalPointerTable<FlagSet>,
+    pointee_types: PointerTable<'a, PointeeTypes<'tcx>>,
+    last_use: &'a LastUse,
+    mir: &'a Body<'tcx>,
+    loc: Location,
+    sub_loc: Vec<SubLoc>,
+    errors: DontRewriteFnReason,
+    info_map: HashMap<(Location, Vec<SubLoc>), SublocInfo<'tcx>>,
+}
+
+impl<'a, 'tcx> CollectInfoVisitor<'a, 'tcx> {
+    pub fn new(
+        acx: &'a AnalysisCtxt<'a, 'tcx>,
+        asn: &'a Assignment,
+        pointee_types: PointerTable<'a, PointeeTypes<'tcx>>,
+        last_use: &'a LastUse,
+        mir: &'a Body<'tcx>,
+    ) -> CollectInfoVisitor<'a, 'tcx> {
+        let perms = asn.perms();
+        let flags = asn.flags();
+        CollectInfoVisitor {
+            acx,
+            perms,
+            flags,
+            pointee_types,
+            last_use,
+            mir,
+            loc: Location {
+                block: BasicBlock::from_usize(0),
+                statement_index: 0,
+            },
+            sub_loc: Vec::new(),
+            errors: DontRewriteFnReason::empty(),
+
+            info_map: HashMap::new(),
+        }
+    }
+
+    fn err(&mut self, reason: DontRewriteFnReason) {
+        self.errors.insert(reason);
+    }
+
+    fn enter<F: FnOnce(&mut Self) -> R, R>(&mut self, sub: SubLoc, f: F) -> R {
+        self.sub_loc.push(sub);
+        let r = f(self);
+        self.sub_loc.pop();
+        r
+    }
+
+    fn enter_dest<F: FnOnce(&mut Self) -> R, R>(&mut self, f: F) -> R {
+        self.enter(SubLoc::Dest, f)
+    }
+
+    fn enter_rvalue<F: FnOnce(&mut Self) -> R, R>(&mut self, f: F) -> R {
+        self.enter(SubLoc::Rvalue, f)
+    }
+
+    fn enter_call_arg<F: FnOnce(&mut Self) -> R, R>(&mut self, i: usize, f: F) -> R {
+        self.enter(SubLoc::CallArg(i), f)
+    }
+
+    fn enter_rvalue_operand<F: FnOnce(&mut Self) -> R, R>(&mut self, i: usize, f: F) -> R {
+        self.enter(SubLoc::RvalueOperand(i), f)
+    }
+
+    fn enter_rvalue_place<F: FnOnce(&mut Self) -> R, R>(&mut self, i: usize, f: F) -> R {
+        self.enter(SubLoc::RvaluePlace(i), f)
+    }
+
+    fn enter_operand_place<F: FnOnce(&mut Self) -> R, R>(&mut self, f: F) -> R {
+        self.enter(SubLoc::OperandPlace, f)
+    }
+
+    fn enter_place_deref_pointer<F: FnOnce(&mut Self) -> R, R>(&mut self, f: F) -> R {
+        self.enter(SubLoc::PlaceDerefPointer, f)
+    }
+
+    fn enter_place_field_base<F: FnOnce(&mut Self) -> R, R>(&mut self, f: F) -> R {
+        self.enter(SubLoc::PlaceFieldBase, f)
+    }
+
+    fn enter_place_index_array<F: FnOnce(&mut Self) -> R, R>(&mut self, f: F) -> R {
+        self.enter(SubLoc::PlaceIndexArray, f)
+    }
+
+
+    fn lty_to_subloc_types(&self, lty: LTy<'tcx>) -> (SublocType<'tcx>, SublocType<'tcx>) {
+        let tcx = self.acx.tcx();
+        let ty = lty.ty;
+        let ptr = lty.label;
+
+        if ptr.is_none() {
+            // Non-pointer case.
+            return (SublocType::Other(lty.ty), SublocType::Other(lty.ty));
+        }
+
+        let old_pointee_ty = match *lty.ty.kind() {
+            TyKind::Ref(_, ty, _) => ty,
+            TyKind::RawPtr(mt) => mt.ty,
+            TyKind::Adt(adt_def, substs) if adt_def.is_box() => substs.type_at(0),
+            _ => unreachable!("type {lty:?} has PointerId but has non-pointer TyKind?"),
+        };
+        let old_ptr_desc = type_desc::unpack_pointer_type(tcx, lty.ty, old_pointee_ty);
+        let old_desc = old_ptr_desc.to_type_desc(old_pointee_ty);
+        let new_desc = type_desc::perms_to_desc_with_pointee(
+            tcx,
+            old_pointee_ty,
+            lty.ty,
+            self.perms[ptr],
+            self.flags[ptr],
+        );
+        // FIXME: new_desc needs to reflect pointee_type analysis results
+        (SublocType::Ptr(old_desc), SublocType::Ptr(new_desc))
+    }
+
+    fn emit_info(&mut self, info: SublocInfo<'tcx>) {
+        let key = (self.loc, self.sub_loc.clone());
+        let old = self.info_map.insert(key, info);
+        assert!(old.is_none(), "duplicate entry for {:?} {:?}", self.loc, self.sub_loc);
+    }
+
+    fn emit(
+        &mut self,
+        lty: LTy<'tcx>,
+        can_move: bool,
+        can_mutate: bool,
+        access: PlaceAccess,
+    ) {
+        self.emit_adjust(lty, can_move, can_mutate, access, |x| x)
+    }
+
+    fn emit_adjust(
+        &mut self,
+        lty: LTy<'tcx>,
+        can_move: bool,
+        can_mutate: bool,
+        access: PlaceAccess,
+        adjust_new_ty: impl FnOnce(SublocType<'tcx>) -> SublocType<'tcx>,
+    ) {
+        let (old_ty, new_ty) = self.lty_to_subloc_types(lty);
+        let new_ty = adjust_new_ty(new_ty);
+        self.emit_info(SublocInfo {
+            old_ty,
+            new_ty,
+            expect_ty: new_ty,
+            can_move,
+            can_mutate,
+            access,
+        });
+    }
+
+    /// Helper for temporaries / rvalues.  These can always be moved and mutated, since they are
+    /// only temporary.
+    fn emit_temp(&mut self, lty: LTy<'tcx>) {
+        self.emit_temp_adjust(lty, |x| x)
+    }
+
+    fn emit_temp_adjust(
+        &mut self,
+        lty: LTy<'tcx>,
+        adjust_new_ty: impl FnOnce(SublocType<'tcx>) -> SublocType<'tcx>,
+    ) {
+        self.emit_adjust(lty, true, true, PlaceAccess::Move, adjust_new_ty)
+    }
+
+
+    /// Get the pointee type of `lty`.  Returns the inferred pointee type from `self.pointee_types`
+    /// if one is available, or the pointee type as represented in `lty` itself otherwise.  Returns
+    /// `None` if `lty` is not a `RawPtr` or `Ref` type.
+    ///
+    /// TODO: This does not yet have any pointer-to-pointer support.  For example, if `lty` is
+    /// `*mut *mut c_void` where the inner pointer is known to point to `u8`, this method will
+    /// still return `*mut c_void` instead of `*mut u8`.
+    fn pointee_lty(&self, lty: LTy<'tcx>) -> Option<LTy<'tcx>> {
+        if !matches!(lty.kind(), TyKind::Ref(..) | TyKind::RawPtr(..)) {
+            return None;
+        }
+        debug_assert_eq!(lty.args.len(), 1);
+        let ptr = lty.label;
+        if !ptr.is_none() {
+            if let Some(pointee_lty) = self.pointee_types[ptr].get_sole_lty() {
+                return Some(pointee_lty);
+            }
+        }
+        Some(lty.args[0])
+    }
+
+    fn is_nullable(&self, ptr: PointerId) -> bool {
+        !ptr.is_none()
+            && !self.perms[ptr].contains(PermissionSet::NON_NULL)
+            && !self.flags[ptr].contains(FlagSet::FIXED)
+    }
+
+    fn is_dyn_owned(&self, lty: LTy) -> bool {
+        if !matches!(lty.kind(), TyKind::Ref(..) | TyKind::RawPtr(..)) {
+            return false;
+        }
+        if lty.label.is_none() {
+            return false;
+        }
+        let perms = self.perms[lty.label];
+        let flags = self.flags[lty.label];
+        if flags.contains(FlagSet::FIXED) {
+            return false;
+        }
+        let desc = type_desc::perms_to_desc(lty.ty, perms, flags);
+        desc.dyn_owned
+    }
+
+    /// Check whether the `Place` identified by `which` within the current statement or terminator
+    /// is the last use of a local.
+    fn is_last_use(&self, which: last_use::WhichPlace) -> bool {
+        self.last_use.is_last_use(self.loc, which)
+    }
+
+    fn current_sub_loc_as_which_place(&self) -> Option<last_use::WhichPlace> {
+        // This logic is a bit imprecise, but should be correct in the cases where we actually call
+        // it (namely, when the `Place`/`Rvalue` is simply a `Local`).
+        let mut which = None;
+        for sl in &self.sub_loc {
+            match *sl {
+                SubLoc::Dest => { which = Some(last_use::WhichPlace::Lvalue); },
+                SubLoc::Rvalue => {
+                    which = Some(last_use::WhichPlace::Operand(0));
+                },
+                SubLoc::CallArg(i) => {
+                    // In a call, `WhichPlace::Operand(0)` refers to the callee function.
+                    which = Some(last_use::WhichPlace::Operand(i + 1));
+                },
+                SubLoc::RvalueOperand(i) => {
+                    which = Some(last_use::WhichPlace::Operand(i));
+                },
+                SubLoc::RvaluePlace(_) => {},
+                SubLoc::OperandPlace => {},
+                SubLoc::PlaceDerefPointer => {},
+                SubLoc::PlaceFieldBase => {},
+                SubLoc::PlaceIndexArray => {},
+            }
+        }
+        which
+    }
+
+    /// Like `is_last_use`, but infers `WhichPlace` based on `self.sub_loc`.
+    fn current_sub_loc_is_last_use(&self) -> bool {
+        if let Some(which) = self.current_sub_loc_as_which_place() {
+            self.is_last_use(which)
+        } else {
+            false
+        }
+    }
+
+    fn visit_statement(&mut self, stmt: &Statement<'tcx>, loc: Location) {
+        let _g = panic_detail::set_current_span(stmt.source_info.span);
+        eprintln!(
+            "subloc_info::visit_statement: {:?} @ {:?}: {:?}",
+            loc, stmt.source_info.span, stmt
+        );
+        self.loc = loc;
+        debug_assert!(self.sub_loc.is_empty());
+
+        match stmt.kind {
+            StatementKind::Assign(ref x) => {
+                let (pl, ref rv) = **x;
+
+                self.enter_dest(|v| {
+                    v.visit_place(pl, PlaceAccess::Mut);
+                });
+
+                self.enter_rvalue(|v| {
+                    v.visit_rvalue(rv);
+                });
+            }
+            StatementKind::FakeRead(..) => {}
+            StatementKind::SetDiscriminant { .. } => todo!("statement {:?}", stmt),
+            StatementKind::Deinit(..) => {}
+            StatementKind::StorageLive(..) => {}
+            StatementKind::StorageDead(..) => {}
+            StatementKind::Retag(..) => {}
+            StatementKind::AscribeUserType(..) => {}
+            StatementKind::Coverage(..) => {}
+            StatementKind::CopyNonOverlapping(..) => todo!("statement {:?}", stmt),
+            StatementKind::Nop => {}
+        }
+    }
+
+    fn visit_terminator(&mut self, term: &Terminator<'tcx>, loc: Location) {
+        let tcx = self.acx.tcx();
+        let _g = panic_detail::set_current_span(term.source_info.span);
+        self.loc = loc;
+        debug_assert!(self.sub_loc.is_empty());
+
+        match term.kind {
+            TerminatorKind::Goto { .. } => {}
+            TerminatorKind::SwitchInt { .. } => {}
+            TerminatorKind::Resume => {}
+            TerminatorKind::Abort => {}
+            TerminatorKind::Return => {}
+            TerminatorKind::Unreachable => {}
+            TerminatorKind::Drop { .. } => {}
+            TerminatorKind::DropAndReplace { .. } => {}
+            TerminatorKind::Call {
+                ref func,
+                ref args,
+                destination,
+                target: _,
+                ..
+            } => {
+                let func_ty = func.ty(self.mir, tcx);
+                let pl_ty = self.acx.type_of(destination);
+
+                self.enter_rvalue(|v| {
+                    for (i, arg) in args.iter().enumerate() {
+                        v.enter_call_arg(i, |v| v.visit_operand(arg));
+                    }
+                });
+
+                // Special cases for particular functions.
+                match ty_callee(tcx, func_ty) {
+                    // Normal call to a local function.
+                    Callee::LocalDef { def_id, substs: _ } => {
+                        if let Some(lsig) = self.acx.gacx.fn_sigs.get(&def_id) {
+                            self.enter_rvalue(|v| v.emit_temp(lsig.output));
+                        }
+                    }
+
+                    Callee::PtrOffset { .. } => {
+                        // Set the call result type to match the destination type as closely as we
+                        // can.  The argument will be downcast to this type, then offset.  However,
+                        // our `PtrOffset` rewrite can't output `Single` or `Array` directly, so in
+                        // those cases, the rewrite will operate on `Slice` and downcast afterward.
+                        self.enter_rvalue(|v| v.emit_temp_adjust(pl_ty, |mut slty| {
+                            if let SublocType::Ptr(ref mut desc) = slty {
+                                match desc.qty {
+                                    Quantity::Single | Quantity::Array => {
+                                        desc.qty = Quantity::Slice;
+                                    },
+                                    Quantity::Slice | Quantity::OffsetPtr => {},
+                                }
+                            }
+                            slty
+                        }));
+                    }
+
+                    Callee::SliceAsPtr { .. } => {
+                        // Set result type equal to the argument type.  The rewriter will insert an
+                        // appropriate cast to convert to the destination type.
+                        assert_eq!(args.len(), 1);
+                        let arg_lty = self.acx.type_of(&args[0]);
+                        self.enter_rvalue(|v| v.emit_temp(arg_lty))
+                    }
+
+                    Callee::Memcpy | Callee::Memset => {
+                        // Match the type of the first (`dest`) argument exactly.  The rewrite is
+                        // responsible for preserving any combination of `Ownership` and
+                        // `Quantity`.
+                        assert_eq!(args.len(), 3);
+                        let arg_lty = self.acx.type_of(&args[0]);
+                        self.enter_rvalue(|v| v.emit_temp(arg_lty));
+                    }
+
+                    Callee::IsNull => {
+                        // Result type is simply `bool`, which should be the same as the dest type.
+                        self.enter_rvalue(|v| v.emit_temp(pl_ty));
+                    }
+
+                    Callee::Null { .. } => {
+                        // Match the destination type, but `null()` always outputs a nullable
+                        // pointer.
+                        self.enter_rvalue(|v| v.emit_temp_adjust(pl_ty, |mut slty| {
+                            if let SublocType::Ptr(ref mut desc) = slty {
+                                desc.option = true;
+                            }
+                            slty
+                        }));
+                    }
+
+                    Callee::Malloc | Callee::Calloc | Callee::Realloc => {
+                        // Match the destination type, but always produce a non-optional `Box`.
+                        self.enter_rvalue(|v| v.emit_temp_adjust(pl_ty, |mut slty| {
+                            if let SublocType::Ptr(ref mut desc) = slty {
+                                desc.option = false;
+                                desc.own = Ownership::Box;
+                            }
+                            slty
+                        }));
+                    }
+
+                    Callee::Free => {
+                        // Result type is simply `()`, which should be the same as the dest type.
+                        self.enter_rvalue(|v| v.emit_temp(pl_ty));
+                    }
+
+                    _ => {}
+                }
+            }
+            TerminatorKind::Assert { .. } => {}
+            TerminatorKind::Yield { .. } => {}
+            TerminatorKind::GeneratorDrop => {}
+            TerminatorKind::FalseEdge { .. } => {}
+            TerminatorKind::FalseUnwind { .. } => {}
+            TerminatorKind::InlineAsm { .. } => todo!("terminator {:?}", term),
+        }
+    }
+
+    fn visit_rvalue(&mut self, rv: &Rvalue<'tcx>) {
+        eprintln!("subloc_info::visit_rvalue: {:?}", rv);
+
+        let rv_lty = self.acx.type_of_rvalue(rv, self.loc);
+        let can_move = false;   // TODO
+        let can_mutate = false; // TODO
+        self.emit(rv_lty, can_move, can_mutate, PlaceAccess::Move);
+
+        match *rv {
+            Rvalue::Use(ref op) => {
+                self.enter_rvalue_operand(0, |v| v.visit_operand(op));
+            }
+            Rvalue::Repeat(ref op, _) => {
+                self.enter_rvalue_operand(0, |v| v.visit_operand(op));
+            }
+            Rvalue::Ref(_rg, kind, pl) => {
+                let mutbl = match kind {
+                    BorrowKind::Mut { .. } => true,
+                    BorrowKind::Shared | BorrowKind::Shallow | BorrowKind::Unique => false,
+                };
+                self.enter_rvalue_place(0, |v| v.visit_place(pl, PlaceAccess::from_bool(mutbl)));
+            }
+            Rvalue::ThreadLocalRef(_def_id) => {
+                todo!("Rvalue::ThreadLocalRef")
+            }
+            Rvalue::AddressOf(mutbl, pl) => {
+                self.enter_rvalue_place(0, |v| v.visit_place(pl, PlaceAccess::from_mutbl(mutbl)));
+            }
+            Rvalue::Len(pl) => {
+                self.enter_rvalue_place(0, |v| v.visit_place(pl, PlaceAccess::Imm));
+            }
+            Rvalue::Cast(_kind, ref op, ty) => {
+                self.enter_rvalue_operand(0, |v| v.visit_operand(op));
+            }
+            Rvalue::BinaryOp(_bop, ref ops) => {
+                self.enter_rvalue_operand(0, |v| v.visit_operand(&ops.0));
+                self.enter_rvalue_operand(1, |v| v.visit_operand(&ops.1));
+            }
+            Rvalue::CheckedBinaryOp(_bop, ref ops) => {
+                self.enter_rvalue_operand(0, |v| v.visit_operand(&ops.0));
+                self.enter_rvalue_operand(1, |v| v.visit_operand(&ops.1));
+            }
+            Rvalue::NullaryOp(..) => {}
+            Rvalue::UnaryOp(_uop, ref op) => {
+                self.enter_rvalue_operand(0, |v| v.visit_operand(op));
+            }
+            Rvalue::Discriminant(pl) => {
+                self.enter_rvalue_place(0, |v| v.visit_place(pl, PlaceAccess::Imm));
+            }
+            Rvalue::Aggregate(ref _kind, ref ops) => {
+                for (i, op) in ops.iter().enumerate() {
+                    self.enter_rvalue_operand(i, |v| v.visit_operand(op));
+                }
+            }
+            Rvalue::ShallowInitBox(ref op, _ty) => {
+                self.enter_rvalue_operand(0, |v| v.visit_operand(op));
+            }
+            Rvalue::CopyForDeref(pl) => {
+                self.enter_rvalue_place(0, |v| v.visit_place(pl, PlaceAccess::Imm));
+            }
+        }
+    }
+
+    fn visit_operand(&mut self, op: &Operand<'tcx>) {
+        match *op {
+            Operand::Copy(pl) | Operand::Move(pl) => {
+                let pl_lty = self.acx.type_of(pl);
+                // Moving out of a `DynOwned` pointer requires `Mut` access rather than `Move`.
+                // TODO: this should probably check `desc.dyn_owned` rather than perms directly
+                let access = if !pl_lty.label.is_none() && self.perms[pl_lty.label].contains(PermissionSet::FREE) {
+                    PlaceAccess::Mut
+                } else {
+                    PlaceAccess::Move
+                };
+                self.enter_operand_place(|v| v.visit_place(pl, access));
+            }
+            Operand::Constant(..) => {}
+        }
+    }
+
+    /*
+    /// Like [`Self::visit_operand`], but takes an expected `TypeDesc` instead of an expected `LTy`.
+    fn visit_operand_desc(&mut self, op: &Operand<'tcx>) {
+        match *op {
+            Operand::Copy(pl) | Operand::Move(pl) => {
+                let pl_lty = self.acx.type_of(pl);
+                // Moving out of a `DynOwned` pointer requires `Mut` access rather than `Move`.
+                // TODO: this should probably check `desc.dyn_owned` rather than perms directly
+                let access = if !pl_lty.label.is_none() && self.perms[pl_lty.label].contains(PermissionSet::FREE) {
+                    PlaceAccess::Mut
+                } else {
+                    PlaceAccess::Move
+                };
+                self.enter_operand_place(|v| v.visit_place(pl, access, RequireSinglePointer::Yes));
+
+                if !pl_lty.label.is_none() {
+                    self.emit_cast_lty_desc(pl_lty, expect_desc);
+                }
+            }
+            Operand::Constant(..) => {}
+        }
+    }
+    */
+
+    fn visit_place(
+        &mut self,
+        pl: Place<'tcx>,
+        access: PlaceAccess,
+    ) {
+        let mut ltys = Vec::with_capacity(1 + pl.projection.len());
+        ltys.push(self.acx.type_of(pl.local));
+        for proj in pl.projection {
+            let prev_lty = ltys.last().copied().unwrap();
+            ltys.push(self.acx.projection_lty(prev_lty, &proj));
+        }
+        self.visit_place_ref(pl.as_ref(), &ltys, access);
+    }
+
+    /// Generate rewrites for a `Place` represented as a `PlaceRef`.  `proj_ltys` gives the `LTy`
+    /// for the `Local` and after each projection.  `access` describes how the place is being used:
+    /// immutably, mutably, or being moved out of.
+    fn visit_place_ref(
+        &mut self,
+        pl: PlaceRef<'tcx>,
+        proj_ltys: &[LTy<'tcx>],
+        access: PlaceAccess,
+    ) {
+        let (&last_proj, rest) = match pl.projection.split_last() {
+            Some(x) => x,
+            None => {
+                // `pl` is just a local with no projections.
+                let pl_lty = proj_ltys[0];
+                let can_move = self.current_sub_loc_is_last_use();
+                // We assume all locals are mutable, or at least can be made mutable if needed.
+                let can_mutate = true;
+                self.emit(pl_lty, can_move, can_mutate, access);
+                return;
+            },
+        };
+
+        // TODO: downgrade Move to Imm if the new type is Copy
+
+        let proj_lty = proj_ltys[pl.projection.len()];
+        let can_move = false;   // TODO
+        let can_mutate = false; // TODO
+        self.emit(proj_lty, can_move, can_mutate, access);
+
+        let base_pl = PlaceRef {
+            local: pl.local,
+            projection: rest,
+        };
+        match last_proj {
+            PlaceElem::Deref => {
+                let cast_can_move = base_pl.is_local() && self.current_sub_loc_is_last_use();
+                self.enter_place_deref_pointer(|v| {
+                    v.visit_place_ref(base_pl, proj_ltys, access);
+                });
+            }
+            PlaceElem::Field(_idx, _ty) => {
+                self.enter_place_field_base(|v| v.visit_place_ref(base_pl, proj_ltys, access));
+            }
+            PlaceElem::Index(_) | PlaceElem::ConstantIndex { .. } | PlaceElem::Subslice { .. } => {
+                self.enter_place_index_array(|v| v.visit_place_ref(base_pl, proj_ltys, access));
+            }
+            PlaceElem::Downcast(_, _) => todo!("PlaceElem::Downcast"),
+        }
+    }
+
+    /// Visit a `Callee::PtrOffset` call, and emit the `SublocInfo` for the call/RHS.
+    fn visit_ptr_offset(&mut self, op: &Operand<'tcx>, result_ty: LTy<'tcx>) {
+        todo!("visit_ptr_offset")
+            /*
+        // Compute the expected type for the argument, and emit a cast if needed.
+        let result_ptr = result_ty.label;
+        let result_desc =
+            type_desc::perms_to_desc(result_ty.ty, self.perms[result_ptr], self.flags[result_ptr]);
+
+        let arg_expect_desc = TypeDesc {
+            own: result_desc.own,
+            qty: match result_desc.qty {
+                Quantity::Single => Quantity::Slice,
+                Quantity::Slice => Quantity::Slice,
+                Quantity::OffsetPtr => Quantity::OffsetPtr,
+                Quantity::Array => unreachable!("perms_to_desc should not return Quantity::Array"),
+            },
+            dyn_owned: result_desc.dyn_owned,
+            option: result_desc.option,
+            pointee_ty: result_desc.pointee_ty,
+        };
+
+        self.enter_rvalue(|v| {
+            v.enter_call_arg(0, |v| v.visit_operand_desc(op, arg_expect_desc));
+
+            // Emit `OffsetSlice` for the offset itself.
+            let mutbl = matches!(result_desc.own, Ownership::Mut);
+            if !result_desc.option {
+                v.emit(RewriteKind::OffsetSlice { mutbl });
+            } else {
+                v.emit(RewriteKind::OptionMapOffsetSlice { mutbl });
+            }
+
+            // The `OffsetSlice` operation returns something of the same type as its input.
+            // Afterward, we must cast the result to the `result_ty`/`result_desc`.
+            v.emit_cast_desc_desc(arg_expect_desc, result_desc);
+        });
+        */
+    }
+
+    fn visit_slice_as_ptr(&mut self, elem_ty: Ty<'tcx>, op: &Operand<'tcx>, result_lty: LTy<'tcx>) {
+        todo!("visit_slice_as_ptr")
+        /*
+        let op_lty = self.acx.type_of(op);
+        let op_ptr = op_lty.label;
+        let result_ptr = result_lty.label;
+
+        let op_desc = type_desc::perms_to_desc_with_pointee(
+            self.acx.tcx(),
+            elem_ty,
+            op_lty.ty,
+            self.perms[op_ptr],
+            self.flags[op_ptr],
+        );
+
+        let result_desc = type_desc::perms_to_desc_with_pointee(
+            self.acx.tcx(),
+            elem_ty,
+            result_lty.ty,
+            self.perms[result_ptr],
+            self.flags[result_ptr],
+        );
+
+        self.enter_rvalue(|v| {
+            // Generate a cast of our own, replacing the `as_ptr` call.
+            // TODO: leave the `as_ptr` in place if we can't produce a working cast
+            v.emit(RewriteKind::RemoveAsPtr);
+            v.emit_cast_desc_desc(op_desc, result_desc);
+        });
+        */
+    }
+}
+
+pub fn collect_subloc_info<'tcx>(
+    acx: &AnalysisCtxt<'_, 'tcx>,
+    asn: &Assignment,
+    pointee_types: PointerTable<PointeeTypes<'tcx>>,
+    last_use: &LastUse,
+    mir: &Body<'tcx>,
+) -> HashMap<(Location, Vec<SubLoc>), SublocInfo<'tcx>> {
+    let mut v = CollectInfoVisitor::new(acx, asn, pointee_types, last_use, mir);
+
+    for (bb_id, bb) in mir.basic_blocks().iter_enumerated() {
+        for (i, stmt) in bb.statements.iter().enumerate() {
+            let loc = Location {
+                block: bb_id,
+                statement_index: i,
+            };
+            v.visit_statement(stmt, loc);
+        }
+
+        if let Some(ref term) = bb.terminator {
+            let loc = Location {
+                block: bb_id,
+                statement_index: bb.statements.len(),
+            };
+            v.visit_terminator(term, loc);
+        }
+    }
+
+    v.info_map
+}

--- a/c2rust-analyze/src/rewrite/expr/subloc_info.rs
+++ b/c2rust-analyze/src/rewrite/expr/subloc_info.rs
@@ -110,6 +110,20 @@ impl<'a, 'tcx> TypeConversionContext<'a, 'tcx> {
             new_desc.pointee_ty = pointee_lty.ty;
         }
 
+        // FIXME (hack): currently we sometimes get a desc with `pointee_ty = [u32]` etc, instead
+        // of `pointee_ty = u32` + `qty = Slice`.  This causes confusion in later passes, so here
+        // we hack around it.
+        // TODO: investigate why this happens and fix the underlying issue
+        if new_desc.qty == Quantity::Single {
+            if let &TyKind::Slice(elem_ty) = new_desc.pointee_ty.kind() {
+                new_desc.qty = Quantity::Slice;
+                new_desc.pointee_ty = elem_ty;
+            //} else if let &TyKind::Array(elem_ty, _) = new_desc.pointee_ty.kind() {
+            //    new_desc.qty = Quantity::Array;
+            //    new_desc.pointee_ty = elem_ty;
+            }
+        }
+
         (SublocType::Ptr(old_desc), SublocType::Ptr(new_desc))
     }
 

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -59,13 +59,19 @@ pub struct PtrDesc {
 
 impl<'tcx> From<TypeDesc<'tcx>> for PtrDesc {
     fn from(x: TypeDesc<'tcx>) -> PtrDesc {
+        x.to_ptr_desc()
+    }
+}
+
+impl TypeDesc<'_> {
+    pub fn to_ptr_desc(self) -> PtrDesc {
         let TypeDesc {
             own,
             qty,
             dyn_owned,
             option,
             pointee_ty: _,
-        } = x;
+        } = self;
         PtrDesc {
             own,
             qty,

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -138,7 +138,7 @@ fn perms_to_ptr_desc(perms: PermissionSet, flags: FlagSet) -> PtrDesc {
 
 /// Obtain the `TypeDesc` for a pointer.  `ptr_ty` should be the `Ty` of the pointer, and `perms`
 /// and `flags` should be taken from its outermost `PointerId`.
-pub fn perms_to_desc(ptr_ty: Ty, perms: PermissionSet, flags: FlagSet) -> TypeDesc {
+pub fn perms_to_desc<'tcx>(ptr_ty: Ty<'tcx>, perms: PermissionSet, flags: FlagSet) -> TypeDesc<'tcx> {
     // The FIXED case should be handled by calling `perm_to_desc_with_pointee` instead.
     assert!(
         !flags.contains(FlagSet::FIXED),
@@ -160,7 +160,7 @@ pub fn perms_to_desc(ptr_ty: Ty, perms: PermissionSet, flags: FlagSet) -> TypeDe
 
 /// Obtain the `TypeDesc` for a pointer to a local.  `local_ty` should be the `Ty` of the local
 /// itself, and `perms` and `flags` should be taken from its `addr_of_local` `PointerId`.
-pub fn local_perms_to_desc(local_ty: Ty, perms: PermissionSet, flags: FlagSet) -> TypeDesc {
+pub fn local_perms_to_desc<'tcx>(local_ty: Ty<'tcx>, perms: PermissionSet, flags: FlagSet) -> TypeDesc<'tcx> {
     let ptr_desc = perms_to_ptr_desc(perms, flags);
     let pointee_ty = local_ty;
     ptr_desc.to_type_desc(pointee_ty)


### PR DESCRIPTION
This is a WIP refactor of `mir_op`.  I don't have time to finish it at the moment, but I'm posting this PR and including some notes here so it doesn't get lost.  Currently it works on trivial examples like `offset1`, but fails on more interesting ones like `algo_md5`.  It mostly seems to be failing while trying to produce nonsensical casts, but there are also a lot of unimplemented `Callee` cases in the new `mir_op` that will surely cause other problems later on.

---

This branch refactors the MIR rewrite generation pass (`rewrite::expr::mir_op`) to separate `LTy`/`TypeDesc` handling from the actual generation of casts and other rewrites.  It divides `mir_op` into three separate passes: the first collects type and other metadata for each MIR node, the second determines which casts are needed to produce a well-typed program after type rewriting, and the third inserts the casts and any other necessary rewrites.

These passes work on a representation called `SublocInfo`.  A "subloc" or "node" is a piece of MIR at finer granularity than a `Location`.  For example, given the statement `_2 = Use(move _1)`, a `SubLoc` path can refer to the whole statement, the destination place `_2`, the rvalue `Use(move_1)`, the operand `move _1`, or the place `_1`.  Each of these can have its own `SublocInfo` that describes its type and other information about the surrounding context or how it can be used.

The three new passes in more detail:

* `SublocInfo` collection: This pass computes the "new type" of each node, which is the type it would have after the types of all defs and locals are rewritten to match their `LTy`s.  This can produce inconsistent results, such as giving the LHS and RHS of an assignment different types.  This pass also records other metadata, such as the access mode (imm or mut) for `Place`s.
* `SublocInfo` typechecking: This pass checks for inconsistencies and computes the "expected type" of each node, which is the type it should have in order to make it usable in the surrounding context.  By default, the node's expected type is identical to its new type, but it may be changed to resolve a type error.  For example, in an inconsistent assignment (where the LHS and RHS have different new types), the expected type of the RHS will be set to match the new (and expected) type of the LHS.  There are also some cases, mostly around special functions like `offset`, where this pass will adjust a node's new type instead of its expected type.
* Rewrite generation: This pass adds casts around any node whose expected type doesn't match its new type, and also adds rewrites for special functions like `offset`.  This is similar to the behavior of the existing `mir_op` pass, but it's driven entirely by `SublocInfo` entries, rather than directly consulting `LTy`s.  

Advantages of the new design:

* Easier debugging: In case of a bad rewrite, we'll be able to inspect the `SublocInfo`s to determine whether it's an issue with the rewrite itself or with `SublocInfo` generation.
* Better targetability: This approach should make it easier to suppress rewrites in parts of the code where they're not wanted.  Specifically, if a group of nodes have their new types set to match their old, unrewritten types, then there will be no inconsistencies detected in the typechecking pass, the expected types will all be set to match the new types, and no casts will be inserted.
* Decoupling from analysis: Only the `SublocInfo` collection phase interacts directly with analysis results (`LTy`s).  This means we could implement an alternate version of that pass with a different strategy for determining new types, while reusing all the rest of the rewriting machinery.

Limitations:

* Handling of each special function is now spread across the three passes.  The three pieces for each function are tightly coupled (in many cases there are comments along the lines of "the rewriting pass will do X, so here in collection/typechecking we can do Y").  Probably this can be refactored to put the collection, typechecking, and rewriting logic for each function in one place and having the passes dispatch to the appropriate code for each `Callee` they encounter.
* A similar issue applies to non-function MIR constructs.  This is somewhat inherent to the design, as we need the two `SublocInfo` passes to only request casts that the rewriting pass can handle.
* To further improve targetability, we should be more explicit about which calls to special functions should be fully rewritten (e.g. converting `offset` to a subslice operation) and which should be left alone.  Currently this is handled in a roundabout way: some of the inputs and/or outputs of the function are marked `FIXED` in the analysis, so their new types are left as raw pointers, and the rewriting pass knows to skip the normal rewrite if it sees raw pointers there.
