### PR TITLE
transpile: handle all cases of extra braces in string initializers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,17 +895,15 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.29.0"
+version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a28d25139df397cbca21408bb742cf6837e04cdbebf1b07b760caf971d6a972"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
  "console",
  "globset",
- "lazy_static",
- "linked-hash-map",
+ "once_cell",
  "similar",
  "walkdir",
- "yaml-rust",
 ]
 
 [[package]]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
@@ -1,0 +1,72 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/str_init.rs
+input_file: c2rust-transpile/tests/snapshots/str_init.c
+---
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#[no_mangle]
+pub unsafe extern "C" fn ptr() {
+    let mut _s: *const std::ffi::c_char = b"hello\0" as *const u8
+        as *const std::ffi::c_char;
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_deduced_length() {
+    let mut _s: [std::ffi::c_char; 6] = *::core::mem::transmute::<
+        &[u8; 6],
+        &mut [std::ffi::c_char; 6],
+    >(b"hello\0");
+}
+#[no_mangle]
+pub unsafe extern "C" fn array() {
+    let mut _s: [std::ffi::c_char; 10] = *::core::mem::transmute::<
+        &[u8; 10],
+        &mut [std::ffi::c_char; 10],
+    >(b"hello\0\0\0\0\0");
+}
+#[no_mangle]
+pub unsafe extern "C" fn int_array_extra_braces() {
+    let mut _a: [[std::ffi::c_int; 10]; 3] = [
+        [
+            1 as std::ffi::c_int,
+            2 as std::ffi::c_int,
+            3 as std::ffi::c_int,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ],
+        [0; 10],
+        [0; 10],
+    ];
+}
+#[no_mangle]
+pub unsafe extern "C" fn ptr_extra_braces() {
+    let mut _s: *const std::ffi::c_char = b"hello\0" as *const u8
+        as *const std::ffi::c_char;
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_extra_braces() {
+    let _s: [std::ffi::c_char; 10] = *::core::mem::transmute::<
+        &[u8; 10],
+        &[std::ffi::c_char; 10],
+    >(b"hello\0\0\0\0\0");
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_of_ptrs() {
+    let mut _s: [*const std::ffi::c_char; 3] = [
+        b"hello\0" as *const u8 as *const std::ffi::c_char,
+        0 as *const std::ffi::c_char,
+        0 as *const std::ffi::c_char,
+    ];
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
@@ -12,6 +12,17 @@ input_file: c2rust-transpile/tests/snapshots/str_init.c
     unused_assignments,
     unused_mut
 )]
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct s {
+    pub entries: [[std::ffi::c_char; 10]; 3],
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct alpn_spec {
+    pub entries: [[std::ffi::c_char; 10]; 3],
+    pub count: std::ffi::c_uint,
+}
 #[no_mangle]
 pub unsafe extern "C" fn ptr() {
     let mut _s: *const std::ffi::c_char = b"hello\0" as *const u8
@@ -69,4 +80,65 @@ pub unsafe extern "C" fn array_of_ptrs() {
         0 as *const std::ffi::c_char,
         0 as *const std::ffi::c_char,
     ];
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_of_arrays() {
+    let mut _s: [[std::ffi::c_char; 10]; 3] = [
+        *::core::mem::transmute::<
+            &[u8; 10],
+            &mut [std::ffi::c_char; 10],
+        >(b"hello\0\0\0\0\0"),
+        [0; 10],
+        [0; 10],
+    ];
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_of_arrays_static() {
+    static mut _S: [[std::ffi::c_char; 10]; 3] = unsafe {
+        [
+            *::core::mem::transmute::<
+                &[u8; 10],
+                &[std::ffi::c_char; 10],
+            >(b"hello\0\0\0\0\0"),
+            [0; 10],
+            [0; 10],
+        ]
+    };
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_of_arrays_static_struct() {
+    static mut _S: s = unsafe {
+        {
+            let mut init = s {
+                entries: [
+                    *::core::mem::transmute::<
+                        &[u8; 10],
+                        &mut [std::ffi::c_char; 10],
+                    >(b"hello\0\0\0\0\0"),
+                    [0; 10],
+                    [0; 10],
+                ],
+            };
+            init
+        }
+    };
+}
+#[no_mangle]
+pub unsafe extern "C" fn curl_alpn_spec() {
+    static mut _ALPN_SPEC_H11: alpn_spec = unsafe {
+        {
+            let mut init = alpn_spec {
+                entries: [
+                    *::core::mem::transmute::<
+                        &[u8; 10],
+                        &mut [std::ffi::c_char; 10],
+                    >(b"http/1.1\0\0"),
+                    [0; 10],
+                    [0; 10],
+                ],
+                count: 1 as std::ffi::c_int as std::ffi::c_uint,
+            };
+            init
+        }
+    };
 }

--- a/c2rust-transpile/tests/snapshots/str_init.c
+++ b/c2rust-transpile/tests/snapshots/str_init.c
@@ -26,8 +26,6 @@ void array_of_ptrs(void) {
     const char* _s[3] = {"hello"};
 }
 
-#if 0
-
 void array_of_arrays(void) {
     char _s[3][10] = {"hello"};
 }
@@ -63,5 +61,3 @@ void curl_alpn_spec(void) {
         { ALPN_HTTP_1_1 }, 1
     };
 }
-
-#endif

--- a/c2rust-transpile/tests/snapshots/str_init.c
+++ b/c2rust-transpile/tests/snapshots/str_init.c
@@ -1,0 +1,67 @@
+void ptr(void) {
+    const char *_s = "hello";
+}
+
+void array_deduced_length(void) {
+    char _s[] = "hello";
+}
+
+void array(void) {
+    char _s[10] = "hello";
+}
+
+void int_array_extra_braces(void) {
+    int _a[3][10] = {{1, 2, 3}};
+}
+
+void ptr_extra_braces(void) {
+    const char *_s = {"hello"};
+}
+
+void array_extra_braces(void) {
+    const char _s[10] = {"hello"};
+}
+
+void array_of_ptrs(void) {
+    const char* _s[3] = {"hello"};
+}
+
+#if 0
+
+void array_of_arrays(void) {
+    char _s[3][10] = {"hello"};
+}
+
+void array_of_arrays_static(void) {
+    static const char _S[3][10] = {"hello"};
+}
+
+void array_of_arrays_static_struct(void) {
+    struct s {
+        char entries[3][10];
+    };
+
+    static const struct s _S = {
+        {"hello"},
+    };
+}
+
+// From curl.
+void curl_alpn_spec(void) {
+    #define ALPN_ENTRIES_MAX 3
+    #define ALPN_NAME_MAX    10
+    #define ALPN_HTTP_1_1    "http/1.1"
+
+    struct alpn_spec {
+        char     entries[ALPN_ENTRIES_MAX][ALPN_NAME_MAX];
+        // TODO Changed from `size_t` since `size_t` is still platform-dependent for now.
+        // Undo once #1266 lands.
+        unsigned count; /* number of entries */
+    };
+
+    static const struct alpn_spec _ALPN_SPEC_H11 = {
+        { ALPN_HTTP_1_1 }, 1
+    };
+}
+
+#endif

--- a/c2rust-transpile/tests/snapshots/str_init.rs
+++ b/c2rust-transpile/tests/snapshots/str_init.rs
@@ -1,0 +1,67 @@
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#[no_mangle]
+pub unsafe extern "C" fn ptr() {
+    let mut _s: *const std::ffi::c_char = b"hello\0" as *const u8
+        as *const std::ffi::c_char;
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_deduced_length() {
+    let mut _s: [std::ffi::c_char; 6] = *::core::mem::transmute::<
+        &[u8; 6],
+        &mut [std::ffi::c_char; 6],
+    >(b"hello\0");
+}
+#[no_mangle]
+pub unsafe extern "C" fn array() {
+    let mut _s: [std::ffi::c_char; 10] = *::core::mem::transmute::<
+        &[u8; 10],
+        &mut [std::ffi::c_char; 10],
+    >(b"hello\0\0\0\0\0");
+}
+#[no_mangle]
+pub unsafe extern "C" fn int_array_extra_braces() {
+    let mut _a: [[std::ffi::c_int; 10]; 3] = [
+        [
+            1 as std::ffi::c_int,
+            2 as std::ffi::c_int,
+            3 as std::ffi::c_int,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ],
+        [0; 10],
+        [0; 10],
+    ];
+}
+#[no_mangle]
+pub unsafe extern "C" fn ptr_extra_braces() {
+    let mut _s: *const std::ffi::c_char = b"hello\0" as *const u8
+        as *const std::ffi::c_char;
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_extra_braces() {
+    let _s: [std::ffi::c_char; 10] = *::core::mem::transmute::<
+        &[u8; 10],
+        &[std::ffi::c_char; 10],
+    >(b"hello\0\0\0\0\0");
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_of_ptrs() {
+    let mut _s: [*const std::ffi::c_char; 3] = [
+        b"hello\0" as *const u8 as *const std::ffi::c_char,
+        0 as *const std::ffi::c_char,
+        0 as *const std::ffi::c_char,
+    ];
+}

--- a/c2rust-transpile/tests/snapshots/str_init.rs
+++ b/c2rust-transpile/tests/snapshots/str_init.rs
@@ -7,6 +7,17 @@
     unused_assignments,
     unused_mut
 )]
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct s {
+    pub entries: [[std::ffi::c_char; 10]; 3],
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct alpn_spec {
+    pub entries: [[std::ffi::c_char; 10]; 3],
+    pub count: std::ffi::c_uint,
+}
 #[no_mangle]
 pub unsafe extern "C" fn ptr() {
     let mut _s: *const std::ffi::c_char = b"hello\0" as *const u8
@@ -64,4 +75,65 @@ pub unsafe extern "C" fn array_of_ptrs() {
         0 as *const std::ffi::c_char,
         0 as *const std::ffi::c_char,
     ];
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_of_arrays() {
+    let mut _s: [[std::ffi::c_char; 10]; 3] = [
+        *::core::mem::transmute::<
+            &[u8; 10],
+            &mut [std::ffi::c_char; 10],
+        >(b"hello\0\0\0\0\0"),
+        [0; 10],
+        [0; 10],
+    ];
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_of_arrays_static() {
+    static mut _S: [[std::ffi::c_char; 10]; 3] = unsafe {
+        [
+            *::core::mem::transmute::<
+                &[u8; 10],
+                &[std::ffi::c_char; 10],
+            >(b"hello\0\0\0\0\0"),
+            [0; 10],
+            [0; 10],
+        ]
+    };
+}
+#[no_mangle]
+pub unsafe extern "C" fn array_of_arrays_static_struct() {
+    static mut _S: s = unsafe {
+        {
+            let mut init = s {
+                entries: [
+                    *::core::mem::transmute::<
+                        &[u8; 10],
+                        &mut [std::ffi::c_char; 10],
+                    >(b"hello\0\0\0\0\0"),
+                    [0; 10],
+                    [0; 10],
+                ],
+            };
+            init
+        }
+    };
+}
+#[no_mangle]
+pub unsafe extern "C" fn curl_alpn_spec() {
+    static mut _ALPN_SPEC_H11: alpn_spec = unsafe {
+        {
+            let mut init = alpn_spec {
+                entries: [
+                    *::core::mem::transmute::<
+                        &[u8; 10],
+                        &mut [std::ffi::c_char; 10],
+                    >(b"http/1.1\0\0"),
+                    [0; 10],
+                    [0; 10],
+                ],
+                count: 1 as std::ffi::c_int as std::ffi::c_uint,
+            };
+            init
+        }
+    };
 }

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -30,7 +30,7 @@ clap = { version = "3.2", features = ["derive"] }
 c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.20.0" }
 
 [dev-dependencies]
-insta = "1.15"
+insta = "1.43.1"
 
 [package.metadata.rust-analyzer] 
 rustc_private = true

--- a/pdg/src/main.rs
+++ b/pdg/src/main.rs
@@ -373,7 +373,7 @@ mod tests {
     fn analysis_tests_misc_pdg_snapshot_debug() -> eyre::Result<()> {
         init();
         let pdg = analysis_tests_misc_pdg_snapshot(Profile::Debug, Default::default())?;
-        insta::assert_display_snapshot!(pdg);
+        insta::assert_snapshot!(pdg);
         Ok(())
     }
 
@@ -381,7 +381,7 @@ mod tests {
     fn analysis_tests_misc_pdg_snapshot_release() -> eyre::Result<()> {
         init();
         let pdg = analysis_tests_misc_pdg_snapshot(Profile::Release, Default::default())?;
-        insta::assert_display_snapshot!(pdg);
+        insta::assert_snapshot!(pdg);
         Ok(())
     }
 


### PR DESCRIPTION
* Fixes #1264.

We need to handle the 4 cases in `str_init.c` with identical initializers:
* `ptr_extra_braces`
* `array_extra_braces`
* `array_of_ptrs`
* `array_of_arrays`

All 4 have different types, but the same initializer, which is possible because C allows extra braces around any initializer element.  For non-string literal elements, the clang AST already fixes this up, but doesn't for string literals, so we need to handle them specially.  The default logic handles all except `array_extra_braces`.

`array_extra_braces` is uniquely identified by:
* there being only one element in the initializer list
* the element type of the array being `CTypeKind::Char` (w/o this, `array_of_arrays` is included)
* the expr kind being a string literal (`CExprKind::Literal` of a `CLiteral::String`).