### PR TITLE
Support `__float128`, which shows up in clang headers on some systems

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -423,6 +423,7 @@ class TypeEncoder final : public TypeVisitor<TypeEncoder> {
             case BuiltinType::SveBool: return TagSveBool;
             case BuiltinType::SveBoolx2: return TagSveBoolx2;
             case BuiltinType::SveBoolx4: return TagSveBoolx4;
+            case BuiltinType::Float128: return TagFloat128;
 #endif
             default:
                 auto pol = clang::PrintingPolicy(Context->getLangOpts());

--- a/c2rust-ast-exporter/src/ast_tags.hpp
+++ b/c2rust-ast-exporter/src/ast_tags.hpp
@@ -147,6 +147,8 @@ enum TypeTag {
     TagSveBool,
     TagSveBoolx2,
     TagSveBoolx4,
+
+    TagFloat128,
 };
 
 enum StringTypeTag {

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -813,6 +813,12 @@ impl ConversionContext {
                     self.processed_nodes.insert(new_id, OTHER_TYPE);
                 }
 
+                TypeTag::TagFloat128 => {
+                    let ty = CTypeKind::Float128;
+                    self.add_type(new_id, not_located(ty));
+                    self.processed_nodes.insert(new_id, OTHER_TYPE);
+                }
+
                 TypeTag::TagVectorType => {
                     let elt =
                         from_value(ty_node.extras[0].clone()).expect("Vector child not found");

--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -285,7 +285,7 @@ fn immediate_type_children(kind: &CTypeKind) -> Vec<SomeId> {
         TypeOfExpr(e) => intos![e],
         Void | Bool | Short | Int | Long | LongLong | UShort | UInt | ULong | ULongLong | SChar
         | UChar | Char | Double | LongDouble | Float | Int128 | UInt128 | BuiltinFn | Half
-        | BFloat16 | UnhandledSveType => {
+        | BFloat16 | UnhandledSveType | Float128 => {
             vec![]
         }
 

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1687,6 +1687,8 @@ pub enum CTypeKind {
     // ARM Scalable Vector Extension types
     // TODO: represent all the individual types in AArch64SVEACLETypes.def
     UnhandledSveType,
+
+    Float128,
 }
 
 impl CTypeKind {
@@ -1713,6 +1715,7 @@ impl CTypeKind {
             UInt128 => "unsigned __int128",
             Half => "half",
             BFloat16 => "bfloat16",
+            Float128 => "__float128",
             _ => unimplemented!("Printer::print_type({:?})", self),
         }
     }

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -325,7 +325,9 @@ impl TypeConverter {
             CTypeKind::UChar => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_uchar"]))),
             CTypeKind::Char => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_char"]))),
             CTypeKind::Double => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_double"]))),
-            CTypeKind::LongDouble => Ok(mk().path_ty(mk().path(vec!["f128", "f128"]))),
+            CTypeKind::LongDouble | CTypeKind::Float128 => {
+                Ok(mk().path_ty(mk().path(vec!["f128", "f128"])))
+            }
             CTypeKind::Float => Ok(mk().path_ty(mk().path(vec!["std", "ffi", "c_float"]))),
             CTypeKind::Int128 => Ok(mk().path_ty(mk().path(vec!["i128"]))),
             CTypeKind::UInt128 => Ok(mk().path_ty(mk().path(vec!["u128"]))),

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4888,7 +4888,8 @@ impl<'c> Translation<'c> {
         match type_kind {
             // libc can be accessed from anywhere as of Rust 2019 by full path
             Void | Char | SChar | UChar | Short | UShort | Int | UInt | Long | ULong | LongLong
-            | ULongLong | Int128 | UInt128 | Half | BFloat16 | Float | Double | LongDouble => {}
+            | ULongLong | Int128 | UInt128 | Half | BFloat16 | Float | Double | LongDouble
+            | Float128 => {}
             // Bool uses the bool type, so no dependency on libc
             Bool => {}
             Paren(ctype)


### PR DESCRIPTION
Without this, translation can fail with:

`warning: c2rust: Encountered unsupported BuiltinType kind 478 for type __float128`

followed by:

`thread 'main' panicked at 'Type conversion not implemented for TagTypeUnknown expecting 3', c2rust-transpile/src/c_ast/conversion.rs:827:22`
