### PR TITLE
ci: run `c2rust-testsuite` on all PRs, not just those into `master`

### DIFF
--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches: [ master, feature/ci-dev ]
   pull_request:
-    branches: [ master ]
   # allow using from other repos (in particular, c2rust-testsuite)
   workflow_call:
 


### PR DESCRIPTION
Running only on PRs directly into `master` missed broken CI in #1305.