### PR TITLE
ci: remove x86_64 macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
             os: Linux
             arch: x86_64
             clang-version: 15
-          - runner: macos-13
-            os: macOS
-            arch: x86_64
-            clang-version: 17
           - runner: macos-15
             os: macOS
             arch: aarch64


### PR DESCRIPTION
GitHub is removing x86_64 macOS from GitHub Actions in September and Rust is deprecating `x86_64-apple-darwin` to tier 2 with host tools. This job is also usually the slowest, so it's a bottleneck as well.

* https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down
* https://blog.rust-lang.org/2025/08/19/demoting-x86-64-apple-darwin-to-tier-2-with-host-tools/