### PR TITLE
Add `tests/requirements.txt` dependencies into nix python environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,24 @@
                 llvmPackages_14.llvm
                 llvmPackages_14.libllvm
                 openssl
-                python3
+                (python3.withPackages
+                  (python-pkgs:
+                    with python-pkgs;
+                    [ "bencode-python3"
+                      cbor
+                      colorlog
+                      mako
+                      pip
+                      plumbum
+                      psutil
+                      pygments
+                      typing
+                      "scan-build"
+                      pyyaml
+                      toml
+                    ]
+                  )
+                )
                 zlib
                 (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
               ];


### PR DESCRIPTION
The nix development environment was missing some python packages, which meant it couldn't run some of the test scripts, e.g.:

```
./scripts/test_translator.py -d tests
```

This makes sure the necessary libraries from `tests/requirements.txt` are included. There may be better ways to do this (e.g., using something like https://github.com/nix-community/pip2nix to generate this automatically), but I'm not too familiar with the python ecosystem, and this seemed like a simpler solution for now.

Thanks!