### PR TITLE
Allow running multiple transpiles in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "syn 1.0.109",
+ "tempfile",
 ]
 
 [[package]]

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -37,6 +37,7 @@ smallvec = "1.0"
 strum = "0.24"
 strum_macros = "0.24"
 syn = { version = "1.0", features = ["full", "extra-traits", "parsing", "printing"]}
+tempfile = "3.5.0"
 
 [features]
 # Force static linking of LLVM

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -25,6 +25,7 @@ use itertools::Itertools;
 use log::{info, warn};
 use regex::Regex;
 use serde_derive::Serialize;
+pub use tempfile::TempDir;
 
 use crate::c_ast::Printer;
 use crate::c_ast::*;
@@ -226,8 +227,18 @@ fn get_module_name(
     file.to_str().map(String::from)
 }
 
-pub fn create_temp_compile_commands(sources: &[PathBuf]) -> PathBuf {
-    let temp_path = std::env::temp_dir().join("compile_commands.json");
+pub fn create_temp_compile_commands(sources: &[PathBuf]) -> (TempDir, PathBuf) {
+    // If we generate the same path here on every run, then we can't run
+    // multiple transpiles in parallel, so we need a unique path. But clang
+    // won't read this file unless it is named exactly "compile_commands.json",
+    // so we can't change the filename. Instead, create a temporary directory
+    // with a unique name, and put the file there.
+    let temp_dir = tempfile::Builder::new()
+        .prefix("c2rust-")
+        .tempdir()
+        .expect("Failed to create temporary directory for compile_commands.json");
+    let temp_path = temp_dir.path().join("compile_commands.json");
+
     let compile_commands: Vec<CompileCmd> = sources
         .iter()
         .map(|source_file| {
@@ -252,8 +263,7 @@ pub fn create_temp_compile_commands(sources: &[PathBuf]) -> PathBuf {
         File::create(&temp_path).expect("Failed to create temporary compile_commands.json");
     file.write_all(json_content.as_bytes())
         .expect("Failed to write to temporary compile_commands.json");
-
-    temp_path
+    (temp_dir, temp_path)
 }
 
 /// Main entry point to transpiler. Called from CLI tools with the result of


### PR DESCRIPTION
If c2rust-transpile needs to generate a temporary compile_commands.json, previously it used a fixed path for it across all invocations. Instead, create a uniquely-named temporary directory for it, so that parallel transpiles don't clobber each other.

I've used a two-year-old release of tempfile to avoid adding a bunch of duplicate versions of other crates to Cargo.lock, but presumably some upgrades ought to happen sooner or later.