### PR TITLE
transpile: tests: snapshots: hard-code nightly toolchain for now

### DIFF
--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -109,6 +109,7 @@ fn transpile(platform: Option<&str>, c_path: &Path) {
     let rlib_path = format!("lib{crate_name}.rlib");
     let status = Command::new("rustc")
         .args(&[
+            "+nightly-2022-08-08",
             "--crate-type",
             "lib",
             "--edition",


### PR DESCRIPTION
I realized this is broken if we try to build on stable, like when publishing.  @fw-immunant already had a fix for this, so it's very trivial.