### PR TITLE
transpile: use a repeat expression for arrays with a single zero initializer

### DIFF
--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -180,6 +180,27 @@ impl<'c> Translation<'c> {
             CTypeKind::ConstantArray(ty, n) => {
                 // Convert all of the provided initializer values
 
+                let to_array_element = |id: CExprId| -> TranslationResult<_> {
+                    self.convert_expr(ctx.used(), id)?.result_map(|x| {
+                        // Array literals require all of their elements to be
+                        // the correct type; they will not use implicit casts to
+                        // change mut to const. This becomes a problem when an
+                        // array literal is used in a position where there is no
+                        // type information available to force its type to the
+                        // correct const or mut variation. To avoid this issue
+                        // we manually insert the otherwise elided casts in this
+                        // particular context.
+                        if let CExprKind::ImplicitCast(ty, _, CastKind::ConstCast, _, _) =
+                            self.ast_context[id].kind
+                        {
+                            let t = self.convert_type(ty.ctype)?;
+                            Ok(mk().cast_expr(x, t))
+                        } else {
+                            Ok(x)
+                        }
+                    })
+                };
+
                 // We need to handle the 4 cases in `str_init.c` with identical initializers:
                 // * `ptr_extra_braces`
                 // * `array_extra_braces`
@@ -194,55 +215,56 @@ impl<'c> Translation<'c> {
                 // * there being only one element in the initializer list
                 // * the element type of the array being `CTypeKind::Char` (w/o this, `array_of_arrays` is included)
                 // * the expr kind being a string literal (`CExprKind::Literal` of a `CLiteral::String`).
-                if let &[id] = ids {
+                let is_string_literal = |id: CExprId| {
                     let ty_kind = &self.ast_context.resolve_type(ty).kind;
                     let expr_kind = &self.ast_context.index(id).kind;
                     let is_char_array = matches!(*ty_kind, CTypeKind::Char);
                     let is_str_literal =
                         matches!(*expr_kind, CExprKind::Literal(_, CLiteral::String { .. }));
-                    if is_char_array && is_str_literal {
-                        return self.convert_expr(ctx.used(), id);
-                    }
-                }
+                    is_char_array && is_str_literal
+                };
 
-                if ids.is_empty() {
-                    // this was likely a C array of the form `int x[16] = {}`,
-                    // we'll emit that as [0; 16].
-                    let len = mk().lit_expr(mk().int_unsuffixed_lit(n as u128));
-                    self.implicit_default_expr(ty, ctx.is_static)?
-                        .and_then(|default_value| {
-                            Ok(WithStmts::new_val(mk().repeat_expr(default_value, len)))
-                        })
-                } else {
-                    Ok(ids
-                        .iter()
-                        .map(|id| {
-                            self.convert_expr(ctx.used(), *id)?.result_map(|x| {
-                                // Array literals require all of their elements to be
-                                // the correct type; they will not use implicit casts to
-                                // change mut to const. This becomes a problem when an
-                                // array literal is used in a position where there is no
-                                // type information available to force its type to the
-                                // correct const or mut variation. To avoid this issue
-                                // we manually insert the otherwise elided casts in this
-                                // particular context.
-                                if let CExprKind::ImplicitCast(ty, _, CastKind::ConstCast, _, _) =
-                                    self.ast_context[*id].kind
-                                {
-                                    let t = self.convert_type(ty.ctype)?;
-                                    Ok(mk().cast_expr(x, t))
-                                } else {
-                                    Ok(x)
-                                }
-                            })
-                        })
-                        .chain(
-                            // Pad out the array literal with default values to the desired size
-                            iter::repeat(self.implicit_default_expr(ty, ctx.is_static))
-                                .take(n - ids.len()),
-                        )
-                        .collect::<TranslationResult<WithStmts<_>>>()?
-                        .map(|vals| mk().array_expr(vals)))
+                let is_zero_literal = |id: CExprId| {
+                    matches!(
+                        self.ast_context.index(id).kind,
+                        CExprKind::Literal(_, CLiteral::Integer(0, _base))
+                    )
+                };
+
+                match ids {
+                    [] => {
+                        // this was likely a C array of the form `int x[16] = {}`,
+                        // we'll emit that as [0; 16].
+                        let len = mk().lit_expr(mk().int_unsuffixed_lit(n as u128));
+                        let zeroed = self.implicit_default_expr(ty, ctx.is_static)?;
+                        Ok(zeroed.map(|default_value| mk().repeat_expr(default_value, len)))
+                    }
+                    &[single] if is_string_literal(single) => {
+                        // Need to check to see if the next item is a string literal,
+                        // if it is need to treat it as a declaration, rather than
+                        // an init list. https://github.com/GaloisInc/C2Rust/issues/40
+                        self.convert_expr(ctx.used(), single)
+                    }
+                    &[single] if is_zero_literal(single) && n > 1 => {
+                        // this was likely a C array of the form `int x[16] = { 0 }`,
+                        // we'll emit that as [0; 16].
+                        let len = mk().lit_expr(mk().int_unsuffixed_lit(n as u128));
+                        Ok(to_array_element(single)?
+                            .map(|default_value| mk().repeat_expr(default_value, len)))
+                    }
+                    [..] => {
+                        Ok(ids
+                            .iter()
+                            .copied()
+                            .map(to_array_element)
+                            .chain(
+                                // Pad out the array literal with default values to the desired size
+                                iter::repeat(self.implicit_default_expr(ty, ctx.is_static))
+                                    .take(n - ids.len()),
+                            )
+                            .collect::<TranslationResult<WithStmts<_>>>()?
+                            .map(|vals| mk().array_expr(vals)))
+                    }
                 }
             }
             CTypeKind::Struct(struct_id) => {

--- a/c2rust-transpile/tests/snapshots/arrays.c
+++ b/c2rust-transpile/tests/snapshots/arrays.c
@@ -3,7 +3,7 @@
 static char simple[] = "mystring";
 static char *foo = "mystring";
 
-void entry(const unsigned buffer_size, int buffer[const]) {
+void entry(void) {
     int arr[1][1] = { 1 };
     arr[0][0] += 9;
 
@@ -23,81 +23,28 @@ void entry(const unsigned buffer_size, int buffer[const]) {
     int arr6[2] = { 1, 2, 3 };
     int arr7[0] = { 1234 };
 
-    int i = 0;
-
     char abc[] = "abc";
-    buffer[i++] = abc[0];
-    buffer[i++] = abc[1];
-    buffer[i++] = abc[2];
-    buffer[i++] = abc[3];
 
     char def[] = {'d','e','f'};
-    buffer[i++] = def[0];
-    buffer[i++] = def[1];
-    buffer[i++] = def[2];
 
     char part[2] = {1};
-    buffer[i++] = part[0];
-    buffer[i++] = part[1];
 
     char *abcptr = "abc";
-    buffer[i++] = abcptr[0];
-    buffer[i++] = abcptr[1];
-    buffer[i++] = abcptr[2];
-    buffer[i++] = abcptr[3];
 
     char init[] = {"abcd"};
-    buffer[i++] = init[0];
-    buffer[i++] = init[1];
-    buffer[i++] = init[2];
-    buffer[i++] = init[3];
 
     char too_long[3] = "abcde";
-    buffer[i++] = too_long[0];
-    buffer[i++] = too_long[1];
-    buffer[i++] = too_long[2];
 
     char too_short[20] = "abc";
-    buffer[i++] = too_short[0];
-    buffer[i++] = too_short[1];
-    buffer[i++] = too_short[2];
-    buffer[i++] = too_short[3];
-    buffer[i++] = too_short[4];
-    buffer[i++] = too_short[5];
-    buffer[i++] = too_short[6];
 
 // TODO re-enable after #1266 adds portable support for translating `wchar_t`.
 #if 0
     wchar_t wide1[] = L"x";
-    buffer[i++] = wide1[0];
-    buffer[i++] = wide1[1];
 
     wchar_t wide2[3] = L"x";
-    buffer[i++] = wide2[0];
-    buffer[i++] = wide2[1];
-    buffer[i++] = wide2[2];
 
     wchar_t wide3[1] = L"xy";
-    buffer[i++] = wide3[0];
 #endif
-
-    buffer[i++] = simple[0];
-    buffer[i++] = simple[1];
-    buffer[i++] = simple[2];
-    buffer[i++] = simple[3];
-    buffer[i++] = simple[4];
-    buffer[i++] = simple[5];
-    buffer[i++] = simple[6];
-    buffer[i++] = simple[7];
-
-    buffer[i++] = foo[0];
-    buffer[i++] = foo[1];
-    buffer[i++] = foo[2];
-    buffer[i++] = foo[3];
-    buffer[i++] = foo[4];
-    buffer[i++] = foo[5];
-    buffer[i++] = foo[6];
-    buffer[i++] = foo[7];
 
     // Test that we can get the address of the element past the end of the array
     char *past_end = &simple[sizeof(simple)];
@@ -115,5 +62,4 @@ void short_initializer() {
 
     struct {short x; int y;} single_struct[1] = { { 1, 2 } };
     struct {short x; int y;} many_struct[3] = { { 1, 2 } };
-
 }

--- a/c2rust-transpile/tests/snapshots/arrays.c
+++ b/c2rust-transpile/tests/snapshots/arrays.c
@@ -1,0 +1,119 @@
+#include <stdlib.h>
+
+static char simple[] = "mystring";
+static char *foo = "mystring";
+
+void entry(const unsigned buffer_size, int buffer[const]) {
+    int arr[1][1] = { 1 };
+    arr[0][0] += 9;
+
+    int arr2[16] = {};
+    arr2[15] += 9;
+
+    struct {char* x; int y;} arr3[1] = {};
+    arr3[0].y += 9;
+
+    int arr4[16] = {0};
+    arr4[15] += 9;
+
+    struct {short; int y;} arr5[1] = { { 1, 2 } };
+    arr5[0].y += 9;
+
+    // excess elements
+    int arr6[2] = { 1, 2, 3 };
+    int arr7[0] = { 1234 };
+
+    int i = 0;
+
+    char abc[] = "abc";
+    buffer[i++] = abc[0];
+    buffer[i++] = abc[1];
+    buffer[i++] = abc[2];
+    buffer[i++] = abc[3];
+
+    char def[] = {'d','e','f'};
+    buffer[i++] = def[0];
+    buffer[i++] = def[1];
+    buffer[i++] = def[2];
+
+    char part[2] = {1};
+    buffer[i++] = part[0];
+    buffer[i++] = part[1];
+
+    char *abcptr = "abc";
+    buffer[i++] = abcptr[0];
+    buffer[i++] = abcptr[1];
+    buffer[i++] = abcptr[2];
+    buffer[i++] = abcptr[3];
+
+    char init[] = {"abcd"};
+    buffer[i++] = init[0];
+    buffer[i++] = init[1];
+    buffer[i++] = init[2];
+    buffer[i++] = init[3];
+
+    char too_long[3] = "abcde";
+    buffer[i++] = too_long[0];
+    buffer[i++] = too_long[1];
+    buffer[i++] = too_long[2];
+
+    char too_short[20] = "abc";
+    buffer[i++] = too_short[0];
+    buffer[i++] = too_short[1];
+    buffer[i++] = too_short[2];
+    buffer[i++] = too_short[3];
+    buffer[i++] = too_short[4];
+    buffer[i++] = too_short[5];
+    buffer[i++] = too_short[6];
+
+// TODO re-enable after #1266 adds portable support for translating `wchar_t`.
+#if 0
+    wchar_t wide1[] = L"x";
+    buffer[i++] = wide1[0];
+    buffer[i++] = wide1[1];
+
+    wchar_t wide2[3] = L"x";
+    buffer[i++] = wide2[0];
+    buffer[i++] = wide2[1];
+    buffer[i++] = wide2[2];
+
+    wchar_t wide3[1] = L"xy";
+    buffer[i++] = wide3[0];
+#endif
+
+    buffer[i++] = simple[0];
+    buffer[i++] = simple[1];
+    buffer[i++] = simple[2];
+    buffer[i++] = simple[3];
+    buffer[i++] = simple[4];
+    buffer[i++] = simple[5];
+    buffer[i++] = simple[6];
+    buffer[i++] = simple[7];
+
+    buffer[i++] = foo[0];
+    buffer[i++] = foo[1];
+    buffer[i++] = foo[2];
+    buffer[i++] = foo[3];
+    buffer[i++] = foo[4];
+    buffer[i++] = foo[5];
+    buffer[i++] = foo[6];
+    buffer[i++] = foo[7];
+
+    // Test that we can get the address of the element past the end of the array
+    char *past_end = &simple[sizeof(simple)];
+    past_end = &foo[8];
+}
+
+void short_initializer() {
+    int empty_brackets[16] = {};
+    int brackets_with_zero[16] = {0};
+    int brackets_with_one[4] = {1};
+
+    // excess elements
+    int excess_elements_1[2] = { 1, 2, 3 };
+    int excess_elements_2[0] = { 1234 };
+
+    struct {short x; int y;} single_struct[1] = { { 1, 2 } };
+    struct {short x; int y;} many_struct[3] = { { 1, 2 } };
+
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
@@ -1,0 +1,339 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/arrays.rs
+input_file: c2rust-transpile/tests/snapshots/arrays.c
+---
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct C2RustUnnamed {
+    pub y: std::ffi::c_int,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct C2RustUnnamed_0 {
+    pub x: *mut std::ffi::c_char,
+    pub y: std::ffi::c_int,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct C2RustUnnamed_1 {
+    pub x: std::ffi::c_short,
+    pub y: std::ffi::c_int,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct C2RustUnnamed_2 {
+    pub x: std::ffi::c_short,
+    pub y: std::ffi::c_int,
+}
+static mut simple: [std::ffi::c_char; 9] = unsafe {
+    *::core::mem::transmute::<&[u8; 9], &mut [std::ffi::c_char; 9]>(b"mystring\0")
+};
+static mut foo: *mut std::ffi::c_char = b"mystring\0" as *const u8
+    as *const std::ffi::c_char as *mut std::ffi::c_char;
+#[no_mangle]
+pub unsafe extern "C" fn entry(
+    buffer_size: std::ffi::c_uint,
+    buffer: *mut std::ffi::c_int,
+) {
+    let mut arr: [[std::ffi::c_int; 1]; 1] = [[1 as std::ffi::c_int]];
+    arr[0 as std::ffi::c_int as usize][0 as std::ffi::c_int as usize]
+        += 9 as std::ffi::c_int;
+    let mut arr2: [std::ffi::c_int; 16] = [0; 16];
+    arr2[15 as std::ffi::c_int as usize] += 9 as std::ffi::c_int;
+    let mut arr3: [C2RustUnnamed_0; 1] = [C2RustUnnamed_0 {
+        x: 0 as *mut std::ffi::c_char,
+        y: 0,
+    }; 1];
+    arr3[0 as std::ffi::c_int as usize].y += 9 as std::ffi::c_int;
+    let mut arr4: [std::ffi::c_int; 16] = [
+        0 as std::ffi::c_int,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ];
+    arr4[15 as std::ffi::c_int as usize] += 9 as std::ffi::c_int;
+    let mut arr5: [C2RustUnnamed; 1] = [
+        {
+            let mut init = C2RustUnnamed {
+                y: 1 as std::ffi::c_int,
+            };
+            init
+        },
+    ];
+    arr5[0 as std::ffi::c_int as usize].y += 9 as std::ffi::c_int;
+    let mut arr6: [std::ffi::c_int; 2] = [1 as std::ffi::c_int, 2 as std::ffi::c_int];
+    let mut arr7: [std::ffi::c_int; 0] = [0; 0];
+    let mut i: std::ffi::c_int = 0 as std::ffi::c_int;
+    let mut abc: [std::ffi::c_char; 4] = *::core::mem::transmute::<
+        &[u8; 4],
+        &mut [std::ffi::c_char; 4],
+    >(b"abc\0");
+    let fresh0 = i;
+    i = i + 1;
+    *buffer.offset(fresh0 as isize) = abc[0 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh1 = i;
+    i = i + 1;
+    *buffer.offset(fresh1 as isize) = abc[1 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh2 = i;
+    i = i + 1;
+    *buffer.offset(fresh2 as isize) = abc[2 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh3 = i;
+    i = i + 1;
+    *buffer.offset(fresh3 as isize) = abc[3 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let mut def: [std::ffi::c_char; 3] = [
+        'd' as i32 as std::ffi::c_char,
+        'e' as i32 as std::ffi::c_char,
+        'f' as i32 as std::ffi::c_char,
+    ];
+    let fresh4 = i;
+    i = i + 1;
+    *buffer.offset(fresh4 as isize) = def[0 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh5 = i;
+    i = i + 1;
+    *buffer.offset(fresh5 as isize) = def[1 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh6 = i;
+    i = i + 1;
+    *buffer.offset(fresh6 as isize) = def[2 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let mut part: [std::ffi::c_char; 2] = [1 as std::ffi::c_int as std::ffi::c_char, 0];
+    let fresh7 = i;
+    i = i + 1;
+    *buffer.offset(fresh7 as isize) = part[0 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh8 = i;
+    i = i + 1;
+    *buffer.offset(fresh8 as isize) = part[1 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let mut abcptr: *mut std::ffi::c_char = b"abc\0" as *const u8
+        as *const std::ffi::c_char as *mut std::ffi::c_char;
+    let fresh9 = i;
+    i = i + 1;
+    *buffer.offset(fresh9 as isize) = *abcptr.offset(0 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let fresh10 = i;
+    i = i + 1;
+    *buffer.offset(fresh10 as isize) = *abcptr.offset(1 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let fresh11 = i;
+    i = i + 1;
+    *buffer.offset(fresh11 as isize) = *abcptr.offset(2 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let fresh12 = i;
+    i = i + 1;
+    *buffer.offset(fresh12 as isize) = *abcptr.offset(3 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let mut init: [std::ffi::c_char; 5] = *::core::mem::transmute::<
+        &[u8; 5],
+        &mut [std::ffi::c_char; 5],
+    >(b"abcd\0");
+    let fresh13 = i;
+    i = i + 1;
+    *buffer.offset(fresh13 as isize) = init[0 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh14 = i;
+    i = i + 1;
+    *buffer.offset(fresh14 as isize) = init[1 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh15 = i;
+    i = i + 1;
+    *buffer.offset(fresh15 as isize) = init[2 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh16 = i;
+    i = i + 1;
+    *buffer.offset(fresh16 as isize) = init[3 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let mut too_long: [std::ffi::c_char; 3] = *::core::mem::transmute::<
+        &[u8; 3],
+        &mut [std::ffi::c_char; 3],
+    >(b"abc");
+    let fresh17 = i;
+    i = i + 1;
+    *buffer.offset(fresh17 as isize) = too_long[0 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh18 = i;
+    i = i + 1;
+    *buffer.offset(fresh18 as isize) = too_long[1 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh19 = i;
+    i = i + 1;
+    *buffer.offset(fresh19 as isize) = too_long[2 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let mut too_short: [std::ffi::c_char; 20] = *::core::mem::transmute::<
+        &[u8; 20],
+        &mut [std::ffi::c_char; 20],
+    >(b"abc\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+    let fresh20 = i;
+    i = i + 1;
+    *buffer.offset(fresh20 as isize) = too_short[0 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh21 = i;
+    i = i + 1;
+    *buffer.offset(fresh21 as isize) = too_short[1 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh22 = i;
+    i = i + 1;
+    *buffer.offset(fresh22 as isize) = too_short[2 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh23 = i;
+    i = i + 1;
+    *buffer.offset(fresh23 as isize) = too_short[3 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh24 = i;
+    i = i + 1;
+    *buffer.offset(fresh24 as isize) = too_short[4 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh25 = i;
+    i = i + 1;
+    *buffer.offset(fresh25 as isize) = too_short[5 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh26 = i;
+    i = i + 1;
+    *buffer.offset(fresh26 as isize) = too_short[6 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh27 = i;
+    i = i + 1;
+    *buffer.offset(fresh27 as isize) = simple[0 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh28 = i;
+    i = i + 1;
+    *buffer.offset(fresh28 as isize) = simple[1 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh29 = i;
+    i = i + 1;
+    *buffer.offset(fresh29 as isize) = simple[2 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh30 = i;
+    i = i + 1;
+    *buffer.offset(fresh30 as isize) = simple[3 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh31 = i;
+    i = i + 1;
+    *buffer.offset(fresh31 as isize) = simple[4 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh32 = i;
+    i = i + 1;
+    *buffer.offset(fresh32 as isize) = simple[5 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh33 = i;
+    i = i + 1;
+    *buffer.offset(fresh33 as isize) = simple[6 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh34 = i;
+    i = i + 1;
+    *buffer.offset(fresh34 as isize) = simple[7 as std::ffi::c_int as usize]
+        as std::ffi::c_int;
+    let fresh35 = i;
+    i = i + 1;
+    *buffer.offset(fresh35 as isize) = *foo.offset(0 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let fresh36 = i;
+    i = i + 1;
+    *buffer.offset(fresh36 as isize) = *foo.offset(1 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let fresh37 = i;
+    i = i + 1;
+    *buffer.offset(fresh37 as isize) = *foo.offset(2 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let fresh38 = i;
+    i = i + 1;
+    *buffer.offset(fresh38 as isize) = *foo.offset(3 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let fresh39 = i;
+    i = i + 1;
+    *buffer.offset(fresh39 as isize) = *foo.offset(4 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let fresh40 = i;
+    i = i + 1;
+    *buffer.offset(fresh40 as isize) = *foo.offset(5 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let fresh41 = i;
+    i = i + 1;
+    *buffer.offset(fresh41 as isize) = *foo.offset(6 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let fresh42 = i;
+    i = i + 1;
+    *buffer.offset(fresh42 as isize) = *foo.offset(7 as std::ffi::c_int as isize)
+        as std::ffi::c_int;
+    let mut past_end: *mut std::ffi::c_char = &mut *simple
+        .as_mut_ptr()
+        .offset(
+            ::core::mem::size_of::<[std::ffi::c_char; 9]>() as std::ffi::c_ulong as isize,
+        ) as *mut std::ffi::c_char;
+    past_end = &mut *foo.offset(8 as std::ffi::c_int as isize) as *mut std::ffi::c_char;
+}
+#[no_mangle]
+pub unsafe extern "C" fn short_initializer() {
+    let mut empty_brackets: [std::ffi::c_int; 16] = [0; 16];
+    let mut brackets_with_zero: [std::ffi::c_int; 16] = [
+        0 as std::ffi::c_int,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ];
+    let mut brackets_with_one: [std::ffi::c_int; 4] = [1 as std::ffi::c_int, 0, 0, 0];
+    let mut excess_elements_1: [std::ffi::c_int; 2] = [
+        1 as std::ffi::c_int,
+        2 as std::ffi::c_int,
+    ];
+    let mut excess_elements_2: [std::ffi::c_int; 0] = [0; 0];
+    let mut single_struct: [C2RustUnnamed_2; 1] = [
+        {
+            let mut init = C2RustUnnamed_2 {
+                x: 1 as std::ffi::c_int as std::ffi::c_short,
+                y: 2 as std::ffi::c_int,
+            };
+            init
+        },
+    ];
+    let mut many_struct: [C2RustUnnamed_1; 3] = [
+        {
+            let mut init = C2RustUnnamed_1 {
+                x: 1 as std::ffi::c_int as std::ffi::c_short,
+                y: 2 as std::ffi::c_int,
+            };
+            init
+        },
+        C2RustUnnamed_1 { x: 0, y: 0 },
+        C2RustUnnamed_1 { x: 0, y: 0 },
+    ];
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
@@ -41,10 +41,7 @@ static mut simple: [std::ffi::c_char; 9] = unsafe {
 static mut foo: *mut std::ffi::c_char = b"mystring\0" as *const u8
     as *const std::ffi::c_char as *mut std::ffi::c_char;
 #[no_mangle]
-pub unsafe extern "C" fn entry(
-    buffer_size: std::ffi::c_uint,
-    buffer: *mut std::ffi::c_int,
-) {
+pub unsafe extern "C" fn entry() {
     let mut arr: [[std::ffi::c_int; 1]; 1] = [[1 as std::ffi::c_int]];
     arr[0 as std::ffi::c_int as usize][0 as std::ffi::c_int as usize]
         += 9 as std::ffi::c_int;
@@ -68,203 +65,30 @@ pub unsafe extern "C" fn entry(
     arr5[0 as std::ffi::c_int as usize].y += 9 as std::ffi::c_int;
     let mut arr6: [std::ffi::c_int; 2] = [1 as std::ffi::c_int, 2 as std::ffi::c_int];
     let mut arr7: [std::ffi::c_int; 0] = [0; 0];
-    let mut i: std::ffi::c_int = 0 as std::ffi::c_int;
     let mut abc: [std::ffi::c_char; 4] = *::core::mem::transmute::<
         &[u8; 4],
         &mut [std::ffi::c_char; 4],
     >(b"abc\0");
-    let fresh0 = i;
-    i = i + 1;
-    *buffer.offset(fresh0 as isize) = abc[0 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh1 = i;
-    i = i + 1;
-    *buffer.offset(fresh1 as isize) = abc[1 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh2 = i;
-    i = i + 1;
-    *buffer.offset(fresh2 as isize) = abc[2 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh3 = i;
-    i = i + 1;
-    *buffer.offset(fresh3 as isize) = abc[3 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
     let mut def: [std::ffi::c_char; 3] = [
         'd' as i32 as std::ffi::c_char,
         'e' as i32 as std::ffi::c_char,
         'f' as i32 as std::ffi::c_char,
     ];
-    let fresh4 = i;
-    i = i + 1;
-    *buffer.offset(fresh4 as isize) = def[0 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh5 = i;
-    i = i + 1;
-    *buffer.offset(fresh5 as isize) = def[1 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh6 = i;
-    i = i + 1;
-    *buffer.offset(fresh6 as isize) = def[2 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
     let mut part: [std::ffi::c_char; 2] = [1 as std::ffi::c_int as std::ffi::c_char, 0];
-    let fresh7 = i;
-    i = i + 1;
-    *buffer.offset(fresh7 as isize) = part[0 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh8 = i;
-    i = i + 1;
-    *buffer.offset(fresh8 as isize) = part[1 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
     let mut abcptr: *mut std::ffi::c_char = b"abc\0" as *const u8
         as *const std::ffi::c_char as *mut std::ffi::c_char;
-    let fresh9 = i;
-    i = i + 1;
-    *buffer.offset(fresh9 as isize) = *abcptr.offset(0 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
-    let fresh10 = i;
-    i = i + 1;
-    *buffer.offset(fresh10 as isize) = *abcptr.offset(1 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
-    let fresh11 = i;
-    i = i + 1;
-    *buffer.offset(fresh11 as isize) = *abcptr.offset(2 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
-    let fresh12 = i;
-    i = i + 1;
-    *buffer.offset(fresh12 as isize) = *abcptr.offset(3 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
     let mut init: [std::ffi::c_char; 5] = *::core::mem::transmute::<
         &[u8; 5],
         &mut [std::ffi::c_char; 5],
     >(b"abcd\0");
-    let fresh13 = i;
-    i = i + 1;
-    *buffer.offset(fresh13 as isize) = init[0 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh14 = i;
-    i = i + 1;
-    *buffer.offset(fresh14 as isize) = init[1 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh15 = i;
-    i = i + 1;
-    *buffer.offset(fresh15 as isize) = init[2 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh16 = i;
-    i = i + 1;
-    *buffer.offset(fresh16 as isize) = init[3 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
     let mut too_long: [std::ffi::c_char; 3] = *::core::mem::transmute::<
         &[u8; 3],
         &mut [std::ffi::c_char; 3],
     >(b"abc");
-    let fresh17 = i;
-    i = i + 1;
-    *buffer.offset(fresh17 as isize) = too_long[0 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh18 = i;
-    i = i + 1;
-    *buffer.offset(fresh18 as isize) = too_long[1 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh19 = i;
-    i = i + 1;
-    *buffer.offset(fresh19 as isize) = too_long[2 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
     let mut too_short: [std::ffi::c_char; 20] = *::core::mem::transmute::<
         &[u8; 20],
         &mut [std::ffi::c_char; 20],
     >(b"abc\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
-    let fresh20 = i;
-    i = i + 1;
-    *buffer.offset(fresh20 as isize) = too_short[0 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh21 = i;
-    i = i + 1;
-    *buffer.offset(fresh21 as isize) = too_short[1 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh22 = i;
-    i = i + 1;
-    *buffer.offset(fresh22 as isize) = too_short[2 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh23 = i;
-    i = i + 1;
-    *buffer.offset(fresh23 as isize) = too_short[3 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh24 = i;
-    i = i + 1;
-    *buffer.offset(fresh24 as isize) = too_short[4 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh25 = i;
-    i = i + 1;
-    *buffer.offset(fresh25 as isize) = too_short[5 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh26 = i;
-    i = i + 1;
-    *buffer.offset(fresh26 as isize) = too_short[6 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh27 = i;
-    i = i + 1;
-    *buffer.offset(fresh27 as isize) = simple[0 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh28 = i;
-    i = i + 1;
-    *buffer.offset(fresh28 as isize) = simple[1 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh29 = i;
-    i = i + 1;
-    *buffer.offset(fresh29 as isize) = simple[2 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh30 = i;
-    i = i + 1;
-    *buffer.offset(fresh30 as isize) = simple[3 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh31 = i;
-    i = i + 1;
-    *buffer.offset(fresh31 as isize) = simple[4 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh32 = i;
-    i = i + 1;
-    *buffer.offset(fresh32 as isize) = simple[5 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh33 = i;
-    i = i + 1;
-    *buffer.offset(fresh33 as isize) = simple[6 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh34 = i;
-    i = i + 1;
-    *buffer.offset(fresh34 as isize) = simple[7 as std::ffi::c_int as usize]
-        as std::ffi::c_int;
-    let fresh35 = i;
-    i = i + 1;
-    *buffer.offset(fresh35 as isize) = *foo.offset(0 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
-    let fresh36 = i;
-    i = i + 1;
-    *buffer.offset(fresh36 as isize) = *foo.offset(1 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
-    let fresh37 = i;
-    i = i + 1;
-    *buffer.offset(fresh37 as isize) = *foo.offset(2 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
-    let fresh38 = i;
-    i = i + 1;
-    *buffer.offset(fresh38 as isize) = *foo.offset(3 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
-    let fresh39 = i;
-    i = i + 1;
-    *buffer.offset(fresh39 as isize) = *foo.offset(4 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
-    let fresh40 = i;
-    i = i + 1;
-    *buffer.offset(fresh40 as isize) = *foo.offset(5 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
-    let fresh41 = i;
-    i = i + 1;
-    *buffer.offset(fresh41 as isize) = *foo.offset(6 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
-    let fresh42 = i;
-    i = i + 1;
-    *buffer.offset(fresh42 as isize) = *foo.offset(7 as std::ffi::c_int as isize)
-        as std::ffi::c_int;
     let mut past_end: *mut std::ffi::c_char = &mut *simple
         .as_mut_ptr()
         .offset(

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
@@ -55,24 +55,7 @@ pub unsafe extern "C" fn entry(
         y: 0,
     }; 1];
     arr3[0 as std::ffi::c_int as usize].y += 9 as std::ffi::c_int;
-    let mut arr4: [std::ffi::c_int; 16] = [
-        0 as std::ffi::c_int,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    ];
+    let mut arr4: [std::ffi::c_int; 16] = [0 as std::ffi::c_int; 16];
     arr4[15 as std::ffi::c_int as usize] += 9 as std::ffi::c_int;
     let mut arr5: [C2RustUnnamed; 1] = [
         {
@@ -292,24 +275,7 @@ pub unsafe extern "C" fn entry(
 #[no_mangle]
 pub unsafe extern "C" fn short_initializer() {
     let mut empty_brackets: [std::ffi::c_int; 16] = [0; 16];
-    let mut brackets_with_zero: [std::ffi::c_int; 16] = [
-        0 as std::ffi::c_int,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    ];
+    let mut brackets_with_zero: [std::ffi::c_int; 16] = [0 as std::ffi::c_int; 16];
     let mut brackets_with_one: [std::ffi::c_int; 4] = [1 as std::ffi::c_int, 0, 0, 0];
     let mut excess_elements_1: [std::ffi::c_int; 2] = [
         1 as std::ffi::c_int,


### PR DESCRIPTION
translate

```c
unsigned short data[DATA_SIZE] = {0};
```

to 

```rust
let mut data: [libc::c_ushort; 65535] = [0 as libc::c_int as libc::c_ushort; 65535];
```

instead of a literal with 65535 zeros.

I also simplified the logic. Although https://github.com/GaloisInc/C2Rust/issues/40 is a dead link I believe the second commit is correct.