### PR TITLE
Fix getBitWidthValue compilation error on LLVM 20+

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -2213,8 +2213,12 @@ class TranslateASTVisitor final
 
                          // 2. Encode bitfield width if any
                          if (D->isBitField()) {
+#if LLVM_VERSION_MAJOR >= 20
+                             cbor_encode_uint(array, D->getBitWidthValue());
+#else
                              cbor_encode_uint(
                                  array, D->getBitWidthValue(*this->Context));
+#endif
                          } else {
                              cbor_encode_null(array);
                          };


### PR DESCRIPTION
Introduced by upstream in https://github.com/llvm/llvm-project/pull/122289

Ref: https://github.com/iovisor/bcc/pull/5194
