### PR TITLE
transpile: expand `--translate-const-macros conservative` to handle statements

### DIFF
--- a/c2rust-transpile/tests/snapshots/macros.c
+++ b/c2rust-transpile/tests/snapshots/macros.c
@@ -37,6 +37,17 @@ struct S {
 #define TERNARY LITERAL_BOOL ? 1 : 2
 #define MEMBER LITERAL_STRUCT.i
 
+#define STMT_EXPR                                                              \
+  ({                                                                           \
+    int builtin = BUILTIN;                                                     \
+    char indexing = INDEXING;                                                  \
+    float mixed = MIXED_ARITHMETIC;                                            \
+    for (int i = 0; i < builtin; i++) {                                        \
+      mixed += (float)indexing;                                                \
+    }                                                                          \
+    mixed;                                                                     \
+  })
+
 void local_muts() {
   int literal_int = LITERAL_INT;
   bool literal_bool = LITERAL_BOOL;
@@ -71,6 +82,7 @@ void local_muts() {
   const struct S *ref_struct = REF_LITERAL;
   int ternary = TERNARY;
   int member = MEMBER;
+  float stmt_expr = STMT_EXPR;
 }
 
 void local_consts() {
@@ -107,6 +119,7 @@ void local_consts() {
   const struct S *const ref_struct = REF_LITERAL;
   const int ternary = TERNARY;
   const int member = MEMBER;
+  const float stmt_expr = STMT_EXPR;
 }
 
 // TODO These are declared in the global scope and thus clash,
@@ -146,6 +159,7 @@ void local_static_consts() {
   static const struct S *const ref_struct = REF_LITERAL;
   static const int ternary = TERNARY;
   static const int member = MEMBER;
+  static const float stmt_expr = STMT_EXPR;
 }
 #endif
 
@@ -186,6 +200,7 @@ static const char *const global_static_const_ref_indexing = REF_MACRO;
 static const struct S *const global_static_const_ref_struct = REF_LITERAL;
 static const int global_static_const_ternary = TERNARY;
 static const int global_static_const_member = MEMBER;
+// static const float global_static_const_stmt_expr = STMT_EXPR; // Statement expression not allowed at file scope.
 
 void global_static_consts() {
   // Need to use `static`s or else they'll be removed when translated.
@@ -222,6 +237,7 @@ void global_static_consts() {
   (void)global_static_const_ref_struct;
   (void)global_static_const_ternary;
   (void)global_static_const_member;
+  // (void)global_static_const_stmt_expr;
 }
 
 // global consts
@@ -259,6 +275,7 @@ const char *const global_const_ref_indexing = REF_MACRO;
 const struct S *const global_const_ref_struct = REF_LITERAL;
 const int global_const_ternary = TERNARY;
 const int global_const_member = MEMBER;
+// const float global_const_stmt_expr = STMT_EXPR; // Statement expression not allowed at file scope.
 
 typedef unsigned long long U64;
 

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -59,6 +59,23 @@ pub const NESTED_STRUCT: S = unsafe {
 pub const PARENS: std::ffi::c_int = unsafe { NESTED_INT * (LITERAL_CHAR + true_0) };
 pub const WIDENING_CAST: std::ffi::c_int = unsafe { LITERAL_INT };
 pub const CONVERSION_CAST: std::ffi::c_int = unsafe { LITERAL_INT };
+pub const STMT_EXPR: std::ffi::c_float = unsafe {
+    ({
+        let mut builtin: std::ffi::c_int = (LITERAL_INT as std::ffi::c_uint).leading_zeros() as i32;
+        let mut indexing: std::ffi::c_char =
+            (*::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0"))
+                [LITERAL_FLOAT as std::ffi::c_int as usize];
+        let mut mixed: std::ffi::c_float =
+            (LITERAL_INT as std::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as std::ffi::c_double
+                - true_0 as std::ffi::c_double) as std::ffi::c_float;
+        let mut i: std::ffi::c_int = 0 as std::ffi::c_int;
+        while i < builtin {
+            mixed += indexing as std::ffi::c_float;
+            i += 1;
+        }
+        mixed
+    })
+};
 #[no_mangle]
 pub unsafe extern "C" fn local_muts() {
     let mut literal_int: std::ffi::c_int = LITERAL_INT;
@@ -119,6 +136,7 @@ pub unsafe extern "C" fn local_muts() {
         2 as std::ffi::c_int
     };
     let mut member: std::ffi::c_int = LITERAL_STRUCT.i;
+    let mut stmt_expr: std::ffi::c_float = STMT_EXPR;
 }
 #[no_mangle]
 pub unsafe extern "C" fn local_consts() {
@@ -180,6 +198,7 @@ pub unsafe extern "C" fn local_consts() {
         2 as std::ffi::c_int
     };
     let member: std::ffi::c_int = LITERAL_STRUCT.i;
+    let stmt_expr: std::ffi::c_float = STMT_EXPR;
 }
 static mut global_static_const_literal_int: std::ffi::c_int = LITERAL_INT;
 static mut global_static_const_literal_bool: bool = LITERAL_BOOL != 0;


### PR DESCRIPTION
This handles all statements except for `goto`s and their labels.

`goto`s are tricky, because they can be non-local and jump out of the context of the macro.  A `goto` and its labels are `const` if the whole state machine we compile to has all `const` statements, but determining what that is exactly is trickier, and might depend on the context in which the macro is used.  This is probably fairly uncommon, so we just assume it's not `const` for now.

Note that in C, labels are for `goto`s.  There are no labeled `break`s and `continue`s.