### PR TITLE
Remove more unnecessary `libc` usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,6 @@ name = "c2rust-bitfields"
 version = "0.20.0"
 dependencies = [
  "c2rust-bitfields-derive",
- "libc",
 ]
 
 [[package]]

--- a/c2rust-bitfields/Cargo.toml
+++ b/c2rust-bitfields/Cargo.toml
@@ -14,8 +14,5 @@ categories.workspace = true
 [dependencies]
 c2rust-bitfields-derive = { version = "0.20.0", path = "../c2rust-bitfields-derive" }
 
-[dev-dependencies]
-libc = "0.2"
-
 [features]
 no_std = []

--- a/c2rust-bitfields/README.md
+++ b/c2rust-bitfields/README.md
@@ -43,9 +43,9 @@ And this is enough to build our rust struct:
 #[repr(C, align(1))]
 #[derive(BitfieldStruct)]
 struct Date {
-    #[bitfield(name = "day", ty = "libc::c_uchar", bits = "0..=4")]
-    #[bitfield(name = "month", ty = "libc::c_uchar", bits = "5..=8")]
-    #[bitfield(name = "year", ty = "libc::c_ushort", bits = "9..=23")]
+    #[bitfield(name = "day", ty = "std::ffi::c_uchar", bits = "0..=4")]
+    #[bitfield(name = "month", ty = "std::ffi::c_uchar", bits = "5..=8")]
+    #[bitfield(name = "year", ty = "std::ffi::c_ushort", bits = "9..=23")]
     day_month_year: [u8; 3]
 }
 

--- a/c2rust-bitfields/c2rust-tests/test_structs.rs
+++ b/c2rust-bitfields/c2rust-tests/test_structs.rs
@@ -1,5 +1,5 @@
 use c2rust_bitfields::BitfieldStruct;
-use libc::{c_double, c_short, c_uchar, c_uint, c_ulong, c_ushort};
+use std::ffi::{c_double, c_short, c_uchar, c_uint, c_ulong, c_ushort};
 use std::mem::{size_of, transmute};
 
 #[link(name = "test")]
@@ -46,8 +46,8 @@ struct CompactDate {
     // Compact combination of d + m
     // which can't be accessed via ptr in C anyway
     // so we combine the fields into one:
-    #[bitfield(name = "d", ty = "libc::c_uchar", bits = "0..=4")]
-    #[bitfield(name = "m", ty = "libc::c_uchar", bits = "8..=11")]
+    #[bitfield(name = "d", ty = "std::ffi::c_uchar", bits = "0..=4")]
+    #[bitfield(name = "m", ty = "std::ffi::c_uchar", bits = "8..=11")]
     d_m: [u8; 2],
     y: u16,
 }
