### PR TITLE
`transpile`: Support unaligned reads and writes

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -1641,10 +1641,29 @@ class TranslateASTVisitor final
 
     bool VisitUnaryOperator(UnaryOperator *UO) {
         std::vector<void *> childIds = {UO->getSubExpr()};
-        encode_entry(UO, TagUnaryOperator, childIds, [UO](CborEncoder *array) {
+
+        encode_entry(UO, TagUnaryOperator, childIds, [this, UO](CborEncoder *array) {
             cbor_encode_string(array, UO->getOpcodeStr(UO->getOpcode()).str());
             cbor_encode_boolean(array, UO->isPrefix());
+
+            if (UO->getOpcode() == UO_Deref) {
+                QualType eltTy = UO->getSubExpr()->getType()->getPointeeType();
+                CharUnits align = Context->getTypeAlignInChars(eltTy);
+
+                if (auto *TD = eltTy->getAs<TypedefType>()) {
+                    QualType naturalTy = TD->getDecl()->getUnderlyingType();
+                    CharUnits naturalAlign = Context->getPreferredTypeAlignInChars(naturalTy);
+
+                    if (align < naturalAlign) {
+                        cbor_encode_int(array, align.getQuantity());
+                    } else {
+                        cbor_encode_int(array, -1);
+                    }
+
+                }
+            }
         });
+
         return true;
     }
 

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -1250,7 +1250,14 @@ impl ConversionContext {
                         .as_str()
                     {
                         "&" => UnOp::AddressOf,
-                        "*" => UnOp::Deref,
+                        "*" => {
+                            let align: i32 = from_value(node.extras[2].clone())
+                                .expect("Expected prefix information");
+
+                            UnOp::Deref {
+                                unaligned: align != -1,
+                            }
+                        }
                         "+" => UnOp::Plus,
                         "-" => UnOp::Negate,
                         "~" => UnOp::Complement,

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1230,20 +1230,20 @@ pub enum CastKind {
 /// Represents a unary operator in C (6.5.3 Unary operators) and GNU C extensions
 #[derive(Debug, Clone, Copy)]
 pub enum UnOp {
-    AddressOf,     // &x
-    Deref,         // *x
-    Plus,          // +x
-    PostIncrement, // x++
-    PreIncrement,  // ++x
-    Negate,        // -x
-    PostDecrement, // x--
-    PreDecrement,  // --x
-    Complement,    // ~x
-    Not,           // !x
-    Real,          // [GNU C] __real x
-    Imag,          // [GNU C] __imag x
-    Extension,     // [GNU C] __extension__ x
-    Coawait,       // [C++ Coroutines] co_await x
+    AddressOf,                 // &x
+    Deref { unaligned: bool }, // *x
+    Plus,                      // +x
+    PostIncrement,             // x++
+    PreIncrement,              // ++x
+    Negate,                    // -x
+    PostDecrement,             // x--
+    PreDecrement,              // --x
+    Complement,                // ~x
+    Not,                       // !x
+    Real,                      // [GNU C] __real x
+    Imag,                      // [GNU C] __imag x
+    Extension,                 // [GNU C] __extension__ x
+    Coawait,                   // [C++ Coroutines] co_await x
 }
 
 impl UnOp {
@@ -1251,7 +1251,7 @@ impl UnOp {
         use UnOp::*;
         match self {
             AddressOf => "&",
-            Deref => "*",
+            Deref { .. } => "*",
             Plus => "+",
             PreIncrement => "++",
             PostIncrement => "++",

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3045,6 +3045,17 @@ impl<'c> Translation<'c> {
         Ok(mk().call_expr(read_volatile_expr, vec![addr_lhs]))
     }
 
+    /// Write to a `lhs` that may be unaligned
+    pub fn unaligned_write(
+        &self,
+        lhs: Box<Expr>,
+        lhs_type: CQualTypeId,
+        rhs: Box<Expr>,
+    ) -> TranslationResult<Box<Expr>> {
+        let addr_lhs = self.addr_lhs(lhs, lhs_type, true)?;
+        Ok(mk().method_call_expr(addr_lhs, "write_unaligned", vec![rhs]))
+    }
+
     // Compute the offset multiplier for variable length array indexing
     // Rust type: usize
     pub fn compute_size_of_expr(&self, type_id: CTypeId) -> Option<Box<Expr>> {

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -283,6 +283,11 @@ impl<'c> Translation<'c> {
             .get_qual_type()
             .ok_or_else(|| format_err!("bad initial lhs type"))?;
 
+        let is_unaligned = matches!(
+            initial_lhs,
+            CExprKind::Unary(_, c_ast::UnOp::Deref { unaligned: true }, _, _)
+        );
+
         let bitfield_id = match initial_lhs {
             CExprKind::Member(_, _, decl_id, _, _) => {
                 let kind = &self.ast_context[*decl_id].kind;
@@ -357,7 +362,17 @@ impl<'c> Translation<'c> {
                     use c_ast::BinOp::*;
                     let assign_stmt = match op {
                         // Regular (possibly volatile) assignment
-                        Assign if !is_volatile => WithStmts::new_val(mk().assign_expr(write, rhs)),
+                        Assign if !is_volatile => {
+                            if is_unaligned {
+                                WithStmts::new_val(self.unaligned_write(
+                                    write,
+                                    initial_lhs_type_id,
+                                    rhs,
+                                )?)
+                            } else {
+                                WithStmts::new_val(mk().assign_expr(write, rhs))
+                            }
+                        }
                         Assign => WithStmts::new_val(self.volatile_write(
                             write,
                             initial_lhs_type_id,
@@ -822,7 +837,7 @@ impl<'c> Translation<'c> {
 
                 match arg_kind {
                     // C99 6.5.3.2 para 4
-                    CExprKind::Unary(_, c_ast::UnOp::Deref, target, _) => {
+                    CExprKind::Unary(_, c_ast::UnOp::Deref { unaligned: _ }, target, _) => {
                         return self.convert_expr(ctx, *target)
                     }
                     // An AddrOf DeclRef/Member is safe to not decay if the translator isn't already giving a hard
@@ -889,7 +904,7 @@ impl<'c> Translation<'c> {
             c_ast::UnOp::PreDecrement => self.convert_pre_increment(ctx, cqual_type, false, arg),
             c_ast::UnOp::PostIncrement => self.convert_post_increment(ctx, cqual_type, true, arg),
             c_ast::UnOp::PostDecrement => self.convert_post_increment(ctx, cqual_type, false, arg),
-            c_ast::UnOp::Deref => {
+            c_ast::UnOp::Deref { unaligned } => {
                 match self.ast_context[arg].kind {
                     CExprKind::Unary(_, c_ast::UnOp::AddressOf, arg_, _) => {
                         self.convert_expr(ctx.used(), arg_)
@@ -903,7 +918,23 @@ impl<'c> Translation<'c> {
                                     Ok(unwrap_function_pointer(val))
                                 } else if let Some(_vla) = self.compute_size_of_expr(ctype) {
                                     Ok(val)
+                                } else if unaligned {
+                                    // We should use read_unaligned here:
+                                    // mk().method_call_expr(val, "read_unaligned", vec![]);
+                                    // but that interferes with `write_unaligned`
+
+                                    let mut val = 
+                                        mk().unary_expr(UnOp::Deref(Default::default()), val);
+
+                                    // If the type on the other side of the pointer we are dereferencing is volatile and
+                                    // this whole expression is not an LValue, we should make this a volatile read
+                                    if lrvalue.is_rvalue() && cqual_type.qualifiers.is_volatile
+                                    {
+                                        val = self.volatile_read(val, cqual_type)?
+                                    }
+                                    Ok(val)
                                 } else {
+                                    dbg!("otherwise");
                                     let mut val =
                                         mk().unary_expr(UnOp::Deref(Default::default()), val);
 

--- a/c2rust-transpile/tests/snapshots/aligned_read_write.c
+++ b/c2rust-transpile/tests/snapshots/aligned_read_write.c
@@ -1,0 +1,19 @@
+#include <stdint.h>
+
+typedef __attribute__((aligned(1))) uint32_t unaligned_uint32;
+
+uint32_t unaligned_read(const void* ptr) {
+    return *((const unaligned_uint32*)ptr);
+}
+
+uint32_t aligned_read(const void* ptr) {
+    return *((const uint32_t*)ptr);
+}
+
+void unaligned_write(void* ptr, uint32_t value) {
+    *((unaligned_uint32*)ptr) = value;
+}
+
+void aligned_write(const void* ptr, uint32_t value) {
+    *((uint32_t*)ptr) = value;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@aligned_read_write.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@aligned_read_write.c.snap
@@ -1,0 +1,39 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: "&rust"
+input_file: c2rust-transpile/tests/snapshots/aligned_read_write.c
+---
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+pub type __uint32_t = std::ffi::c_uint;
+pub type uint32_t = __uint32_t;
+pub type unaligned_uint32 = uint32_t;
+#[no_mangle]
+pub unsafe extern "C" fn unaligned_read(mut ptr: *const std::ffi::c_void) -> uint32_t {
+    return *(ptr as *const unaligned_uint32);
+}
+#[no_mangle]
+pub unsafe extern "C" fn aligned_read(mut ptr: *const std::ffi::c_void) -> uint32_t {
+    return *(ptr as *const uint32_t);
+}
+#[no_mangle]
+pub unsafe extern "C" fn unaligned_write(
+    mut ptr: *mut std::ffi::c_void,
+    mut value: uint32_t,
+) {
+    (ptr as *mut unaligned_uint32).write_unaligned(value);
+}
+#[no_mangle]
+pub unsafe extern "C" fn aligned_write(
+    mut ptr: *const std::ffi::c_void,
+    mut value: uint32_t,
+) {
+    *(ptr as *mut uint32_t) = value;
+}


### PR DESCRIPTION
This is very work-in-progress, but I think I need some pointers here. I'll add some inline comments.