### PR TITLE
CI updates (Ubuntu 22, LLVM 15, pinned `once_cell`)

### DIFF
--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -79,7 +79,7 @@ jobs:
         sudo apt-get -qq update
         sudo apt-get -qq install    \
             libbrotli-dev           \
-            libclang-12-dev         \
+            libclang-15-dev         \
             libgcrypt20             \
             libreadline-dev         \
             libidn2-dev             \
@@ -102,7 +102,7 @@ jobs:
     # Working dir is /home/runner/work/c2rust/c2rust
     - name: Build c2rust
       run: |
-        export LLVM_CONFIG_PATH=/usr/bin/llvm-config-12
+        export LLVM_CONFIG_PATH=/usr/bin/llvm-config-15
         cargo build --release
 
     # TODO(pl): figure out why compile_commands.json may cause json-c to fail

--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -13,9 +13,9 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build-on-ubuntu-2004:
+  build-on-ubuntu-2204:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
 
 [[package]]
 name = "os_str_bytes"

--- a/analysis/runtime/Cargo.toml
+++ b/analysis/runtime/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.0.1"
-once_cell = "1"
+once_cell = "=1.21.2"
 enum_dispatch = "0.3"
 fs-err = "2"
 crossbeam-queue = "0.3"


### PR DESCRIPTION
you should probably also just merge

- #1214
- #1212

pinning the `once_cell` version is a bit of a hack. It would not be needed if the rust version would update to `1.70.0`: https://doc.rust-lang.org/beta/std/cell/struct.OnceCell.html

The github CI action still fails to translate curl even with these changes, and it doesn't really give any error message. So I'm not sure what to do with that.