### PR TITLE
Upgrade to Syn 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "log",
- "prettyplease 0.2.32",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -289,9 +289,9 @@ name = "c2rust-ast-printer"
 version = "0.20.0"
 dependencies = [
  "log",
- "prettyplease 0.1.25",
+ "prettyplease",
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1163,16 +1163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ name = "c2rust-ast-builder"
 version = "0.20.0"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -387,7 +387,7 @@ dependencies = [
  "smallvec",
  "strum",
  "strum_macros",
- "syn 1.0.109",
+ "syn 2.0.101",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ version = "0.20.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/c2rust-ast-builder/Cargo.toml
+++ b/c2rust-ast-builder/Cargo.toml
@@ -13,4 +13,4 @@ categories.workspace = true
 
 [dependencies]
 proc-macro2 = { version = "1.0", features = ["span-locations"]}
-syn = { version = "1.0", features = ["full", "extra-traits", "printing", "clone-impls"]}
+syn = { version = "2.0", features = ["full", "extra-traits", "printing", "clone-impls"]}

--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -500,6 +500,36 @@ impl Make<Signature> for Box<FnDecl> {
     }
 }
 
+impl Make<String> for i32 {
+    fn make(self, mk: &Builder) -> String {
+        (self as i128).make(mk)
+    }
+}
+
+impl Make<String> for i64 {
+    fn make(self, mk: &Builder) -> String {
+        (self as i128).make(mk)
+    }
+}
+
+impl Make<String> for u64 {
+    fn make(self, mk: &Builder) -> String {
+        (self as u128).make(mk)
+    }
+}
+
+impl Make<String> for i128 {
+    fn make(self, _mk: &Builder) -> String {
+        self.to_string()
+    }
+}
+
+impl Make<String> for u128 {
+    fn make(self, _mk: &Builder) -> String {
+        self.to_string()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Builder {
     // The builder holds a set of "modifiers", such as visibility and mutability.  Functions for
@@ -1067,8 +1097,12 @@ impl Builder {
         Lit::Int(LitInt::new(&format!("{}{}", i, ty), self.span))
     }
 
-    pub fn int_unsuffixed_lit(self, i: u128) -> Lit {
-        Lit::Int(LitInt::new(&format!("{}", i), self.span))
+    pub fn int_unsuffixed_lit<S>(self, s: S) -> Lit
+    where
+        S: Make<String>,
+    {
+        let s = s.make(&self);
+        Lit::Int(LitInt::new(&s, self.span))
     }
 
     pub fn float_lit(self, s: &str, ty: &str) -> Lit {

--- a/c2rust-ast-printer/Cargo.toml
+++ b/c2rust-ast-printer/Cargo.toml
@@ -13,6 +13,6 @@ categories.workspace = true
 
 [dependencies]
 log = "0.4"
-syn = { version = "1.0", features = ["full", "proc-macro", "printing", "clone-impls"] }
+syn = { version = "2.0", features = ["full", "proc-macro", "printing", "clone-impls"] }
 proc-macro2 = "1.0"
-prettyplease = "0.1.9"
+prettyplease = "0.2"

--- a/c2rust-ast-printer/src/pprust.rs
+++ b/c2rust-ast-printer/src/pprust.rs
@@ -143,7 +143,7 @@ fn ret_expr() -> syn::Expr {
 }
 
 pub fn expr_to_string(e: &syn::Expr) -> String {
-    let s = to_string(move || minimal_file(syn::Stmt::Expr(e.clone())));
+    let s = to_string(move || minimal_file(syn::Stmt::Expr(e.clone(), None)));
     strip_main_fn(&s).trim_end_matches(';').to_owned()
 }
 
@@ -161,17 +161,17 @@ pub fn pat_to_string(p: &syn::Pat) -> String {
     let e = syn::Expr::Let(syn::ExprLet {
         attrs: vec![],
         let_token: Default::default(),
-        pat: p.clone(),
+        pat: Box::new(p.clone()),
         eq_token: Default::default(),
         expr: ret_expr,
     });
     let expr_str = expr_to_string(&e);
     expr_str
-        .trim_start_matches("let")
+        .trim_start_matches("(let")
         .trim_start()
         .trim_end()
         .trim_end_matches(';')
-        .trim_end_matches("return")
+        .trim_end_matches("return)")
         .trim_end()
         .trim_end_matches('=')
         .trim_end()

--- a/c2rust-ast-printer/src/pprust/tests.rs
+++ b/c2rust-ast-printer/src/pprust/tests.rs
@@ -28,6 +28,6 @@ fn test_path_to_string() {
 
 #[test]
 fn test_stmt_to_string() {
-    let stmt = syn::Stmt::Semi(ret_expr(), Default::default());
+    let stmt = syn::Stmt::Expr(ret_expr(), Some(syn::token::Semi::default()));
     assert_eq!(stmt_to_string(&stmt), "return;");
 }

--- a/c2rust-bitfields-derive/Cargo.toml
+++ b/c2rust-bitfields-derive/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 
 [dependencies]
 proc-macro2 = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 
 [lib]

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = "1.0"
 smallvec = "1.0"
 strum = "0.24"
 strum_macros = "0.24"
-syn = { version = "1.0", features = ["full", "extra-traits", "parsing", "printing"]}
+syn = { version = "2.0", features = ["full", "extra-traits", "parsing", "printing"]}
 tempfile = "3.5.0"
 
 [features]

--- a/c2rust-transpile/src/cfg/inc_cleanup.rs
+++ b/c2rust-transpile/src/cfg/inc_cleanup.rs
@@ -33,7 +33,7 @@ impl IncCleanup {
 
         let mut removed_tail_expr = false;
 
-        if let Stmt::Expr(expr, _) = &mut stmt {
+        if let Stmt::Expr(expr, None) = &mut stmt {
             match expr {
                 Expr::If(ExprIf {
                     cond: _,
@@ -74,7 +74,7 @@ impl IncCleanup {
     }
 
     fn is_idempotent_tail_expr(&self, stmt: &Stmt) -> bool {
-        let tail_expr = if let Stmt::Expr(expr, _token) = stmt {
+        let tail_expr = if let Stmt::Expr(expr, Some(_token)) = stmt {
             expr
         } else {
             return false;
@@ -151,7 +151,7 @@ fn cleanup_if(stmt: Stmt) -> Stmt {
                 );
             } else if block.stmts.len() == 1 {
                 // flatten nested if expression to else if chain
-                if let Stmt::Expr(Expr::If(nested_if_expr), _semi) = &block.stmts[0] {
+                if let Stmt::Expr(Expr::If(nested_if_expr), None) = &block.stmts[0] {
                     return Stmt::Expr(
                         Expr::If(ExprIf {
                             cond: cond.clone(),

--- a/c2rust-transpile/src/cfg/inc_cleanup.rs
+++ b/c2rust-transpile/src/cfg/inc_cleanup.rs
@@ -131,7 +131,7 @@ fn cleanup_if(stmt: Stmt) -> Stmt {
             else_branch: Some((token, else_)),
             ..
         }),
-        _semi,
+        None,
     ) = &stmt
     {
         if let Expr::Block(ExprBlock {

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -30,6 +30,7 @@ use std::io;
 use std::io::Write;
 use std::ops::Deref;
 use std::ops::Index;
+use syn::Lit;
 use syn::{spanned::Spanned, Arm, Expr, Pat, Stmt};
 
 use failure::format_err;
@@ -91,6 +92,17 @@ impl Label {
 
     fn to_string_expr(&self) -> Box<Expr> {
         mk().lit_expr(self.debug_print())
+    }
+
+    fn to_int_lit(&self) -> Lit {
+        let mut s = DefaultHasher::new();
+        self.hash(&mut s);
+        let as_num = s.finish();
+        mk().int_lit(as_num as u128, "")
+    }
+
+    fn to_string_lit(&self) -> Lit {
+        mk().str_lit(&self.debug_print())
     }
 }
 
@@ -1835,7 +1847,8 @@ impl CfgBuilder {
                             .to_pure_expr()
                         {
                             Some(expr) => match *expr {
-                                Expr::Lit(..) | Expr::Path(..) => Some(expr),
+                                Expr::Lit(lit) => Some(mk().lit_pat(lit.lit)),
+                                Expr::Path(path) => Some(mk().path_pat(path.path, path.qself)),
                                 _ => None,
                             },
                             _ => None,
@@ -1843,10 +1856,15 @@ impl CfgBuilder {
                     }
                     _ => None,
                 };
-                let branch = match branch {
-                    Some(expr) => expr,
-                    None => translator.convert_constant(cie)?,
+
+                let pat = match branch {
+                    Some(pat) => pat,
+                    None => match cie {
+                        ConstIntExpr::U(n) => mk().lit_pat(mk().int_unsuffixed_lit(n as u128)),
+                        ConstIntExpr::I(n) => mk().lit_pat(mk().int_unsuffixed_lit(n as u128)),
+                    },
                 };
+
                 self.switch_expr_cases
                     .last_mut()
                     .ok_or_else(|| {
@@ -1856,7 +1874,7 @@ impl CfgBuilder {
                         )
                     })?
                     .cases
-                    .push((mk().lit_pat(branch), this_label.clone()));
+                    .push((pat, this_label.clone()));
 
                 // Sub stmt
                 let sub_stmt_next =

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -1860,8 +1860,8 @@ impl CfgBuilder {
                 let pat = match branch {
                     Some(pat) => pat,
                     None => match cie {
-                        ConstIntExpr::U(n) => mk().lit_pat(mk().int_unsuffixed_lit(n as u128)),
-                        ConstIntExpr::I(n) => mk().lit_pat(mk().int_unsuffixed_lit(n as u128)),
+                        ConstIntExpr::U(n) => mk().lit_pat(mk().int_unsuffixed_lit(n)),
+                        ConstIntExpr::I(n) => mk().lit_pat(mk().int_unsuffixed_lit(n)),
                     },
                 };
 

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -530,7 +530,7 @@ impl StructureState {
                     }
                     (false, false) => {
                         fn is_expr(kind: &Stmt) -> bool {
-                            matches!(kind, Stmt::Expr(Expr::If(..) | Expr::Block(..), _semi))
+                            matches!(kind, Stmt::Expr(Expr::If(..) | Expr::Block(..), None))
                         }
 
                         // Do the else statements contain a single If, IfLet or
@@ -542,7 +542,7 @@ impl StructureState {
                             let stmt_expr = els_stmts.swap_remove(0);
                             let stmt_expr_span = stmt_expr.span();
                             let mut els_expr = match stmt_expr {
-                                Stmt::Expr(e, _semi) => e,
+                                Stmt::Expr(e, None) => e,
                                 _ => panic!("is_els_expr out of sync"),
                             };
                             els_expr.set_span(stmt_expr_span);
@@ -605,7 +605,7 @@ impl StructureState {
                 let (body, body_span) = self.to_stmt(*body, comment_store);
 
                 // TODO: this is ugly but it needn't be. We are just pattern matching on particular ASTs.
-                if let Some(stmt @ &Stmt::Expr(ref expr, _semi)) = body.first() {
+                if let Some(stmt @ &Stmt::Expr(ref expr, None)) = body.first() {
                     let stmt_span = stmt.span();
                     let span = if !stmt_span.is_dummy() {
                         stmt_span
@@ -625,7 +625,7 @@ impl StructureState {
                                 expr: None,
                                 ..
                             }),
-                            _token,
+                            Some(_),
                         )] = then_branch.stmts.as_slice()
                         {
                             let e = mk().while_expr(

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -246,7 +246,7 @@ impl TypeConverter {
             Some(ret) => self.convert(ctxt, ret.ctype)?,
         };
 
-        let variadic = is_variadic.then(|| mk().variadic_arg(vec![]));
+        let variadic = is_variadic.then(|| mk().bare_variadic_arg());
 
         let fn_ty = (
             barefn_inputs,

--- a/c2rust-transpile/src/rust_ast/comment_store.rs
+++ b/c2rust-transpile/src/rust_ast/comment_store.rs
@@ -302,8 +302,7 @@ pub fn insert_comment_attrs(attrs: &mut Vec<Attribute>, new_comments: SmallVec<[
             pound_token: Default::default(),
             style: AttrStyle::Inner(Default::default()),
             bracket_token: Default::default(),
-            path: make_comment_path(),
-            tokens,
+            meta: Meta::Path(make_comment_path()),
         };
         attrs.push(attr);
     }

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -662,7 +662,7 @@ impl<'c> Translation<'c> {
             // Skip over, there's no way to implement it in Rust
             "__builtin_unwind_init" => Ok(WithStmts::new_val(self.panic_or_err("no value"))),
             "__builtin_unreachable" => Ok(WithStmts::new(
-                vec![mk().semi_stmt(mk().mac_expr(mk().mac(
+                vec![mk().semi_stmt(mk().mac_expr(mk().mac::<Vec<TokenTree>>(
                     mk().path(vec!["unreachable"]),
                     vec![],
                     MacroDelimiter::Paren(Default::default()),

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -16,7 +16,7 @@ impl<'c> Translation<'c> {
         base: IntBase,
     ) -> TranslationResult<Box<Expr>> {
         let lit = match base {
-            IntBase::Dec => mk().int_unsuffixed_lit(val.into()),
+            IntBase::Dec => mk().int_unsuffixed_lit(val),
             IntBase::Hex => mk().float_unsuffixed_lit(&format!("0x{:x}", val)),
             IntBase::Oct => mk().float_unsuffixed_lit(&format!("0o{:o}", val)),
         };

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -357,11 +357,11 @@ pub fn stmts_block(mut stmts: Vec<Stmt>) -> Block {
             Expr::Block(ExprBlock {
                 block, label: None, ..
             }),
-            _semi,
+            None,
         )) if stmts.is_empty() => return block,
         Some(mut s) => {
-            if let Stmt::Expr(e, _semi) = s {
-                s = Stmt::Expr(e, _semi);
+            if let Stmt::Expr(e, None) = s {
+                s = Stmt::Expr(e, Some(Default::default()));
             }
             stmts.push(s);
         }
@@ -4025,7 +4025,7 @@ impl<'c> Translation<'c> {
                     expr: ret_val,
                     ..
                 }),
-                _,
+                Some(_),
             ) = stmt
             {
                 if blbl.ident == mk().label(lbl.pretty_print()).name.ident {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -279,24 +279,6 @@ pub struct Translation<'c> {
     cur_file: RefCell<Option<FileId>>,
 }
 
-fn simple_metaitem(name: &str) -> NestedMeta {
-    let meta_item = mk().meta_path(name);
-
-    mk().nested_meta_item(NestedMeta::Meta(meta_item))
-}
-
-fn int_arg_metaitem(name: &str, arg: u128) -> NestedMeta {
-    let lit = mk().int_unsuffixed_lit(arg);
-    let inner = Meta::List(MetaList {
-        path: mk().path(name),
-        paren_token: Default::default(),
-        nested: FromIterator::from_iter(
-            vec![mk().nested_meta_item(NestedMeta::Lit(lit))].into_iter(),
-        ),
-    });
-    NestedMeta::Meta(inner)
-}
-
 fn cast_int(val: Box<Expr>, name: &str, need_lit_suffix: bool) -> Box<Expr> {
     let opt_literal_val = match &*val {
         Expr::Lit(ref l) => match &l.lit {
@@ -371,12 +353,15 @@ fn vec_expr(val: Box<Expr>, count: Box<Expr>) -> Box<Expr> {
 pub fn stmts_block(mut stmts: Vec<Stmt>) -> Block {
     match stmts.pop() {
         None => {}
-        Some(Stmt::Expr(Expr::Block(ExprBlock {
-            block, label: None, ..
-        }))) if stmts.is_empty() => return block,
+        Some(Stmt::Expr(
+            Expr::Block(ExprBlock {
+                block, label: None, ..
+            }),
+            _semi,
+        )) if stmts.is_empty() => return block,
         Some(mut s) => {
-            if let Stmt::Expr(e) = s {
-                s = Stmt::Semi(e, Default::default());
+            if let Stmt::Expr(e, _semi) = s {
+                s = Stmt::Expr(e, _semi);
             }
             stmts.push(s);
         }
@@ -900,7 +885,6 @@ fn item_ident(i: &Item) -> Option<&Ident> {
         ForeignMod(_ifm) => return None,
         Impl(_ii) => return None,
         Macro(im) => return im.ident.as_ref(),
-        Macro2(im2) => &im2.ident,
         Mod(im) => &im.ident,
         Static(is) => &is.ident,
         Struct(is) => &is.ident,
@@ -931,7 +915,6 @@ fn item_vis(i: &Item) -> Option<Visibility> {
             ForeignMod(_ifm) => return None,
             Impl(_ii) => return None,
             Macro(_im) => return None,
-            Macro2(im2) => &im2.vis,
             Mod(im) => &im.vis,
             Static(is) => &is.vis,
             Struct(is) => &is.vis,
@@ -1054,21 +1037,15 @@ fn arrange_header(t: &Translation, is_binary: bool) -> (Vec<syn::Attribute>, Vec
         for (key, mut values) in pragmas {
             values.sort_unstable();
             // generate #[key(values)]
-            let value_attr_vec = values
-                .into_iter()
-                .map(|value| mk().nested_meta_item(mk().meta_path(value)))
-                .collect::<Vec<_>>();
-            let item = mk().meta_list(vec![key], value_attr_vec);
-            for attr in mk()
-                .meta_item_attr(AttrStyle::Inner(Default::default()), item)
-                .as_inner_attrs()
-            {
-                out_attrs.push(attr);
-            }
+            let meta = mk().meta_list(vec![key], values);
+            let attr = mk().attribute(AttrStyle::Inner(Default::default()), meta);
+            out_attrs.push(attr);
         }
 
         if t.tcfg.emit_no_std {
-            out_attrs.push(mk().single_attr("no_std").as_inner_attrs()[0].clone());
+            let meta = mk().meta_path("no_std");
+            let attr = mk().attribute(AttrStyle::Inner(Default::default()), meta);
+            out_attrs.push(attr);
         }
 
         if is_binary {
@@ -1100,8 +1077,7 @@ fn add_src_loc_attr(attrs: &mut Vec<syn::Attribute>, src_loc: &Option<SrcLoc>) {
     if let Some(src_loc) = src_loc.as_ref() {
         let loc_str = format!("{}:{}", src_loc.line, src_loc.column);
         let meta = mk().meta_namevalue(vec!["c2rust", "src_loc"], loc_str);
-        let prepared = mk().prepare_meta(meta);
-        let attr = mk().attribute(AttrStyle::Outer, prepared.path, prepared.tokens);
+        let attr = mk().attribute(AttrStyle::Outer, meta);
         attrs.push(attr);
     }
 }
@@ -1130,7 +1106,6 @@ fn item_attrs(item: &mut Item) -> Option<&mut Vec<syn::Attribute>> {
         ForeignMod(ItemForeignMod { ref mut attrs, .. }) => attrs,
         Impl(ItemImpl { ref mut attrs, .. }) => attrs,
         Macro(ItemMacro { ref mut attrs, .. }) => attrs,
-        Macro2(ItemMacro2 { ref mut attrs, .. }) => attrs,
         Mod(ItemMod { ref mut attrs, .. }) => attrs,
         Static(ItemStatic { ref mut attrs, .. }) => attrs,
         Struct(ItemStruct { ref mut attrs, .. }) => attrs,
@@ -1526,8 +1501,8 @@ impl<'c> Translation<'c> {
                 mk().meta_list(
                     "cfg_attr",
                     vec![
-                        mk().nested_meta_item(mk().meta_namevalue("target_os", "linux")),
-                        mk().nested_meta_item(mk().meta_namevalue("link_section", ".init_array")),
+                        mk().meta_namevalue("target_os", "linux"),
+                        mk().meta_namevalue("link_section", ".init_array"),
                     ],
                 ),
             )
@@ -1536,8 +1511,8 @@ impl<'c> Translation<'c> {
                 mk().meta_list(
                     "cfg_attr",
                     vec![
-                        mk().nested_meta_item(mk().meta_namevalue("target_os", "windows")),
-                        mk().nested_meta_item(mk().meta_namevalue("link_section", ".CRT$XIB")),
+                        mk().meta_namevalue("target_os", "windows"),
+                        mk().meta_namevalue("link_section", ".CRT$XIB"),
                     ],
                 ),
             )
@@ -1546,10 +1521,8 @@ impl<'c> Translation<'c> {
                 mk().meta_list(
                     "cfg_attr",
                     vec![
-                        mk().nested_meta_item(mk().meta_namevalue("target_os", "macos")),
-                        mk().nested_meta_item(
-                            mk().meta_namevalue("link_section", "__DATA,__mod_init_func"),
-                        ),
+                        mk().meta_namevalue("target_os", "macos"),
+                        mk().meta_namevalue("link_section", "__DATA,__mod_init_func"),
                     ],
                 ),
             );
@@ -1649,7 +1622,7 @@ impl<'c> Translation<'c> {
                     self.use_crate(ExternCrate::C2RustBitfields);
                 }
 
-                let mut reprs = vec![simple_metaitem("C")];
+                let mut reprs = vec![mk().meta_path("C")];
                 let max_field_alignment = if is_packed {
                     // `__attribute__((packed))` forces a max alignment of 1,
                     // overriding `#pragma pack`; this is also what clang does
@@ -1658,8 +1631,8 @@ impl<'c> Translation<'c> {
                     max_field_alignment
                 };
                 match max_field_alignment {
-                    Some(1) => reprs.push(simple_metaitem("packed")),
-                    Some(mf) if mf > 1 => reprs.push(int_arg_metaitem("packed", mf as u128)),
+                    Some(1) => reprs.push(mk().meta_path("packed")),
+                    Some(mf) if mf > 1 => reprs.push(mk().meta_list("packed", vec![mf])),
                     _ => {}
                 }
 
@@ -1692,8 +1665,8 @@ impl<'c> Translation<'c> {
                     // https://github.com/rust-lang/rust/issues/33626
                     let outer_ty = mk().path_ty(vec![name.clone()]);
                     let outer_reprs = vec![
-                        simple_metaitem("C"),
-                        int_arg_metaitem("align", alignment as u128),
+                        mk().meta_path("C"),
+                        mk().meta_list("align", vec![alignment]),
                         // TODO: copy others from `reprs` above
                     ];
                     let repr_attr = mk().meta_list("repr", outer_reprs);
@@ -2283,21 +2256,21 @@ impl<'c> Translation<'c> {
                 args.push(mk().arg(ty, pat))
             }
 
-            if is_variadic {
+            let variadic = if is_variadic {
                 // function definitions
-                if let Some(body_id) = body {
-                    let arg_va_list_name = self.register_va_decls(body_id);
-
+                let mut builder = mk();
+                let arg_va_list_name = if let Some(body_id) = body {
                     // FIXME: detect mutability requirements.
-                    let pat = mk()
-                        .set_mutbl(Mutability::Mutable)
-                        .ident_pat(arg_va_list_name);
-                    args.push(mk().arg(mk().cvar_args_ty(), pat));
+                    builder = builder.set_mutbl(Mutability::Mutable);
+                    Some(self.register_va_decls(body_id))
                 } else {
-                    // function declarations
-                    args.push(mk().arg(mk().cvar_args_ty(), mk().wild_pat()));
-                }
-            }
+                    None
+                };
+
+                Some(builder.variadic_arg(arg_va_list_name))
+            } else {
+                None
+            };
 
             // handle return type
             let ret = match return_type {
@@ -2316,12 +2289,7 @@ impl<'c> Translation<'c> {
                 ReturnType::Type(Default::default(), ret)
             };
 
-            let decl = mk().fn_decl(
-                new_name,
-                args,
-                is_variadic.then(|| mk().variadic_arg(vec![])),
-                ret,
-            );
+            let decl = mk().fn_decl(new_name, args, variadic, ret);
 
             if let Some(body) = body {
                 // Translating an actual function
@@ -3749,7 +3717,7 @@ impl<'c> Translation<'c> {
                             };
                             let bare_ty = (
                                 vec![mk().bare_arg(mk().infer_ty(), None::<Box<Ident>>); args.len()],
-                                None::<Variadic>,
+                                None::<BareVariadic>,
                                 ret_ty
                             );
                             mk().barefn_ty(bare_ty)
@@ -4051,7 +4019,7 @@ impl<'c> Translation<'c> {
         compound_stmt_id: CStmtId,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         fn as_semi_break_stmt(stmt: &Stmt, lbl: &cfg::Label) -> Option<Option<Box<Expr>>> {
-            if let Stmt::Semi(
+            if let Stmt::Expr(
                 Expr::Break(ExprBreak {
                     label: Some(blbl),
                     expr: ret_val,

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -73,12 +73,7 @@ fn add_arch_use(store: &mut ItemStore, arch_name: &str, item_name: &str) {
         item_name,
         mk().meta_item_attr(
             AttrStyle::Outer,
-            mk().meta_list(
-                "cfg",
-                vec![NestedMeta::Meta(
-                    mk().meta_namevalue("target_arch", arch_name),
-                )],
-            ),
+            mk().meta_list("cfg", vec![mk().meta_namevalue("target_arch", arch_name)]),
         )
         .pub_(),
     );

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -313,7 +313,7 @@ impl<'a> Translation<'a> {
                 } => {
                     let ty = mk().array_ty(
                         mk().ident_ty("u8"),
-                        mk().lit_expr(mk().int_unsuffixed_lit(bytes.into())),
+                        mk().lit_expr(mk().int_unsuffixed_lit(bytes)),
                     );
                     let mut field = mk();
                     let field_attrs = attrs.iter().map(|attr| {
@@ -340,7 +340,7 @@ impl<'a> Translation<'a> {
                     let field_name = next_padding_field();
                     let ty = mk().array_ty(
                         mk().ident_ty("u8"),
-                        mk().lit_expr(mk().int_unsuffixed_lit(bytes.into())),
+                        mk().lit_expr(mk().int_unsuffixed_lit(bytes)),
                     );
 
                     // Mark it with `#[bitfield(padding)]`
@@ -442,7 +442,7 @@ impl<'a> Translation<'a> {
                 } => {
                     let array_expr = mk().repeat_expr(
                         mk().lit_expr(mk().int_unsuffixed_lit(0)),
-                        mk().lit_expr(mk().int_unsuffixed_lit(bytes.into())),
+                        mk().lit_expr(mk().int_unsuffixed_lit(bytes)),
                     );
                     let field = mk().field(field_name, array_expr);
 
@@ -452,7 +452,7 @@ impl<'a> Translation<'a> {
                     let field_name = next_padding_field();
                     let array_expr = mk().repeat_expr(
                         mk().lit_expr(mk().int_unsuffixed_lit(0)),
-                        mk().lit_expr(mk().int_unsuffixed_lit(bytes.into())),
+                        mk().lit_expr(mk().int_unsuffixed_lit(bytes)),
                     );
                     let field = mk().field(field_name, array_expr);
 
@@ -612,7 +612,7 @@ impl<'a> Translation<'a> {
                 } => {
                     let array_expr = mk().repeat_expr(
                         mk().lit_expr(mk().int_unsuffixed_lit(0)),
-                        mk().lit_expr(mk().int_unsuffixed_lit(bytes.into())),
+                        mk().lit_expr(mk().int_unsuffixed_lit(bytes)),
                     );
                     let field = mk().field(field_name, array_expr);
 
@@ -622,7 +622,7 @@ impl<'a> Translation<'a> {
                     let field_name = next_padding_field();
                     let array_expr = mk().repeat_expr(
                         mk().lit_expr(mk().int_unsuffixed_lit(0)),
-                        mk().lit_expr(mk().int_unsuffixed_lit(bytes.into())),
+                        mk().lit_expr(mk().int_unsuffixed_lit(bytes)),
                     );
                     let field = mk().field(field_name, array_expr);
 

--- a/c2rust-transpile/src/translator/structs.rs
+++ b/c2rust-transpile/src/translator/structs.rs
@@ -755,7 +755,7 @@ impl<'a> Translation<'a> {
                         }
 
                         let last_expr = match block.stmts[last] {
-                            Stmt::Expr(ref expr, _semi) => expr.clone(),
+                            Stmt::Expr(ref expr, None) => expr.clone(),
                             _ => return Err(TranslationError::generic("Expected Expr Stmt")),
                         };
                         let method_call =


### PR DESCRIPTION
upgrade to syn 2 for crate `c2rust-transpile`, `c2rust-ast-builder`, `c2rust-bitfields-derive`, and `c2rust-ast-printer`. `c2rust-macros` excluded because it only used by `c2rust-refactor`

syn introduces many breaking changes which can be viewed in https://github.com/dtolnay/syn/releases/tag/2.0.0
