### PR TITLE
transpile: remove invalid `Punct::new(' ')` in `fn convert_asm` and update `proc-macro2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -966,7 +966,6 @@ impl<'c> Translation<'c> {
             tokens.push(TokenTree::Punct(Punct::new(',', Alone)));
             let result = mk().call_expr(mk().ident_expr("out"), vec![mk().lit_expr(clobber)]);
             push_expr(&mut tokens, result);
-            tokens.push(TokenTree::Punct(Punct::new(' ', Alone)));
             push_expr(&mut tokens, mk().ident_expr("_"));
         }
 


### PR DESCRIPTION
`' '` is not a valid punctuation, and newer versions of `proc_macro2` don't allow it.  However, we don't seem to need the space here at all, as `zstd` (from `c2rust-testsuite`) still transpiles and compiles successfully without it.

This also updates to `proc-macro` `1.0.95` (from `1.0.86`) to test this.

#1243 should be able to be merged after this.