### PR TITLE
transpile: add docs and some renames/refactors for code related to macros

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1032,19 +1032,19 @@ pub enum OffsetOfKind {
 /// As per the C standard, qualifiers on types make sense only on lvalues.
 #[derive(Debug, Clone)]
 pub enum CExprKind {
-    // Literals
+    /// Literal.
     Literal(CQualTypeId, CLiteral),
 
-    // Unary operator.
+    /// Unary operator.
     Unary(CQualTypeId, UnOp, CExprId, LRValue),
 
-    // Unary type operator.
+    /// Unary type operator.
     UnaryType(CQualTypeId, UnTypeOp, Option<CExprId>, CQualTypeId),
 
-    // Offsetof expression.
+    /// `offsetof` expression.
     OffsetOf(CQualTypeId, OffsetOfKind),
 
-    // Binary operator
+    /// Binary operator.
     Binary(
         CQualTypeId,
         BinOp,
@@ -1054,67 +1054,80 @@ pub enum CExprKind {
         Option<CQualTypeId>,
     ),
 
-    // Implicit cast
+    /// Implicit cast.
     ImplicitCast(CQualTypeId, CExprId, CastKind, Option<CFieldId>, LRValue),
 
-    // Explicit cast
+    /// Explicit cast.
     ExplicitCast(CQualTypeId, CExprId, CastKind, Option<CFieldId>, LRValue),
 
-    // Constant context expression
+    /// Constant context expression.
     ConstantExpr(CQualTypeId, CExprId, Option<ConstIntExpr>),
 
-    // Reference to a decl (a variable, for instance)
+    /// Reference to a decl (a variable, for instance).
     // TODO: consider enforcing what types of declarations are allowed here
     DeclRef(CQualTypeId, CDeclId, LRValue),
 
-    // Function call
+    /// Function call.
     Call(CQualTypeId, CExprId, Vec<CExprId>),
 
-    // Member access
+    /// Member access.
     Member(CQualTypeId, CExprId, CDeclId, MemberKind, LRValue),
 
-    // Array subscript access
+    /// Array subscript access.
     ArraySubscript(CQualTypeId, CExprId, CExprId, LRValue),
 
-    // Ternary conditional operator
+    /// Ternary conditional operator.
     Conditional(CQualTypeId, CExprId, CExprId, CExprId),
 
-    // Binary conditional operator ?: GNU extension
+    /// Binary conditional operator `?:` (GNU extension).
     BinaryConditional(CQualTypeId, CExprId, CExprId),
 
-    // Initializer list - type, initializers, union field, syntactic form
+    /// Initializer list.
+    ///
+    /// * type
+    /// * initializers
+    /// * union field
+    /// * syntactic form
     InitList(CQualTypeId, Vec<CExprId>, Option<CFieldId>, Option<CExprId>),
 
-    // Designated initializer
+    /// Designated initializer.
     ImplicitValueInit(CQualTypeId),
 
-    // Parenthesized expression (ignored, but needed so we have a corresponding
-    // node)
+    /// Parenthesized expression.
+    ///
+    /// Ignored, but needed so we have a corresponding node.
     Paren(CQualTypeId, CExprId),
 
-    // Compound literal
+    /// Compound literal.
     CompoundLiteral(CQualTypeId, CExprId),
 
-    // Predefined expr
+    /// Predefined expression.
     Predefined(CQualTypeId, CExprId),
 
-    // Statement expression
+    /// Statement expression.
     Statements(CQualTypeId, CStmtId),
 
-    // Variable argument list
+    /// Variable argument list.
     VAArg(CQualTypeId, CExprId),
 
-    // Unsupported vector operations,
+    /// Unsupported shuffle vector operation.
     ShuffleVector(CQualTypeId, Vec<CExprId>),
+
+    /// Unsupported convert vector operation.
     ConvertVector(CQualTypeId, Vec<CExprId>),
 
-    // From syntactic form of initializer list expressions
+    /// From syntactic form of initializer list expressions.
     DesignatedInitExpr(CQualTypeId, Vec<Designator>, CExprId),
 
-    // GNU choose expr. Condition, true expr, false expr, was condition true?
+    /// GNU choose expression.
+    ///
+    /// * condition
+    /// * true expr
+    /// * false expr
+    /// * was condition true?
     Choose(CQualTypeId, CExprId, CExprId, CExprId, bool),
 
-    // GNU/C11 atomic expr
+    /// GNU/C11 atomic expression.
     Atomic {
         typ: CQualTypeId,
         name: String,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3189,14 +3189,15 @@ impl<'c> Translation<'c> {
         );
 
         if self.tcfg.translate_const_macros {
-            if let Some(converted) = self.convert_macro_expansion(ctx, expr_id)? {
+            if let Some(converted) = self.convert_const_macro_expansion(ctx, expr_id)? {
                 return Ok(converted);
             }
         }
 
         if self.tcfg.translate_fn_macros {
             let text = self.ast_context.macro_expansion_text.get(&expr_id);
-            if let Some(converted) = text.and_then(|text| self.convert_macro_invocation(ctx, text))
+            if let Some(converted) =
+                text.and_then(|text| self.convert_fn_macro_invocation(ctx, text))
             {
                 return Ok(converted);
             }
@@ -3907,7 +3908,7 @@ impl<'c> Translation<'c> {
     /// See [`TranspilerConfig::translate_const_macros`].
     ///
     /// [`TranspilerConfig::translate_const_macros`]: crate::TranspilerConfig::translate_const_macros
-    fn convert_macro_expansion(
+    fn convert_const_macro_expansion(
         &self,
         ctx: ExprContext,
         expr_id: CExprId,
@@ -3985,7 +3986,7 @@ impl<'c> Translation<'c> {
     /// See [`TranspilerConfig::translate_fn_macros`].
     ///
     /// [`TranspilerConfig::translate_fn_macros`]: crate::TranspilerConfig::translate_fn_macros
-    fn convert_macro_invocation(
+    fn convert_fn_macro_invocation(
         &self,
         _ctx: ExprContext,
         text: &str,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3912,72 +3912,72 @@ impl<'c> Translation<'c> {
         ctx: ExprContext,
         expr_id: CExprId,
     ) -> TranslationResult<Option<WithStmts<Box<Expr>>>> {
-        if let Some(macs) = self.ast_context.macro_invocations.get(&expr_id) {
-            // Find the first macro after the macro we're currently
-            // expanding, if any.
-            if let Some(macro_id) = macs
-                .splitn(2, |macro_id| ctx.expanding_macro(macro_id))
-                .last()
-                .unwrap()
-                .first()
-            {
-                trace!("  found macro expansion: {:?}", macro_id);
-                // Ensure that we've converted this macro and that it has a
-                // valid definition
-                let expansion = self.macro_expansions.borrow().get(macro_id).cloned();
-                let macro_ty = match expansion {
-                    // expansion exists
-                    Some(Some(expansion)) => expansion.ty,
+        let macros = match self.ast_context.macro_invocations.get(&expr_id) {
+            Some(macros) => macros.as_slice(),
+            None => return Ok(None),
+        };
 
-                    // expansion wasn't possible
-                    Some(None) => return Ok(None),
+        // Find the first macro after the macro we're currently expanding, if any.
+        let first_macro = macros
+            .splitn(2, |macro_id| ctx.expanding_macro(macro_id))
+            .last()
+            .unwrap()
+            .first();
+        let macro_id = match first_macro {
+            Some(macro_id) => macro_id,
+            None => return Ok(None),
+        };
 
-                    // We haven't tried to expand it yet
-                    None => {
-                        self.convert_decl(ctx, *macro_id)?;
-                        if let Some(Some(expansion)) = self.macro_expansions.borrow().get(macro_id)
-                        {
-                            expansion.ty
-                        } else {
-                            return Ok(None);
-                        }
-                    }
-                };
-                let rustname = self
-                    .renamer
-                    .borrow_mut()
-                    .get(macro_id)
-                    .ok_or_else(|| format_err!("Macro name not declared"))?;
+        trace!("  found macro expansion: {macro_id:?}");
+        // Ensure that we've converted this macro and that it has a valid definition.
+        let expansion = self.macro_expansions.borrow().get(macro_id).cloned();
+        let macro_ty = match expansion {
+            // Expansion exists.
+            Some(Some(expansion)) => expansion.ty,
 
-                if let Some(cur_file) = self.cur_file.borrow().as_ref() {
-                    self.add_import(*cur_file, *macro_id, &rustname);
-                }
+            // Expansion wasn't possible.
+            Some(None) => return Ok(None),
 
-                let val = WithStmts::new_val(mk().path_expr(vec![rustname]));
-
-                let expr_kind = &self.ast_context[expr_id].kind;
-                if let Some(expr_ty) = expr_kind.get_qual_type() {
-                    return self
-                        .convert_cast(
-                            ctx,
-                            CQualTypeId::new(macro_ty),
-                            expr_ty,
-                            val,
-                            None,
-                            None,
-                            None,
-                        )
-                        .map(Some);
+            // We haven't tried to expand it yet.
+            None => {
+                self.convert_decl(ctx, *macro_id)?;
+                if let Some(Some(expansion)) = self.macro_expansions.borrow().get(macro_id) {
+                    expansion.ty
                 } else {
-                    return Ok(Some(val));
+                    return Ok(None);
                 }
-
-                // TODO: May need to handle volatile reads here, see
-                // DeclRef below
             }
+        };
+        let rust_name = self
+            .renamer
+            .borrow_mut()
+            .get(macro_id)
+            .ok_or_else(|| format_err!("Macro name not declared"))?;
+
+        if let Some(cur_file) = self.cur_file.borrow().as_ref() {
+            self.add_import(*cur_file, *macro_id, &rust_name);
         }
 
-        Ok(None)
+        let val = WithStmts::new_val(mk().path_expr(vec![rust_name]));
+
+        let expr_kind = &self.ast_context[expr_id].kind;
+        if let Some(expr_ty) = expr_kind.get_qual_type() {
+            self.convert_cast(
+                ctx,
+                CQualTypeId::new(macro_ty),
+                expr_ty,
+                val,
+                None,
+                None,
+                None,
+            )
+            .map(Some)
+        } else {
+            Ok(Some(val))
+        }
+
+        // TODO: May need to handle volatile reads here.
+        // See `DeclRef` below.
     }
 
     /// Convert the expansion of a function-like macro.

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3902,6 +3902,11 @@ impl<'c> Translation<'c> {
         Ok(expr)
     }
 
+    /// Convert the expansion of a const-like macro.
+    ///
+    /// See [`TranspilerConfig::translate_const_macros`].
+    ///
+    /// [`TranspilerConfig::translate_const_macros`]: crate::TranspilerConfig::translate_const_macros
     fn convert_macro_expansion(
         &self,
         ctx: ExprContext,
@@ -3975,6 +3980,11 @@ impl<'c> Translation<'c> {
         Ok(None)
     }
 
+    /// Convert the expansion of a function-like macro.
+    ///
+    /// See [`TranspilerConfig::translate_fn_macros`].
+    ///
+    /// [`TranspilerConfig::translate_fn_macros`]: crate::TranspilerConfig::translate_fn_macros
     fn convert_macro_invocation(
         &self,
         _ctx: ExprContext,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2174,15 +2174,15 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<(Box<Expr>, CTypeId)> {
         let (val, ty) = expansions
             .iter()
-            .try_fold::<Option<(WithStmts<Box<Expr>>, CTypeId)>, _, _>(None, |canonical, id| {
-                let ty = self.ast_context[*id]
+            .try_fold::<Option<(WithStmts<Box<Expr>>, CTypeId)>, _, _>(None, |canonical, &id| {
+                let ty = self.ast_context[id]
                     .kind
                     .get_type()
                     .ok_or_else(|| format_err!("Invalid expression type"))?;
                 let (expr_id, ty) = self
                     .ast_context
-                    .resolve_expr_type_id(*id)
-                    .unwrap_or((*id, ty));
+                    .resolve_expr_type_id(id)
+                    .unwrap_or((id, ty));
                 let expr = self.convert_expr(ctx, expr_id)?;
 
                 // Join ty and cur_ty to the smaller of the two types. If the


### PR DESCRIPTION
As I was working to understand the code that works with macros, I added some documentation, renamed some functions to be more descriptive, and made a few minor refactors.