### PR TITLE
`transpile`: impl `__builtin_ia32_pause` and `__builtin_arm_yield`

### DIFF
--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -357,9 +357,14 @@ impl<'c> Translation<'c> {
                 })
             }
 
-            "__builtin_ia32_pause" => {
+            "__builtin_ia32_pause" | "__builtin_arm_yield" => {
                 // `spin_loop()` is implemented as `_mm_pause()` (the `pause` instruction) on `x86`/`x86_64`,
                 // but it's the safe and cross-platform version of it, so prefer it.
+                // On `arm`, it's implemented as `yield`, although on `aarch64`,
+                // it's implemented as `isb` instead as this is more efficient.
+                // See <https://github.com/rust-lang/rust/commit/c064b6560b7ce0adeb9bbf5d7dcf12b1acb0c807>.
+                // `core::arch::aarch64::__yield()` could be used instead,
+                // but it's unstable (`#![feature(stdarch_arm_hints)]`), so it's not ideal.
                 let spin_loop = mk().abs_path_expr(vec!["core", "hint", "spin_loop"]);
                 let call = mk().call_expr(spin_loop, vec![]);
                 self.convert_side_effects_expr(

--- a/c2rust-transpile/tests/snapshots/pause.c
+++ b/c2rust-transpile/tests/snapshots/pause.c
@@ -1,3 +1,0 @@
-void pause(void) {
-    __builtin_ia32_pause();
-}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@spin.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@spin.c.snap
@@ -1,7 +1,7 @@
 ---
 source: c2rust-transpile/tests/snapshots.rs
-expression: cat tests/snapshots/pause.rs
-input_file: c2rust-transpile/tests/snapshots/pause.c
+expression: cat tests/snapshots/spin.rs
+input_file: c2rust-transpile/tests/snapshots/spin.c
 ---
 #![allow(
     dead_code,
@@ -13,6 +13,6 @@ input_file: c2rust-transpile/tests/snapshots/pause.c
     unused_mut
 )]
 #[no_mangle]
-pub unsafe extern "C" fn pause() {
+pub unsafe extern "C" fn spin() {
     ::core::hint::spin_loop();
 }

--- a/c2rust-transpile/tests/snapshots/spin.c
+++ b/c2rust-transpile/tests/snapshots/spin.c
@@ -1,0 +1,7 @@
+void spin(void) {
+#if defined(__x86_64__) || defined(__i386__)
+    __builtin_ia32_pause();
+#elif defined(__aarch64__) || defined(__arm__)
+    __builtin_arm_yield();
+#endif
+}

--- a/c2rust-transpile/tests/snapshots/spin.rs
+++ b/c2rust-transpile/tests/snapshots/spin.rs
@@ -8,6 +8,6 @@
     unused_mut
 )]
 #[no_mangle]
-pub unsafe extern "C" fn pause() {
+pub unsafe extern "C" fn spin() {
     ::core::hint::spin_loop();
 }


### PR DESCRIPTION
* Part of #1245.

Required to transpile modern curl (see https://github.com/curl/curl/issues/9058).