### PR TITLE
transpile: fix doc tests on aarch64 (`c_char` is unsigned there)

### DIFF
--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -406,7 +406,7 @@ impl<'a> Translation<'a> {
     ///         non_bf: 32,
     ///         _pad: [0; 2],
     ///     };
-    ///     init.set_bf1(-12);
+    ///     init.set_bf1(-12i8 as _);
     ///     init.set_bf2(34);
     ///     init
     /// }


### PR DESCRIPTION
While reviewing some other PRs, I noticed doc tests fail on aarch64 since `c_char` is unsigned there.