### PR TITLE
Release 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "c2rust"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "c2rust-build-paths",
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-analysis-rt"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bincode",
  "crossbeam-queue",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-analyze"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -235,11 +235,11 @@ dependencies = [
 
 [[package]]
 name = "c2rust-asm-casts"
-version = "0.19.0"
+version = "0.20.0"
 
 [[package]]
 name = "c2rust-ast-builder"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-ast-exporter"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bindgen",
  "c2rust-build-paths",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-ast-printer"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "log",
  "prettyplease 0.1.25",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-bitfields"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "c2rust-bitfields-derive",
  "libc",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-bitfields-derive"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -289,14 +289,14 @@ dependencies = [
 
 [[package]]
 name = "c2rust-build-paths"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "print_bytes",
 ]
 
 [[package]]
 name = "c2rust-instrument"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-pdg"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bincode",
  "c2rust-analysis-rt",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "c2rust-transpile"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "c2rust-ast-builder",
  "c2rust-ast-exporter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 authors = ["The C2Rust Project Developers <c2rust@immunant.com>"]
 edition = "2021"
 rust-version = "1.65"

--- a/analysis/runtime/Cargo.toml
+++ b/analysis/runtime/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+publish = false
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/analysis/tests/lighttpd-minimal/Cargo.toml
+++ b/analysis/tests/lighttpd-minimal/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.19.0" }
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.20.0" }
 
 [features]
 miri = []

--- a/analysis/tests/lighttpd/Cargo.toml
+++ b/analysis/tests/lighttpd/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.19.0" }
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.20.0" }
 
 [features]
 miri = []

--- a/analysis/tests/minimal/Cargo.toml
+++ b/analysis/tests/minimal/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.19.0" }
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.20.0" }
 
 [features]
 miri = []

--- a/analysis/tests/misc/Cargo.toml
+++ b/analysis/tests/misc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.19.0" }
+c2rust-analysis-rt = { path = "../../runtime", optional = true, version = "0.20.0" }
 
 [features]
 miri = []

--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -15,7 +15,7 @@ categories.workspace = true
 polonius-engine = "0.13.0"
 rustc-hash = "1.1.0"
 bitflags = "1.3.2"
-c2rust-pdg = { path = "../pdg" }
+c2rust-pdg = { path = "../pdg", version = "0.20.0"}
 bincode = "1.0"
 serde = "1.0"
 assert_matches = "1.5.0"

--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+publish = false
 
 [dependencies]
 polonius-engine = "0.13.0"

--- a/c2rust-analyze/Cargo.toml
+++ b/c2rust-analyze/Cargo.toml
@@ -32,11 +32,11 @@ toml_edit = "0.19.8"
 sha2 = "0.10.8"
 
 [build-dependencies]
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.20.0" }
 print_bytes = "1.1"
 
 [dev-dependencies]
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.20.0" }
 clap = { version = "4.1.9", features = ["derive"] }
 shlex = "1.3.0"
 

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -426,7 +426,7 @@ fn parse_def_id(s: &str) -> Result<DefId, String> {
     };
 
     let rendered = format!("{:?}", def_id);
