### PR TITLE
Reapply "transpile: make `--translate-{const,fn}-macros conservative` the default for the CLI, too"

### DIFF
--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -46,10 +46,10 @@ type TranspileResult = Result<(PathBuf, PragmaVec, CrateSet), ()>;
 #[derive(Default, Debug)]
 pub enum TranslateMacros {
     /// Don't translate any macros.
-    #[default]
     None,
 
     /// Translate the conservative subset of macros known to always work.
+    #[default]
     Conservative,
 
     /// Try to translate more, but this is experimental and not guaranteed to work.

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-use c2rust_transpile::{ReplaceMode, TranslateMacros, TranspilerConfig};
+use c2rust_transpile::{ReplaceMode, TranspilerConfig};
 
 fn config() -> TranspilerConfig {
     TranspilerConfig {
@@ -36,8 +36,8 @@ fn config() -> TranspilerConfig {
         enabled_warnings: Default::default(),
         emit_no_std: false,
         output_dir: None,
-        translate_const_macros: TranslateMacros::Conservative,
-        translate_fn_macros: TranslateMacros::Conservative,
+        translate_const_macros: Default::default(),
+        translate_fn_macros: Default::default(),
         disable_refactoring: false,
         preserve_unused_functions: false,
         log_level: log::LevelFilter::Warn,

--- a/c2rust/src/bin/c2rust-transpile.rs
+++ b/c2rust/src/bin/c2rust-transpile.rs
@@ -162,10 +162,10 @@ struct Args {
 #[derive(Default, Debug, PartialEq, Eq, ValueEnum, Clone)]
 pub enum TranslateMacros {
     /// Don't translate any macros.
-    #[default]
     None,
 
     /// Translate the conservative subset of macros known to always work.
+    #[default]
     Conservative,
 
     /// Try to translate more, but this is experimental and not guaranteed to work.


### PR DESCRIPTION
This reverts commit 7dbab5e773006bf2b7a60b15e6295d54067ae347.

With #1312 in front of this, this commit should now be properly tested.

For now, this should fail CI, and then I'll fix it.