### PR TITLE
ci: run on both Ubuntu 22.04 and ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - runner: macos-13
             os: macOS
             arch: x86_64
+      fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - runner: macos-13
             os: macOS
             arch: x86_64
+            clang-version: 17
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:
@@ -72,7 +73,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           # `bash` needed b/c macOS ships with bash 3, which doesn't support arrays properly
-          brew install -q cmake ninja gpg llvm@17 bash
+          brew install -q cmake ninja gpg llvm@${{ matrix.clang-version }} bash
 
       - uses: astral-sh/setup-uv@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
 
 jobs:
@@ -13,6 +13,11 @@ jobs:
           - runner: ubuntu-latest
             os: Linux
             arch: x86_64
+            clang-version: 18
+          - runner: ubuntu-22.04
+            os: Linux
+            arch: x86_64
+            clang-version: 15
           - runner: macos-13
             os: macOS
             arch: x86_64
@@ -39,7 +44,7 @@ jobs:
             git \
             gperf \
             libbrotli-dev \
-            libclang-dev \
+            libclang-${{ matrix.clang-version }}-dev \
             libgcrypt20 \
             libreadline-dev \
             libidn2-dev \
@@ -48,6 +53,7 @@ jobs:
             libnghttp2-dev \
             libpcre3-dev \
             libpsl-dev \
+            libreadline-dev \
             librtmp-dev \
             libssl-dev \
             libtool \
@@ -66,7 +72,7 @@ jobs:
         run: |
           # `bash` needed b/c macOS ships with bash 3, which doesn't support arrays properly
           brew install -q cmake ninja gpg llvm@17 bash
-      
+
       - uses: astral-sh/setup-uv@v6
 
       - name: Install Python Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
             arch: x86_64
             clang-version: 17
       fail-fast: false
+    name: "test (${{ matrix.runner }}: ${{ matrix.os }} ${{ matrix.arch}}, Clang ${{ matrix.clang-version }})"
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -15,9 +15,21 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build-on-ubuntu-2204:
+  run-testsuite:
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            os: Linux
+            arch: x86_64
+            clang-version: 18
+          - runner: ubuntu-22.04
+            os: Linux
+            arch: x86_64
+            clang-version: 15
+      fail-fast: false
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -82,8 +94,9 @@ jobs:
       run: |
         sudo apt-get -qq update
         sudo apt-get -qq install    \
+            build-essential         \
             libbrotli-dev           \
-            libclang-15-dev         \
+            libclang-${{ matrix.clang-version }}-dev \
             libgcrypt20             \
             libreadline-dev         \
             libidn2-dev             \
@@ -106,7 +119,7 @@ jobs:
     # Working dir is /home/runner/work/c2rust/c2rust
     - name: Build c2rust
       run: |
-        export LLVM_CONFIG_PATH=/usr/bin/llvm-config-15
+        export LLVM_CONFIG_PATH=/usr/bin/llvm-config-${{ matrix.clang-version }}
         cargo build --release
 
     # TODO(pl): figure out why compile_commands.json may cause json-c to fail
@@ -119,7 +132,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: testsuite-build-artifacts
+        name: testsuite-${{ matrix.runner }}-artifacts
         path: |
           ${{ github.workspace }}/testsuite/**/*.log
           ${{ github.workspace }}/testsuite/**/compile_commands.json

--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -28,6 +28,7 @@ jobs:
             arch: x86_64
             clang-version: 15
       fail-fast: false
+    name: "run-testsuite (${{ matrix.runner }}: ${{ matrix.os }} ${{ matrix.arch}}, Clang ${{ matrix.clang-version }})"
     # The type of runner that the job will run on
     runs-on: ${{ matrix.runner }}
 

--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -233,9 +233,16 @@ class TestDirectory:
         # set self.target to a known-working target tuple for it
         self.target = None
 
-        # include the compiler resource directory in compile_commands.json
-        _, stdout, _ = clang["-print-resource-dir"].run(retcode=None)
-        self.clang_resource_dir = " \"-I{}/include\",".format(stdout.strip())
+        # include the compiler resource directory in compile_commands.json.
+        # we should never have to do this but for some reason SIMD includes
+        # are broken without it on macOS 12.
+        # limit this to macOS because if we do happen to have multiple versions of Clang around, we
+        # don't know which to use here, and using the wrong can one break things badly
+        if sys.platform == "darwin":
+            _, stdout, _ = clang["-print-resource-dir"].run(retcode=None)
+            self.clang_resource_dir = " \"-I{}/include\",".format(stdout.strip())
+        else:
+            self.clang_resource_dir = ""
 
         # parse target arch from directory name if it includes a dot
         split_by_dots = self.name.split('.')


### PR DESCRIPTION
We were previously running the testsuite on 22.04 and in-repo tests on ubuntu-latest (currently 24.04). Now, run both on both. This is particularly useful coverage because 22.04 uses Clang 15, which we do support but which differs substantially in some behaviors from later versions.

Split out from #1266.