### PR TITLE
Translate C integer types to portable Rust types

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -2795,6 +2795,8 @@ constexpr size_t size(const _Tp (&)[_Sz]) noexcept {
 // parsed and string literals are always treated as constant.
 static std::vector<const char *> augment_argv(int argc, const char *argv[]) {
     const char *const extras[] = {
+        "-extra-arg=-fno-builtin-strlen",  // builtin strlen wrongly returns
+                                           // unsigned long despite declaration
         "-extra-arg=-fparse-all-comments", // always parse comments
         "-extra-arg=-Wwrite-strings",      // string literals are constant
         "-extra-arg=-D_FORTIFY_SOURCE=0",  // we don't want to use checked

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -2027,6 +2027,9 @@ impl ConversionContext {
                             "uintptr_t" => CTypeKind::UIntPtr,
                             // unlike `size_t`, `ssize_t` does not have a clang-provided `#define`.
                             "ssize_t" => CTypeKind::SSize,
+                            // macOS defines `ssize_t` from `__darwin_ssize_t` in many headers,
+                            // so we should handle `__darwin_ssize_t` itself.
+                            "__darwin_ssize_t" => CTypeKind::SSize,
                             "__uint8_t" => CTypeKind::UInt8,
                             "__uint16_t" => CTypeKind::UInt16,
                             "__uint32_t" => CTypeKind::UInt32,

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -1993,6 +1993,8 @@ impl ConversionContext {
                             "uintmax_t" => CTypeKind::UIntMax,
                             "intptr_t" => CTypeKind::IntPtr,
                             "uintptr_t" => CTypeKind::UIntPtr,
+                            // unlike `size_t`, `ssize_t` does not have a clang-provided `#define`.
+                            "ssize_t" => CTypeKind::SSize,
                             "__uint8_t" => CTypeKind::UInt8,
                             "__uint16_t" => CTypeKind::UInt16,
                             "__uint32_t" => CTypeKind::UInt32,

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -2037,6 +2037,15 @@ impl ConversionContext {
                             "__int32_t" => CTypeKind::Int32,
                             "__int64_t" => CTypeKind::Int64,
                             "__int128_t" => CTypeKind::Int128,
+                            // macOS stdint.h typedefs [u]intN_t directly:
+                            "int8_t" => CTypeKind::Int8,
+                            "int16_t" => CTypeKind::Int16,
+                            "int32_t" => CTypeKind::Int32,
+                            "int64_t" => CTypeKind::Int64,
+                            "uint8_t" => CTypeKind::UInt8,
+                            "uint16_t" => CTypeKind::UInt16,
+                            "uint32_t" => CTypeKind::UInt32,
+                            "uint64_t" => CTypeKind::UInt64,
                             _ => {
                                 log::debug!("Unknown fixed-size type typedef {name}!");
                                 return None;

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -695,6 +695,14 @@ impl ConversionContext {
                         CTypeKind::Function(ret, arguments, is_variadic, is_noreturn, has_proto);
                     self.add_type(new_id, not_located(function_ty));
                     self.processed_nodes.insert(new_id, FUNC_TYPE);
+
+                    // In addition to creating the function type for this node, ensure that a
+                    // corresponding function pointer type is created. We may need to reference this
+                    // type depending on how uses of functions of this type are translated.
+                    let pointer_ty = CTypeKind::Pointer(CQualTypeId::new(CTypeId(new_id)));
+                    let new_id = self.id_mapper.fresh_id();
+                    self.add_type(new_id, not_located(pointer_ty));
+                    self.processed_nodes.insert(new_id, OTHER_TYPE);
                 }
 
                 TypeTag::TagTypeOfType if expected_ty & TYPE != 0 => {

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -2060,6 +2060,12 @@ impl ConversionContext {
                                     .to_str()
                                     .map(|s| s.starts_with("__stddef_"))
                                     .unwrap_or(false)
+                            // for macos
+                                || filename == "_types.h"
+                                || filename
+                                    .to_str()
+                                    .map(|s| s.starts_with("_int") || s.starts_with("_uint"))
+                                    .unwrap_or(false)
                             {
                                 typ = id_for_name(&*name).unwrap_or(typ);
                             }

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -443,6 +443,14 @@ impl ConversionContext {
             self.typed_context.comments.push(comment);
         }
 
+        // Add Rust fixed-size types.
+        for rust_type_kind in CTypeKind::PULLBACK_KINDS {
+            let new_id = self.id_mapper.fresh_id();
+            self.add_type(new_id, not_located(rust_type_kind));
+            self.processed_nodes
+                .insert(new_id, self::node_types::OTHER_TYPE);
+        }
+
         // Continue popping Clang nodes off of the stack of nodes we have promised to visit
         while let Some((node_id, expected_ty)) = self.visit_as.pop() {
             // Check if we've already processed this node. If so, ascertain that it has the right

--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -285,7 +285,9 @@ fn immediate_type_children(kind: &CTypeKind) -> Vec<SomeId> {
         TypeOfExpr(e) => intos![e],
         Void | Bool | Short | Int | Long | LongLong | UShort | UInt | ULong | ULongLong | SChar
         | UChar | Char | Double | LongDouble | Float | Int128 | UInt128 | BuiltinFn | Half
-        | BFloat16 | UnhandledSveType | Float128 => {
+        | BFloat16 | UnhandledSveType | Float128 | Int8 | Int16 | Int32 | Int64 | IntPtr
+        | UInt8 | UInt16 | UInt32 | UInt64 | UIntPtr | IntMax | UIntMax | Size | SSize
+        | PtrDiff | WChar => {
             vec![]
         }
 

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -464,6 +464,12 @@ impl TypedAstContext {
         ty.map(|ty| (expr_id, ty))
     }
 
+    pub fn type_for_kind(&self, kind: &CTypeKind) -> Option<CTypeId> {
+        self.c_types
+            .iter()
+            .find_map(|(id, k)| if kind == &k.kind { Some(*id) } else { None })
+    }
+
     pub fn resolve_type_id(&self, typ: CTypeId) -> CTypeId {
         use CTypeKind::*;
         let ty = match self.index(typ).kind {
@@ -972,6 +978,7 @@ pub enum CDeclKind {
         name: String,
         typ: CQualTypeId,
         is_implicit: bool,
+        target_dependent_macro: Option<String>,
     },
 
     // Struct

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1431,6 +1431,37 @@ impl BinOp {
         }
     }
 
+    /// Does the rust equivalent of this operator have type (T, T) -> U?
+    #[rustfmt::skip]
+    pub fn input_types_same(&self) -> bool {
+        use BinOp::*;
+        self.all_types_same() || match self {
+            Less => true,
+            Greater => true,
+            LessEqual => true,
+            GreaterEqual => true,
+            EqualEqual => true,
+            NotEqual => true,
+
+            And => true,
+            Or => true,
+
+            AssignAdd => true,
+            AssignSubtract => true,
+            AssignMultiply => true,
+            AssignDivide => true,
+            AssignModulus => true,
+            AssignBitXor => true,
+            AssignShiftLeft => true,
+            AssignShiftRight => true,
+            AssignBitOr => true,
+            AssignBitAnd => true,
+
+            Assign => true,
+            _ => false,
+        }
+    }
+
     /// Does the rust equivalent of this operator have type (T, T) -> T?
     /// This ignores cases where one argument is a pointer and we translate to `.offset()`.
     pub fn all_types_same(&self) -> bool {

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -508,15 +508,17 @@ impl TypedAstContext {
     }
 
     /// Return the list of types for a list of declared function parameters.
+    ///
+    /// Returns `None` if one of the parameters is not a `CDeclKind::Variable`, e.g. if it was not a
+    /// function parameter but actually some other kind of declaration.
     pub fn tys_of_params(&self, parameters: &[CDeclId]) -> Option<Vec<CQualTypeId>> {
-        let mut param_tys = vec![];
-        for p in parameters {
-            match self.index(*p).kind {
-                CDeclKind::Variable { typ, .. } => param_tys.push(CQualTypeId::new(typ.ctype)),
-                _ => return None,
-            }
-        }
-        return Some(param_tys);
+        parameters
+            .iter()
+            .map(|p| match self.index(*p).kind {
+                CDeclKind::Variable { typ, .. } => Some(CQualTypeId::new(typ.ctype)),
+                _ => None,
+            })
+            .collect()
     }
 
     /// Return the most precise possible CTypeKind for the given function declaration.

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1751,9 +1751,35 @@ pub enum CTypeKind {
     Float128,
     // Atomic types (6.7.2.4)
     Atomic(CQualTypeId),
+
+    // Rust sized types, pullback'd into C so that we can treat uint16_t, etc. as real types.
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    IntPtr,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    UIntPtr,
+    IntMax,
+    UIntMax,
+    Size,
+    SSize,
+    PtrDiff,
+    WChar,
 }
 
 impl CTypeKind {
+    pub const PULLBACK_KINDS: [CTypeKind; 16] = {
+        use CTypeKind::*;
+        [
+            Int8, Int16, Int32, Int64, IntPtr, UInt8, UInt16, UInt32, UInt64, UIntPtr, IntMax,
+            UIntMax, Size, SSize, PtrDiff, WChar,
+        ]
+    };
+
     pub fn as_str(&self) -> &'static str {
         use CTypeKind::*;
         match self {
@@ -1778,6 +1804,24 @@ impl CTypeKind {
             Half => "half",
             BFloat16 => "bfloat16",
             Float128 => "__float128",
+
+            Int8 => "int8_t",
+            Int16 => "int16_t",
+            Int32 => "int32_t",
+            Int64 => "int64_t",
+            IntPtr => "intptr_t",
+            UInt8 => "uint8_t",
+            UInt16 => "uint16_t",
+            UInt32 => "uint32_t",
+            UInt64 => "uint64_t",
+            UIntPtr => "uintptr_t",
+            IntMax => "intmax_t",
+            UIntMax => "uintmax_t",
+            Size => "size_t",
+            SSize => "ssize_t",
+            PtrDiff => "ptrdiff_t",
+            WChar => "wchar_t",
+
             _ => unimplemented!("Printer::print_type({:?})", self),
         }
     }
@@ -1843,14 +1887,43 @@ impl CTypeKind {
         use CTypeKind::*;
         matches!(
             self,
-            Bool | UChar | UInt | UShort | ULong | ULongLong | UInt128
+            Bool | UChar
+                | UInt
+                | UShort
+                | ULong
+                | ULongLong
+                | UInt128
+                | UInt8
+                | UInt16
+                | UInt32
+                | UInt64
+                | UIntPtr
+                | UIntMax
+                | Size
+                | WChar
         )
     }
 
     pub fn is_signed_integral_type(&self) -> bool {
         use CTypeKind::*;
         // `Char` is true on the platforms we handle
-        matches!(self, Char | SChar | Int | Short | Long | LongLong | Int128)
+        matches!(
+            self,
+            Char | SChar
+                | Int
+                | Short
+                | Long
+                | LongLong
+                | Int128
+                | Int8
+                | Int16
+                | Int32
+                | Int64
+                | IntPtr
+                | IntMax
+                | SSize
+                | PtrDiff
+        )
     }
 
     pub fn is_floating_type(&self) -> bool {

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1396,6 +1396,24 @@ impl BinOp {
             Comma => ", ",
         }
     }
+
+    /// Does the rust equivalent of this operator have type (T, T) -> T?
+    /// This ignores cases where one argument is a pointer and we translate to `.offset()`.
+    pub fn all_types_same(&self) -> bool {
+        use BinOp::*;
+        match self {
+            Multiply => true,
+            Divide => true,
+            Modulus => true,
+            Add => true,
+            Subtract => true,
+
+            BitAnd => true,
+            BitXor => true,
+            BitOr => true,
+            _ => false,
+        }
+    }
 }
 
 impl Display for BinOp {

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -494,7 +494,7 @@ impl TypedAstContext {
 
     /// Extract decl of referenced function.
     /// Looks for ImplicitCast(FunctionToPointerDecay, DeclRef(function_decl))
-    pub fn function_declref_decl(&self, func_expr: CExprId) -> Option<&CDeclKind> {
+    pub fn fn_declref_decl(&self, func_expr: CExprId) -> Option<&CDeclKind> {
         use CastKind::FunctionToPointerDecay;
         if let CExprKind::ImplicitCast(_, fexp, FunctionToPointerDecay, _, _) = self[func_expr].kind
         {
@@ -544,12 +544,8 @@ impl TypedAstContext {
 
     /// Return the id of the most precise possible type for the function referenced by the given
     /// expression, if any.
-    pub fn function_declref_ty_with_declared_args(
-        &self,
-        func_expr: CExprId,
-    ) -> Option<CQualTypeId> {
-        if let Some(func_decl @ CDeclKind::Function { .. }) = self.function_declref_decl(func_expr)
-        {
+    pub fn fn_declref_ty_with_declared_args(&self, func_expr: CExprId) -> Option<CQualTypeId> {
+        if let Some(func_decl @ CDeclKind::Function { .. }) = self.fn_declref_decl(func_expr) {
             let kind_with_declared_args = self.fn_decl_ty_with_declared_args(func_decl);
             let specific_typ = self
                 .type_for_kind(&kind_with_declared_args)

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -808,7 +808,13 @@ impl TypedAstContext {
                                 && !self.ast_context[rhs_resolved].kind.is_pointer();
 
                             if op.all_types_same() && neither_ptr {
-                                Some(lhs_type_id)
+                                if CTypeKind::PULLBACK_KINDS
+                                    .contains(&self.ast_context[lhs_resolved].kind)
+                                {
+                                    Some(lhs_type_id)
+                                } else {
+                                    Some(rhs_type_id)
+                                }
                             } else if op == BinOp::ShiftLeft || op == BinOp::ShiftRight {
                                 Some(lhs_type_id)
                             } else {

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -333,6 +333,23 @@ impl TypeConverter {
             CTypeKind::UInt128 => Ok(mk().path_ty(mk().path(vec!["u128"]))),
             CTypeKind::BFloat16 => Ok(mk().path_ty(mk().path(vec!["bf16"]))),
 
+            CTypeKind::Int8 => Ok(mk().path_ty(mk().path(vec!["i8"]))),
+            CTypeKind::Int16 => Ok(mk().path_ty(mk().path(vec!["i16"]))),
+            CTypeKind::Int32 => Ok(mk().path_ty(mk().path(vec!["i32"]))),
+            CTypeKind::Int64 => Ok(mk().path_ty(mk().path(vec!["i64"]))),
+            CTypeKind::IntPtr => Ok(mk().path_ty(mk().path(vec!["isize"]))),
+            CTypeKind::UInt8 => Ok(mk().path_ty(mk().path(vec!["u8"]))),
+            CTypeKind::UInt16 => Ok(mk().path_ty(mk().path(vec!["u16"]))),
+            CTypeKind::UInt32 => Ok(mk().path_ty(mk().path(vec!["u32"]))),
+            CTypeKind::UInt64 => Ok(mk().path_ty(mk().path(vec!["u64"]))),
+            CTypeKind::UIntPtr => Ok(mk().path_ty(mk().path(vec!["usize"]))),
+            CTypeKind::IntMax => Ok(mk().path_ty(mk().path(vec!["libc", "intmax_t"]))),
+            CTypeKind::UIntMax => Ok(mk().path_ty(mk().path(vec!["libc", "uintmax_t"]))),
+            CTypeKind::Size => Ok(mk().path_ty(mk().path(vec!["usize"]))),
+            CTypeKind::SSize => Ok(mk().path_ty(mk().path(vec!["isize"]))),
+            CTypeKind::PtrDiff => Ok(mk().path_ty(mk().path(vec!["isize"]))),
+            CTypeKind::WChar => Ok(mk().path_ty(mk().path(vec!["libc", "wchar_t"]))),
+
             CTypeKind::Pointer(qtype) => self.convert_pointer(ctxt, qtype),
 
             CTypeKind::Elaborated(ref ctype) => self.convert(ctxt, *ctype),

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -811,7 +811,7 @@ impl<'c> Translation<'c> {
 
             // First, convert output expr if present
             let out_expr = if let Some((output_idx, out_expr)) = operand.out_expr {
-                let mut out_expr = self.convert_expr(ctx.used(), out_expr)?;
+                let mut out_expr = self.convert_expr(ctx.used(), out_expr, None)?;
                 stmts.append(out_expr.stmts_mut());
                 let mut out_expr = out_expr.into_value();
 
@@ -856,7 +856,7 @@ impl<'c> Translation<'c> {
 
             // Then, handle input expr if present
             let in_expr = if let Some((input_idx, in_expr)) = operand.in_expr {
-                let mut in_expr = self.convert_expr(ctx.used(), in_expr)?;
+                let mut in_expr = self.convert_expr(ctx.used(), in_expr, None)?;
                 stmts.append(in_expr.stmts_mut());
                 let mut in_expr = in_expr.into_value();
 

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -52,14 +52,14 @@ impl<'c> Translation<'c> {
         val2_id: Option<CExprId>,
         weak_id: Option<CExprId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let ptr = self.convert_expr(ctx.used(), ptr_id)?;
+        let ptr = self.convert_expr(ctx.used(), ptr_id, None)?;
         let order = self.convert_memordering(order_id);
         let val1 = val1_id
-            .map(|x| self.convert_expr(ctx.used(), x))
+            .map(|x| self.convert_expr(ctx.used(), x, None))
             .transpose()?;
         let order_fail = order_fail_id.and_then(|x| self.convert_memordering(x));
         let val2 = val2_id
-            .map(|x| self.convert_expr(ctx.used(), x))
+            .map(|x| self.convert_expr(ctx.used(), x, None))
             .transpose()?;
         let weak = weak_id.and_then(|x| self.convert_constant_bool(x));
 
@@ -179,7 +179,7 @@ impl<'c> Translation<'c> {
                         if name == "__atomic_exchange" {
                             // LLVM stores the ret pointer in the order_fail slot
                             order_fail_id
-                                .map(|x| self.convert_expr(ctx.used(), x))
+                                .map(|x| self.convert_expr(ctx.used(), x, None))
                                 .transpose()?
                                 .expect("__atomic_exchange must have a ret pointer argument")
                                 .and_then(|ret| {

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -714,7 +714,7 @@ impl<'c> Translation<'c> {
         method_name: &str,
         args: &[CExprId],
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let args = self.convert_exprs(ctx.used(), args)?;
+        let args = self.convert_exprs(ctx.used(), args, None)?;
         args.and_then(|args| {
             let [a, b, c]: [_; 3] = args
                 .try_into()
@@ -753,7 +753,7 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let name = &builtin_name[10..];
         let mem = mk().path_expr(vec!["libc", name]);
-        let args = self.convert_exprs(ctx.used(), args)?;
+        let args = self.convert_exprs(ctx.used(), args, None)?;
         args.and_then(|args| {
             if args.len() != arg_types.len() {
                 // This should not generally happen, as the C frontend checks these first

--- a/c2rust-transpile/src/translator/comments.rs
+++ b/c2rust-transpile/src/translator/comments.rs
@@ -1,5 +1,5 @@
 use super::Translation;
-use crate::c_ast::iterators::{NodeVisitor, SomeId};
+use crate::c_ast::iterators::{immediate_children_all_types, NodeVisitor, SomeId};
 use crate::c_ast::{CDeclId, CDeclKind, CommentContext, SrcLoc, TypedAstContext};
 use crate::rust_ast::comment_store::CommentStore;
 use crate::rust_ast::{pos_to_span, SpanExt};
@@ -69,6 +69,9 @@ impl<'c> CommentLocator<'c> {
 }
 
 impl<'c> NodeVisitor for CommentLocator<'c> {
+    fn children(&mut self, id: SomeId) -> Vec<SomeId> {
+        immediate_children_all_types(self.ast_context, id)
+    }
     fn pre(&mut self, mut id: SomeId) -> bool {
         // Don't traverse into unvisited top-level decls, we should visit those
         // in sorted order.
@@ -171,7 +174,7 @@ impl<'c> Translation<'c> {
                 top_decls: &top_decls,
                 last_id: None,
             };
-            visitor.visit_tree(&self.ast_context, SomeId::Decl(*decl_id));
+            visitor.visit_tree(SomeId::Decl(*decl_id));
         }
         self.spans = spans;
     }

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -72,14 +72,28 @@ impl<'c> Translation<'c> {
         mk().cast_expr(value, target_ty)
     }
 
+    /// Return whether the literal can be directly translated as this type. This does not check
+    /// that the literal fits into the type's range of values (as doing so is in general dependent
+    /// on the target platform), just that it is the appropriate kind for the type.
+    pub fn literal_kind_matches_ty(&self, lit: &CLiteral, ty: CQualTypeId) -> bool {
+        let ty_kind = &self.ast_context.resolve_type(ty.ctype).kind;
+        match *lit {
+            CLiteral::Integer(..) if ty_kind.is_integral_type() && !ty_kind.is_bool() => true,
+            // `convert_literal` always casts these to i32.
+            CLiteral::Character(..) => matches!(ty_kind, CTypeKind::Int32),
+            CLiteral::Floating(..) if ty_kind.is_floating_type() => true,
+            _ => false,
+        }
+    }
+
     /// Convert a C literal expression to a Rust expression
     pub fn convert_literal(
         &self,
         ctx: ExprContext,
         ty: CQualTypeId,
-        kind: &CLiteral,
+        lit: &CLiteral,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        match *kind {
+        match *lit {
             CLiteral::Integer(val, base) => Ok(WithStmts::new_val(self.mk_int_lit(ty, val, base)?)),
 
             CLiteral::Character(val) => {

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -181,7 +181,7 @@ impl<'c> Translation<'c> {
                 // Convert all of the provided initializer values
 
                 let to_array_element = |id: CExprId| -> TranslationResult<_> {
-                    self.convert_expr(ctx.used(), id)?.result_map(|x| {
+                    self.convert_expr(ctx.used(), id, None)?.result_map(|x| {
                         // Array literals require all of their elements to be
                         // the correct type; they will not use implicit casts to
                         // change mut to const. This becomes a problem when an
@@ -245,7 +245,7 @@ impl<'c> Translation<'c> {
                         // * `ptr_extra_braces`
                         // * `array_of_ptrs`
                         // * `array_of_arrays`
-                        self.convert_expr(ctx.used(), single)
+                        self.convert_expr(ctx.used(), single, None)
                     }
                     &[single] if is_zero_literal(single) && n > 1 => {
                         // This was likely a C array of the form `int x[16] = { 0 }`.
@@ -291,18 +291,18 @@ impl<'c> Translation<'c> {
             }
             CTypeKind::Pointer(_) => {
                 let id = ids.first().unwrap();
-                self.convert_expr(ctx.used(), *id)
+                self.convert_expr(ctx.used(), *id, None)
             }
             CTypeKind::Enum(_) => {
                 let id = ids.first().unwrap();
-                self.convert_expr(ctx.used(), *id)
+                self.convert_expr(ctx.used(), *id, None)
             }
             CTypeKind::Vector(CQualTypeId { ctype, .. }, len) => {
                 self.vector_list_initializer(ctx, ids, ctype, len)
             }
             ref kind if kind.is_integral_type() => {
                 let id = ids.first().unwrap();
-                self.convert_expr(ctx.used(), *id)
+                self.convert_expr(ctx.used(), *id, None)
             }
             ref t => Err(format_err!("Init list not implemented for {:?}", t).into()),
         }
@@ -330,7 +330,7 @@ impl<'c> Translation<'c> {
                         let val = if ids.is_empty() {
                             self.implicit_default_expr(field_ty.ctype, ctx.is_static)?
                         } else {
-                            self.convert_expr(ctx.used(), ids[0])?
+                            self.convert_expr(ctx.used(), ids[0], None)?
                         };
 
                         Ok(val.map(|v| {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2498,7 +2498,7 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<Vec<Stmt>> {
         // Function body scope
         self.with_scope(|| {
-            let (graph, store) = cfg::Cfg::from_stmts(self, ctx, body_ids, ret)?;
+            let (graph, store) = cfg::Cfg::from_stmts(self, ctx, body_ids, ret, None)?;
             self.convert_cfg(name, graph, store, IndexSet::new(), true)
         })
     }

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3182,6 +3182,8 @@ impl<'c> Translation<'c> {
         Ok(WithStmts::new_val(call))
     }
 
+    /// Convert multiple expressions (while collecting a context of statements) given either all or
+    /// none of their expected types
     #[allow(clippy::vec_box/*, reason = "not worth a substantial refactor"*/)]
     fn convert_exprs(
         &self,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3911,6 +3911,14 @@ impl<'c> Translation<'c> {
                         });
                     }
 
+                    // if the context wants a different type, add a cast
+                    if let Some(expected_ty) = override_ty {
+                        if expected_ty != qual_ty {
+                            let ty = self.convert_type(expected_ty.ctype)?;
+                            val = val.map(|v| mk().cast_expr(v, ty));
+                        }
+                    }
+
                     Ok(val)
                 }
             }

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4960,6 +4960,11 @@ impl<'c> Translation<'c> {
             Void | Char | SChar | UChar | Short | UShort | Int | UInt | Long | ULong | LongLong
             | ULongLong | Int128 | UInt128 | Half | BFloat16 | Float | Double | LongDouble
             | Float128 => {}
+            // other libc types
+            WChar | IntMax | UIntMax => {}
+            // Built-in Rust sized types
+            Int8 | Int16 | Int32 | Int64 | IntPtr | UInt8 | UInt16 | UInt32 | UInt64 | UIntPtr
+            | Size | SSize | PtrDiff => {}
             // Bool uses the bool type, so no dependency on libc
             Bool => {}
             Paren(ctype)

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3396,7 +3396,7 @@ impl<'c> Translation<'c> {
 
             OffsetOf(ty, ref kind) => match kind {
                 OffsetOfKind::Constant(val) => Ok(WithStmts::new_val(self.mk_int_lit(
-                    ty,
+                    override_ty.unwrap_or(ty),
                     *val,
                     IntBase::Dec,
                 )?)),
@@ -3453,7 +3453,7 @@ impl<'c> Translation<'c> {
                     ));
 
                     // Cast type
-                    let cast_ty = self.convert_type(ty.ctype)?;
+                    let cast_ty = self.convert_type(override_ty.unwrap_or(ty).ctype)?;
                     let cast_expr = mk().cast_expr(mac, cast_ty);
 
                     Ok(WithStmts::new_val(cast_expr))

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3507,7 +3507,7 @@ impl<'c> Translation<'c> {
             }
 
             Unary(type_id, op, arg, lrvalue) => {
-                self.convert_unary_operator(ctx, op, type_id, arg, lrvalue)
+                self.convert_unary_operator(ctx, op, override_ty.unwrap_or(type_id), arg, lrvalue)
             }
 
             Conditional(ty, cond, lhs, rhs) => {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3836,7 +3836,15 @@ impl<'c> Translation<'c> {
                     };
                     let args = self.convert_exprs(ctx.used(), args, arg_tys)?;
 
-                    let res: TranslationResult<_> = Ok(args.map(|args| mk().call_expr(func, args)));
+                    let mut call_expr = args.map(|args| mk().call_expr(func, args));
+                    if let Some(expected_ty) = override_ty {
+                        if call_expr_ty != expected_ty {
+                            let ret_ty = self.convert_type(expected_ty.ctype)?;
+                            call_expr = call_expr.map(|call| mk().cast_expr(call, ret_ty));
+                        }
+                    }
+
+                    let res: TranslationResult<_> = Ok(call_expr);
                     res
                 })?;
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3522,7 +3522,7 @@ impl<'c> Translation<'c> {
                     // If we're casting a function, look for its declared ty to use as a more
                     // precise source type. The AST node's type will not preserve typedef arg types
                     // but the function's declaration will.
-                    if let Some(func_decl) = self.ast_context.function_declref_decl(expr) {
+                    if let Some(func_decl) = self.ast_context.fn_declref_decl(expr) {
                         let kind_with_declared_args =
                             self.ast_context.fn_decl_ty_with_declared_args(func_decl);
                         let func_ty = self
@@ -3828,7 +3828,7 @@ impl<'c> Translation<'c> {
                 };
 
                 let mut arg_tys = if let Some(CDeclKind::Function { parameters, .. }) =
-                    self.ast_context.function_declref_decl(func)
+                    self.ast_context.fn_declref_decl(func)
                 {
                     self.ast_context.tys_of_params(parameters)
                 } else {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3382,6 +3382,13 @@ impl<'c> Translation<'c> {
                     val = mk().method_call_expr(val, "as_mut_ptr", vec![]);
                 }
 
+                // if the context wants a different type, add a cast
+                if let Some(expected_ty) = override_ty {
+                    if expected_ty != qual_ty {
+                        val = mk().cast_expr(val, self.convert_type(expected_ty.ctype)?);
+                    }
+                }
+
                 let mut res = WithStmts::new_val(val);
                 res.merge_unsafe(set_unsafe);
                 Ok(res)

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3496,11 +3496,7 @@ impl<'c> Translation<'c> {
                     return Ok(val);
                 }
 
-                let target_ty = if kind == CastKind::ArrayToPointerDecay {
-                    ty
-                } else {
-                    override_ty.unwrap_or(ty)
-                };
+                let target_ty = override_ty.unwrap_or(ty);
 
                 self.convert_cast(
                     ctx,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3495,10 +3495,17 @@ impl<'c> Translation<'c> {
                 if self.casting_simd_builtin_call(expr, is_explicit, kind) {
                     return Ok(val);
                 }
+
+                let target_ty = if kind == CastKind::ArrayToPointerDecay {
+                    ty
+                } else {
+                    override_ty.unwrap_or(ty)
+                };
+
                 self.convert_cast(
                     ctx,
                     source_ty,
-                    ty,
+                    target_ty,
                     val,
                     Some(expr),
                     Some(kind),
@@ -3587,7 +3594,15 @@ impl<'c> Translation<'c> {
             }
 
             Binary(type_id, op, lhs, rhs, opt_lhs_type_id, opt_res_type_id) => self
-                .convert_binary_expr(ctx, type_id, op, lhs, rhs, opt_lhs_type_id, opt_res_type_id)
+                .convert_binary_expr(
+                    ctx,
+                    override_ty.unwrap_or(type_id),
+                    op,
+                    lhs,
+                    rhs,
+                    opt_lhs_type_id,
+                    opt_res_type_id,
+                )
                 .map_err(|e| e.add_loc(self.ast_context.display_loc(src_loc))),
 
             ArraySubscript(_, ref lhs, ref rhs, _) => {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -506,6 +506,11 @@ pub fn translate(
         t.ast_context
             .prune_unwanted_decls(tcfg.preserve_unused_functions);
 
+        // Normalize AST types between Clang < 16 and later versions. Ensures that
+        // binary and unary operators' expr types agree with their argument types
+        // in the presence of typedefs.
+        t.ast_context.bubble_expr_types();
+
         enum Name<'a> {
             Var(&'a str),
             Type(&'a str),

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3778,7 +3778,7 @@ impl<'c> Translation<'c> {
                     _ => false,
                 };
 
-                let arg_tys = if let Some(CDeclKind::Function { parameters, .. }) =
+                let mut arg_tys = if let Some(CDeclKind::Function { parameters, .. }) =
                     self.ast_context.function_declref_decl(func)
                 {
                     self.ast_context.tys_of_params(parameters)
@@ -3834,10 +3834,12 @@ impl<'c> Translation<'c> {
                                     transmute_expr(mk().infer_ty(), target_ty, fn_ptr)
                                 })
                             }
-                            Some(_) => {
+                            Some(CTypeKind::Function(_, ty_arg_tys, ..)) => {
+                                arg_tys = Some(ty_arg_tys.clone());
                                 // Normal function pointer
                                 callee.map(unwrap_function_pointer)
                             }
+                            Some(_) => panic!("function pointer did not point to CTYpeKind::Function: {fn_ty:?}"),
                         }
                     }
                 };

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3169,10 +3169,13 @@ impl<'c> Translation<'c> {
         &self,
         ctx: ExprContext,
         exprs: &[CExprId],
+        arg_tys: Option<&[CQualTypeId]>,
     ) -> TranslationResult<WithStmts<Vec<Box<Expr>>>> {
+        assert!(arg_tys.map(|tys| tys.len() == exprs.len()).unwrap_or(true));
         exprs
             .iter()
-            .map(|arg| self.convert_expr(ctx, *arg, None))
+            .enumerate()
+            .map(|(n, arg)| self.convert_expr(ctx, *arg, arg_tys.map(|tys| tys[n])))
             .collect()
     }
 
@@ -3768,7 +3771,7 @@ impl<'c> Translation<'c> {
                     // We want to decay refs only when function is variadic
                     ctx.decay_ref = DecayRef::from(is_variadic);
 
-                    let args = self.convert_exprs(ctx.used(), args)?;
+                    let args = self.convert_exprs(ctx.used(), args, None)?;
 
                     let res: TranslationResult<_> = Ok(args.map(|args| mk().call_expr(func, args)));
                     res

--- a/c2rust-transpile/src/translator/named_references.rs
+++ b/c2rust-transpile/src/translator/named_references.rs
@@ -107,7 +107,7 @@ impl<'c> Translation<'c> {
             .get_qual_type()
             .ok_or_else(|| format_err!("bad reference type"))?;
         let read = |write| self.read(reference_ty, write);
-        let reference = self.convert_expr(ctx.used(), reference)?;
+        let reference = self.convert_expr(ctx.used(), reference, Some(reference_ty))?;
         reference.and_then(|reference| {
             if !uses_read && is_lvalue(&reference) {
                 Ok(WithStmts::new_val(NamedReference {

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -151,6 +151,8 @@ impl<'c> Translation<'c> {
                         };
                         lhs_type_id = ty;
                         rhs_type_id = ty;
+                    } else if matches!(op, ShiftLeft | ShiftRight) {
+                        lhs_type_id = type_id;
                     }
                 }
 

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -311,12 +311,7 @@ impl<'c> Translation<'c> {
         };
 
         if let Some(field_id) = bitfield_id {
-            let rhs_expr = if compute_lhs_type_id.ctype == initial_lhs_type_id.ctype {
-                rhs_translation.to_expr()
-            } else {
-                mk().cast_expr(rhs_translation.to_expr(), ty)
-            };
-
+            let rhs_expr = mk().cast_expr(rhs_translation.to_expr(), ty);
             return self.convert_bitfield_assignment_op_with_rhs(ctx, op, lhs, rhs_expr, *field_id);
         }
 

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -289,7 +289,7 @@ impl<'c> Translation<'c> {
             .ok_or_else(|| format_err!("bad initial lhs type"))?;
 
         // First, translate the rhs. Then, if it must match the lhs but doesn't, add a cast.
-        let mut rhs_translation = self.convert_expr(ctx.used(), rhs, None)?;
+        let mut rhs_translation = self.convert_expr(ctx.used(), rhs, Some(rhs_type_id))?;
         let lhs_rhs_types_must_match = {
             let lhs_resolved = self.ast_context.resolve_type_id(lhs_type_id.ctype);
             let rhs_resolved = self.ast_context.resolve_type_id(rhs_type_id.ctype);

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -127,6 +127,7 @@ impl<'c> Translation<'c> {
                 // case we don't want to homogenize arg types.
                 if !self.ast_context.index(lhs_resolved).kind.is_pointer()
                     && !self.ast_context.index(rhs_resolved).kind.is_pointer()
+                    && !self.ast_context.index(type_id.ctype).kind.is_pointer()
                 {
                     if op.all_types_same() {
                         // Ops like division and bitxor accept inputs of their expected result type.

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -279,6 +279,14 @@ impl<'c> Translation<'c> {
         compute_type: Option<CQualTypeId>,
         result_type: Option<CQualTypeId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
+        if op == c_ast::BinOp::Assign {
+            assert!(compute_type.is_none());
+            assert!(result_type.is_none());
+        } else {
+            assert!(compute_type.is_some());
+            assert!(result_type.is_some());
+        }
+
         let rhs_type_id = self
             .ast_context
             .index(rhs)

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -221,7 +221,7 @@ impl<'c> Translation<'c> {
                 .map(|arg| self.clean_int_or_vector_param(*arg)),
         );
 
-        let param_translation = self.convert_exprs(ctx.used(), &processed_args)?;
+        let param_translation = self.convert_exprs(ctx.used(), &processed_args, None)?;
         param_translation.and_then(|call_params| {
             let call = mk().call_expr(mk().ident_expr(fn_name), call_params);
 
@@ -297,7 +297,7 @@ impl<'c> Translation<'c> {
         ctype: CTypeId,
         len: usize,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let param_translation = self.convert_exprs(ctx, ids)?;
+        let param_translation = self.convert_exprs(ctx, ids, None)?;
         param_translation.and_then(|mut params| {
             // When used in a static, we cannot call the standard functions since they
             // are not const and so we are forced to transmute
@@ -384,8 +384,11 @@ impl<'c> Translation<'c> {
         }
 
         let mask_expr_id = self.get_shuffle_vector_mask(&child_expr_ids[2..])?;
-        let param_translation =
-            self.convert_exprs(ctx.used(), &[first_expr_id, second_expr_id, mask_expr_id])?;
+        let param_translation = self.convert_exprs(
+            ctx.used(),
+            &[first_expr_id, second_expr_id, mask_expr_id],
+            None,
+        )?;
         param_translation.and_then(|params| {
             let [first, second, third]: [_; 3] = params
                 .try_into()

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -525,8 +525,8 @@ impl<'a> Translation<'a> {
                     let field = init.map(|init| mk().field(field_name, init));
                     fields.push(field);
                 }
-                Both(field_id, (field_name, _, bitfield_width, use_inner_type)) => {
-                    let mut expr = self.convert_expr(ctx.used(), *field_id, None)?;
+                Both(field_id, (field_name, ty, bitfield_width, use_inner_type)) => {
+                    let mut expr = self.convert_expr(ctx.used(), *field_id, Some(ty))?;
 
                     if use_inner_type {
                         // See comment above

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -526,7 +526,7 @@ impl<'a> Translation<'a> {
                     fields.push(field);
                 }
                 Both(field_id, (field_name, _, bitfield_width, use_inner_type)) => {
-                    let mut expr = self.convert_expr(ctx.used(), *field_id)?;
+                    let mut expr = self.convert_expr(ctx.used(), *field_id, None)?;
 
                     if use_inner_type {
                         // See comment above

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -144,7 +144,7 @@ impl<'c> Translation<'c> {
         val_id: CExprId,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         if self.tcfg.translate_valist {
-            let val = self.convert_expr(ctx.expect_valistimpl().used(), val_id)?;
+            let val = self.convert_expr(ctx.expect_valistimpl().used(), val_id, None)?;
 
             // The current implementation of the C-variadics feature doesn't allow us to
             // return `Option<fn(...) -> _>` from `VaList::arg`, so we detect function pointers

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -94,6 +94,13 @@ fn transpile(platform: Option<&str>, c_path: &Path) {
     };
     insta::assert_snapshot!(snapshot_name, &rs, &debug_expr);
 
+    // Using rustc itself to build snapshots that reference libc is difficult because we don't know
+    // the appropriate --extern libc=/path/to/liblibc-XXXXXXXXXXXXXXXX.rlib to pass. Skip for now,
+    // as we've already compared the literal text.
+    if rs.contains("libc::") {
+        return;
+    }
+
     // Don't need to worry about platform clashes here, as this is immediately deleted.
     let rlib_path = format!("lib{crate_name}.rlib");
     let status = Command::new("rustc")

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -98,6 +98,10 @@ fn transpile(platform: Option<&str>, c_path: &Path) {
     // the appropriate --extern libc=/path/to/liblibc-XXXXXXXXXXXXXXXX.rlib to pass. Skip for now,
     // as we've already compared the literal text.
     if rs.contains("libc::") {
+        eprintln!(
+            "warning: skipping compiling {} with rustc since it depends on libc",
+            rs_path.display()
+        );
         return;
     }
 

--- a/c2rust-transpile/tests/snapshots/incomplete_arrays.c
+++ b/c2rust-transpile/tests/snapshots/incomplete_arrays.c
@@ -1,0 +1,5 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+extern uint32_t SOME_INTS[];

--- a/c2rust-transpile/tests/snapshots/os-specific/types.c
+++ b/c2rust-transpile/tests/snapshots/os-specific/types.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h> // for ptrdiff_t and ssize_t on Linux
+#include <sys/types.h> // for ssize_t on macOS
+
+int intvar = 0;
+
+size_t sizevar = 0;
+ssize_t ssizevar = 0;
+intptr_t intptrvar = 0;
+uintptr_t uintptrvar = 0;
+ptrdiff_t ptrdiffvar = 0;
+
+uint8_t uint8var = 0;
+uint16_t uint16var = 0;
+uint32_t uint32var = 0;
+uint64_t uint64var = 0;
+int8_t int8var = 0;
+int16_t int16var = 0;
+int32_t int32var = 0;
+int64_t int64var = 0;
+
+intmax_t maxvar = 0;
+uintmax_t umaxvar = 0;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@rnd.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@rnd.c.snap
@@ -20,15 +20,15 @@ pub type __uint32_t = std::ffi::c_uint;
 pub type int32_t = __int32_t;
 pub type uint32_t = __uint32_t;
 #[no_mangle]
-pub static mut cur_rand_seed: uint32_t = 0 as std::ffi::c_int as uint32_t;
+pub static mut cur_rand_seed: uint32_t = 0 as uint32_t;
 #[no_mangle]
 pub unsafe extern "C" fn set_rand_seed(mut s: uint32_t) {
     cur_rand_seed = s;
 }
 #[no_mangle]
 pub unsafe extern "C" fn get_rand_seed() -> uint32_t {
-    let INCREMENT: uint32_t = 1 as std::ffi::c_int as uint32_t;
-    let MULTIPLIER: uint32_t = 0x15a4e35 as std::ffi::c_int as uint32_t;
+    let INCREMENT: uint32_t = 1 as uint32_t;
+    let MULTIPLIER: uint32_t = 0x15a4e35 as uint32_t;
     cur_rand_seed = MULTIPLIER
         .wrapping_mul(cur_rand_seed)
         .wrapping_add(INCREMENT);

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@rnd.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@rnd.c.snap
@@ -13,7 +13,7 @@ input_file: c2rust-transpile/tests/snapshots/os-specific/rnd.c
     unused_mut
 )]
 extern "C" {
-    fn abs(_: std::ffi::c_int) -> std::ffi::c_int;
+    fn abs(__x: std::ffi::c_int) -> std::ffi::c_int;
 }
 pub type __int32_t = i32;
 pub type __uint32_t = u32;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@rnd.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@rnd.c.snap
@@ -15,8 +15,8 @@ input_file: c2rust-transpile/tests/snapshots/os-specific/rnd.c
 extern "C" {
     fn abs(_: std::ffi::c_int) -> std::ffi::c_int;
 }
-pub type __int32_t = std::ffi::c_int;
-pub type __uint32_t = std::ffi::c_uint;
+pub type __int32_t = i32;
+pub type __uint32_t = u32;
 pub type int32_t = __int32_t;
 pub type uint32_t = __uint32_t;
 #[no_mangle]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@rnd.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@rnd.c.snap
@@ -32,6 +32,6 @@ pub unsafe extern "C" fn get_rand_seed() -> uint32_t {
     cur_rand_seed = MULTIPLIER
         .wrapping_mul(cur_rand_seed)
         .wrapping_add(INCREMENT);
-    let mut ret: uint32_t = abs(cur_rand_seed as int32_t) as uint32_t;
+    let mut ret: uint32_t = abs(cur_rand_seed as std::ffi::c_int) as uint32_t;
     return ret;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@types.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@types.c.snap
@@ -1,0 +1,71 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+assertion_line: 69
+expression: cat tests/snapshots/platform-specific/types.rs
+input_file: c2rust-transpile/tests/snapshots/platform-specific/types.c
+---
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+pub type size_t = usize;
+pub type __int8_t = i8;
+pub type __uint8_t = u8;
+pub type __int16_t = i16;
+pub type __uint16_t = u16;
+pub type __int32_t = i32;
+pub type __uint32_t = u32;
+pub type __int64_t = i64;
+pub type __uint64_t = u64;
+pub type ssize_t = isize;
+pub type int8_t = __int8_t;
+pub type int16_t = __int16_t;
+pub type int32_t = __int32_t;
+pub type int64_t = __int64_t;
+pub type uint8_t = __uint8_t;
+pub type uint16_t = __uint16_t;
+pub type uint32_t = __uint32_t;
+pub type uint64_t = __uint64_t;
+pub type intptr_t = isize;
+pub type uintptr_t = usize;
+pub type intmax_t = libc::intmax_t;
+pub type uintmax_t = libc::uintmax_t;
+pub type ptrdiff_t = isize;
+#[no_mangle]
+pub static mut intvar: std::ffi::c_int = 0 as std::ffi::c_int;
+#[no_mangle]
+pub static mut sizevar: size_t = 0 as size_t;
+#[no_mangle]
+pub static mut ssizevar: ssize_t = 0 as ssize_t;
+#[no_mangle]
+pub static mut intptrvar: intptr_t = 0 as intptr_t;
+#[no_mangle]
+pub static mut uintptrvar: uintptr_t = 0 as uintptr_t;
+#[no_mangle]
+pub static mut ptrdiffvar: ptrdiff_t = 0 as ptrdiff_t;
+#[no_mangle]
+pub static mut uint8var: uint8_t = 0 as uint8_t;
+#[no_mangle]
+pub static mut uint16var: uint16_t = 0 as uint16_t;
+#[no_mangle]
+pub static mut uint32var: uint32_t = 0 as uint32_t;
+#[no_mangle]
+pub static mut uint64var: uint64_t = 0 as uint64_t;
+#[no_mangle]
+pub static mut int8var: int8_t = 0 as int8_t;
+#[no_mangle]
+pub static mut int16var: int16_t = 0 as int16_t;
+#[no_mangle]
+pub static mut int32var: int32_t = 0 as int32_t;
+#[no_mangle]
+pub static mut int64var: int64_t = 0 as int64_t;
+#[no_mangle]
+pub static mut maxvar: intmax_t = 0 as intmax_t;
+#[no_mangle]
+pub static mut umaxvar: uintmax_t = 0 as uintmax_t;
+

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@rnd.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@rnd.c.snap
@@ -30,6 +30,6 @@ pub unsafe extern "C" fn get_rand_seed() -> uint32_t {
     cur_rand_seed = MULTIPLIER
         .wrapping_mul(cur_rand_seed)
         .wrapping_add(INCREMENT);
-    let mut ret: uint32_t = abs(cur_rand_seed as int32_t) as uint32_t;
+    let mut ret: uint32_t = abs(cur_rand_seed as std::ffi::c_int) as uint32_t;
     return ret;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@rnd.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@rnd.c.snap
@@ -15,8 +15,8 @@ input_file: c2rust-transpile/tests/snapshots/os-specific/rnd.c
 extern "C" {
     fn abs(_: std::ffi::c_int) -> std::ffi::c_int;
 }
-pub type int32_t = std::ffi::c_int;
-pub type uint32_t = std::ffi::c_uint;
+pub type int32_t = i32;
+pub type uint32_t = u32;
 #[no_mangle]
 pub static mut cur_rand_seed: uint32_t = 0 as uint32_t;
 #[no_mangle]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@rnd.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@rnd.c.snap
@@ -18,15 +18,15 @@ extern "C" {
 pub type int32_t = std::ffi::c_int;
 pub type uint32_t = std::ffi::c_uint;
 #[no_mangle]
-pub static mut cur_rand_seed: uint32_t = 0 as std::ffi::c_int as uint32_t;
+pub static mut cur_rand_seed: uint32_t = 0 as uint32_t;
 #[no_mangle]
 pub unsafe extern "C" fn set_rand_seed(mut s: uint32_t) {
     cur_rand_seed = s;
 }
 #[no_mangle]
 pub unsafe extern "C" fn get_rand_seed() -> uint32_t {
-    let INCREMENT: uint32_t = 1 as std::ffi::c_int as uint32_t;
-    let MULTIPLIER: uint32_t = 0x15a4e35 as std::ffi::c_int as uint32_t;
+    let INCREMENT: uint32_t = 1 as uint32_t;
+    let MULTIPLIER: uint32_t = 0x15a4e35 as uint32_t;
     cur_rand_seed = MULTIPLIER
         .wrapping_mul(cur_rand_seed)
         .wrapping_add(INCREMENT);

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@types.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@types.c.snap
@@ -1,0 +1,66 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+assertion_line: 69
+expression: cat tests/snapshots/platform-specific/types.rs
+input_file: c2rust-transpile/tests/snapshots/platform-specific/types.c
+---
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+pub type __darwin_ptrdiff_t = isize;
+pub type __darwin_size_t = usize;
+pub type __darwin_ssize_t = isize;
+pub type int8_t = i8;
+pub type int16_t = i16;
+pub type int32_t = i32;
+pub type int64_t = i64;
+pub type intptr_t = isize;
+pub type uintptr_t = usize;
+pub type size_t = __darwin_size_t;
+pub type uint8_t = u8;
+pub type uint16_t = u16;
+pub type uint32_t = u32;
+pub type uint64_t = u64;
+pub type intmax_t = libc::intmax_t;
+pub type uintmax_t = libc::uintmax_t;
+pub type ptrdiff_t = __darwin_ptrdiff_t;
+pub type ssize_t = __darwin_ssize_t;
+#[no_mangle]
+pub static mut intvar: std::ffi::c_int = 0 as std::ffi::c_int;
+#[no_mangle]
+pub static mut sizevar: size_t = 0 as size_t;
+#[no_mangle]
+pub static mut ssizevar: ssize_t = 0 as ssize_t;
+#[no_mangle]
+pub static mut intptrvar: intptr_t = 0 as intptr_t;
+#[no_mangle]
+pub static mut uintptrvar: uintptr_t = 0 as uintptr_t;
+#[no_mangle]
+pub static mut ptrdiffvar: ptrdiff_t = 0 as ptrdiff_t;
+#[no_mangle]
+pub static mut uint8var: uint8_t = 0 as uint8_t;
+#[no_mangle]
+pub static mut uint16var: uint16_t = 0 as uint16_t;
+#[no_mangle]
+pub static mut uint32var: uint32_t = 0 as uint32_t;
+#[no_mangle]
+pub static mut uint64var: uint64_t = 0 as uint64_t;
+#[no_mangle]
+pub static mut int8var: int8_t = 0 as int8_t;
+#[no_mangle]
+pub static mut int16var: int16_t = 0 as int16_t;
+#[no_mangle]
+pub static mut int32var: int32_t = 0 as int32_t;
+#[no_mangle]
+pub static mut int64var: int64_t = 0 as int64_t;
+#[no_mangle]
+pub static mut maxvar: intmax_t = 0 as intmax_t;
+#[no_mangle]
+pub static mut umaxvar: uintmax_t = 0 as uintmax_t;
+

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn entry() {
     >(b"abc\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
     let mut past_end: *mut std::ffi::c_char = &mut *simple
         .as_mut_ptr()
-        .offset(::core::mem::size_of::<[std::ffi::c_char; 9]>() as std::ffi::c_ulong as isize)
+        .offset(::core::mem::size_of::<[std::ffi::c_char; 9]>() as isize)
         as *mut std::ffi::c_char;
     past_end = &mut *foo.offset(8 as std::ffi::c_int as isize) as *mut std::ffi::c_char;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn short_initializer() {
     let mut excess_elements_2: [std::ffi::c_int; 0] = [0; 0];
     let mut single_struct: [C2RustUnnamed_2; 1] = [{
         let mut init = C2RustUnnamed_2 {
-            x: 1 as std::ffi::c_int as std::ffi::c_short,
+            x: 1 as std::ffi::c_short,
             y: 2 as std::ffi::c_int,
         };
         init
@@ -102,7 +102,7 @@ pub unsafe extern "C" fn short_initializer() {
     let mut many_struct: [C2RustUnnamed_1; 3] = [
         {
             let mut init = C2RustUnnamed_1 {
-                x: 1 as std::ffi::c_int as std::ffi::c_short,
+                x: 1 as std::ffi::c_short,
                 y: 2 as std::ffi::c_int,
             };
             init

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@factorial.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@factorial.c.snap
@@ -14,8 +14,8 @@ input_file: c2rust-transpile/tests/snapshots/factorial.c
 )]
 #[no_mangle]
 pub unsafe extern "C" fn factorial(mut n: std::ffi::c_ushort) -> std::ffi::c_ushort {
-    let mut result: std::ffi::c_ushort = 1 as std::ffi::c_int as std::ffi::c_ushort;
-    let mut i: std::ffi::c_ushort = 1 as std::ffi::c_int as std::ffi::c_ushort;
+    let mut result: std::ffi::c_ushort = 1 as std::ffi::c_ushort;
+    let mut i: std::ffi::c_ushort = 1 as std::ffi::c_ushort;
     while (i as std::ffi::c_int) < n as std::ffi::c_int {
         result = (result as std::ffi::c_int * i as std::ffi::c_int) as std::ffi::c_ushort;
         i = i.wrapping_add(1);

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@incomplete_arrays.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@incomplete_arrays.c.snap
@@ -1,0 +1,16 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+assertion_line: 80
+expression: cat tests/snapshots/incomplete_arrays.rs
+input_file: c2rust-transpile/tests/snapshots/incomplete_arrays.c
+---
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn curl_alpn_spec() {
                     [0; 10],
                     [0; 10],
                 ],
-                count: 1 as std::ffi::c_int as std::ffi::c_uint,
+                count: 1 as std::ffi::c_uint,
             };
             init
         }

--- a/tests/arrays/Cargo.toml
+++ b/tests/arrays/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+libc = "0.2"


### PR DESCRIPTION
This substantially improves our fidelity of type translation for common integral types. We now recognize types like `size_t` and `uint8_t` and convert them to the appropriate platform-independent Rust types. This is nontrivial because C-the-language does not have exact-width types and instead defines them via platform-dependent mappings to types with platform-dependent sizes, such as `unsigned long` and `unsigned char`. We have to preëmpt Clang to introduce a distinction between these types and "native" C ones when we convert the AST after exporting; to make effective use of this type information in translation we need to pass the expected type of the translated expression downward through conversion of expressions and statements.