### PR TITLE
transpile: unconditionally make `const`s use `unsafe` blocks for `--translate-const-macros conservative`

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2152,7 +2152,7 @@ impl<'c> Translation<'c> {
         ctx: ExprContext,
         expansions: &[CExprId],
     ) -> TranslationResult<(Box<Expr>, CTypeId)> {
-        let (val, ty) = expansions
+        let (mut val, ty) = expansions
             .iter()
             .try_fold::<Option<(WithStmts<Box<Expr>>, CTypeId)>, _, _>(None, |canonical, &id| {
                 self.can_convert_const_macro_expansion(id)?;
@@ -2189,6 +2189,7 @@ impl<'c> Translation<'c> {
             })?
             .ok_or_else(|| format_err!("Could not find a valid type for macro"))?;
 
+        val.set_unsafe();
         val.to_unsafe_pure_expr()
             .map(|val| (val, ty))
             .ok_or_else(|| TranslationError::generic("Macro expansion is not a pure expression"))

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.snap
@@ -37,4 +37,4 @@ pub unsafe extern "C" fn c11_atomics(mut x: std::ffi::c_int) -> std::ffi::c_int 
     fresh1.1;
     return x;
 }
-pub const __ATOMIC_SEQ_CST: std::ffi::c_int = 5 as std::ffi::c_int;
+pub const __ATOMIC_SEQ_CST: std::ffi::c_int = unsafe { 5 as std::ffi::c_int };

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -30,8 +30,8 @@ pub struct fn_ptrs {
     pub fn2: Option<unsafe extern "C" fn(std::ffi::c_int) -> std::ffi::c_int>,
 }
 pub type zstd_platform_dependent_type = std::ffi::c_long;
-pub const UINTPTR_MAX: std::ffi::c_ulong = 18446744073709551615 as std::ffi::c_ulong;
-pub const NESTED_INT: std::ffi::c_int = 0xffff as std::ffi::c_int;
+pub const UINTPTR_MAX: std::ffi::c_ulong = unsafe { 18446744073709551615 as std::ffi::c_ulong };
+pub const NESTED_INT: std::ffi::c_int = unsafe { 0xffff as std::ffi::c_int };
 #[no_mangle]
 pub unsafe extern "C" fn local_muts() {
     let mut literal_int: std::ffi::c_int = 0xffff as std::ffi::c_int;
@@ -367,7 +367,7 @@ pub static mut global_const_member: std::ffi::c_int = 0;
 pub unsafe extern "C" fn test_fn_macro(mut x: std::ffi::c_int) -> std::ffi::c_int {
     return x * x;
 }
-pub const TEST_CONST2: std::ffi::c_int = 2 as std::ffi::c_int;
+pub const TEST_CONST2: std::ffi::c_int = unsafe { 2 as std::ffi::c_int };
 #[no_mangle]
 pub unsafe extern "C" fn reference_define() -> std::ffi::c_int {
     let mut x: std::ffi::c_int = 1 as std::ffi::c_int;
@@ -388,8 +388,8 @@ pub static mut fns: fn_ptrs = {
 };
 #[no_mangle]
 pub static mut p: *const fn_ptrs = unsafe { &fns as *const fn_ptrs };
-pub const ZSTD_WINDOWLOG_MAX_32: std::ffi::c_int = 30 as std::ffi::c_int;
-pub const ZSTD_WINDOWLOG_MAX_64: std::ffi::c_int = 31 as std::ffi::c_int;
+pub const ZSTD_WINDOWLOG_MAX_32: std::ffi::c_int = unsafe { 30 as std::ffi::c_int };
+pub const ZSTD_WINDOWLOG_MAX_64: std::ffi::c_int = unsafe { 31 as std::ffi::c_int };
 #[no_mangle]
 pub unsafe extern "C" fn test_zstd() -> U64 {
     return (if ::core::mem::size_of::<zstd_platform_dependent_type>() as std::ffi::c_ulong


### PR DESCRIPTION
* Split out of #1306.

Some operations, such as ptr arithmetic, are `unsafe` and can be done in const macros.  So as an initially overly conservative implementation, just make all `const`s use `unsafe` blocks in case `unsafe` operations are used.  This is what we already do for `fn`s, for example, even if all of the operations in a `fn` are safe.  We can improve this, but for now, this works and is correct.