### PR TITLE
transpile: enable `--translate-const-macros` in snapshot tests

### DIFF
--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -37,7 +37,7 @@ fn config() -> TranspilerConfig {
         enabled_warnings: Default::default(),
         emit_no_std: false,
         output_dir: None,
-        translate_const_macros: false,
+        translate_const_macros: true,
         translate_fn_macros: false,
         disable_refactoring: false,
         preserve_unused_functions: false,

--- a/c2rust-transpile/tests/snapshots/atomics.rs
+++ b/c2rust-transpile/tests/snapshots/atomics.rs
@@ -39,3 +39,4 @@ pub unsafe extern "C" fn c11_atomics(mut x: std::ffi::c_int) -> std::ffi::c_int 
     fresh1.1;
     return x;
 }
+pub const __ATOMIC_SEQ_CST: std::ffi::c_int = 5 as std::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.snap
@@ -1,6 +1,5 @@
 ---
 source: c2rust-transpile/tests/snapshots.rs
-assertion_line: 67
 expression: cat tests/snapshots/atomics.rs
 input_file: c2rust-transpile/tests/snapshots/atomics.c
 ---
@@ -45,4 +44,4 @@ pub unsafe extern "C" fn c11_atomics(mut x: std::ffi::c_int) -> std::ffi::c_int 
     fresh1.1;
     return x;
 }
-
+pub const __ATOMIC_SEQ_CST: std::ffi::c_int = 5 as std::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
@@ -125,20 +125,14 @@ pub unsafe extern "C" fn array_of_arrays_static_struct() {
 }
 #[no_mangle]
 pub unsafe extern "C" fn curl_alpn_spec() {
-    static mut _ALPN_SPEC_H11: alpn_spec = unsafe {
-        {
-            let mut init = alpn_spec {
-                entries: [
-                    *::core::mem::transmute::<
-                        &[u8; 10],
-                        &mut [std::ffi::c_char; 10],
-                    >(b"http/1.1\0\0"),
-                    [0; 10],
-                    [0; 10],
-                ],
-                count: 1 as std::ffi::c_int as std::ffi::c_uint,
-            };
-            init
-        }
+    static mut _ALPN_SPEC_H11: alpn_spec = {
+        let mut init = alpn_spec {
+            entries: [ALPN_HTTP_1_1, [0; 10], [0; 10]],
+            count: 1 as std::ffi::c_int as std::ffi::c_uint,
+        };
+        init
     };
 }
+pub const ALPN_HTTP_1_1: [std::ffi::c_char; 10] = unsafe {
+    *::core::mem::transmute::<&[u8; 10], &mut [std::ffi::c_char; 10]>(b"http/1.1\0\0")
+};

--- a/c2rust-transpile/tests/snapshots/str_init.rs
+++ b/c2rust-transpile/tests/snapshots/str_init.rs
@@ -120,20 +120,14 @@ pub unsafe extern "C" fn array_of_arrays_static_struct() {
 }
 #[no_mangle]
 pub unsafe extern "C" fn curl_alpn_spec() {
-    static mut _ALPN_SPEC_H11: alpn_spec = unsafe {
-        {
-            let mut init = alpn_spec {
-                entries: [
-                    *::core::mem::transmute::<
-                        &[u8; 10],
-                        &mut [std::ffi::c_char; 10],
-                    >(b"http/1.1\0\0"),
-                    [0; 10],
-                    [0; 10],
-                ],
-                count: 1 as std::ffi::c_int as std::ffi::c_uint,
-            };
-            init
-        }
+    static mut _ALPN_SPEC_H11: alpn_spec = {
+        let mut init = alpn_spec {
+            entries: [ALPN_HTTP_1_1, [0; 10], [0; 10]],
+            count: 1 as std::ffi::c_int as std::ffi::c_uint,
+        };
+        init
     };
 }
+pub const ALPN_HTTP_1_1: [std::ffi::c_char; 10] = unsafe {
+    *::core::mem::transmute::<&[u8; 10], &mut [std::ffi::c_char; 10]>(b"http/1.1\0\0")
+};


### PR DESCRIPTION
`--translate-const-macros` doesn't fully work in all cases yet (see #1295), but it works for our current snapshot tests, so enabling it while we implement #1295 (a minimal version) will help with testing.