### PR TITLE
More driveby cleanups

### DIFF
--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -230,9 +230,15 @@ pub struct ConversionContext {
     visit_as: Vec<(ClangId, NodeType)>,
 
     /// Typed context we are building up during the conversion
-    pub typed_context: TypedAstContext,
+    typed_context: TypedAstContext,
 
     pub invalid_clang_ast: bool,
+}
+
+impl ConversionContext {
+    pub fn into_typed_context(self) -> TypedAstContext {
+        self.typed_context
+    }
 }
 
 fn display_loc(ctx: &AstContext, loc: &Option<SrcSpan>) -> Option<DisplaySrcSpan> {

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1652,7 +1652,7 @@ pub enum CTypeKind {
     // Function type (6.7.5.3)
     //
     // Note a function taking no arguments should have one `void` argument. Functions without any
-    // arguments and in K&R format.
+    // arguments are in K&R format.
     // Flags: is_variable_argument, is_noreturn, has prototype
     Function(CQualTypeId, Vec<CQualTypeId>, bool, bool, bool),
 

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -528,7 +528,7 @@ fn transpile_single(
         if conv.invalid_clang_ast && tcfg.fail_on_error {
             panic!("Clang AST was invalid");
         }
-        conv.typed_context
+        conv.into_typed_context()
     };
 
     if tcfg.dump_typed_context {

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -233,6 +233,7 @@ impl<'c> Translation<'c> {
         }
     }
 
+    /// Translate an assignment binary operator
     fn convert_assignment_operator(
         &self,
         ctx: ExprContext,
@@ -262,7 +263,7 @@ impl<'c> Translation<'c> {
         )
     }
 
-    /// Translate an assignment binary operator
+    /// Translate an assignment binary operator, provided a pre-translated RHS expression
     fn convert_assignment_operator_with_rhs(
         &self,
         ctx: ExprContext,

--- a/c2rust/src/bin/c2rust-transpile.rs
+++ b/c2rust/src/bin/c2rust-transpile.rs
@@ -238,10 +238,15 @@ fn main() {
             panic!("Compile commands JSON and multiple sources provided.
                 Exactly one compile_commands.json file should be provided, or a list of source files, but not both.");
         }
+        let cc_json_path = &args.compile_commands[0];
         // Only one file provided and it's a JSON file
-        match fs::canonicalize(&args.compile_commands[0]) {
+        match fs::canonicalize(cc_json_path) {
             Ok(canonical_path) => canonical_path,
-            Err(e) => panic!("Failed to canonicalize path: {:?}", e),
+            Err(e) => panic!(
+                "Failed to canonicalize path {}: {:?}",
+                cc_json_path.display(),
+                e
+            ),
         }
     } else {
         // Handle as a list of source files


### PR DESCRIPTION
No semantic changes except for an improved error message when the `compile_commands.json` passed an as argument does not exist.