### PR TITLE
Apply clippy fixes to stable crates

### DIFF
--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -154,7 +154,7 @@ fn use_tree_with_prefix(prefix: Path, leaf: UseTree) -> UseTree {
 }
 
 fn punct<T, P: Default>(x: Vec<T>) -> Punctuated<T, P> {
-    Punctuated::from_iter(x.into_iter())
+    Punctuated::from_iter(x)
 }
 
 fn punct_box<T, P: Default>(x: Vec<Box<T>>) -> Punctuated<T, P> {

--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -342,7 +342,7 @@ impl Make<TokenStream> for Vec<String> {
         let mut first = true;
 
         for s in self {
-            if first == false {
+            if !first {
                 tokens.push(TokenTree::Punct(Punct::new(',', Spacing::Alone)));
             } else {
                 first = false;
@@ -361,7 +361,7 @@ impl Make<TokenStream> for Vec<&str> {
         let mut first = true;
 
         for s in self {
-            if first == false {
+            if !first {
                 tokens.push(TokenTree::Punct(Punct::new(',', Spacing::Alone)));
             } else {
                 first = false;
@@ -380,7 +380,7 @@ impl Make<TokenStream> for Vec<u64> {
         let mut first = true;
 
         for s in self {
-            if first == false {
+            if !first {
                 tokens.push(TokenTree::Punct(Punct::new(',', Spacing::Alone)));
             } else {
                 first = false;
@@ -400,7 +400,7 @@ impl Make<TokenStream> for Vec<Meta> {
         let mut first = true;
 
         for meta in self {
-            if first == false {
+            if !first {
                 let tt = TokenTree::Punct(Punct::new(',', Spacing::Alone));
 
                 tokens.extend(vec![tt]);

--- a/c2rust-ast-exporter/build.rs
+++ b/c2rust-ast-exporter/build.rs
@@ -129,12 +129,12 @@ fn build_native(llvm_info: &LLVMInfo) {
                 // Where to find LLVM/Clang CMake files
                 .define(
                     "LLVM_DIR",
-                    &env::var("CMAKE_LLVM_DIR")
+                    env::var("CMAKE_LLVM_DIR")
                         .unwrap_or_else(|_| format!("{}/cmake/llvm", llvm_lib_dir)),
                 )
                 .define(
                     "Clang_DIR",
-                    &env::var("CMAKE_CLANG_DIR")
+                    env::var("CMAKE_CLANG_DIR")
                         .unwrap_or_else(|_| format!("{}/cmake/clang", llvm_lib_dir)),
                 )
                 // What to build
@@ -269,7 +269,7 @@ impl LLVMInfo {
         let lib_dir = {
             let path_str = env::var("LLVM_LIB_DIR")
                 .ok()
-                .or_else(|| invoke_command(llvm_config.as_deref(), &["--libdir"]))
+                .or_else(|| invoke_command(llvm_config.as_deref(), ["--libdir"]))
                 .expect(llvm_config_missing);
             String::from(
                 Path::new(&path_str)
@@ -279,7 +279,7 @@ impl LLVMInfo {
             )
         };
 
-        let llvm_shared_libs = invoke_command(llvm_config.as_deref(), &["--libs", "--link-shared"]);
+        let llvm_shared_libs = invoke_command(llvm_config.as_deref(), ["--libs", "--link-shared"]);
 
         // <sysroot>/lib/rustlib/<target>/lib/ contains a libLLVM DSO for the
         // rust compiler. On MacOS, this lib is named libLLVM.dylib, which will
@@ -304,7 +304,7 @@ impl LLVMInfo {
                 dylib_file.push_str(dylib_suffix);
                 let sysroot = invoke_command(
                     env::var_os("RUSTC").map(PathBuf::from).as_deref(),
-                    &["--print=sysroot"],
+                    ["--print=sysroot"],
                 )
                 .unwrap();
 
@@ -339,7 +339,7 @@ impl LLVMInfo {
 
         let llvm_major_version = {
             let version =
-                invoke_command(llvm_config.as_deref(), &["--version"]).expect(llvm_config_missing);
+                invoke_command(llvm_config.as_deref(), ["--version"]).expect(llvm_config_missing);
             let emsg = format!("invalid version string {}", version);
             version
                 .split('.')
@@ -378,7 +378,7 @@ impl LLVMInfo {
         libs.extend(
             env::var("LLVM_SYSTEM_LIBS")
                 .ok()
-                .or_else(|| invoke_command(llvm_config.as_deref(), &["--system-libs", link_mode]))
+                .or_else(|| invoke_command(llvm_config.as_deref(), ["--system-libs", link_mode]))
                 .unwrap_or_default()
                 .split_whitespace()
                 .map(|lib| String::from(lib.trim_start_matches("-l"))),

--- a/c2rust-ast-exporter/src/lib.rs
+++ b/c2rust-ast-exporter/src/lib.rs
@@ -109,6 +109,7 @@ unsafe fn marshal_result(result: *const ffi::ExportResult) -> HashMap<String, Ve
         // Convert CBOR bytes
         let csize = *res.sizes.offset(i);
         let cbytes = *res.bytes.offset(i);
+        #[allow(clippy::unnecessary_cast /*, reason = "needed on x86_64-unknown-linux-gnu" */)]
         let bytes = slice::from_raw_parts(cbytes, csize as usize);
         let mut v = Vec::new();
         v.extend_from_slice(bytes);

--- a/c2rust-bitfields/src/lib.rs
+++ b/c2rust-bitfields/src/lib.rs
@@ -46,7 +46,7 @@ macro_rules! impl_int {
     ($($typ: ident),+) => {
         $(
             impl FieldType for $typ {
-                const IS_SIGNED: bool = $typ::min_value() != 0;
+                const IS_SIGNED: bool = $typ::MIN != 0;
 
                 fn get_bit(&self, bit: usize) -> bool {
                     ((*self >> bit) & 1) == 1

--- a/c2rust-build-paths/src/lib.rs
+++ b/c2rust-build-paths/src/lib.rs
@@ -21,7 +21,7 @@ impl SysRoot {
     pub fn resolve() -> Self {
         let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
         let output = Command::new(rustc)
-            .args(&["--print", "sysroot"])
+            .args(["--print", "sysroot"])
             .output()
             .expect("could not invoke `rustc` to find rust sysroot");
         // trim, but `str::trim` doesn't exist on `[u8]`

--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -83,7 +83,7 @@ pub fn emit_build_files<'lcmd>(
         .unwrap();
 
     if !build_dir.exists() {
-        fs::create_dir_all(&build_dir)
+        fs::create_dir_all(build_dir)
             .unwrap_or_else(|_| panic!("couldn't create build directory: {}", build_dir.display()));
     }
 
@@ -299,8 +299,7 @@ fn emit_cargo_toml<'lcmd>(
             crate_json
                 .as_object()
                 .cloned() // FIXME: we need to clone it because there's no `into_object`
-                .unwrap()
-                .into_iter(),
+                .unwrap(),
         );
     }
 
@@ -316,7 +315,7 @@ fn maybe_write_to_file(output_path: &Path, output: String, overwrite: bool) -> O
         return None;
     }
 
-    let mut file = match File::create(&output_path) {
+    let mut file = match File::create(output_path) {
         Ok(file) => file,
         Err(e) => panic!("Unable to open file for writing: {}", e),
     };

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -2164,7 +2164,7 @@ impl ConversionContext {
 
                     let initializer = node
                         .children
-                        .get(0)
+                        .first()
                         .into_iter()
                         .flatten()
                         .map(|id| self.visit_expr(*id))

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -2420,8 +2420,8 @@ mod tests {
                 let b = locs[j];
                 for c in locs.iter().take(n) {
                     let ab = ctx.compare_src_locs(&a, &b);
-                    let bc = ctx.compare_src_locs(&b, &c);
-                    let ac = ctx.compare_src_locs(&a, &c);
+                    let bc = ctx.compare_src_locs(&b, c);
+                    let ac = ctx.compare_src_locs(&a, c);
                     if ab == bc {
                         let [ab, bc, ac] = [ab, bc, ac].map(|ord| match ord {
                             Ordering::Less => "<",

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1602,49 +1602,23 @@ impl BinOp {
     #[rustfmt::skip]
     pub fn input_types_same(&self) -> bool {
         use BinOp::*;
-        self.all_types_same() || match self {
-            Less => true,
-            Greater => true,
-            LessEqual => true,
-            GreaterEqual => true,
-            EqualEqual => true,
-            NotEqual => true,
-
-            And => true,
-            Or => true,
-
-            AssignAdd => true,
-            AssignSubtract => true,
-            AssignMultiply => true,
-            AssignDivide => true,
-            AssignModulus => true,
-            AssignBitXor => true,
-            AssignShiftLeft => true,
-            AssignShiftRight => true,
-            AssignBitOr => true,
-            AssignBitAnd => true,
-
-            Assign => true,
-            _ => false,
-        }
+        self.all_types_same() || matches!(self,
+            Less | Greater | LessEqual | GreaterEqual | EqualEqual | NotEqual
+            | And | Or
+            | AssignAdd | AssignSubtract | AssignMultiply | AssignDivide | AssignModulus
+            | AssignBitXor | AssignShiftLeft | AssignShiftRight | AssignBitOr | AssignBitAnd
+            | Assign
+        )
     }
 
     /// Does the rust equivalent of this operator have type (T, T) -> T?
     /// This ignores cases where one argument is a pointer and we translate to `.offset()`.
     pub fn all_types_same(&self) -> bool {
         use BinOp::*;
-        match self {
-            Multiply => true,
-            Divide => true,
-            Modulus => true,
-            Add => true,
-            Subtract => true,
-
-            BitAnd => true,
-            BitXor => true,
-            BitOr => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            Multiply | Divide | Modulus | Add | Subtract | BitAnd | BitXor | BitOr
+        )
     }
 }
 
@@ -2444,8 +2418,7 @@ mod tests {
             let a = locs[i];
             for j in 0..n {
                 let b = locs[j];
-                for k in 0..n {
-                    let c = locs[k];
+                for c in locs.iter().take(n) {
                     let ab = ctx.compare_src_locs(&a, &b);
                     let bc = ctx.compare_src_locs(&b, &c);
                     let ac = ctx.compare_src_locs(&a, &c);

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -354,7 +354,7 @@ impl<L: Serialize> Serialize for GenTerminator<L> {
                 ref cases,
             } => {
                 let mut cases_sane: Vec<(String, &L)> = vec![];
-                for &(ref p, ref l) in cases {
+                for (p, l) in cases {
                     let pat: String = pprust::pat_to_string(p);
                     cases_sane.push((pat, l));
                 }
@@ -580,16 +580,13 @@ impl Cfg<Label, StmtOrDecl> {
                 _ => None,
             })
         {
-            c_label_to_goto
-                .entry(target)
-                .or_insert(IndexSet::new())
-                .insert(x);
+            c_label_to_goto.entry(target).or_default().insert(x);
         }
 
         let mut cfg_builder = CfgBuilder::new(c_label_to_goto);
         let entry = cfg_builder.entry.clone();
         cfg_builder.per_stmt_stack.push(PerStmt::new(
-            stmt_ids.get(0).cloned(),
+            stmt_ids.first().cloned(),
             entry.clone(),
             IndexSet::new(),
         ));
@@ -1105,9 +1102,8 @@ impl DeclStmtStore {
 
     /// Extract the Rust statements for the full declaration and initializers. DEBUGGING ONLY.
     pub fn peek_decl_and_assign(&self, decl_id: CDeclId) -> TranslationResult<Vec<Stmt>> {
-        let &DeclStmtInfo {
-            ref decl_and_assign,
-            ..
+        let DeclStmtInfo {
+            decl_and_assign, ..
         } = self
             .store
             .get(&decl_id)
@@ -1759,7 +1755,7 @@ impl CfgBuilder {
                 self.last_per_stmt_mut()
                     .c_labels_used
                     .entry(label_id)
-                    .or_insert(IndexSet::new())
+                    .or_default()
                     .insert(stmt_id);
 
                 Ok(None)

--- a/c2rust-transpile/src/cfg/multiples.rs
+++ b/c2rust-transpile/src/cfg/multiples.rs
@@ -94,7 +94,7 @@ impl<Lbl: Hash + Ord + Clone> MultipleInfo<Lbl> {
         self.multiples = self
             .multiples
             .iter()
-            .filter_map(|(entries, &(ref join_lbl, ref arms))| {
+            .filter_map(|(entries, (join_lbl, arms))| {
                 let entries: BTreeSet<Lbl> = entries
                     .iter()
                     .map(|lbl| rewrites.get(lbl).unwrap_or(lbl).clone())
@@ -122,7 +122,7 @@ impl<Lbl: Hash + Ord + Clone> MultipleInfo<Lbl> {
 
     /// Add in information about a new multiple
     pub fn add_multiple(&mut self, join: Lbl, arms: Vec<(Lbl, IndexSet<Lbl>)>) {
-        let entry_set: BTreeSet<Lbl> = arms.iter().map(|&(ref l, _)| l.clone()).collect();
+        let entry_set: BTreeSet<Lbl> = arms.iter().map(|(l, _)| l.clone()).collect();
         let arm_map: IndexMap<Lbl, IndexSet<Lbl>> = arms.into_iter().collect();
 
         if arm_map.len() > 1 {

--- a/c2rust-transpile/src/cfg/relooper.rs
+++ b/c2rust-transpile/src/cfg/relooper.rs
@@ -154,10 +154,7 @@ impl RelooperState {
             let mut flipped_map: IndexMap<Label, IndexSet<Label>> = IndexMap::new();
             for (lbl, vals) in map {
                 for val in vals {
-                    flipped_map
-                        .entry(val)
-                        .or_insert(IndexSet::new())
-                        .insert(lbl.clone());
+                    flipped_map.entry(val).or_default().insert(lbl.clone());
                 }
             }
             flipped_map
@@ -289,7 +286,7 @@ impl RelooperState {
 
             let mut closure: IndexMap<V, IndexSet<V>> = IndexMap::new();
             for (f, t) in edges {
-                closure.entry(f).or_insert(IndexSet::new()).insert(t);
+                closure.entry(f).or_default().insert(t);
             }
 
             closure
@@ -358,7 +355,7 @@ impl RelooperState {
             // Partition blocks into those belonging in or after the loop
             let (mut body_blocks, mut follow_blocks): (StructuredBlocks, StructuredBlocks) = blocks
                 .into_iter()
-                .partition(|&(ref lbl, _)| new_returns.contains(lbl) || entries.contains(lbl));
+                .partition(|(lbl, _)| new_returns.contains(lbl) || entries.contains(lbl));
             let mut follow_entries = out_edges(&body_blocks);
 
             // Try to match an existing loop (from the initial C)
@@ -433,7 +430,7 @@ impl RelooperState {
         for entry in &entries {
             reachable_from
                 .entry(entry.clone())
-                .or_insert(IndexSet::new())
+                .or_default()
                 .insert(entry.clone());
         }
 
@@ -442,7 +439,7 @@ impl RelooperState {
             reachable_from
                 .into_iter()
                 .map(|(lbl, reachable)| (lbl, &reachable & &entries.clone()))
-                .filter(|&(_, ref reachable)| reachable.len() == 1)
+                .filter(|(_, reachable)| reachable.len() == 1)
                 .collect(),
         );
 
@@ -460,8 +457,8 @@ impl RelooperState {
 
         let unhandled_entries: IndexSet<Label> = entries
             .iter()
+            .filter(|&e| !handled_entries.contains_key(e))
             .cloned()
-            .filter(|e| !handled_entries.contains_key(e))
             .collect();
 
         let mut handled_blocks: StructuredBlocks = IndexMap::new();
@@ -561,69 +558,66 @@ fn simplify_structure<Stmt: Clone>(structures: Vec<Structure<Stmt>>) -> Vec<Stru
             } => {
                 // Here, we ensure that all labels in a terminator are mentioned only once in the
                 // terminator.
-                let terminator: GenTerminator<StructureLabel<Stmt>> = if let &Switch {
-                    ref expr,
-                    ref cases,
-                } = terminator
-                {
-                    // Here, we group patterns by the label they go to.
-                    type Merged = IndexMap<Label, Vec<Pat>>;
-                    let mut merged_goto: Merged = IndexMap::new();
-                    let mut merged_exit: Merged = IndexMap::new();
+                let terminator: GenTerminator<StructureLabel<Stmt>> =
+                    if let Switch { expr, cases } = terminator {
+                        // Here, we group patterns by the label they go to.
+                        type Merged = IndexMap<Label, Vec<Pat>>;
+                        let mut merged_goto: Merged = IndexMap::new();
+                        let mut merged_exit: Merged = IndexMap::new();
 
-                    for (pat, lbl) in cases {
-                        let (lbl, merged) = match lbl {
-                            StructureLabel::GoTo(lbl) => (lbl, &mut merged_goto),
-                            StructureLabel::ExitTo(lbl) => (lbl, &mut merged_exit),
-                            _ => panic!("simplify_structure: Nested precondition violated"),
-                        };
-                        merged
-                            .entry(lbl.clone())
-                            .or_insert(Default::default())
-                            .push(pat.clone());
-                    }
+                        for (pat, lbl) in cases {
+                            let (lbl, merged) = match lbl {
+                                StructureLabel::GoTo(lbl) => (lbl, &mut merged_goto),
+                                StructureLabel::ExitTo(lbl) => (lbl, &mut merged_exit),
+                                _ => panic!("simplify_structure: Nested precondition violated"),
+                            };
+                            merged
+                                .entry(lbl.clone())
+                                .or_insert(Default::default())
+                                .push(pat.clone());
+                        }
 
-                    // When converting these patterns back into a vector, we have to be careful to
-                    // preserve their initial order (so that the default pattern doesn't end up on
-                    // top).
-                    let mut cases_new = Vec::new();
-                    for (_, lbl) in cases.iter().rev() {
-                        use StructureLabel::*;
-                        match lbl {
-                            GoTo(lbl) => match merged_goto.swap_remove(lbl) {
-                                None => {}
-                                Some(mut pats) => {
-                                    let pat = if pats.len() == 1 {
-                                        pats.pop().unwrap()
-                                    } else {
-                                        mk().or_pat(pats)
-                                    };
-                                    cases_new.push((pat, GoTo(lbl.clone())))
-                                }
-                            },
-                            ExitTo(lbl) => match merged_exit.swap_remove(lbl) {
-                                None => {}
-                                Some(mut pats) => {
-                                    let pat = if pats.len() == 1 {
-                                        pats.pop().unwrap()
-                                    } else {
-                                        mk().or_pat(pats)
-                                    };
-                                    cases_new.push((pat, ExitTo(lbl.clone())))
-                                }
-                            },
-                            _ => panic!("simplify_structure: Nested precondition violated"),
-                        };
-                    }
-                    cases_new.reverse();
+                        // When converting these patterns back into a vector, we have to be careful to
+                        // preserve their initial order (so that the default pattern doesn't end up on
+                        // top).
+                        let mut cases_new = Vec::new();
+                        for (_, lbl) in cases.iter().rev() {
+                            use StructureLabel::*;
+                            match lbl {
+                                GoTo(lbl) => match merged_goto.swap_remove(lbl) {
+                                    None => {}
+                                    Some(mut pats) => {
+                                        let pat = if pats.len() == 1 {
+                                            pats.pop().unwrap()
+                                        } else {
+                                            mk().or_pat(pats)
+                                        };
+                                        cases_new.push((pat, GoTo(lbl.clone())))
+                                    }
+                                },
+                                ExitTo(lbl) => match merged_exit.swap_remove(lbl) {
+                                    None => {}
+                                    Some(mut pats) => {
+                                        let pat = if pats.len() == 1 {
+                                            pats.pop().unwrap()
+                                        } else {
+                                            mk().or_pat(pats)
+                                        };
+                                        cases_new.push((pat, ExitTo(lbl.clone())))
+                                    }
+                                },
+                                _ => panic!("simplify_structure: Nested precondition violated"),
+                            };
+                        }
+                        cases_new.reverse();
 
-                    Switch {
-                        expr: expr.clone(),
-                        cases: cases_new,
-                    }
-                } else {
-                    terminator.clone()
-                };
+                        Switch {
+                            expr: expr.clone(),
+                            cases: cases_new,
+                        }
+                    } else {
+                        terminator.clone()
+                    };
 
                 match acc_structures.pop() {
                     Some(Structure::Multiple {

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -285,7 +285,7 @@ fn structured_cfg_help<S: StructuredStatement<E = Box<Expr>, P = Pat, L = Label,
                         Switch { expr, cases } => {
                             let branched_cases = cases
                                 .iter()
-                                .map(|&(ref pat, ref slbl)| Ok((pat.clone(), branch(slbl)?)))
+                                .map(|(pat, slbl)| Ok((pat.clone(), branch(slbl)?)))
                                 .collect::<TranslationResult<_>>()?;
 
                             S::mk_match(expr.clone(), branched_cases)

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -26,10 +26,8 @@ pub fn structured_cfg(
     // If the very last statement in the vector is a `return`, we can either cut it out or replace
     // it with the returned value.
     if cut_out_trailing_ret {
-        if let Some(Stmt::Expr(ret, _)) = stmts.last() {
-            if let Expr::Return(ExprReturn { expr: None, .. }) = ret {
-                stmts.pop();
-            }
+        if let Some(Stmt::Expr(Expr::Return(ExprReturn { expr: None, .. }), _)) = stmts.last() {
+            stmts.pop();
         }
     }
 

--- a/c2rust-transpile/src/compile_cmds/mod.rs
+++ b/c2rust-transpile/src/compile_cmds/mod.rs
@@ -180,7 +180,7 @@ pub fn get_compile_commands(
     let v: Vec<Rc<CompileCmd>> = serde_json::from_reader(f)?;
 
     // apply the filter argument, if any
-    let v = if let &Some(ref re) = filter {
+    let v = if let Some(re) = filter {
         v.into_iter()
             .filter(|c| re.is_match(c.file.to_str().unwrap()))
             .collect::<Vec<Rc<CompileCmd>>>()

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -442,7 +442,7 @@ fn get_extra_args_macos() -> Vec<String> {
         let usr_incl = Path::new("/usr/include");
         if !usr_incl.exists() {
             let output = process::Command::new("xcrun")
-                .args(&["--show-sdk-path"])
+                .args(["--show-sdk-path"])
                 .output()
                 .expect("failed to run `xcrun` subcommand");
             let mut sdk_path = String::from_utf8(output.stdout).unwrap();
@@ -477,7 +477,7 @@ fn reorganize_definitions(
     invoke_refactor(build_dir)?;
     // fix the formatting of the output of `c2rust-refactor`
     let status = process::Command::new("cargo")
-        .args(&["fmt"])
+        .args(["fmt"])
         .current_dir(build_dir)
         .status()?;
     if !status.success() {
@@ -617,7 +617,7 @@ fn get_output_path(
         // Create the parent directory if it doesn't exist
         let parent = output_path.parent().unwrap();
         if !parent.exists() {
-            fs::create_dir_all(&parent).unwrap_or_else(|_| {
+            fs::create_dir_all(parent).unwrap_or_else(|_| {
                 panic!("couldn't create source directory: {}", parent.display())
             });
         }

--- a/c2rust-transpile/src/rust_ast/set_span.rs
+++ b/c2rust-transpile/src/rust_ast/set_span.rs
@@ -186,7 +186,7 @@ set_span_impl!(enum ImplItem, s via
 
 impl SetSpan for Block {
     fn set_span(&mut self, s: Span) {
-        if self.stmts.is_empty() == false {
+        if !self.stmts.is_empty() {
             self.stmts[0].set_span(s);
         }
     }

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -134,7 +134,7 @@ fn parse_constraints(
     }
 
     // Handle register names
-    let mut constraints = constraints.replace('{', "\"").replace('}', "\"");
+    let mut constraints = constraints.replace(['{', '}'], "\"");
 
     // Convert (simple) constraints to ones rustc understands
     match &*constraints {
@@ -673,13 +673,7 @@ impl<'c> Translation<'c> {
         let mut tokens: Vec<TokenTree> = vec![];
 
         let mut tied_operands = HashMap::new();
-        for (
-            input_idx,
-            &AsmOperand {
-                ref constraints, ..
-            },
-        ) in inputs.iter().enumerate()
-        {
+        for (input_idx, AsmOperand { constraints, .. }) in inputs.iter().enumerate() {
             let constraints_digits = constraints.trim_matches(|c: char| !c.is_ascii_digit());
             if let Ok(output_idx) = constraints_digits.parse::<usize>() {
                 let output_key = (output_idx, true);
@@ -1009,7 +1003,7 @@ impl<'c> Translation<'c> {
         stmts.push(mac);
 
         // Push the post-macro statements
-        stmts.extend(post_stmts.into_iter());
+        stmts.extend(post_stmts);
 
         Ok(stmts)
     }

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -1,6 +1,8 @@
 #![deny(missing_docs)]
 //! This module provides basic support for converting inline assembly statements.
 
+use std::fmt::{self as fmt, Display, Formatter};
+
 use crate::diagnostics::TranslationResult;
 
 use super::*;
@@ -17,17 +19,20 @@ enum ArgDirSpec {
     InLateOut,
 }
 
-impl ToString for ArgDirSpec {
-    fn to_string(&self) -> String {
+impl Display for ArgDirSpec {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         use ArgDirSpec::*;
-        match self {
-            In => "in",
-            Out => "out",
-            InOut => "inout",
-            LateOut => "lateout",
-            InLateOut => "inlateout",
-        }
-        .to_owned()
+        write!(
+            f,
+            "{}",
+            match self {
+                In => "in",
+                Out => "out",
+                InOut => "inout",
+                LateOut => "lateout",
+                InLateOut => "inlateout",
+            }
+        )
     }
 }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -227,11 +227,11 @@ impl FuncContext {
     }
 
     pub fn get_name(&self) -> &str {
-        return self.name.as_ref().unwrap();
+        self.name.as_ref().unwrap()
     }
 
     pub fn get_va_list_arg_name(&self) -> &str {
-        return self.va_list_arg_name.as_ref().unwrap();
+        self.va_list_arg_name.as_ref().unwrap()
     }
 }
 
@@ -435,8 +435,7 @@ fn clean_path(mod_names: &RefCell<IndexMap<String, PathBuf>>, path: Option<&path
             .unwrap()
             .to_str()
             .unwrap()
-            .replace('.', "_")
-            .replace('-', "_")
+            .replace(['.', '-'], "_")
     }
 
     let mut file_path: String = path.map_or("internal".to_string(), path_to_str);
@@ -1243,9 +1242,7 @@ impl<'c> Translation<'c> {
         F: FnOnce(&mut ItemStore) -> T,
     {
         let mut item_stores = self.items.borrow_mut();
-        let item_store = item_stores
-            .entry(Self::cur_file(self))
-            .or_insert_with(ItemStore::new);
+        let item_store = item_stores.entry(Self::cur_file(self)).or_default();
         f(item_store)
     }
 
@@ -3390,7 +3387,7 @@ impl<'c> Translation<'c> {
                 // need to cast it to fn() to ensure that it has a real address.
                 let mut set_unsafe = false;
                 if ctx.needs_address() {
-                    if let &CDeclKind::Function { ref parameters, .. } = decl {
+                    if let CDeclKind::Function { parameters, .. } = decl {
                         let ty = self.convert_type(qual_ty.ctype)?;
                         let actual_ty = self
                             .type_converter
@@ -4999,9 +4996,7 @@ impl<'c> Translation<'c> {
             let attrs = item_attrs(&mut item).expect("no attrs field on unexpected item variant");
             add_src_loc_attr(attrs, &decl.loc.as_ref().map(|x| x.begin()));
             let mut item_stores = self.items.borrow_mut();
-            let items = item_stores
-                .entry(decl_file_id.unwrap())
-                .or_insert(ItemStore::new());
+            let items = item_stores.entry(decl_file_id.unwrap()).or_default();
 
             items.add_item(item);
         } else {
@@ -5020,9 +5015,7 @@ impl<'c> Translation<'c> {
                 .expect("no attrs field on unexpected foreign item variant");
             add_src_loc_attr(attrs, &decl.loc.as_ref().map(|x| x.begin()));
             let mut items = self.items.borrow_mut();
-            let mod_block_items = items
-                .entry(decl_file_id.unwrap())
-                .or_insert(ItemStore::new());
+            let mod_block_items = items.entry(decl_file_id.unwrap()).or_default();
 
             mod_block_items.add_foreign_item(item);
         } else {
@@ -5059,7 +5052,7 @@ impl<'c> Translation<'c> {
         self.items
             .borrow_mut()
             .entry(decl_file_id)
-            .or_insert(ItemStore::new())
+            .or_default()
             .add_use(module_path, ident_name);
     }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4929,8 +4929,8 @@ impl<'c> Translation<'c> {
             // is already in the form `(x <op> y) as <ty>` where `<op>` is a Rust operator
             // that returns a boolean, we can simple output `x <op> y` or `!(x <op> y)`.
             if let Expr::Cast(ExprCast { expr: ref arg, .. }) = *unparen(&val) {
-                if let Expr::Binary(ExprBinary { op, .. }) = *unparen(arg) {
-                    match op {
+                if let Expr::Binary(ExprBinary {
+                    op:
                         BinOp::Or(_)
                         | BinOp::And(_)
                         | BinOp::Eq(_)
@@ -4938,19 +4938,19 @@ impl<'c> Translation<'c> {
                         | BinOp::Lt(_)
                         | BinOp::Le(_)
                         | BinOp::Gt(_)
-                        | BinOp::Ge(_) => {
-                            if target {
-                                // If target == true, just return the argument
-                                return Box::new(unparen(arg).clone());
-                            } else {
-                                // If target == false, return !arg
-                                return mk().unary_expr(
-                                    UnOp::Not(Default::default()),
-                                    Box::new(unparen(arg).clone()),
-                                );
-                            }
-                        }
-                        _ => {}
+                        | BinOp::Ge(_),
+                    ..
+                }) = *unparen(arg)
+                {
+                    if target {
+                        // If target == true, just return the argument
+                        return Box::new(unparen(arg).clone());
+                    } else {
+                        // If target == false, return !arg
+                        return mk().unary_expr(
+                            UnOp::Not(Default::default()),
+                            Box::new(unparen(arg).clone()),
+                        );
                     }
                 }
             }

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -50,7 +50,7 @@ fn config() -> TranspilerConfig {
 /// It could be the `target_arch`, `target_os`, some combination, or something else.
 fn transpile(platform: Option<&str>, c_path: &Path) {
     let status = Command::new("clang")
-        .args(&[
+        .args([
             "-c",
             "-o",
             "/dev/null",
@@ -108,7 +108,7 @@ fn transpile(platform: Option<&str>, c_path: &Path) {
     // Don't need to worry about platform clashes here, as this is immediately deleted.
     let rlib_path = format!("lib{crate_name}.rlib");
     let status = Command::new("rustc")
-        .args(&[
+        .args([
             "+nightly-2022-08-08",
             "--crate-type",
             "lib",

--- a/c2rust/src/main.rs
+++ b/c2rust/src/main.rs
@@ -85,7 +85,7 @@ impl SubCommand {
                 self.name
             )
         })?;
-        let status = Command::new(&path).args(args).status()?;
+        let status = Command::new(path).args(args).status()?;
         process::exit(status.code().unwrap_or(1));
     }
 }


### PR DESCRIPTION
This applies a selection of fixes (mostly auto-applied, some manually implemented or suppressed) from Rust 1.88.0 which remain backwards-compatible with c2rust's pinned 1.65 nightly.

I've split them into separate commits under the assumption that it makes review slightly easier. I assume this branch would be squash merged.