### PR TITLE
fix compilation error on clang/llvm 21

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -1148,7 +1148,13 @@ class TranslateASTVisitor final
                     // into); clang does this conversion, but rustc doesn't
                     convertedConstraint += '*';
                 }
+
+#if CLANG_VERSION_MAJOR < 21
                 convertedConstraint += SimplifyConstraint(constraint.str());
+#else
+                convertedConstraint += SimplifyConstraint(constraint);
+#endif
+
                 outputs.push_back(convertedConstraint);
                 output_infos.push_back(std::move(info));
             }
@@ -1162,7 +1168,11 @@ class TranslateASTVisitor final
                     // See above
                     convertedConstraint += '*';
                 }
+#if CLANG_VERSION_MAJOR < 21
                 convertedConstraint += SimplifyConstraint(constraint.str());
+#else
+                convertedConstraint += SimplifyConstraint(constraint);
+#endif
                 inputs.emplace_back(convertedConstraint);
             }
             for (unsigned i = 0, num = E->getNumClobbers(); i < num; ++i) {


### PR DESCRIPTION
GCCAsmStmt::getOutputConstraint() now return `std::string` instead of `StringRef`. this change is introduced in https://github.com/llvm/llvm-project/pull/131003