### PR TITLE
Fix two test failures.

### DIFF
--- a/tests/arrays/src/incomplete_arrays.c
+++ b/tests/arrays/src/incomplete_arrays.c
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-extern uint32_t SOME_INTS[];
+extern unsigned SOME_INTS[];
 
 bool check_some_ints(void) {
         return SOME_INTS[0] == 2

--- a/tests/arrays/src/test_arrays.rs
+++ b/tests/arrays/src/test_arrays.rs
@@ -19,9 +19,9 @@ extern "C" {
 }
 
 #[no_mangle]
-pub static SOME_INTS: [u32; 4] = [2, 0, 1, 8];
+pub static SOME_INTS: [c_uint; 4] = [2, 0, 1, 8];
 #[no_mangle]
-pub static rust_SOME_INTS: [u32; 4] = [2, 0, 1, 8];
+pub static rust_SOME_INTS: [c_uint; 4] = [2, 0, 1, 8];
 
 const BUFFER_SIZE: usize = 49;
 const BUFFER_SIZE2: usize = 2;


### PR DESCRIPTION
When running the `arrays` tests I get two failures. The first one looks like this:
```
 [ FAILED ] translate incomplete_arrays.c
 incomplete_arrays.c:5:8: error: unknown type name 'uint32_t'
     5 | extern uint32_t SOME_INTS[];
```
The second failure somehow follows on from that.

That error message comes from clang/LLVM. I don't know why it's complaining. The source file includes `<stdint.h>`.

Anyway, this commit changes the type used from `uint32_t` to `unsigned`, which avoids the problem and fixes the the two failures.