### PR TITLE
Reduce `libc` usage in `c2rust-transpile`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,6 @@ dependencies = [
  "handlebars",
  "indexmap",
  "itertools",
- "libc",
  "log",
  "log-reroute",
  "pathdiff",

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -23,7 +23,6 @@ fern = { version = "0.6", features = ["colored"] }
 handlebars = "4.2"
 indexmap = { version = "1.0.1", features = ["serde-1"] }
 itertools = "0.10"
-libc = "0.2"
 log = "0.4"
 log-reroute = "0.1"
 pathdiff = "0.2"

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -272,7 +272,7 @@ impl TypeConverter {
             // in the case of pointers.
             CTypeKind::Void => Ok(mk()
                 .set_mutbl(mutbl)
-                .ptr_ty(mk().path_ty(vec!["libc", "c_void"]))),
+                .ptr_ty(mk().path_ty(vec!["std", "ffi", "c_void"]))),
 
             CTypeKind::VariableArray(mut elt, _len) => {
                 while let CTypeKind::VariableArray(elt_, _) = ctxt.resolve_type(elt).kind {
@@ -313,20 +313,20 @@ impl TypeConverter {
         match ctxt.index(ctype).kind {
             CTypeKind::Void => Ok(mk().tuple_ty(vec![])),
             CTypeKind::Bool => Ok(mk().path_ty(mk().path(vec!["bool"]))),
-            CTypeKind::Short => Ok(mk().path_ty(mk().path(vec!["libc", "c_short"]))),
-            CTypeKind::Int => Ok(mk().path_ty(mk().path(vec!["libc", "c_int"]))),
-            CTypeKind::Long => Ok(mk().path_ty(mk().path(vec!["libc", "c_long"]))),
-            CTypeKind::LongLong => Ok(mk().path_ty(mk().path(vec!["libc", "c_longlong"]))),
-            CTypeKind::UShort => Ok(mk().path_ty(mk().path(vec!["libc", "c_ushort"]))),
-            CTypeKind::UInt => Ok(mk().path_ty(mk().path(vec!["libc", "c_uint"]))),
-            CTypeKind::ULong => Ok(mk().path_ty(mk().path(vec!["libc", "c_ulong"]))),
-            CTypeKind::ULongLong => Ok(mk().path_ty(mk().path(vec!["libc", "c_ulonglong"]))),
-            CTypeKind::SChar => Ok(mk().path_ty(mk().path(vec!["libc", "c_schar"]))),
-            CTypeKind::UChar => Ok(mk().path_ty(mk().path(vec!["libc", "c_uchar"]))),
-            CTypeKind::Char => Ok(mk().path_ty(mk().path(vec!["libc", "c_char"]))),
-            CTypeKind::Double => Ok(mk().path_ty(mk().path(vec!["libc", "c_double"]))),
+            CTypeKind::Short => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_short"]))),
+            CTypeKind::Int => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_int"]))),
+            CTypeKind::Long => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_long"]))),
+            CTypeKind::LongLong => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_longlong"]))),
+            CTypeKind::UShort => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_ushort"]))),
+            CTypeKind::UInt => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_uint"]))),
+            CTypeKind::ULong => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_ulong"]))),
+            CTypeKind::ULongLong => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_ulonglong"]))),
+            CTypeKind::SChar => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_schar"]))),
+            CTypeKind::UChar => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_uchar"]))),
+            CTypeKind::Char => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_char"]))),
+            CTypeKind::Double => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_double"]))),
             CTypeKind::LongDouble => Ok(mk().path_ty(mk().path(vec!["f128", "f128"]))),
-            CTypeKind::Float => Ok(mk().path_ty(mk().path(vec!["libc", "c_float"]))),
+            CTypeKind::Float => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_float"]))),
             CTypeKind::Int128 => Ok(mk().path_ty(mk().path(vec!["i128"]))),
             CTypeKind::UInt128 => Ok(mk().path_ty(mk().path(vec!["u128"]))),
             CTypeKind::BFloat16 => Ok(mk().path_ty(mk().path(vec!["bf16"]))),

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -83,7 +83,7 @@ impl<'c> Translation<'c> {
                 Ok(val.map(|v| {
                     let val = mk().method_call_expr(v, "is_sign_negative", vec![]);
 
-                    mk().cast_expr(val, mk().path_ty(vec!["libc", "c_int"]))
+                    mk().cast_expr(val, mk().path_ty(vec!["std", "ffi", "c_int"]))
                 }))
             }
             "__builtin_ffs" | "__builtin_ffsl" | "__builtin_ffsll" => {

--- a/c2rust-transpile/src/translator/main_function.rs
+++ b/c2rust-transpile/src/translator/main_function.rs
@@ -58,7 +58,7 @@ impl<'c> Translation<'c> {
                     Some(mk().path_ty(vec![mk().path_segment_with_args(
                         "Vec",
                         mk().angle_bracketed_args(vec![
-                            mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_char"])),
+                            mk().mutbl().ptr_ty(mk().path_ty(vec!["std", "ffi", "c_char"])),
                         ]),
                     )])),
                     Some(mk().call_expr(mk().path_expr(vec!["Vec", "new"]), vec![])),
@@ -126,7 +126,7 @@ impl<'c> Translation<'c> {
                     Some(mk().path_ty(vec![mk().path_segment_with_args(
                         "Vec",
                         mk().angle_bracketed_args(vec![
-                            mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_char"])),
+                            mk().mutbl().ptr_ty(mk().path_ty(vec!["std", "ffi", "c_char"])),
                         ]),
                     )])),
                     Some(mk().call_expr(mk().path_expr(vec!["Vec", "new"]), vec![])),

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -1091,7 +1091,7 @@ fn arrange_header(t: &Translation, is_binary: bool) -> (Vec<syn::Attribute>, Vec
 
 /// Convert a boolean expression to a c_int
 fn bool_to_int(val: Box<Expr>) -> Box<Expr> {
-    mk().cast_expr(val, mk().path_ty(vec!["libc", "c_int"]))
+    mk().cast_expr(val, mk().path_ty(vec!["std", "ffi", "c_int"]))
 }
 
 /// Add a src_loc = "line:col" attribute to an item/foreign_item
@@ -3273,7 +3273,7 @@ impl<'c> Translation<'c> {
                     UnTypeOp::PreferredAlignOf => self.compute_align_of_type(arg_ty.ctype, true)?,
                 };
 
-                Ok(result.map(|x| mk().cast_expr(x, mk().path_ty(vec!["libc", "c_ulong"]))))
+                Ok(result.map(|x| mk().cast_expr(x, mk().path_ty(vec!["std", "ffi", "c_ulong"]))))
             }
 
             ConstantExpr(_ty, child, value) => {

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -935,7 +935,7 @@ impl<'c> Translation<'c> {
 
             c_ast::UnOp::Not => {
                 let val = self.convert_condition(ctx, false, arg)?;
-                Ok(val.map(|x| mk().cast_expr(x, mk().path_ty(vec!["libc", "c_int"]))))
+                Ok(val.map(|x| mk().cast_expr(x, mk().path_ty(vec!["std", "ffi", "c_int"]))))
             }
             c_ast::UnOp::Extension => {
                 let arg = self.convert_expr(ctx, arg)?;

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -284,8 +284,8 @@ impl<'a> Translation<'a> {
     /// #[derive(BitfieldStruct, Clone, Copy)]
     /// #[repr(C, align(2))]
     /// struct Foo {
-    ///     #[bitfield(name = "bf1", ty = "libc::c_char", bits = "0..=9")]
-    ///     #[bitfield(name = "bf2", ty = "libc::c_uchar",bits = "10..=15")]
+    ///     #[bitfield(name = "bf1", ty = "std::ffi::c_char", bits = "0..=9")]
+    ///     #[bitfield(name = "bf2", ty = "std::ffi::c_uchar",bits = "10..=15")]
     ///     bf1_bf2: [u8; 2],
     ///     non_bf: u64,
     ///     _pad: [u8; 2],
@@ -392,8 +392,8 @@ impl<'a> Translation<'a> {
     /// # #[derive(BitfieldStruct, Clone, Copy)]
     /// # #[repr(C, align(2))]
     /// # struct Foo {
-    /// #     #[bitfield(name = "bf1", ty = "libc::c_char", bits = "0..=9")]
-    /// #     #[bitfield(name = "bf2", ty = "libc::c_uchar",bits = "10..=15")]
+    /// #     #[bitfield(name = "bf1", ty = "std::ffi::c_char", bits = "0..=9")]
+    /// #     #[bitfield(name = "bf2", ty = "std::ffi::c_uchar",bits = "10..=15")]
     /// #     bf1_bf2: [u8; 2],
     /// #     non_bf: u64,
     /// #     _pad: [u8; 2],

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -193,7 +193,9 @@ impl<'c> Translation<'c> {
                 })
             {
                 real_arg_ty = Some(arg_ty.clone());
-                arg_ty = mk().mutbl().ptr_ty(mk().path_ty(vec!["libc", "c_void"]));
+                arg_ty = mk()
+                    .mutbl()
+                    .ptr_ty(mk().path_ty(vec!["std", "ffi", "c_void"]));
             }
 
             val.and_then(|val| {

--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -392,7 +392,6 @@ class TestDirectory:
 
         rust_file_builder = RustFileBuilder()
         rust_file_builder.add_features([
-            "libc",
             "extern_types",
             "simd_ffi",
             "stdsimd",

--- a/tests/statics/src/test_sections.rs
+++ b/tests/statics/src/test_sections.rs
@@ -38,7 +38,7 @@ pub fn test_sectioned_used_static() {
 
         let pos = lines
             .iter()
-            .position(|&x| x == "static mut rust_used_static4: libc::c_int = 1 as libc::c_int;")
+            .position(|&x| x == "static mut rust_used_static4: std::ffi::c_int = 1 as std::ffi::c_int;")
             .expect("Did not find expected static string in source");
         // The ordering of these attributes is not stable between LLVM versions
         assert!(
@@ -47,7 +47,7 @@ pub fn test_sectioned_used_static() {
         );
 
         // This static is pub, but we want to ensure it has attributes applied
-        assert!(src.contains("#[link_section = \"fb\"]\npub static mut rust_initialized_extern: libc::c_int = 1 as libc::c_int;"));
-        assert!(src.contains("extern \"C\" {\n    #[link_name = \"no_attrs\"]\n    static mut rust_aliased_static: libc::c_int;"))
+        assert!(src.contains("#[link_section = \"fb\"]\npub static mut rust_initialized_extern: std::ffi::c_int = 1 as std::ffi::c_int;"));
+        assert!(src.contains("extern \"C\" {\n    #[link_name = \"no_attrs\"]\n    static mut rust_aliased_static: std::ffi::c_int;"))
     }
 }


### PR DESCRIPTION
Mostly in the output, but also in its own code.