### PR TITLE
transpile: expand `--translate-const-macros conservative` to a lot more `CExprKind`s

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -71,14 +71,14 @@ pub struct TypedAstContext {
     pub label_names: IndexMap<CLabelId, Rc<str>>,
 
     // map expressions to the stack of macros they were expanded from
-    pub macro_invocations: HashMap<CExprId, Vec<CDeclId>>,
+    pub macro_invocations: IndexMap<CExprId, Vec<CDeclId>>,
 
     // map macro decls to the expressions they expand to
-    pub macro_expansions: HashMap<CDeclId, Vec<CExprId>>,
+    pub macro_expansions: IndexMap<CDeclId, Vec<CExprId>>,
 
     // map expressions to the text of the macro invocation they expanded from,
     // if any
-    pub macro_expansion_text: HashMap<CExprId, String>,
+    pub macro_expansion_text: IndexMap<CExprId, String>,
 
     pub comments: Vec<Located<String>>,
 
@@ -178,9 +178,9 @@ impl TypedAstContext {
             file_map,
             include_map,
             parents: HashMap::new(),
-            macro_invocations: HashMap::new(),
-            macro_expansions: HashMap::new(),
-            macro_expansion_text: HashMap::new(),
+            macro_invocations: Default::default(),
+            macro_expansions: Default::default(),
+            macro_expansion_text: Default::default(),
             label_names: Default::default(),
 
             comments: Vec::new(),

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -532,7 +532,7 @@ impl TypedAstContext {
         }
     }
 
-    // Pessimistically try to check if an expression doesn't return. If it does, or we can't tell
+    /// Pessimistically try to check if an expression doesn't return. If it does, or we can't tell
     /// that it doesn't, return `false`.
     pub fn expr_diverges(&self, expr_id: CExprId) -> bool {
         let func_id = match self.index(expr_id).kind {
@@ -553,6 +553,70 @@ impl TypedAstContext {
             CTypeKind::Function(_, _, _, no_return, _) => no_return,
             _ => false,
         }
+    }
+
+    /// Pessimistically try to check if an expression is `const`.
+    /// If it's not, or we can't tell if it is, return `false`.
+    pub fn is_const_expr(&self, expr: CExprId) -> bool {
+        use CExprKind::*;
+        let is_const = |expr| self.is_const_expr(expr);
+        match self[expr].kind {
+            // A literal is always `const`.
+            Literal(_, _) => true,
+            // Unary ops should be `const`.
+            // TODO handle `f128` or use the primitive type.
+            Unary(_, _, expr, _) => is_const(expr),
+            // Not sure what a `None` `CExprId` means here
+            // or how to detect a `sizeof` of a VLA, which is non-`const`.
+            UnaryType(_, _, _, _) => true,
+            // Not sure what a `OffsetOfKind::Variable` means.
+            OffsetOf(_, _) => true,
+            // `ptr::offset` (ptr `BinOp::Add`) was `const` stabilized in `1.61.0`.
+            // `ptr::offset_from` (ptr `BinOp::Subtract`) was `const` stabilized in `1.65.0`.
+            // TODO `f128` is not yet handled, as we should eventually
+            // switch to the (currently unstable) `f128` primitive type (#1262).
+            Binary(_, _, lhs, rhs, _, _) => is_const(lhs) && is_const(rhs),
+            // `as` casts are always `const`.
+            ImplicitCast(_, _, _, _, _) => true,
+            // `as` casts are always `const`.
+            // TODO This is `const`, although there's a bug #853.
+            ExplicitCast(_, _, _, _, _) => true,
+            // This is used in `const` locations like `match` patterns and array lengths, so it must be `const`.
+            ConstantExpr(_, _, _) => true,
+            // A reference in an already otherwise `const` context should be `const` itself.
+            DeclRef(_, _, _) => true,
+            Call(_, fn_expr, ref args) => {
+                let is_const_fn = false; // TODO detect which `fn`s are `const`.
+                is_const(fn_expr) && args.iter().copied().all(is_const) && is_const_fn
+            }
+            Member(_, expr, _, _, _) => is_const(expr),
+            ArraySubscript(_, array, index, _) => is_const(array) && is_const(index),
+            Conditional(_, cond, if_true, if_false) => {
+                is_const(cond) && is_const(if_true) && is_const(if_false)
+            }
+            BinaryConditional(_, cond, if_false) => is_const(cond) && is_const(if_false),
+            InitList(_, ref inits, _, _) => inits.iter().copied().all(is_const),
+            ImplicitValueInit(_) => true,
+            Paren(_, expr) => is_const(expr),
+            CompoundLiteral(_, expr) => is_const(expr),
+            Predefined(_, expr) => is_const(expr),
+            Statements(_, stmt) => self.is_const_stmt(stmt),
+            VAArg(_, expr) => is_const(expr),
+            // SIMD is not yet `const` in Rust.
+            ShuffleVector(_, _) | ConvertVector(_, _) => false,
+            DesignatedInitExpr(_, _, expr) => is_const(expr),
+            Choose(_, cond, if_true, if_false, _) => {
+                is_const(cond) && is_const(if_true) && is_const(if_false)
+            }
+            // Atomics are not yet `const` in Rust.
+            Atomic { .. } => false,
+            BadExpr => false,
+        }
+    }
+
+    pub fn is_const_stmt(&self, _stmt: CStmtId) -> bool {
+        // TODO
+        false
     }
 
     pub fn prune_unwanted_decls(&mut self, want_unused_functions: bool) {
@@ -1024,6 +1088,9 @@ pub enum OffsetOfKind {
 }
 
 /// Represents an expression in C (6.5 Expressions)
+///
+/// This is modeled on Clang's APIs, so where documentation
+/// is lacking here, look at Clang.
 ///
 /// We've kept a qualified type on every node since Clang has this information available, and since
 /// the semantics of translations of certain constructs often depend on the type of the things they

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2187,7 +2187,7 @@ impl<'c> Translation<'c> {
         ctx: ExprContext,
         expansions: &[CExprId],
     ) -> TranslationResult<(Box<Expr>, CTypeId)> {
-        let (val, ty) = expansions
+        let (mut val, ty) = expansions
             .iter()
             .try_fold::<Option<(WithStmts<Box<Expr>>, CTypeId)>, _, _>(None, |canonical, &id| {
                 self.can_convert_const_macro_expansion(id)?;
@@ -2224,6 +2224,7 @@ impl<'c> Translation<'c> {
             })?
             .ok_or_else(|| format_err!("Could not find a valid type for macro"))?;
 
+        val.set_unsafe();
         val.to_unsafe_pure_expr()
             .map(|val| (val, ty))
             .ok_or_else(|| TranslationError::generic("Macro expansion is not a pure expression"))

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2158,15 +2158,16 @@ impl<'c> Translation<'c> {
 
     /// Determine if we're able to convert this const macro expansion.
     fn can_convert_const_macro_expansion(&self, expr_id: CExprId) -> TranslationResult<()> {
-        let kind = &self.ast_context[expr_id].kind;
         match self.tcfg.translate_const_macros {
             TranslateMacros::None => Err(format_err!("translate_const_macros is None"))?,
-            TranslateMacros::Conservative => match *kind {
-                CExprKind::Literal(..) => Ok(()), // Literals are leaf expressions, so they should always be const-compatible.
-                _ => Err(format_err!(
-                    "conservative const macros don't yet allow {kind:?}"
-                ))?,
-            },
+            TranslateMacros::Conservative => {
+                // TODO We still allow `CExprKind::ExplicitCast`s
+                // even though they're broken (see #853).
+                if !self.ast_context.is_const_expr(expr_id) {
+                    Err(format_err!("non-const expr {expr_id:?}"))?;
+                }
+                Ok(())
+            }
             TranslateMacros::Experimental => Ok(()),
         }
     }

--- a/c2rust-transpile/tests/snapshots/macros.c
+++ b/c2rust-transpile/tests/snapshots/macros.c
@@ -282,7 +282,9 @@ struct fn_ptrs {
 
 typedef int (*fn_ptr_ty)(char);
 
-const struct fn_ptrs fns = {NULL, NULL, NULL};
+// TODO Skip for now since it uses `libc`, which we don't test in snapshots.
+// const struct fn_ptrs fns = {NULL, NULL, NULL};
+const struct fn_ptrs fns = {};
 
 // Make sure we can't refer to globals in a const macro
 #define GLOBAL_REF &fns

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.snap
@@ -37,4 +37,4 @@ pub unsafe extern "C" fn c11_atomics(mut x: std::ffi::c_int) -> std::ffi::c_int 
     fresh1.1;
     return x;
 }
-pub const __ATOMIC_SEQ_CST: std::ffi::c_int = 5 as std::ffi::c_int;
+pub const __ATOMIC_SEQ_CST: std::ffi::c_int = unsafe { 5 as std::ffi::c_int };

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -29,7 +29,7 @@ pub struct fn_ptrs {
     pub fn2: Option<unsafe extern "C" fn(std::ffi::c_int) -> std::ffi::c_int>,
 }
 pub type zstd_platform_dependent_type = std::ffi::c_long;
-pub const NESTED_INT: std::ffi::c_int = 0xffff as std::ffi::c_int;
+pub const NESTED_INT: std::ffi::c_int = unsafe { 0xffff as std::ffi::c_int };
 #[no_mangle]
 pub unsafe extern "C" fn local_muts() {
     let mut literal_int: std::ffi::c_int = 0xffff as std::ffi::c_int;
@@ -323,7 +323,7 @@ pub static mut global_const_str_concatenation: [std::ffi::c_char; 18] = unsafe {
 pub unsafe extern "C" fn test_fn_macro(mut x: std::ffi::c_int) -> std::ffi::c_int {
     return x * x;
 }
-pub const TEST_CONST2: std::ffi::c_int = 2 as std::ffi::c_int;
+pub const TEST_CONST2: std::ffi::c_int = unsafe { 2 as std::ffi::c_int };
 #[no_mangle]
 pub unsafe extern "C" fn reference_define() -> std::ffi::c_int {
     let mut x: std::ffi::c_int = 1 as std::ffi::c_int;
@@ -344,8 +344,8 @@ pub static mut fns: fn_ptrs = {
 };
 #[no_mangle]
 pub static mut p: *const fn_ptrs = unsafe { &fns as *const fn_ptrs };
-pub const ZSTD_WINDOWLOG_MAX_32: std::ffi::c_int = 30 as std::ffi::c_int;
-pub const ZSTD_WINDOWLOG_MAX_64: std::ffi::c_int = 31 as std::ffi::c_int;
+pub const ZSTD_WINDOWLOG_MAX_32: std::ffi::c_int = unsafe { 30 as std::ffi::c_int };
+pub const ZSTD_WINDOWLOG_MAX_64: std::ffi::c_int = unsafe { 31 as std::ffi::c_int };
 #[no_mangle]
 pub unsafe extern "C" fn test_zstd() -> U64 {
     return (if ::core::mem::size_of::<zstd_platform_dependent_type>() as std::ffi::c_ulong

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -29,223 +29,190 @@ pub struct fn_ptrs {
     pub fn2: Option<unsafe extern "C" fn(std::ffi::c_int) -> std::ffi::c_int>,
 }
 pub type zstd_platform_dependent_type = std::ffi::c_long;
-pub const NESTED_INT: std::ffi::c_int = unsafe { 0xffff as std::ffi::c_int };
+pub const true_0: std::ffi::c_int = unsafe { 1 as std::ffi::c_int };
+pub const LITERAL_INT: std::ffi::c_int = unsafe { 0xffff as std::ffi::c_int };
+pub const LITERAL_BOOL: std::ffi::c_int = unsafe { true_0 };
+pub const LITERAL_FLOAT: std::ffi::c_double = unsafe { 3.14f64 };
+pub const LITERAL_CHAR: std::ffi::c_int = unsafe { 'x' as i32 };
+pub const LITERAL_STR: [std::ffi::c_char; 6] =
+    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
+pub const LITERAL_STRUCT: S = unsafe {
+    {
+        let mut init = S {
+            i: 5 as std::ffi::c_int,
+        };
+        init
+    }
+};
+pub const NESTED_INT: std::ffi::c_int = unsafe { LITERAL_INT };
+pub const NESTED_BOOL: std::ffi::c_int = unsafe { 1 as std::ffi::c_int };
+pub const NESTED_FLOAT: std::ffi::c_double = unsafe { LITERAL_FLOAT };
+pub const NESTED_CHAR: std::ffi::c_int = unsafe { 'x' as i32 };
+pub const NESTED_STR: [std::ffi::c_char; 6] =
+    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
+pub const NESTED_STRUCT: S = unsafe {
+    {
+        let mut init = S {
+            i: 5 as std::ffi::c_int,
+        };
+        init
+    }
+};
+pub const PARENS: std::ffi::c_int = unsafe { NESTED_INT * (LITERAL_CHAR + true_0) };
+pub const PTR_ARITHMETIC: *const std::ffi::c_char = unsafe {
+    LITERAL_STR
+        .as_ptr()
+        .offset(5 as std::ffi::c_int as isize)
+        .offset(-(3 as std::ffi::c_int as isize))
+};
+pub const WIDENING_CAST: std::ffi::c_int = unsafe { LITERAL_INT };
+pub const CONVERSION_CAST: std::ffi::c_int = unsafe { LITERAL_INT };
 #[no_mangle]
 pub unsafe extern "C" fn local_muts() {
-    let mut literal_int: std::ffi::c_int = 0xffff as std::ffi::c_int;
-    let mut literal_bool: bool = 1 as std::ffi::c_int != 0;
-    let mut literal_float: std::ffi::c_float = 3.14f64 as std::ffi::c_float;
-    let mut literal_char: std::ffi::c_char = 'x' as i32 as std::ffi::c_char;
-    let mut literal_str_ptr: *const std::ffi::c_char =
-        b"hello\0" as *const u8 as *const std::ffi::c_char;
-    let mut literal_str: [std::ffi::c_char; 6] =
-        *::core::mem::transmute::<&[u8; 6], &mut [std::ffi::c_char; 6]>(b"hello\0");
+    let mut literal_int: std::ffi::c_int = LITERAL_INT;
+    let mut literal_bool: bool = LITERAL_BOOL != 0;
+    let mut literal_float: std::ffi::c_float = LITERAL_FLOAT as std::ffi::c_float;
+    let mut literal_char: std::ffi::c_char = LITERAL_CHAR as std::ffi::c_char;
+    let mut literal_str_ptr: *const std::ffi::c_char = LITERAL_STR.as_ptr();
+    let mut literal_str: [std::ffi::c_char; 6] = LITERAL_STR;
     let mut literal_array: [std::ffi::c_int; 3] = [
         1 as std::ffi::c_int,
         2 as std::ffi::c_int,
         3 as std::ffi::c_int,
     ];
-    let mut literal_struct: S = {
-        let mut init = S {
-            i: 5 as std::ffi::c_int,
-        };
-        init
-    };
+    let mut literal_struct: S = LITERAL_STRUCT;
     let mut nested_int: std::ffi::c_int = NESTED_INT;
-    let mut nested_bool: bool = 1 as std::ffi::c_int != 0;
-    let mut nested_float: std::ffi::c_float = 3.14f64 as std::ffi::c_float;
-    let mut nested_char: std::ffi::c_char = 'x' as i32 as std::ffi::c_char;
-    let mut nested_str_ptr: *const std::ffi::c_char =
-        b"hello\0" as *const u8 as *const std::ffi::c_char;
-    let mut nested_str: [std::ffi::c_char; 6] =
-        *::core::mem::transmute::<&[u8; 6], &mut [std::ffi::c_char; 6]>(b"hello\0");
+    let mut nested_bool: bool = NESTED_BOOL != 0;
+    let mut nested_float: std::ffi::c_float = NESTED_FLOAT as std::ffi::c_float;
+    let mut nested_char: std::ffi::c_char = NESTED_CHAR as std::ffi::c_char;
+    let mut nested_str_ptr: *const std::ffi::c_char = NESTED_STR.as_ptr();
+    let mut nested_str: [std::ffi::c_char; 6] = NESTED_STR;
     let mut nested_array: [std::ffi::c_int; 3] = [
         1 as std::ffi::c_int,
         2 as std::ffi::c_int,
         3 as std::ffi::c_int,
     ];
-    let mut nested_struct: S = {
-        let mut init = S {
-            i: 5 as std::ffi::c_int,
-        };
-        init
-    };
-    let mut int_arithmetic: std::ffi::c_int =
-        NESTED_INT + 0xffff as std::ffi::c_int + 1 as std::ffi::c_int;
-    let mut mixed_arithmetic: std::ffi::c_float = (0xffff as std::ffi::c_int as std::ffi::c_double
-        + 3.14f64 * 'x' as i32 as std::ffi::c_double
-        - 1 as std::ffi::c_int as std::ffi::c_double)
-        as std::ffi::c_float;
-    let mut parens: std::ffi::c_int = NESTED_INT * ('x' as i32 + 1 as std::ffi::c_int);
-    let mut ptr_arithmetic: *const std::ffi::c_char = (b"hello\0" as *const u8
-        as *const std::ffi::c_char)
-        .offset(5 as std::ffi::c_int as isize)
-        .offset(-(3 as std::ffi::c_int as isize));
-    let mut widening_cast: std::ffi::c_ulonglong =
-        0xffff as std::ffi::c_int as std::ffi::c_ulonglong;
-    let mut narrowing_cast: std::ffi::c_char = 0xffff as std::ffi::c_int as std::ffi::c_char;
-    let mut conversion_cast: std::ffi::c_double = 0xffff as std::ffi::c_int as std::ffi::c_double;
+    let mut nested_struct: S = NESTED_STRUCT;
+    let mut int_arithmetic: std::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as std::ffi::c_int;
+    let mut mixed_arithmetic: std::ffi::c_float =
+        (LITERAL_INT as std::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as std::ffi::c_double
+            - true_0 as std::ffi::c_double) as std::ffi::c_float;
+    let mut parens: std::ffi::c_int = PARENS;
+    let mut ptr_arithmetic: *const std::ffi::c_char = PTR_ARITHMETIC;
+    let mut widening_cast: std::ffi::c_ulonglong = WIDENING_CAST as std::ffi::c_ulonglong;
+    let mut narrowing_cast: std::ffi::c_char = LITERAL_INT as std::ffi::c_char;
+    let mut conversion_cast: std::ffi::c_double = CONVERSION_CAST as std::ffi::c_double;
     let mut indexing: std::ffi::c_char =
         (*::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0"))
-            [3.14f64 as std::ffi::c_int as usize];
+            [LITERAL_FLOAT as std::ffi::c_int as usize];
     let mut str_concatenation_ptr: *const std::ffi::c_char =
         b"hello hello world\0" as *const u8 as *const std::ffi::c_char;
     let mut str_concatenation: [std::ffi::c_char; 18] =
         *::core::mem::transmute::<&[u8; 18], &mut [std::ffi::c_char; 18]>(b"hello hello world\0");
-    let mut ref_indexing: *const std::ffi::c_char =
-        &*(b"hello\0" as *const u8 as *const std::ffi::c_char)
-            .offset(3.14f64 as std::ffi::c_int as isize) as *const std::ffi::c_char;
-    let mut ref_struct: *const S = &mut {
-        let mut init = S {
-            i: 5 as std::ffi::c_int,
-        };
-        init
-    } as *mut S;
-    let mut ternary: std::ffi::c_int = if 1 as std::ffi::c_int != 0 {
+    let mut ref_indexing: *const std::ffi::c_char = &*NESTED_STR
+        .as_ptr()
+        .offset(LITERAL_FLOAT as std::ffi::c_int as isize)
+        as *const std::ffi::c_char;
+    let mut ref_struct: *const S = &mut LITERAL_STRUCT as *mut S;
+    let mut ternary: std::ffi::c_int = if LITERAL_BOOL != 0 {
         1 as std::ffi::c_int
     } else {
         2 as std::ffi::c_int
     };
-    let mut member: std::ffi::c_int = {
-        let mut init = S {
-            i: 5 as std::ffi::c_int,
-        };
-        init
-    }
-    .i;
+    let mut member: std::ffi::c_int = LITERAL_STRUCT.i;
 }
 #[no_mangle]
 pub unsafe extern "C" fn local_consts() {
-    let literal_int: std::ffi::c_int = 0xffff as std::ffi::c_int;
-    let literal_bool: bool = 1 as std::ffi::c_int != 0;
-    let literal_float: std::ffi::c_float = 3.14f64 as std::ffi::c_float;
-    let literal_char: std::ffi::c_char = 'x' as i32 as std::ffi::c_char;
-    let literal_str_ptr: *const std::ffi::c_char =
-        b"hello\0" as *const u8 as *const std::ffi::c_char;
-    let literal_str: [std::ffi::c_char; 6] =
-        *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0");
+    let literal_int: std::ffi::c_int = LITERAL_INT;
+    let literal_bool: bool = LITERAL_BOOL != 0;
+    let literal_float: std::ffi::c_float = LITERAL_FLOAT as std::ffi::c_float;
+    let literal_char: std::ffi::c_char = LITERAL_CHAR as std::ffi::c_char;
+    let literal_str_ptr: *const std::ffi::c_char = LITERAL_STR.as_ptr();
+    let literal_str: [std::ffi::c_char; 6] = LITERAL_STR;
     let literal_array: [std::ffi::c_int; 3] = [
         1 as std::ffi::c_int,
         2 as std::ffi::c_int,
         3 as std::ffi::c_int,
     ];
-    let literal_struct: S = {
-        let mut init = S {
-            i: 5 as std::ffi::c_int,
-        };
-        init
-    };
+    let literal_struct: S = LITERAL_STRUCT;
     let nested_int: std::ffi::c_int = NESTED_INT;
-    let nested_bool: bool = 1 as std::ffi::c_int != 0;
-    let nested_float: std::ffi::c_float = 3.14f64 as std::ffi::c_float;
-    let nested_char: std::ffi::c_char = 'x' as i32 as std::ffi::c_char;
-    let nested_str_ptr: *const std::ffi::c_char =
-        b"hello\0" as *const u8 as *const std::ffi::c_char;
-    let nested_str: [std::ffi::c_char; 6] =
-        *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0");
+    let nested_bool: bool = NESTED_BOOL != 0;
+    let nested_float: std::ffi::c_float = NESTED_FLOAT as std::ffi::c_float;
+    let nested_char: std::ffi::c_char = NESTED_CHAR as std::ffi::c_char;
+    let nested_str_ptr: *const std::ffi::c_char = NESTED_STR.as_ptr();
+    let nested_str: [std::ffi::c_char; 6] = NESTED_STR;
     let nested_array: [std::ffi::c_int; 3] = [
         1 as std::ffi::c_int,
         2 as std::ffi::c_int,
         3 as std::ffi::c_int,
     ];
-    let nested_struct: S = {
-        let mut init = S {
-            i: 5 as std::ffi::c_int,
-        };
-        init
-    };
-    let int_arithmetic: std::ffi::c_int =
-        NESTED_INT + 0xffff as std::ffi::c_int + 1 as std::ffi::c_int;
-    let mixed_arithmetic: std::ffi::c_float = (0xffff as std::ffi::c_int as std::ffi::c_double
-        + 3.14f64 * 'x' as i32 as std::ffi::c_double
-        - 1 as std::ffi::c_int as std::ffi::c_double)
-        as std::ffi::c_float;
-    let parens: std::ffi::c_int = NESTED_INT * ('x' as i32 + 1 as std::ffi::c_int);
-    let ptr_arithmetic: *const std::ffi::c_char = (b"hello\0" as *const u8
-        as *const std::ffi::c_char)
-        .offset(5 as std::ffi::c_int as isize)
-        .offset(-(3 as std::ffi::c_int as isize));
-    let widening_cast: std::ffi::c_ulonglong = 0xffff as std::ffi::c_int as std::ffi::c_ulonglong;
-    let narrowing_cast: std::ffi::c_char = 0xffff as std::ffi::c_int as std::ffi::c_char;
-    let conversion_cast: std::ffi::c_double = 0xffff as std::ffi::c_int as std::ffi::c_double;
+    let nested_struct: S = NESTED_STRUCT;
+    let int_arithmetic: std::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as std::ffi::c_int;
+    let mixed_arithmetic: std::ffi::c_float =
+        (LITERAL_INT as std::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as std::ffi::c_double
+            - true_0 as std::ffi::c_double) as std::ffi::c_float;
+    let parens: std::ffi::c_int = PARENS;
+    let ptr_arithmetic: *const std::ffi::c_char = PTR_ARITHMETIC;
+    let widening_cast: std::ffi::c_ulonglong = WIDENING_CAST as std::ffi::c_ulonglong;
+    let narrowing_cast: std::ffi::c_char = LITERAL_INT as std::ffi::c_char;
+    let conversion_cast: std::ffi::c_double = CONVERSION_CAST as std::ffi::c_double;
     let indexing: std::ffi::c_char =
         (*::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0"))
-            [3.14f64 as std::ffi::c_int as usize];
+            [LITERAL_FLOAT as std::ffi::c_int as usize];
     let str_concatenation_ptr: *const std::ffi::c_char =
         b"hello hello world\0" as *const u8 as *const std::ffi::c_char;
     let str_concatenation: [std::ffi::c_char; 18] =
         *::core::mem::transmute::<&[u8; 18], &[std::ffi::c_char; 18]>(b"hello hello world\0");
-    let ref_indexing: *const std::ffi::c_char =
-        &*(b"hello\0" as *const u8 as *const std::ffi::c_char)
-            .offset(3.14f64 as std::ffi::c_int as isize) as *const std::ffi::c_char;
-    let ref_struct: *const S = &mut {
-        let mut init = S {
-            i: 5 as std::ffi::c_int,
-        };
-        init
-    } as *mut S;
-    let ternary: std::ffi::c_int = if 1 as std::ffi::c_int != 0 {
+    let ref_indexing: *const std::ffi::c_char = &*NESTED_STR
+        .as_ptr()
+        .offset(LITERAL_FLOAT as std::ffi::c_int as isize)
+        as *const std::ffi::c_char;
+    let ref_struct: *const S = &mut LITERAL_STRUCT as *mut S;
+    let ternary: std::ffi::c_int = if LITERAL_BOOL != 0 {
         1 as std::ffi::c_int
     } else {
         2 as std::ffi::c_int
     };
-    let member: std::ffi::c_int = {
-        let mut init = S {
-            i: 5 as std::ffi::c_int,
-        };
-        init
-    }
-    .i;
+    let member: std::ffi::c_int = LITERAL_STRUCT.i;
 }
-static mut global_static_const_literal_int: std::ffi::c_int = 0xffff as std::ffi::c_int;
-static mut global_static_const_literal_bool: bool = 1 as std::ffi::c_int != 0;
-static mut global_static_const_literal_float: std::ffi::c_float = 3.14f64 as std::ffi::c_float;
-static mut global_static_const_literal_char: std::ffi::c_char = 'x' as i32 as std::ffi::c_char;
-static mut global_static_const_literal_str_ptr: *const std::ffi::c_char =
-    b"hello\0" as *const u8 as *const std::ffi::c_char;
-static mut global_static_const_literal_str: [std::ffi::c_char; 6] =
-    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
+static mut global_static_const_literal_int: std::ffi::c_int = LITERAL_INT;
+static mut global_static_const_literal_bool: bool = LITERAL_BOOL != 0;
+static mut global_static_const_literal_float: std::ffi::c_float =
+    LITERAL_FLOAT as std::ffi::c_float;
+static mut global_static_const_literal_char: std::ffi::c_char = LITERAL_CHAR as std::ffi::c_char;
+static mut global_static_const_literal_str_ptr: *const std::ffi::c_char = LITERAL_STR.as_ptr();
+static mut global_static_const_literal_str: [std::ffi::c_char; 6] = LITERAL_STR;
 static mut global_static_const_literal_array: [std::ffi::c_int; 3] = [
     1 as std::ffi::c_int,
     2 as std::ffi::c_int,
     3 as std::ffi::c_int,
 ];
-static mut global_static_const_literal_struct: S = {
-    let mut init = S { i: 5 };
-    init
-};
+static mut global_static_const_literal_struct: S = LITERAL_STRUCT;
 static mut global_static_const_nested_int: std::ffi::c_int = NESTED_INT;
-static mut global_static_const_nested_bool: bool = 1 as std::ffi::c_int != 0;
-static mut global_static_const_nested_float: std::ffi::c_float = 3.14f64 as std::ffi::c_float;
-static mut global_static_const_nested_char: std::ffi::c_char = 'x' as i32 as std::ffi::c_char;
-static mut global_static_const_nested_str_ptr: *const std::ffi::c_char =
-    b"hello\0" as *const u8 as *const std::ffi::c_char;
-static mut global_static_const_nested_str: [std::ffi::c_char; 6] =
-    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
+static mut global_static_const_nested_bool: bool = NESTED_BOOL != 0;
+static mut global_static_const_nested_float: std::ffi::c_float = NESTED_FLOAT as std::ffi::c_float;
+static mut global_static_const_nested_char: std::ffi::c_char = NESTED_CHAR as std::ffi::c_char;
+static mut global_static_const_nested_str_ptr: *const std::ffi::c_char = NESTED_STR.as_ptr();
+static mut global_static_const_nested_str: [std::ffi::c_char; 6] = NESTED_STR;
 static mut global_static_const_nested_array: [std::ffi::c_int; 3] = [
     1 as std::ffi::c_int,
     2 as std::ffi::c_int,
     3 as std::ffi::c_int,
 ];
-static mut global_static_const_nested_struct: S = {
-    let mut init = S { i: 5 };
-    init
-};
+static mut global_static_const_nested_struct: S = NESTED_STRUCT;
 static mut global_static_const_int_arithmetic: std::ffi::c_int =
-    NESTED_INT + 0xffff as std::ffi::c_int + 1 as std::ffi::c_int;
+    NESTED_INT + LITERAL_INT + 1 as std::ffi::c_int;
 static mut global_static_const_mixed_arithmetic: std::ffi::c_float =
-    (0xffff as std::ffi::c_int as std::ffi::c_double + 3.14f64 * 'x' as i32 as std::ffi::c_double
-        - 1 as std::ffi::c_int as std::ffi::c_double) as std::ffi::c_float;
-static mut global_static_const_parens: std::ffi::c_int =
-    NESTED_INT * ('x' as i32 + 1 as std::ffi::c_int);
+    (LITERAL_INT as std::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as std::ffi::c_double
+        - true_0 as std::ffi::c_double) as std::ffi::c_float;
+static mut global_static_const_parens: std::ffi::c_int = PARENS;
 static mut global_static_const_ptr_arithmetic: *const std::ffi::c_char =
     0 as *const std::ffi::c_char;
 static mut global_static_const_widening_cast: std::ffi::c_ulonglong =
-    0xffff as std::ffi::c_int as std::ffi::c_ulonglong;
-static mut global_static_const_narrowing_cast: std::ffi::c_char =
-    0xffff as std::ffi::c_int as std::ffi::c_char;
+    WIDENING_CAST as std::ffi::c_ulonglong;
+static mut global_static_const_narrowing_cast: std::ffi::c_char = LITERAL_INT as std::ffi::c_char;
 static mut global_static_const_conversion_cast: std::ffi::c_double =
-    0xffff as std::ffi::c_int as std::ffi::c_double;
+    CONVERSION_CAST as std::ffi::c_double;
 static mut global_static_const_indexing: std::ffi::c_char = 0;
 static mut global_static_const_str_concatenation_ptr: *const std::ffi::c_char =
     b"hello hello world\0" as *const u8 as *const std::ffi::c_char;
@@ -253,63 +220,54 @@ static mut global_static_const_str_concatenation: [std::ffi::c_char; 18] = unsaf
     *::core::mem::transmute::<&[u8; 18], &[std::ffi::c_char; 18]>(b"hello hello world\0")
 };
 static mut global_static_const_ref_indexing: *const std::ffi::c_char = 0 as *const std::ffi::c_char;
-static mut global_static_const_ref_struct: *const S = &{
-    let mut init = S { i: 5 };
-    init
-} as *const S as *mut S;
+static mut global_static_const_ref_struct: *const S = &LITERAL_STRUCT as *const S as *mut S;
 static mut global_static_const_ternary: std::ffi::c_int = 0;
 static mut global_static_const_member: std::ffi::c_int = 0;
 #[no_mangle]
 pub unsafe extern "C" fn global_static_consts() {}
 #[no_mangle]
-pub static mut global_const_literal_int: std::ffi::c_int = 0xffff as std::ffi::c_int;
+pub static mut global_const_literal_int: std::ffi::c_int = LITERAL_INT;
 #[no_mangle]
-pub static mut global_const_literal_bool: bool = 1 as std::ffi::c_int != 0;
+pub static mut global_const_literal_bool: bool = LITERAL_BOOL != 0;
 #[no_mangle]
-pub static mut global_const_literal_float: std::ffi::c_float = 3.14f64 as std::ffi::c_float;
+pub static mut global_const_literal_float: std::ffi::c_float = LITERAL_FLOAT as std::ffi::c_float;
 #[no_mangle]
-pub static mut global_const_literal_char: std::ffi::c_char = 'x' as i32 as std::ffi::c_char;
+pub static mut global_const_literal_char: std::ffi::c_char = LITERAL_CHAR as std::ffi::c_char;
 #[no_mangle]
-pub static mut global_const_literal_str_ptr: *const std::ffi::c_char =
-    b"hello\0" as *const u8 as *const std::ffi::c_char;
+pub static mut global_const_literal_str_ptr: *const std::ffi::c_char = LITERAL_STR.as_ptr();
 #[no_mangle]
-pub static mut global_const_literal_str: [std::ffi::c_char; 6] =
-    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
+pub static mut global_const_literal_str: [std::ffi::c_char; 6] = LITERAL_STR;
 #[no_mangle]
 pub static mut global_const_nested_int: std::ffi::c_int = NESTED_INT;
 #[no_mangle]
-pub static mut global_const_nested_bool: bool = 1 as std::ffi::c_int != 0;
+pub static mut global_const_nested_bool: bool = NESTED_BOOL != 0;
 #[no_mangle]
-pub static mut global_const_nested_float: std::ffi::c_float = 3.14f64 as std::ffi::c_float;
+pub static mut global_const_nested_float: std::ffi::c_float = NESTED_FLOAT as std::ffi::c_float;
 #[no_mangle]
-pub static mut global_const_nested_char: std::ffi::c_char = 'x' as i32 as std::ffi::c_char;
+pub static mut global_const_nested_char: std::ffi::c_char = NESTED_CHAR as std::ffi::c_char;
 #[no_mangle]
-pub static mut global_const_nested_str_ptr: *const std::ffi::c_char =
-    b"hello\0" as *const u8 as *const std::ffi::c_char;
+pub static mut global_const_nested_str_ptr: *const std::ffi::c_char = NESTED_STR.as_ptr();
 #[no_mangle]
-pub static mut global_const_nested_str: [std::ffi::c_char; 6] =
-    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
+pub static mut global_const_nested_str: [std::ffi::c_char; 6] = NESTED_STR;
 #[no_mangle]
 pub static mut global_const_int_arithmetic: std::ffi::c_int =
-    NESTED_INT + 0xffff as std::ffi::c_int + 1 as std::ffi::c_int;
+    NESTED_INT + LITERAL_INT + 1 as std::ffi::c_int;
 #[no_mangle]
 pub static mut global_const_mixed_arithmetic: std::ffi::c_float =
-    (0xffff as std::ffi::c_int as std::ffi::c_double + 3.14f64 * 'x' as i32 as std::ffi::c_double
-        - 1 as std::ffi::c_int as std::ffi::c_double) as std::ffi::c_float;
+    (LITERAL_INT as std::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as std::ffi::c_double
+        - true_0 as std::ffi::c_double) as std::ffi::c_float;
 #[no_mangle]
-pub static mut global_const_parens: std::ffi::c_int =
-    NESTED_INT * ('x' as i32 + 1 as std::ffi::c_int);
+pub static mut global_const_parens: std::ffi::c_int = PARENS;
 #[no_mangle]
 pub static mut global_const_ptr_arithmetic: *const std::ffi::c_char = 0 as *const std::ffi::c_char;
 #[no_mangle]
 pub static mut global_const_widening_cast: std::ffi::c_ulonglong =
-    0xffff as std::ffi::c_int as std::ffi::c_ulonglong;
+    WIDENING_CAST as std::ffi::c_ulonglong;
 #[no_mangle]
-pub static mut global_const_narrowing_cast: std::ffi::c_char =
-    0xffff as std::ffi::c_int as std::ffi::c_char;
+pub static mut global_const_narrowing_cast: std::ffi::c_char = LITERAL_INT as std::ffi::c_char;
 #[no_mangle]
 pub static mut global_const_conversion_cast: std::ffi::c_double =
-    0xffff as std::ffi::c_int as std::ffi::c_double;
+    CONVERSION_CAST as std::ffi::c_double;
 #[no_mangle]
 pub static mut global_const_indexing: std::ffi::c_char = 0;
 #[no_mangle]
@@ -323,13 +281,17 @@ pub static mut global_const_str_concatenation: [std::ffi::c_char; 18] = unsafe {
 pub unsafe extern "C" fn test_fn_macro(mut x: std::ffi::c_int) -> std::ffi::c_int {
     return x * x;
 }
-pub const TEST_CONST2: std::ffi::c_int = unsafe { 2 as std::ffi::c_int };
+pub const TEST_CONST1: std::ffi::c_int = unsafe { 1 as std::ffi::c_int };
+pub const TEST_NESTED: std::ffi::c_int = unsafe { 2 as std::ffi::c_int };
+pub const TEST_CONST2: std::ffi::c_int = unsafe { TEST_NESTED };
+pub const TEST_PARENS: std::ffi::c_int =
+    unsafe { (TEST_CONST2 + 1 as std::ffi::c_int) * 3 as std::ffi::c_int };
 #[no_mangle]
 pub unsafe extern "C" fn reference_define() -> std::ffi::c_int {
-    let mut x: std::ffi::c_int = 1 as std::ffi::c_int;
+    let mut x: std::ffi::c_int = TEST_CONST1;
     x += TEST_CONST2;
-    if (3 as std::ffi::c_int) < (TEST_CONST2 + 1 as std::ffi::c_int) * 3 as std::ffi::c_int {
-        x += (TEST_CONST2 + 1 as std::ffi::c_int) * 3 as std::ffi::c_int;
+    if (3 as std::ffi::c_int) < TEST_PARENS {
+        x += TEST_PARENS;
     }
     return x;
 }
@@ -375,22 +337,22 @@ pub unsafe extern "C" fn stmt_expr_inc() -> std::ffi::c_int {
 #[no_mangle]
 pub unsafe extern "C" fn test_switch(mut x: std::ffi::c_int) -> std::ffi::c_int {
     match x {
-        1 => return 10 as std::ffi::c_int,
-        2 => return 20 as std::ffi::c_int,
+        TEST_CONST1 => return 10 as std::ffi::c_int,
+        TEST_NESTED => return 20 as std::ffi::c_int,
         _ => {}
     }
     return 0 as std::ffi::c_int;
 }
+pub const silk_int16_MIN: std::ffi::c_int = unsafe { 0x8000 as std::ffi::c_int };
 #[no_mangle]
 pub unsafe extern "C" fn test_silk_int16_MIN() -> std::ffi::c_int {
     let mut _null: std::ffi::c_char =
-        (*::core::mem::transmute::<&[u8; 1], &[std::ffi::c_char; 1]>(b"\0"))[(0x8000
-            as std::ffi::c_int
+        (*::core::mem::transmute::<&[u8; 1], &[std::ffi::c_char; 1]>(b"\0"))[(silk_int16_MIN
             as std::ffi::c_short
             as std::ffi::c_int
             + 0x8000 as std::ffi::c_int)
             as usize];
-    return 0x8000 as std::ffi::c_int as std::ffi::c_short as std::ffi::c_int;
+    return silk_int16_MIN;
 }
 #[no_mangle]
 pub unsafe extern "C" fn use_extern_value() -> std::ffi::c_int {
@@ -405,31 +367,24 @@ pub unsafe extern "C" fn use_local_value() -> std::ffi::c_int {
     return local_fn();
 }
 unsafe extern "C" fn run_static_initializers() {
-    global_static_const_ptr_arithmetic = (b"hello\0" as *const u8 as *const std::ffi::c_char)
-        .offset(5 as std::ffi::c_int as isize)
-        .offset(-(3 as std::ffi::c_int as isize));
+    global_static_const_ptr_arithmetic = PTR_ARITHMETIC;
     global_static_const_indexing =
         (*::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0"))
-            [3.14f64 as std::ffi::c_int as usize];
-    global_static_const_ref_indexing = &*(b"hello\0" as *const u8 as *const std::ffi::c_char)
-        .offset(3.14f64 as std::ffi::c_int as isize)
+            [LITERAL_FLOAT as std::ffi::c_int as usize];
+    global_static_const_ref_indexing = &*NESTED_STR
+        .as_ptr()
+        .offset(LITERAL_FLOAT as std::ffi::c_int as isize)
         as *const std::ffi::c_char;
-    global_static_const_ternary = if 1 as std::ffi::c_int != 0 {
+    global_static_const_ternary = if LITERAL_BOOL != 0 {
         1 as std::ffi::c_int
     } else {
         2 as std::ffi::c_int
     };
-    global_static_const_member = {
-        let mut init = S { i: 5 };
-        init
-    }
-    .i;
-    global_const_ptr_arithmetic = (b"hello\0" as *const u8 as *const std::ffi::c_char)
-        .offset(5 as std::ffi::c_int as isize)
-        .offset(-(3 as std::ffi::c_int as isize));
+    global_static_const_member = LITERAL_STRUCT.i;
+    global_const_ptr_arithmetic = PTR_ARITHMETIC;
     global_const_indexing =
         (*::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0"))
-            [3.14f64 as std::ffi::c_int as usize];
+            [LITERAL_FLOAT as std::ffi::c_int as usize];
 }
 #[used]
 #[cfg_attr(target_os = "linux", link_section = ".init_array")]


### PR DESCRIPTION
* Fixes #803.

We do this by recursively checking whether an expression is `const`.  This is generally done in a conservative manner, modulo the `ExplicitCast` bug (#853), non-`const` `sizeof(VLA)`s, and `f128`'s non-`const` methods (#1262).  For #853, this does generate incorrect code even on `conservative`, but I'll work on fixing that next.

Statements are not handled yet.

Also, because we now allow certain operations that are `unsafe`, like ptr arithmetic, we wrap all `const`s in an `unsafe` block.  This is similar to how all `fn`s we generate are marked `unsafe fn`s even if they don't contain any `unsafe` operations within them.  We can improve this, but for now, this works and is correct.

Also, the output was being non-deterministic due to the usage of `HashMap`s for macro maps like `macro_invocations`, so I changed these to `IndexMap`s that are order-preserving.