-    if &rendered != orig_s {
+    if rendered != orig_s {
         return Err(format!(
             "path mismatch: after parsing input {}, obtained a different path {:?}",
             orig_s, def_id
@@ -964,7 +964,7 @@ fn run(tcx: TyCtxt) {
             loop_count, num_changed
         );
 
-        if &asn.perms.as_slice()[..gacx.num_global_pointers()] == &old_gasn {
+        if asn.perms.as_slice()[..gacx.num_global_pointers()] == old_gasn {
             break;
         }
     }

--- a/c2rust-analyze/src/analyze.rs
+++ b/c2rust-analyze/src/analyze.rs
@@ -915,7 +915,7 @@ fn run(tcx: TyCtxt) {
                     borrowck::borrowck_mir(
                         &acx,
                         &info.dataflow,
-                        &mut asn.perms_mut(),
+                        asn.perms_mut(),
                         &updates_forbidden,
                         name.as_str(),
                         &mir,
@@ -1117,13 +1117,13 @@ fn run(tcx: TyCtxt) {
                     continue;
                 }
                 ann.emit(span, format_args!("typeof({:?}) = {}", local, ty_str));
-                if static_non_null_ptrs.len() > 0 {
+                if !static_non_null_ptrs.is_empty() {
                     ann.emit(
                         span,
                         format_args!("  static NON_NULL: {:?}", static_non_null_ptrs),
                     );
                 }
-                if dynamic_non_null_ptrs.len() > 0 {
+                if !dynamic_non_null_ptrs.is_empty() {
                     ann.emit(
                         span,
                         format_args!("  dynamic NON_NULL: {:?}", dynamic_non_null_ptrs),

--- a/c2rust-analyze/src/borrowck/type_check.rs
+++ b/c2rust-analyze/src/borrowck/type_check.rs
@@ -126,17 +126,17 @@ impl<'tcx> TypeChecker<'tcx, '_> {
                         {
                             let field_lifetime_param = OriginParam::try_from(field_lifetime_arg).ok();
 
-                            field_lifetime_param.and_then(|field_lifetime_param| {
+                            if let Some((base_lifetime_param, og)) = field_lifetime_param.and_then(|field_lifetime_param| {
                                 base_origin_param_map.get_key_value(&field_lifetime_param)
-                            }).map(|(base_lifetime_param, og)| {
+                            }) {
                                 debug!(
                                     "mapping {base_adt_def:?} lifetime parameter {base_lifetime_param:?} to \
                                     {base_adt_def:?}.{:} struct definition lifetime parameter {field_struct_lifetime_param:?}, \
                                     corresponding to its lifetime parameter {field_lifetime_param:?} within {base_adt_def:?}",
                                     field_def.name
                                 );
-                            field_origin_param_map.push((*field_struct_lifetime_param, *og));
-                            });
+                                field_origin_param_map.push((*field_struct_lifetime_param, *og));
+                            }
                         }
 
                         let origin_params= self.ltcx.arena().alloc_from_iter(field_origin_param_map.into_iter());

--- a/c2rust-analyze/src/context.rs
+++ b/c2rust-analyze/src/context.rs
@@ -958,7 +958,7 @@ impl<'tcx> GlobalAnalysisCtxt<'tcx> {
     }
 
     /// Iterate over the `DefId`s of all functions that should skip rewriting.
-    pub fn iter_fns_skip_rewrite<'a>(&'a self) -> impl Iterator<Item = DefId> + 'a {
+    pub fn iter_fns_skip_rewrite(&self) -> impl Iterator<Item = DefId> + '_ {
         self.dont_rewrite_fns.keys()
     }
 
@@ -1675,7 +1675,7 @@ where
         mem::take(&mut self.new)
     }
 
-    pub fn keys<'a>(&'a self) -> impl Iterator<Item = K> + 'a {
+    pub fn keys(&self) -> impl Iterator<Item = K> + '_ {
         self.m.keys().copied()
     }
 }

--- a/c2rust-analyze/src/last_use.rs
+++ b/c2rust-analyze/src/last_use.rs
@@ -59,7 +59,7 @@ impl LastUse {
         self.set.contains_key(&(loc, which))
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (Location, WhichPlace, Local)> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = (Location, WhichPlace, Local)> + '_ {
         self.set
             .iter()
             .map(|(&(loc, which), &local)| (loc, which, local))

--- a/c2rust-analyze/src/pointer_id.rs
+++ b/c2rust-analyze/src/pointer_id.rs
@@ -63,10 +63,6 @@ impl PartialEq for PointerId {
     fn eq(&self, other: &PointerId) -> bool {
         self.index() == other.index()
     }
-
-    fn ne(&self, other: &PointerId) -> bool {
-        self.index() != other.index()
-    }
 }
 
 impl Eq for PointerId {}

--- a/c2rust-analyze/src/recent_writes.rs
+++ b/c2rust-analyze/src/recent_writes.rs
@@ -123,7 +123,7 @@ impl BlockWrites {
 }
 
 impl RecentWrites {
-    pub fn new<'tcx>(mir: &Body<'tcx>) -> RecentWrites {
+    pub fn new(mir: &Body) -> RecentWrites {
         calc_recent_writes(mir)
     }
 

--- a/c2rust-analyze/src/rewrite/expr/convert.rs
+++ b/c2rust-analyze/src/rewrite/expr/convert.rs
@@ -806,20 +806,20 @@ fn generate_zeroize_code(zero_ty: &ZeroizeType, lv: &str) -> String {
 /// Generate an expression to produce a zeroized version of a value.
 fn generate_zeroize_expr(zero_ty: &ZeroizeType) -> String {
     match *zero_ty {
-        ZeroizeType::Int => format!("0"),
-        ZeroizeType::Bool => format!("false"),
-        ZeroizeType::Option => format!("None"),
+        ZeroizeType::Int => "0".to_string(),
+        ZeroizeType::Bool => "false".to_string(),
+        ZeroizeType::Option => "None".to_string(),
         ZeroizeType::Array(ref elem_zero_ty) => format!(
             "std::array::from_fn(|| {})",
             generate_zeroize_expr(elem_zero_ty)
         ),
         ZeroizeType::Struct(ref name, ref fields) => {
             let mut s = String::new();
-            write!(s, "{} {{\n", name).unwrap();
+            writeln!(s, "{} {{", name).unwrap();
             for (name, field_zero_ty) in fields {
-                write!(s, "{}: {},\n", name, generate_zeroize_expr(field_zero_ty),).unwrap();
+                writeln!(s, "{}: {},", name, generate_zeroize_expr(field_zero_ty),).unwrap();
             }
-            write!(s, "}}\n").unwrap();
+            writeln!(s, "}}").unwrap();
             s
         }
     }

--- a/c2rust-analyze/src/rewrite/expr/mir_op.rs
+++ b/c2rust-analyze/src/rewrite/expr/mir_op.rs
@@ -391,8 +391,8 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
         rewrite::ty::rewrite_lty(
             tcx,
             lty,
-            &self.perms,
-            &self.flags,
+            self.perms,
+            self.flags,
             &self.pointee_types,
             &self.acx.gacx.adt_metadata,
         )
@@ -795,7 +795,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
                                 .intersects(PermissionSet::OFFSET_ADD | PermissionSet::OFFSET_SUB);
 
                             let opt_zero_ty =
-                                ZeroizeType::from_lty(&v.acx, v.perms, v.flags, pointee_lty);
+                                ZeroizeType::from_lty(v.acx, v.perms, v.flags, pointee_lty);
                             let zero_ty = match opt_zero_ty {
                                 Some(x) => x,
                                 // TODO: emit void* cast before bailing out
@@ -1198,7 +1198,7 @@ impl<'a, 'tcx> ExprRewriteVisitor<'a, 'tcx> {
 
         // TODO: downgrade Move to Imm if the new type is Copy
 
-        debug_assert!(pl.projection.len() >= 1);
+        debug_assert!(!pl.projection.is_empty());
         // `LTy` of the base place, before the last projection.
         let base_lty = proj_ltys[pl.projection.len() - 1];
         // `LTy` resulting from applying `last_proj` to `base_lty`.

--- a/c2rust-analyze/src/rewrite/statics.rs
+++ b/c2rust-analyze/src/rewrite/statics.rs
@@ -9,8 +9,8 @@ use rustc_span::Span;
 
 /// For every static, if its write permission does not match its declared mutability, emit a rewrite
 /// changing the declaration to match observed/analyzed usage.
-pub fn gen_static_rewrites<'tcx>(
-    tcx: TyCtxt<'tcx>,
+pub fn gen_static_rewrites(
+    tcx: TyCtxt,
     asn: &Assignment,
     def_id: DefId,
     ptr: PointerId,

--- a/c2rust-analyze/src/type_desc.rs
+++ b/c2rust-analyze/src/type_desc.rs
@@ -76,7 +76,7 @@ impl<'tcx> From<TypeDesc<'tcx>> for PtrDesc {
 }
 
 impl PtrDesc {
-    pub fn to_type_desc<'tcx>(self, pointee_ty: Ty<'tcx>) -> TypeDesc<'tcx> {
+    pub fn to_type_desc(self, pointee_ty: Ty) -> TypeDesc {
         let PtrDesc {
             own,
             qty,

--- a/c2rust-ast-exporter/Cargo.toml
+++ b/c2rust-ast-exporter/Cargo.toml
@@ -23,7 +23,7 @@ bindgen = { version = "0.65", features = ["logging"] }
 clang-sys = "1.3"
 cmake = "0.1.49"
 env_logger = "0.10"
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.20.0" }
 
 [features]
 default = []

--- a/c2rust-bitfields/Cargo.toml
+++ b/c2rust-bitfields/Cargo.toml
@@ -12,7 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-c2rust-bitfields-derive = { version = "0.19.0", path = "../c2rust-bitfields-derive" }
+c2rust-bitfields-derive = { version = "0.20.0", path = "../c2rust-bitfields-derive" }
 
 [dev-dependencies]
 libc = "0.2"

--- a/c2rust-macros/Cargo.toml
+++ b/c2rust-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2rust-macros"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Stephen Crane <sjc@immunant.com>", "The C2Rust Project Developers <c2rust@immunant.com>"]
 edition = "2021"
 description = "Procedural macro support crate for C2Rust"

--- a/c2rust-refactor/Cargo.toml
+++ b/c2rust-refactor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2rust-refactor"
-version = "0.19.0"
+version = "0.20.0"
 authors = [
   "The C2Rust Project Developers <c2rust@immunant.com>",
   "Stuart Pernsteiner <spernsteiner@galois.com>",
@@ -17,18 +17,18 @@ json = "0.12"
 libc = "0.2"
 regex = "1.1"
 ena = "0.13"
-c2rust-ast-builder = { version = "0.19.0", path = "../c2rust-ast-builder" }
-c2rust-ast-printer = { version = "0.19.0", path = "../c2rust-ast-printer" }
+c2rust-ast-builder = { version = "0.20.0", path = "../c2rust-ast-builder" }
+c2rust-ast-printer = { version = "0.20.0", path = "../c2rust-ast-printer" }
 indexmap = { version = "1.0.1", features = ["serde-1"] }
 cargo = "0.44"
 clap = {version = "2.33", features = ["yaml"]}
-c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.19.0" }
+c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.20.0" }
 env_logger = "0.10"
 log = "0.4"
 rlua = "0.17"
 slotmap = {version = "0.4", features = ["unstable"]}
 derive_more = "0.99"
-c2rust-macros = { version = "0.19.0", path = "../c2rust-macros" }
+c2rust-macros = { version = "0.20.0", path = "../c2rust-macros" }
 flame = { version = "0.2.2", optional = true }
 flamer = { version = "0.4", optional = true }
 failure = "0.1"

--- a/c2rust-refactor/runtime/Cargo.toml
+++ b/c2rust-refactor/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2rust_runtime"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Stuart Pernsteiner <spernsteiner@galois.com>"]
 edition = "2021"
 

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -12,10 +12,10 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-c2rust-ast-builder = { version = "0.19.0", path = "../c2rust-ast-builder" }
-c2rust-ast-exporter = { version = "0.19.0", path = "../c2rust-ast-exporter" }
-c2rust-ast-printer = { version = "0.19.0", path = "../c2rust-ast-printer" }
-c2rust-bitfields = { version = "0.19.0", path = "../c2rust-bitfields" }
+c2rust-ast-builder = { version = "0.20.0", path = "../c2rust-ast-builder" }
+c2rust-ast-exporter = { version = "0.20.0", path = "../c2rust-ast-exporter" }
+c2rust-ast-printer = { version = "0.20.0", path = "../c2rust-ast-printer" }
+c2rust-bitfields = { version = "0.20.0", path = "../c2rust-bitfields" }
 colored = "2.0"
 dtoa = "1.0"
 failure = "0.1.5"

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -190,7 +190,7 @@ impl<'c> Translation<'c> {
                 if is_string {
                     let v = ids.first().unwrap();
                     self.convert_expr(ctx.used(), *v)
-                } else if ids.len() == 0 {
+                } else if ids.is_empty() {
                     // this was likely a C array of the form `int x[16] = {}`,
                     // we'll emit that as [0; 16].
                     let len = mk().lit_expr(mk().int_unsuffixed_lit(n as u128));

--- a/c2rust/Cargo.toml
+++ b/c2rust/Cargo.toml
@@ -24,10 +24,10 @@ is_executable = "1.0"
 log = "0.4"
 regex = "1.3"
 shlex = "1.3"
-c2rust-transpile = { version = "0.19.0", path = "../c2rust-transpile" }
+c2rust-transpile = { version = "0.20.0", path = "../c2rust-transpile" }
 
 [build-dependencies]
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.20.0" }
 
 [features]
 # Force static linking of LLVM

--- a/dynamic_instrumentation/Cargo.toml
+++ b/dynamic_instrumentation/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+publish = false
 
 [dependencies]
 anyhow = "1.0"

--- a/dynamic_instrumentation/Cargo.toml
+++ b/dynamic_instrumentation/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 anyhow = "1.0"
 bincode = "1.0.1"
-c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.19.0" }
+c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.20.0" }
 indexmap = "1.9"
 itertools = "0.10"
 once_cell = "1.13"
@@ -30,7 +30,7 @@ tempfile = "3.3"
 rand = "0.8.5"
 
 [build-dependencies]
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.20.0" }
 
 [package.metadata.rust-analyzer] 
 rustc_private = true

--- a/dynamic_instrumentation/src/instrument.rs
+++ b/dynamic_instrumentation/src/instrument.rs
@@ -136,7 +136,8 @@ impl ProjectionSet for Instrumenter {
         // a random 64-bit key for it; the probability of collision
         // is 1/2^32 (because of the birthday paradox), which should
         // be good enough for our use case.
-        *self.projections
+        *self
+            .projections
             .lock()
             .unwrap()
             .entry(proj)

--- a/examples/robotfindskitten/repo/rust/Cargo.toml
+++ b/examples/robotfindskitten/repo/rust/Cargo.toml
@@ -9,7 +9,7 @@ name = "robotfindskitten"
 path = "src/robotfindskitten.rs"
 
 [dependencies]
-c2rust_runtime = { path = "../../../../c2rust-refactor/runtime", version = "0.19.0" }
+c2rust_runtime = { path = "../../../../c2rust-refactor/runtime", version = "0.20.0" }
 rand = "0.5.5"
 pancurses = "0.16.0"
 libc = "0.2"

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 
 [dependencies]
 bincode = "1.0"
-c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.19.0" }
+c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.20.0" }
 indexed_vec = "1.2"
 indexmap = "1.8"
 serde = { version = "1.0", features = ["derive"] }
@@ -26,7 +26,7 @@ linked_hash_set = "0.1"
 clap = { version = "3.2", features = ["derive"] }
 
 [build-dependencies]
-c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.19.0" }
+c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.20.0" }
 
 [dev-dependencies]
 insta = "1.15"

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 categories.workspace = true
+publish = false
 
 [dependencies]
 bincode = "1.0"

--- a/pdg/src/builder.rs
+++ b/pdg/src/builder.rs
@@ -302,7 +302,7 @@ pub fn add_node(
             })
             .map(|nid| pi.with_node(NodeId::from(nid)))
     });
-    let source = direct_source.or(provenance.cloned());
+    let source = direct_source.or_else(|| provenance.cloned());
 
     let function = Func {
         id: dest_fn,

--- a/tests/asm.aarch64/Cargo.toml
+++ b/tests/asm.aarch64/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-asm-casts = { path = "../../c2rust-asm-casts", version = "0.19.0" }
+c2rust-asm-casts = { path = "../../c2rust-asm-casts", version = "0.20.0" }

--- a/tests/asm.x86_64/Cargo.toml
+++ b/tests/asm.x86_64/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-c2rust-asm-casts = { path = "../../c2rust-asm-casts", version = "0.19.0" }
+c2rust-asm-casts = { path = "../../c2rust-asm-casts", version = "0.20.0" }

--- a/tests/structs/Cargo.toml
+++ b/tests/structs/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-c2rust-bitfields = { path = "../../c2rust-bitfields", version = "0.19.0" }
+c2rust-bitfields = { path = "../../c2rust-bitfields", version = "0.20.0" }
 memoffset = "0.2"
 libc = "0.2"


### PR DESCRIPTION
Following as much from [c2rust/wiki/Release-Process](https://github.com/immunant/c2rust/wiki/Release-Process) as still works/applies, plus some extra additions, I ...
* [ ] `cargo outdated -R`: doesn't work due to unknown print request `split-debuginfo`
* [ ] `cargo update`: doesn't work because of old nightly
* [ ] `cargo clippy`:
  * [x] `cargo clippy --fix`
  * [x] Other trivial `cargo clippy` fixes
* [x] `cargo fmt --check`
* [x] Updated versions from `0.19.0` to `0.20.0`.
* [x] Specified missing versions for relative dependencies.
* [x] `cargo build`
* [x] `cargo +stable build -p c2rust`
* [x] Set `publish = false` in crates that are unstable due to `#![feature(rustc_private)]`.

Then I will publish the crates in this order with `cargo +stable -p $package`:
* `c2rust-asm-casts`
* `c2rust-ast-builder`
* `c2rust-ast-printer`
* `c2rust-build-paths`
* `c2rust-ast-exporter`
* `c2rust-bitfields-derive`
* `c2rust-bitfields`
* `c2rust-transpile`
* `c2rust`

or if this works, then I'll use this:

```
cargo +nightly publish --workspace --dry-run -Z package-workspace --exclude c2rust-analysis-rt --exclude c2rust-instrument --exclude c2rust-pdg --exclude c2rust-analyze
```

I need to use `cargo +stable` for this because the pinned nightly does not correctly resolve the `Cargo.lock` for a workspace, and thus tries to incompatibly update it.