### PR TITLE
build: support cmake 4.0

### DIFF
--- a/c2rust-ast-exporter/src/CMakeLists.txt
+++ b/c2rust-ast-exporter/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.5)
 project(ASTExporter)
 
 #################################################

--- a/examples/json-c/repo/CMakeLists.txt
+++ b/examples/json-c/repo/CMakeLists.txt
@@ -1,6 +1,6 @@
 #Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0048 NEW)
 project(json-c VERSION 0.13.1)
 


### PR DESCRIPTION
bump `cmake_minimum_required` to support cmake 4.0 build

```
    CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
      Compatibility with CMake < 3.5 has been removed from CMake.
```