@@ -190,8 +190,8 @@ fn test_overflow() {
 struct OverlappingByteDate {
     // This is also compact, however, the first byte is shared between the two
     // bitfields and the month also has a bit in the second byte
-    #[bitfield(name = "d", ty = "libc::c_ulong", bits = "0..=4")]
-    #[bitfield(name = "m", ty = "libc::c_ushort", bits = "5..=8")]
+    #[bitfield(name = "d", ty = "std::ffi::c_ulong", bits = "0..=4")]
+    #[bitfield(name = "m", ty = "std::ffi::c_ushort", bits = "5..=8")]
     d_m: [u8; 2],
     y: u16,
     #[bitfield(padding)]
@@ -261,11 +261,11 @@ fn test_overlapping_byte_date2() {
 #[derive(BitfieldStruct, Copy, Clone)]
 struct UnnamedBitfield {
     z: f64,
-    #[bitfield(name = "x", ty = "libc::c_ushort", bits = "0..=4")]
+    #[bitfield(name = "x", ty = "std::ffi::c_ushort", bits = "0..=4")]
     x: [u8; 1],
     #[bitfield(padding)]
     _pad: [u8; 1],
-    #[bitfield(name = "y", ty = "libc::c_ushort", bits = "0..=8")]
+    #[bitfield(name = "y", ty = "std::ffi::c_ushort", bits = "0..=8")]
     y: [u8; 2],
 }
 
@@ -301,9 +301,9 @@ fn test_unnamed_bitfield() {
 #[repr(C, align(2))]
 #[derive(BitfieldStruct, Copy, Clone)]
 struct SignedBitfields {
-    #[bitfield(name = "x", ty = "libc::c_short", bits = "0..=3")]
-    #[bitfield(name = "y", ty = "libc::c_ushort", bits = "4..=8")]
-    #[bitfield(name = "z", ty = "libc::c_short", bits = "9..=13")]
+    #[bitfield(name = "x", ty = "std::ffi::c_short", bits = "0..=3")]
+    #[bitfield(name = "y", ty = "std::ffi::c_ushort", bits = "4..=8")]
+    #[bitfield(name = "z", ty = "std::ffi::c_short", bits = "9..=13")]
     x_y_z: [u8; 2],
 }
 
@@ -478,8 +478,8 @@ fn test_signed_underflow_overflow() {
 #[repr(C, align(2))]
 #[derive(BitfieldStruct, Copy, Clone)]
 struct SingleBits {
-    #[bitfield(name = "x", ty = "libc::c_ushort", bits = "0..=0")]
-    #[bitfield(name = "y", ty = "libc::c_short", bits = "1..=1")]
+    #[bitfield(name = "x", ty = "std::ffi::c_ushort", bits = "0..=0")]
+    #[bitfield(name = "y", ty = "std::ffi::c_short", bits = "1..=1")]
     x_y: [u8; 1],
     #[bitfield(padding)]
     _pad: [u8; 1],
@@ -532,9 +532,9 @@ fn test_single_bits() {
 #[repr(C, align(1))]
 #[derive(BitfieldStruct)]
 struct ThreeByteDate {
-    #[bitfield(name = "day", ty = "libc::c_uchar", bits = "0..=4")]
-    #[bitfield(name = "month", ty = "libc::c_uchar", bits = "5..=8")]
-    #[bitfield(name = "year", ty = "libc::c_ushort", bits = "9..=23")]
+    #[bitfield(name = "day", ty = "std::ffi::c_uchar", bits = "0..=4")]
+    #[bitfield(name = "month", ty = "std::ffi::c_uchar", bits = "5..=8")]
+    #[bitfield(name = "year", ty = "std::ffi::c_ushort", bits = "9..=23")]
     day_month_year: [u8; 3],
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,7 @@ Then create a new `.rs` file with the following skeleton (_does not need to be a
 ```rust
 use crate::c_file::rust_example;
 
-use libc::c_int;
+use std::ffi::c_int;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/arrays/Cargo.toml
+++ b/tests/arrays/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/arrays/src/test_arrays.rs
+++ b/tests/arrays/src/test_arrays.rs
@@ -1,7 +1,7 @@
 use crate::arrays::rust_entry;
 use crate::incomplete_arrays::{rust_check_some_ints, rust_entry2, rust_test_sized_array};
 use crate::variable_arrays::{rust_alloca_arrays, rust_variable_arrays};
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/asm.aarch64/Cargo.toml
+++ b/tests/asm.aarch64/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"
 c2rust-asm-casts = { path = "../../c2rust-asm-casts", version = "0.20.0" }

--- a/tests/asm.aarch64/src/test_asm.rs
+++ b/tests/asm.aarch64/src/test_asm.rs
@@ -1,7 +1,7 @@
 //! extern_crate_c2rust_asm_casts
 
 use crate::asm::rust_entry;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/asm.arm/Cargo.toml
+++ b/tests/asm.arm/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/asm.arm/src/test_asm.rs
+++ b/tests/asm.arm/src/test_asm.rs
@@ -1,5 +1,5 @@
 use crate::asm::rust_entry;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/asm.x86_64/Cargo.toml
+++ b/tests/asm.x86_64/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"
 c2rust-asm-casts = { path = "../../c2rust-asm-casts", version = "0.20.0" }

--- a/tests/asm.x86_64/src/test_asm.rs
+++ b/tests/asm.x86_64/src/test_asm.rs
@@ -1,7 +1,7 @@
 //! extern_crate_c2rust_asm_casts
 
 use crate::asm::rust_entry;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/builtins/src/test_builtins.rs
+++ b/tests/builtins/src/test_builtins.rs
@@ -3,7 +3,7 @@
 use crate::atomics::{rust_atomics_entry, rust_new_atomics};
 use crate::math::{rust_ffs, rust_ffsl, rust_ffsll, rust_isfinite, rust_isinf_sign, rust_isnan};
 use crate::mem_x_fns::{rust_assume_aligned, rust_mem_x};
-use libc::{c_char, c_double, c_int, c_long, c_longlong, c_uint};
+use std::ffi::{c_char, c_double, c_int, c_long, c_longlong, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/casts/src/test_casts.rs
+++ b/tests/casts/src/test_casts.rs
@@ -1,7 +1,7 @@
 use crate::cast_funptr::{rust_entry, rust_get_identity, rust_identity};
 use crate::casts::rust_cast_stuff;
 
-use libc::{c_int, c_uint, c_void};
+use std::ffi::{c_int, c_uint, c_void};
 
 use std::mem::transmute;
 
@@ -46,9 +46,9 @@ pub fn test_identity() {
         assert_eq!(rust_id, i);
     }
 
-    let transmuted_rust_identity: unsafe extern "C" fn(_: libc::c_int) -> libc::c_int =
+    let transmuted_rust_identity: unsafe extern "C" fn(_: c_int) -> c_int =
         unsafe { transmute(rust_get_identity()) };
-    let transmuted_identity: unsafe extern "C" fn(_: libc::c_int) -> libc::c_int =
+    let transmuted_identity: unsafe extern "C" fn(_: c_int) -> c_int =
         unsafe { transmute(get_identity()) };
 
     for i in 0..10 {

--- a/tests/conditionals/Cargo.toml
+++ b/tests/conditionals/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/conditionals/src/test_conditionals.rs
+++ b/tests/conditionals/src/test_conditionals.rs
@@ -5,7 +5,7 @@ use crate::unused_conditionals::{
     rust_unused_conditional1, rust_unused_conditional2, rust_unused_conditional3,
 };
 use crate::else_if_chain::rust_entry4;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/enums/Cargo.toml
+++ b/tests/enums/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/enums/src/test_enums.rs
+++ b/tests/enums/src/test_enums.rs
@@ -9,7 +9,7 @@ use crate::non_canonical_enum_def::{
 use crate::top_enum::{rust_entry4, E as otherE};
 use crate::enum_compound::rust_entry6;
 
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/example/Cargo.toml
+++ b/tests/example/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/example/src/test_add.rs
+++ b/tests/example/src/test_add.rs
@@ -1,5 +1,5 @@
 use crate::add::rust_add;
-use libc::c_uint;
+use std::ffi::c_uint;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/example/src/test_sub.rs
+++ b/tests/example/src/test_sub.rs
@@ -1,5 +1,5 @@
 use crate::sub::rust_sub;
-use libc::c_uint;
+use std::ffi::c_uint;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/floats/Cargo.toml
+++ b/tests/floats/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/floats/src/test_no_wrapping_neg.rs
+++ b/tests/floats/src/test_no_wrapping_neg.rs
@@ -1,5 +1,5 @@
 use crate::no_float_wrapping_neg::{rust_double_inc_dec, rust_float_inc_dec, rust_no_wrapping_neg};
-use libc::{c_double, c_float};
+use std::ffi::{c_double, c_float};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/gotos/Cargo.toml
+++ b/tests/gotos/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/gotos/src/test_irreducible.rs
+++ b/tests/gotos/src/test_irreducible.rs
@@ -1,5 +1,5 @@
 use crate::irreducible::rust_irreducible;
-use libc::c_int;
+use std::ffi::c_int;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/gotos/src/test_stmt_expr.rs
+++ b/tests/gotos/src/test_stmt_expr.rs
@@ -1,6 +1,6 @@
 use crate::stmt_expr::rust_stmt_expr_func;
 
-use libc::c_int;
+use std::ffi::c_int;
 
 pub fn test_stmt_expr_relooper() {
     unsafe {

--- a/tests/ints/Cargo.toml
+++ b/tests/ints/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/ints/src/const_test.c
+++ b/tests/ints/src/const_test.c
@@ -1,18 +1,18 @@
 
 // `const`-ness of variable bindings (both in function arguments and locals) in C corresponds
 // directly to `mut`-ness of pattern bindings in Rust.
-int constant_arguments(int const x /* should be 'x: libc::c_int' */) {
-    int const y = x + 2;           // should be 'y: libc::c_int'
+int constant_arguments(int const x /* should be 'x: std::ffi::c_int' */) {
+    int const y = x + 2;           // should be 'y: std::ffi::c_int'
     return y;
 }
 
 // Still just a `const` argument - nothing special here
-void constant_pointer(int *const x /* should be 'x: *mut libc::c_int' */) {
+void constant_pointer(int *const x /* should be 'x: *mut std::ffi::c_int' */) {
     *x += 1;
 }
 
 // `const`-ness of pointee type in C corresponds directly to `const`/`mut` pointers in Rust
-int pointer_to_constant(int const *x /* should be 'mut x: *const libc::c_int' */) {
+int pointer_to_constant(int const *x /* should be 'mut x: *const std::ffi::c_int' */) {
     return x[1] + 1;
 }
 

--- a/tests/ints/src/implicit_int.c
+++ b/tests/ints/src/implicit_int.c
@@ -13,8 +13,8 @@ int identity(x)
 void implicit_int(void)
 {
     // assign to t using the address-of operator
-    my_fn *t = &identity;                    // 't: my_fn: fn(libc::c_int) -> libc::c_int'
+    my_fn *t = &identity;                    // 't: my_fn: fn(std::ffi::c_int) -> std::ffi::c_int'
     // assign to u using function to pointer decay
-    my_fn *u = identity;                    // 't: my_fn: fn(libc::c_int) -> libc::c_int'
+    my_fn *u = identity;                    // 't: my_fn: fn(std::ffi::c_int) -> std::ffi::c_int'
 }
 

--- a/tests/ints/src/test_arithmetic.rs
+++ b/tests/ints/src/test_arithmetic.rs
@@ -1,5 +1,5 @@
 use crate::arithmetic::rust_entry2;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/ints/src/test_compound_assignment.rs
+++ b/tests/ints/src/test_compound_assignment.rs
@@ -1,6 +1,6 @@
 use crate::compound_assignment::rust_compound_assignment;
 
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/ints/src/test_const.rs
+++ b/tests/ints/src/test_const.rs
@@ -1,5 +1,5 @@
 use crate::const_test::rust_entry4;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/ints/src/test_implicit_ints.rs
+++ b/tests/ints/src/test_implicit_ints.rs
@@ -2,7 +2,7 @@
 
 
 use crate::implicit_int::{identity as rust_identity, implicit_int as rust_implicit_int};
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 extern "C" {
     fn identity(_: c_int) -> c_int;

--- a/tests/ints/src/test_ints.rs
+++ b/tests/ints/src/test_ints.rs
@@ -1,6 +1,6 @@
 use crate::chars::rust_multibyte_chars;
 use crate::size_t::rust_entry;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/ints/src/test_sieve_of_eratosthenes.rs
+++ b/tests/ints/src/test_sieve_of_eratosthenes.rs
@@ -1,5 +1,5 @@
 use crate::sieve_of_eratosthenes::rust_sieve_of_eratosthenes;
-use libc::c_int;
+use std::ffi::c_int;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/ints/src/test_volatile.rs
+++ b/tests/ints/src/test_volatile.rs
@@ -1,5 +1,5 @@
 use crate::volatile::rust_entry3;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/items/Cargo.toml
+++ b/tests/items/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/items/src/test_linking.rs
+++ b/tests/items/src/test_linking.rs
@@ -1,5 +1,5 @@
 use crate::linking::{rust_l, rust_w};
-use libc::c_int;
+use std::ffi::c_int;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/items/src/test_noop.rs
+++ b/tests/items/src/test_noop.rs
@@ -1,7 +1,7 @@
 use crate::nofnargs::rust_nofnargs;
 use crate::noop::rust_noop;
 
-use libc::c_int;
+use std::ffi::c_int;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/items/src/test_varargs.rs
+++ b/tests/items/src/test_varargs.rs
@@ -5,7 +5,7 @@ use crate::varargs::{
     rust_simple_vacopy, rust_valist_struct_member, rust_valist_struct_pointer_member,
 };
 
-use libc::c_char;
+use std::ffi::c_char;
 use std::ffi::CString;
 
 #[link(name = "test")]

--- a/tests/longdouble/Cargo.toml
+++ b/tests/longdouble/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2021"
 [dependencies]
 f128 = "0.2"
 num-traits = "0.2.6"
-libc = "0.2"

--- a/tests/loops/Cargo.toml
+++ b/tests/loops/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/loops/src/test_goto.rs
+++ b/tests/loops/src/test_goto.rs
@@ -2,7 +2,7 @@ use crate::goto_linear_cf::rust_goto_linear;
 use crate::goto_loop_cf::rust_goto_loop;
 use crate::goto_switch_cf::rust_goto_switch;
 
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/loops/src/test_loops.rs
+++ b/tests/loops/src/test_loops.rs
@@ -1,5 +1,5 @@
 use crate::break_continue::rust_entry;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/loops/src/test_switch.rs
+++ b/tests/loops/src/test_switch.rs
@@ -1,5 +1,5 @@
 use crate::switch::rust_switch_val;
-use libc::c_int;
+use std::ffi::c_int;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/macros/src/test_define.rs
+++ b/tests/macros/src/test_define.rs
@@ -1,7 +1,7 @@
 use crate::define::{rust_fns, rust_stmt_expr_inc};
 use crate::define::{rust_reference_define, TEST_CONST1, TEST_CONST2, TEST_PARENS};
 use crate::define::{rust_test_zstd, ZSTD_WINDOWLOG_MAX_32, ZSTD_WINDOWLOG_MAX_64};
-use libc::{c_int, c_uint, c_ulong};
+use std::ffi::{c_int, c_uint, c_ulong};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/misc/Cargo.toml
+++ b/tests/misc/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/misc/src/test_exprs.rs
+++ b/tests/misc/src/test_exprs.rs
@@ -1,6 +1,5 @@
 use crate::exprs::rust_exprs;
-use libc::c_int;
-use libc::c_uint;
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/misc/src/test_lvalues.rs
+++ b/tests/misc/src/test_lvalues.rs
@@ -1,5 +1,5 @@
 use crate::lvalues::rust_lvalue;
-use libc::c_int;
+use std::ffi::c_int;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/misc/src/test_memory.rs
+++ b/tests/misc/src/test_memory.rs
@@ -1,6 +1,6 @@
 use crate::malloc::rust_malloc_test;
 use crate::strings_h::rust_setmem;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/misc/src/test_quicksort.rs
+++ b/tests/misc/src/test_quicksort.rs
@@ -1,5 +1,5 @@
 use crate::qsort::{rust_partition, rust_quickSort, rust_swap};
-use libc::c_int;
+use std::ffi::c_int;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/misc/src/test_shadowing.rs
+++ b/tests/misc/src/test_shadowing.rs
@@ -1,5 +1,5 @@
 use crate::shadowing::{rust_shadow, rust_twice};
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/misc/src/test_sizeofs.rs
+++ b/tests/misc/src/test_sizeofs.rs
@@ -1,8 +1,7 @@
 //! feature_core_intrinsics, feature_label_break_value
 
 use crate::sizeofs::rust_sizeofs;
-use libc::c_int;
-use libc::c_uint;
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/misc/src/test_typedef.rs
+++ b/tests/misc/src/test_typedef.rs
@@ -1,6 +1,6 @@
 use crate::typedef::{int_ptr, my_int, rust_entry};
 
-use libc::c_int;
+use std::ffi::c_int;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/misc/src/test_uninitialized.rs
+++ b/tests/misc/src/test_uninitialized.rs
@@ -1,5 +1,5 @@
 use crate::uninitialized::{bar, baz, e, foo, rust_entry2, s, /*myint, myintp,*/ u};
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 extern "C" {
     fn entry2(_: c_uint, _: *mut c_int);

--- a/tests/misc/src/typedef.c
+++ b/tests/misc/src/typedef.c
@@ -1,10 +1,10 @@
 
 // Typedefs should "forget" about their qualifiers for the type synonym
-typedef int my_int;                          // 'type my_int = libc::c_int'
+typedef int my_int;                          // 'type my_int = std::ffi::c_int'
 typedef my_int * int_ptr;                    // 'type int_ptr = *mut my_int'
 typedef int_ptr const const_int_ptr;         // 'type const_int_ptr = int_ptr'
 typedef const_int_ptr indirectly_const_ptr;  // 'type indirectly_const_ptr = const_int_ptr'
-typedef int (my_fn)(int i);                 //  'type my_fn = fn(libc::c_int) -> libc::c_int'
+typedef int (my_fn)(int i);                  // 'type my_fn = fn(std::ffi::c_int) -> std::ffi::c_int'
 
 int identity(int x) { return x; }
 
@@ -18,7 +18,7 @@ int entry(void)
     const_int_ptr w = &x;                    // 'w: const_int_ptr'
     const const_int_ptr v = &x;              // 'v: const_int_ptr'
     indirectly_const_ptr u = &x;             // 'u: indirectly_const_ptr'
-    my_fn *t = &identity;                    // 't: my_fn: fn(libc::c_int) -> libc::c_int' 
+    my_fn *t = &identity;                    // 't: my_fn: fn(std::ffi::c_int) -> std::ffi::c_int' 
 
     typedef int shadowed;
     shadowed n = 1;

--- a/tests/modules/src/test_modules.rs
+++ b/tests/modules/src/test_modules.rs
@@ -1,5 +1,5 @@
 use crate::modules::rust_modules;
-use libc::c_uint;
+use std::ffi::c_uint;
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/pointers/src/test_pointers.rs
+++ b/tests/pointers/src/test_pointers.rs
@@ -6,7 +6,7 @@ use crate::pointer_init::rust_entry;
 use crate::ref_decay::{
     rust_address_cast, rust_bar, rust_bitcast, rust_calls_all, rust_f, rust_foobar,
 };
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/simd.x86_64/Cargo.toml
+++ b/tests/simd.x86_64/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"
 

--- a/tests/statics/src/test_sections.rs
+++ b/tests/statics/src/test_sections.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_os = "macos"))]
 use crate::attributes::{rust_no_attrs, rust_used_static, rust_used_static2, rust_used_static3};
 use crate::sections::*;
-use libc::c_uint;
+use std::ffi::c_uint;
 
 pub fn test_sectioned_statics() {
     unsafe {

--- a/tests/statics/src/test_storage.rs
+++ b/tests/statics/src/test_storage.rs
@@ -1,5 +1,5 @@
 use crate::storage::rust_entry;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/statics/src/test_thread_locals.rs
+++ b/tests/statics/src/test_thread_locals.rs
@@ -1,7 +1,7 @@
 //! feature_thread_local
 
 use crate::thread_locals::rust_thread_entry;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 use std::thread;
 
 #[link(name = "test")]

--- a/tests/structs/src/test_anonymous_decls.rs
+++ b/tests/structs/src/test_anonymous_decls.rs
@@ -1,5 +1,4 @@
 use crate::anonymous_decls::rust_k;
-use libc::{c_int, c_uint};
 
 pub fn test_anonymous_decl() {
     unsafe {

--- a/tests/structs/src/test_flex_array_members.rs
+++ b/tests/structs/src/test_flex_array_members.rs
@@ -1,5 +1,5 @@
 use crate::flex_array_members::rust_exercise_flex_arrays;
-use libc::{c_int, c_uint, size_t};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/structs/src/test_forward.rs
+++ b/tests/structs/src/test_forward.rs
@@ -1,5 +1,5 @@
 use crate::forward::rust_forward;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/structs/src/test_struct_with_exp.rs
+++ b/tests/structs/src/test_struct_with_exp.rs
@@ -1,5 +1,5 @@
 use crate::struct_with_exp::rust_struct_with_exp;
-use libc::{c_int, c_uint, size_t};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {

--- a/tests/structs/src/test_structs.rs
+++ b/tests/structs/src/test_structs.rs
@@ -1,5 +1,6 @@
 use crate::structs::{rust_alignment_entry, rust_entry, Aligned8Struct};
-use libc::{c_int, c_uint, size_t};
+use libc::size_t;
+use std::ffi::{c_int, c_uint};
 use std::mem::align_of;
 
 #[link(name = "test")]

--- a/tests/unions/Cargo.toml
+++ b/tests/unions/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libc = "0.2"

--- a/tests/unions/src/test_unions.rs
+++ b/tests/unions/src/test_unions.rs
@@ -1,5 +1,5 @@
 use crate::unions::rust_entry;
-use libc::{c_int, c_uint};
+use std::ffi::{c_int, c_uint};
 
 #[link(name = "test")]
 extern "C" {


### PR DESCRIPTION
By using `std::ffi` types. A follow-up to #1221 and #1222.