### PR TITLE
correctly construct _ as Ident rather than Punctuation

### DIFF
--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -913,6 +913,7 @@ impl<'c> Translation<'c> {
             // Emit input and/or output expressions, separated by "=>" if both
             push_expr(&mut tokens, mk().paren_expr(constraints_ident));
             if let Some(in_expr) = in_expr {
+                let in_expr_span = in_expr.span();
                 push_expr(&mut tokens, in_expr);
                 if out_expr.is_some() {
                     tokens.push(TokenTree::Punct(Punct::new('=', Joint)));
@@ -923,7 +924,7 @@ impl<'c> Translation<'c> {
                         tokens.push(TokenTree::Punct(Punct::new('=', Joint)));
                         tokens.push(TokenTree::Punct(Punct::new('>', Alone)));
 
-                        tokens.push(TokenTree::Punct(Punct::new('_', Alone)));
+                        tokens.push(TokenTree::Ident(Ident::new("_", in_expr_span)));
                     }
                 }
             }


### PR DESCRIPTION
This fixes another bug like https://github.com/immunant/c2rust/pull/1197: `_` is no puctuation -- another case of https://github.com/dtolnay/proc-macro2/issues/475, fall-out of https://github.com/dtolnay/proc-macro2/issues/470.

## Testing

This enables building RIOT sources again without `--locked`. I'm not entirely sure, but I think the offending assembly was

```c
  __ASM ("rev %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
```

which gets turned into

```rust
    asm!(
        "rev {0}, {1}", lateout(reg) result, inlateout(reg) value => _,
        options(preserves_flags, pure, readonly)
    );
```

where the `_` is the identifier (formerly punctuation) which c2rust trips over.