### PR TITLE
Make `test_translator.py` tests pass on LLVM 19

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -1772,7 +1772,11 @@ class TranslateASTVisitor final
                              case AtomicExpr::AO ## ID:                 \
                                  cbor_encode_string(array, #ID);       \
                                  break;
+#if CLANG_VERSION_MAJOR >= 19
+#include "clang/Basic/Builtins.inc"
+#else
 #include "clang/Basic/Builtins.def"
+#endif
                          default: printError("Unknown atomic builtin: " +
                                              std::to_string(E->getOp()), E);
                          };

--- a/c2rust-build-paths/src/lib.rs
+++ b/c2rust-build-paths/src/lib.rs
@@ -91,6 +91,7 @@ pub fn find_llvm_config() -> Option<PathBuf> {
         .or_else(|| {
             // In PATH
             [
+                "llvm-config-19",
                 "llvm-config-18",
                 "llvm-config-17",
                 "llvm-config-16",
@@ -106,6 +107,7 @@ pub fn find_llvm_config() -> Option<PathBuf> {
                 "llvm-config-7.0",
                 "llvm-config",
                 // Homebrew install locations on Intel macOS
+                "/usr/local/opt/llvm@19/bin/llvm-config",
                 "/usr/local/opt/llvm@18/bin/llvm-config",
                 "/usr/local/opt/llvm@17/bin/llvm-config",
                 "/usr/local/opt/llvm@16/bin/llvm-config",
@@ -119,6 +121,7 @@ pub fn find_llvm_config() -> Option<PathBuf> {
                 "/usr/local/opt/llvm@8/bin/llvm-config",
                 "/usr/local/opt/llvm/bin/llvm-config",
                 // Homebrew install locations on Apple Silicon macOS
+                "/opt/homebrew/opt/llvm@19/bin/llvm-config",
                 "/opt/homebrew/opt/llvm@18/bin/llvm-config",
                 "/opt/homebrew/opt/llvm@17/bin/llvm-config",
                 "/opt/homebrew/opt/llvm@16/bin/llvm-config",


### PR DESCRIPTION
The LLVM builtins file changed name going from 18 to 19.

* Fixes #1228.