### PR TITLE
test_translator: remove `#![feature(nll)]`, stabilized in 1.63

### DIFF
--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -402,7 +402,6 @@ class TestDirectory:
             "extern_types",
             "simd_ffi",
             "stdsimd",
-            "nll",
             "linkage",
             "register_tool",
         ])


### PR DESCRIPTION
Our old pinned nightly is 1.65, so this was already stabilized even back then.