### PR TITLE
`transpile`: emit `.rotate_{left,right}` instead of `core::intrinsics::rotate_{left,right}`

### DIFF
--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -631,18 +631,17 @@ impl<'c> Translation<'c> {
             | "__builtin_rotateleft16"
             | "__builtin_rotateleft32"
             | "__builtin_rotateleft64" => {
-                self.use_feature("core_intrinsics");
-
-                // Emit `rotate_left(arg0, arg1)`
-                let rotate_func = mk().abs_path_expr(vec!["core", "intrinsics", "rotate_left"]);
+                // Emit `arg0.rotate_left(arg1)`
                 let arg0 = self.convert_expr(ctx.used(), args[0])?;
                 let arg1 = self.convert_expr(ctx.used(), args[1])?;
                 arg0.and_then(|arg0| {
                     arg1.and_then(|arg1| {
-                        let call_expr = mk().call_expr(rotate_func, vec![arg0, arg1]);
+                        let arg1 = mk().cast_expr(arg1, mk().path_ty(vec!["u32"]));
+                        let method_call_expr =
+                            mk().method_call_expr(arg0, "rotate_left", vec![arg1]);
                         self.convert_side_effects_expr(
                             ctx,
-                            WithStmts::new_val(call_expr),
+                            WithStmts::new_val(method_call_expr),
                             "Builtin is not supposed to be used",
                         )
                     })
@@ -653,18 +652,17 @@ impl<'c> Translation<'c> {
             | "__builtin_rotateright16"
             | "__builtin_rotateright32"
             | "__builtin_rotateright64" => {
-                self.use_feature("core_intrinsics");
-
-                // Emit `rotate_right(arg0, arg1)`
-                let rotate_func = mk().abs_path_expr(vec!["core", "intrinsics", "rotate_right"]);
+                // Emit `arg0.rotate_right(arg1)`
                 let arg0 = self.convert_expr(ctx.used(), args[0])?;
                 let arg1 = self.convert_expr(ctx.used(), args[1])?;
                 arg0.and_then(|arg0| {
                     arg1.and_then(|arg1| {
-                        let call_expr = mk().call_expr(rotate_func, vec![arg0, arg1]);
+                        let arg1 = mk().cast_expr(arg1, mk().path_ty(vec!["u32"]));
+                        let method_call_expr =
+                            mk().method_call_expr(arg0, "rotate_right", vec![arg1]);
                         self.convert_side_effects_expr(
                             ctx,
-                            WithStmts::new_val(call_expr),
+                            WithStmts::new_val(method_call_expr),
                             "Builtin is not supposed to be used",
                         )
                     })

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -17,6 +17,29 @@ enum LibcFnArgType {
 }
 
 impl<'c> Translation<'c> {
+    /// Convert a call to a rotate builtin.
+    fn convert_builtin_rotate(
+        &self,
+        ctx: ExprContext,
+        args: &[CExprId],
+        rotate_method_name: &'static str,
+    ) -> TranslationResult<WithStmts<Box<Expr>>> {
+        // Emit `arg0.{method_name}(arg1)`
+        let arg0 = self.convert_expr(ctx.used(), args[0])?;
+        let arg1 = self.convert_expr(ctx.used(), args[1])?;
+        arg0.and_then(|arg0| {
+            arg1.and_then(|arg1| {
+                let arg1 = mk().cast_expr(arg1, mk().path_ty(vec!["u32"]));
+                let method_call_expr = mk().method_call_expr(arg0, rotate_method_name, vec![arg1]);
+                self.convert_side_effects_expr(
+                    ctx,
+                    WithStmts::new_val(method_call_expr),
+                    "Builtin is not supposed to be used",
+                )
+            })
+        })
+    }
+
     /// Convert a call to a builtin function to a Rust expression
     pub fn convert_builtin(
         &self,
@@ -630,44 +653,12 @@ impl<'c> Translation<'c> {
             "__builtin_rotateleft8"
             | "__builtin_rotateleft16"
             | "__builtin_rotateleft32"
-            | "__builtin_rotateleft64" => {
-                // Emit `arg0.rotate_left(arg1)`
-                let arg0 = self.convert_expr(ctx.used(), args[0])?;
-                let arg1 = self.convert_expr(ctx.used(), args[1])?;
-                arg0.and_then(|arg0| {
-                    arg1.and_then(|arg1| {
-                        let arg1 = mk().cast_expr(arg1, mk().path_ty(vec!["u32"]));
-                        let method_call_expr =
-                            mk().method_call_expr(arg0, "rotate_left", vec![arg1]);
-                        self.convert_side_effects_expr(
-                            ctx,
-                            WithStmts::new_val(method_call_expr),
-                            "Builtin is not supposed to be used",
-                        )
-                    })
-                })
-            }
+            | "__builtin_rotateleft64" => self.convert_builtin_rotate(ctx, args, "rotate_left"),
 
             "__builtin_rotateright8"
             | "__builtin_rotateright16"
             | "__builtin_rotateright32"
-            | "__builtin_rotateright64" => {
-                // Emit `arg0.rotate_right(arg1)`
-                let arg0 = self.convert_expr(ctx.used(), args[0])?;
-                let arg1 = self.convert_expr(ctx.used(), args[1])?;
-                arg0.and_then(|arg0| {
-                    arg1.and_then(|arg1| {
-                        let arg1 = mk().cast_expr(arg1, mk().path_ty(vec!["u32"]));
-                        let method_call_expr =
-                            mk().method_call_expr(arg0, "rotate_right", vec![arg1]);
-                        self.convert_side_effects_expr(
-                            ctx,
-                            WithStmts::new_val(method_call_expr),
-                            "Builtin is not supposed to be used",
-                        )
-                    })
-                })
-            }
+            | "__builtin_rotateright64" => self.convert_builtin_rotate(ctx, args, "rotate_right"),
 
             _ => Err(format_translation_err!(
                 self.ast_context.display_loc(src_loc),

--- a/c2rust-transpile/tests/snapshots/linux/rotate.rs
+++ b/c2rust-transpile/tests/snapshots/linux/rotate.rs
@@ -7,22 +7,19 @@
     unused_assignments,
     unused_mut
 )]
-#![feature(core_intrinsics)]
 #[no_mangle]
 pub unsafe extern "C" fn rotate_left_64(
     mut x: std::ffi::c_ulonglong,
 ) -> std::ffi::c_ulonglong {
-    return ::core::intrinsics::rotate_left(
-        x as std::ffi::c_ulong,
-        4 as std::ffi::c_int as std::ffi::c_ulong,
-    ) as std::ffi::c_ulonglong;
+    return (x as std::ffi::c_ulong)
+        .rotate_left(4 as std::ffi::c_int as std::ffi::c_ulong as u32)
+        as std::ffi::c_ulonglong;
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_64(
     mut x: std::ffi::c_ulonglong,
 ) -> std::ffi::c_ulonglong {
-    return ::core::intrinsics::rotate_right(
-        x as std::ffi::c_ulong,
-        4 as std::ffi::c_int as std::ffi::c_ulong,
-    ) as std::ffi::c_ulonglong;
+    return (x as std::ffi::c_ulong)
+        .rotate_right(4 as std::ffi::c_int as std::ffi::c_ulong as u32)
+        as std::ffi::c_ulonglong;
 }

--- a/c2rust-transpile/tests/snapshots/rotate.rs
+++ b/c2rust-transpile/tests/snapshots/rotate.rs
@@ -7,41 +7,31 @@
     unused_assignments,
     unused_mut
 )]
-#![feature(core_intrinsics)]
 #[no_mangle]
 pub unsafe extern "C" fn rotate_left_8(mut x: std::ffi::c_uchar) -> std::ffi::c_uchar {
-    return ::core::intrinsics::rotate_left(x, 1 as std::ffi::c_int as std::ffi::c_uchar);
+    return x.rotate_left(1 as std::ffi::c_int as std::ffi::c_uchar as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_left_16(
     mut x: std::ffi::c_ushort,
 ) -> std::ffi::c_ushort {
-    return ::core::intrinsics::rotate_left(
-        x,
-        2 as std::ffi::c_int as std::ffi::c_ushort,
-    );
+    return x.rotate_left(2 as std::ffi::c_int as std::ffi::c_ushort as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_left_32(mut x: std::ffi::c_uint) -> std::ffi::c_uint {
-    return ::core::intrinsics::rotate_left(x, 3 as std::ffi::c_int as std::ffi::c_uint);
+    return x.rotate_left(3 as std::ffi::c_int as std::ffi::c_uint as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_8(mut x: std::ffi::c_uchar) -> std::ffi::c_uchar {
-    return ::core::intrinsics::rotate_right(
-        x,
-        1 as std::ffi::c_int as std::ffi::c_uchar,
-    );
+    return x.rotate_right(1 as std::ffi::c_int as std::ffi::c_uchar as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_16(
     mut x: std::ffi::c_ushort,
 ) -> std::ffi::c_ushort {
-    return ::core::intrinsics::rotate_right(
-        x,
-        2 as std::ffi::c_int as std::ffi::c_ushort,
-    );
+    return x.rotate_right(2 as std::ffi::c_int as std::ffi::c_ushort as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_32(mut x: std::ffi::c_uint) -> std::ffi::c_uint {
-    return ::core::intrinsics::rotate_right(x, 3 as std::ffi::c_int as std::ffi::c_uint);
+    return x.rotate_right(3 as std::ffi::c_int as std::ffi::c_uint as u32);
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@linux__rotate.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@linux__rotate.c.snap
@@ -12,22 +12,19 @@ input_file: c2rust-transpile/tests/snapshots/linux/rotate.c
     unused_assignments,
     unused_mut
 )]
-#![feature(core_intrinsics)]
 #[no_mangle]
 pub unsafe extern "C" fn rotate_left_64(
     mut x: std::ffi::c_ulonglong,
 ) -> std::ffi::c_ulonglong {
-    return ::core::intrinsics::rotate_left(
-        x as std::ffi::c_ulong,
-        4 as std::ffi::c_int as std::ffi::c_ulong,
-    ) as std::ffi::c_ulonglong;
+    return (x as std::ffi::c_ulong)
+        .rotate_left(4 as std::ffi::c_int as std::ffi::c_ulong as u32)
+        as std::ffi::c_ulonglong;
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_64(
     mut x: std::ffi::c_ulonglong,
 ) -> std::ffi::c_ulonglong {
-    return ::core::intrinsics::rotate_right(
-        x as std::ffi::c_ulong,
-        4 as std::ffi::c_int as std::ffi::c_ulong,
-    ) as std::ffi::c_ulonglong;
+    return (x as std::ffi::c_ulong)
+        .rotate_right(4 as std::ffi::c_int as std::ffi::c_ulong as u32)
+        as std::ffi::c_ulonglong;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.snap
@@ -12,41 +12,31 @@ input_file: c2rust-transpile/tests/snapshots/rotate.c
     unused_assignments,
     unused_mut
 )]
-#![feature(core_intrinsics)]
 #[no_mangle]
 pub unsafe extern "C" fn rotate_left_8(mut x: std::ffi::c_uchar) -> std::ffi::c_uchar {
-    return ::core::intrinsics::rotate_left(x, 1 as std::ffi::c_int as std::ffi::c_uchar);
+    return x.rotate_left(1 as std::ffi::c_int as std::ffi::c_uchar as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_left_16(
     mut x: std::ffi::c_ushort,
 ) -> std::ffi::c_ushort {
-    return ::core::intrinsics::rotate_left(
-        x,
-        2 as std::ffi::c_int as std::ffi::c_ushort,
-    );
+    return x.rotate_left(2 as std::ffi::c_int as std::ffi::c_ushort as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_left_32(mut x: std::ffi::c_uint) -> std::ffi::c_uint {
-    return ::core::intrinsics::rotate_left(x, 3 as std::ffi::c_int as std::ffi::c_uint);
+    return x.rotate_left(3 as std::ffi::c_int as std::ffi::c_uint as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_8(mut x: std::ffi::c_uchar) -> std::ffi::c_uchar {
-    return ::core::intrinsics::rotate_right(
-        x,
-        1 as std::ffi::c_int as std::ffi::c_uchar,
-    );
+    return x.rotate_right(1 as std::ffi::c_int as std::ffi::c_uchar as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_16(
     mut x: std::ffi::c_ushort,
 ) -> std::ffi::c_ushort {
-    return ::core::intrinsics::rotate_right(
-        x,
-        2 as std::ffi::c_int as std::ffi::c_ushort,
-    );
+    return x.rotate_right(2 as std::ffi::c_int as std::ffi::c_ushort as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_32(mut x: std::ffi::c_uint) -> std::ffi::c_uint {
-    return ::core::intrinsics::rotate_right(x, 3 as std::ffi::c_int as std::ffi::c_uint);
+    return x.rotate_right(3 as std::ffi::c_int as std::ffi::c_uint as u32);
 }


### PR DESCRIPTION
* Fixes #1256.

These methods are stable (no `core::intrinsics` needed), which is greatly preferred.  Also, being stable means their signatures won't change like the intrinsics have.

cc @folkertdev.