### PR TITLE
Avoid `unsafe` in const macro translations except where necessary

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2700,9 +2700,9 @@ impl<'c> Translation<'c> {
                 let mut init = init?;
 
                 stmts.append(init.stmts_mut());
-                // A const context is not "already unsafe" the way code within a `fn` is (since we
-                // translate all fns as unsafe). Therefore, in const context expose any underlying
-                // unsafety in the initializer with an unsafe block.
+                // A `const` context is not "already unsafe" the way code within a `fn` is
+                // (since we translate all `fn`s as `unsafe`). Therefore, in `const` contexts,
+                // expose any underlying unsafety in the initializer with an `unsafe` block.
                 let init = if ctx.is_const {
                     init.to_unsafe_pure_expr()
                         .expect("init should not have any statements")

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2158,7 +2158,7 @@ impl<'c> Translation<'c> {
         ctx: ExprContext,
         expansions: &[CExprId],
     ) -> TranslationResult<(Box<Expr>, CTypeId)> {
-        let (mut val, ty) = expansions
+        let (val, ty) = expansions
             .iter()
             .try_fold::<Option<(WithStmts<Box<Expr>>, CTypeId)>, _, _>(None, |canonical, &id| {
                 self.can_convert_const_macro_expansion(id)?;
@@ -2195,7 +2195,6 @@ impl<'c> Translation<'c> {
             })?
             .ok_or_else(|| format_err!("Could not find a valid type for macro"))?;
 
-        val.set_unsafe();
         val.to_unsafe_pure_expr()
             .map(|val| (val, ty))
             .ok_or_else(|| TranslationError::generic("Macro expansion is not a pure expression"))

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3846,7 +3846,7 @@ impl<'c> Translation<'c> {
 
                     // Function pointer call
                     _ => {
-                        let callee = self.convert_expr(ctx.used(), func, None)?;
+                        let mut callee = self.convert_expr(ctx.used(), func, None)?;
                         let make_fn_ty = |ret_ty: Box<Type>| {
                             let ret_ty = match *ret_ty {
                                 Type::Tuple(TypeTuple { elems: ref v, .. }) if v.is_empty() => ReturnType::Default,
@@ -3864,6 +3864,7 @@ impl<'c> Translation<'c> {
                                 // K&R function pointer without arguments
                                 let ret_ty = self.convert_type(ret_ty.ctype)?;
                                 let target_ty = make_fn_ty(ret_ty);
+                                callee.set_unsafe();
                                 callee.map(|fn_ptr| {
                                     let fn_ptr = unwrap_function_pointer(fn_ptr);
                                     transmute_expr(mk().infer_ty(), target_ty, fn_ptr)
@@ -3873,6 +3874,7 @@ impl<'c> Translation<'c> {
                                 // We have to infer the return type from our expression type
                                 let ret_ty = self.convert_type(call_expr_ty.ctype)?;
                                 let target_ty = make_fn_ty(ret_ty);
+                                callee.set_unsafe();
                                 callee.map(|fn_ptr| {
                                     transmute_expr(mk().infer_ty(), target_ty, fn_ptr)
                                 })

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -446,7 +446,7 @@ impl<'c> Translation<'c> {
                     let assign_stmt = match op {
                         // Regular (possibly volatile) assignment
                         Assign if !is_volatile => WithStmts::new_val(mk().assign_expr(write, rhs)),
-                        Assign => WithStmts::new_val(self.volatile_write(
+                        Assign => WithStmts::new_unsafe_val(self.volatile_write(
                             write,
                             initial_lhs_type_id,
                             rhs,
@@ -501,7 +501,7 @@ impl<'c> Translation<'c> {
 
                             let write = if is_volatile {
                                 val.and_then(|val| {
-                                    TranslationResult::Ok(WithStmts::new_val(
+                                    TranslationResult::Ok(WithStmts::new_unsafe_val(
                                         self.volatile_write(write, initial_lhs_type_id, val)?,
                                     ))
                                 })?
@@ -887,6 +887,7 @@ impl<'c> Translation<'c> {
 
                 // *p = *p + rhs
                 let assign_stmt = if ty.qualifiers.is_volatile {
+                    is_unsafe = true;
                     self.volatile_write(write, ty, val)?
                 } else {
                     mk().assign_expr(write, val)

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@macros.c.snap
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn size_of_const() -> std::ffi::c_int {
     let mut a: [std::ffi::c_int; 10] = [0; 10];
     return SIZE as std::ffi::c_int;
 }
-pub const SIZE: usize = unsafe { ::core::mem::size_of::<[std::ffi::c_int; 10]>() };
+pub const SIZE: usize = ::core::mem::size_of::<[std::ffi::c_int; 10]>();
 pub const POS: [std::ffi::c_char; 3] =
     unsafe { *::core::mem::transmute::<&[u8; 3], &[std::ffi::c_char; 3]>(b"\"]\0") };
 #[no_mangle]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@macros.c.snap
@@ -31,7 +31,7 @@ pub unsafe extern "C" fn size_of_const() -> std::ffi::c_int {
     let mut a: [std::ffi::c_int; 10] = [0; 10];
     return SIZE as std::ffi::c_int;
 }
-pub const SIZE: usize = unsafe { ::core::mem::size_of::<[std::ffi::c_int; 10]>() };
+pub const SIZE: usize = ::core::mem::size_of::<[std::ffi::c_int; 10]>();
 pub const POS: [std::ffi::c_char; 3] =
     unsafe { *::core::mem::transmute::<&[u8; 3], &[std::ffi::c_char; 3]>(b"\"]\0") };
 #[no_mangle]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.snap
@@ -37,4 +37,4 @@ pub unsafe extern "C" fn c11_atomics(mut x: std::ffi::c_int) -> std::ffi::c_int 
     fresh1.1;
     return x;
 }
-pub const __ATOMIC_SEQ_CST: std::ffi::c_int = unsafe { 5 as std::ffi::c_int };
+pub const __ATOMIC_SEQ_CST: std::ffi::c_int = 5 as std::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -72,9 +72,10 @@ pub const CONVERSION_CAST: std::ffi::c_int = unsafe { LITERAL_INT };
 pub const STMT_EXPR: std::ffi::c_float = unsafe {
     ({
         let mut builtin: std::ffi::c_int = (LITERAL_INT as std::ffi::c_uint).leading_zeros() as i32;
-        let mut indexing: std::ffi::c_char =
+        let mut indexing: std::ffi::c_char = unsafe {
             (*::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0"))
-                [LITERAL_FLOAT as std::ffi::c_int as usize];
+                [LITERAL_FLOAT as std::ffi::c_int as usize]
+        };
         let mut mixed: std::ffi::c_float =
             (LITERAL_INT as std::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as std::ffi::c_double
                 - true_0 as std::ffi::c_double) as std::ffi::c_float;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -30,63 +30,57 @@ pub struct fn_ptrs {
     pub fn2: Option<unsafe extern "C" fn(std::ffi::c_int) -> std::ffi::c_int>,
 }
 pub type zstd_platform_dependent_type = std::ffi::c_long;
-pub const UINTPTR_MAX: std::ffi::c_ulong = unsafe { 18446744073709551615 as std::ffi::c_ulong };
-pub const true_0: std::ffi::c_int = unsafe { 1 as std::ffi::c_int };
-pub const LITERAL_INT: std::ffi::c_int = unsafe { 0xffff as std::ffi::c_int };
-pub const LITERAL_BOOL: std::ffi::c_int = unsafe { true_0 };
-pub const LITERAL_FLOAT: std::ffi::c_double = unsafe { 3.14f64 };
-pub const LITERAL_CHAR: std::ffi::c_int = unsafe { 'x' as i32 };
+pub const UINTPTR_MAX: std::ffi::c_ulong = 18446744073709551615 as std::ffi::c_ulong;
+pub const true_0: std::ffi::c_int = 1 as std::ffi::c_int;
+pub const LITERAL_INT: std::ffi::c_int = 0xffff as std::ffi::c_int;
+pub const LITERAL_BOOL: std::ffi::c_int = true_0;
+pub const LITERAL_FLOAT: std::ffi::c_double = 3.14f64;
+pub const LITERAL_CHAR: std::ffi::c_int = 'x' as i32;
 pub const LITERAL_STR: [std::ffi::c_char; 6] =
     unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
-pub const LITERAL_STRUCT: S = unsafe {
-    {
-        let mut init = S {
-            i: 5 as std::ffi::c_int,
-        };
-        init
-    }
+pub const LITERAL_STRUCT: S = {
+    let mut init = S {
+        i: 5 as std::ffi::c_int,
+    };
+    init
 };
-pub const NESTED_INT: std::ffi::c_int = unsafe { LITERAL_INT };
-pub const NESTED_BOOL: std::ffi::c_int = unsafe { 1 as std::ffi::c_int };
-pub const NESTED_FLOAT: std::ffi::c_double = unsafe { LITERAL_FLOAT };
-pub const NESTED_CHAR: std::ffi::c_int = unsafe { 'x' as i32 };
+pub const NESTED_INT: std::ffi::c_int = LITERAL_INT;
+pub const NESTED_BOOL: std::ffi::c_int = 1 as std::ffi::c_int;
+pub const NESTED_FLOAT: std::ffi::c_double = LITERAL_FLOAT;
+pub const NESTED_CHAR: std::ffi::c_int = 'x' as i32;
 pub const NESTED_STR: [std::ffi::c_char; 6] =
     unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
-pub const NESTED_STRUCT: S = unsafe {
-    {
-        let mut init = S {
-            i: 5 as std::ffi::c_int,
-        };
-        init
-    }
+pub const NESTED_STRUCT: S = {
+    let mut init = S {
+        i: 5 as std::ffi::c_int,
+    };
+    init
 };
-pub const PARENS: std::ffi::c_int = unsafe { NESTED_INT * (LITERAL_CHAR + true_0) };
+pub const PARENS: std::ffi::c_int = NESTED_INT * (LITERAL_CHAR + true_0);
 pub const PTR_ARITHMETIC: *const std::ffi::c_char = unsafe {
     LITERAL_STR
         .as_ptr()
         .offset(5 as std::ffi::c_int as isize)
         .offset(-(3 as std::ffi::c_int as isize))
 };
-pub const WIDENING_CAST: std::ffi::c_int = unsafe { LITERAL_INT };
-pub const CONVERSION_CAST: std::ffi::c_int = unsafe { LITERAL_INT };
-pub const STMT_EXPR: std::ffi::c_float = unsafe {
-    ({
-        let mut builtin: std::ffi::c_int = (LITERAL_INT as std::ffi::c_uint).leading_zeros() as i32;
-        let mut indexing: std::ffi::c_char = unsafe {
-            (*::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0"))
-                [LITERAL_FLOAT as std::ffi::c_int as usize]
-        };
-        let mut mixed: std::ffi::c_float =
-            (LITERAL_INT as std::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as std::ffi::c_double
-                - true_0 as std::ffi::c_double) as std::ffi::c_float;
-        let mut i: std::ffi::c_int = 0 as std::ffi::c_int;
-        while i < builtin {
-            mixed += indexing as std::ffi::c_float;
-            i += 1;
-        }
-        mixed
-    })
-};
+pub const WIDENING_CAST: std::ffi::c_int = LITERAL_INT;
+pub const CONVERSION_CAST: std::ffi::c_int = LITERAL_INT;
+pub const STMT_EXPR: std::ffi::c_float = ({
+    let mut builtin: std::ffi::c_int = (LITERAL_INT as std::ffi::c_uint).leading_zeros() as i32;
+    let mut indexing: std::ffi::c_char = unsafe {
+        (*::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0"))
+            [LITERAL_FLOAT as std::ffi::c_int as usize]
+    };
+    let mut mixed: std::ffi::c_float = (LITERAL_INT as std::ffi::c_double
+        + NESTED_FLOAT * LITERAL_CHAR as std::ffi::c_double
+        - true_0 as std::ffi::c_double) as std::ffi::c_float;
+    let mut i: std::ffi::c_int = 0 as std::ffi::c_int;
+    while i < builtin {
+        mixed += indexing as std::ffi::c_float;
+        i += 1;
+    }
+    mixed
+});
 #[no_mangle]
 pub unsafe extern "C" fn local_muts() {
     let mut literal_int: std::ffi::c_int = LITERAL_INT;
@@ -334,11 +328,11 @@ pub static mut global_const_member: std::ffi::c_int = 0;
 pub unsafe extern "C" fn test_fn_macro(mut x: std::ffi::c_int) -> std::ffi::c_int {
     return x * x;
 }
-pub const TEST_CONST1: std::ffi::c_int = unsafe { 1 as std::ffi::c_int };
-pub const TEST_NESTED: std::ffi::c_int = unsafe { 2 as std::ffi::c_int };
-pub const TEST_CONST2: std::ffi::c_int = unsafe { TEST_NESTED };
+pub const TEST_CONST1: std::ffi::c_int = 1 as std::ffi::c_int;
+pub const TEST_NESTED: std::ffi::c_int = 2 as std::ffi::c_int;
+pub const TEST_CONST2: std::ffi::c_int = TEST_NESTED;
 pub const TEST_PARENS: std::ffi::c_int =
-    unsafe { (TEST_CONST2 + 1 as std::ffi::c_int) * 3 as std::ffi::c_int };
+    (TEST_CONST2 + 1 as std::ffi::c_int) * 3 as std::ffi::c_int;
 #[no_mangle]
 pub unsafe extern "C" fn reference_define() -> std::ffi::c_int {
     let mut x: std::ffi::c_int = TEST_CONST1;
@@ -359,8 +353,8 @@ pub static mut fns: fn_ptrs = {
 };
 #[no_mangle]
 pub static mut p: *const fn_ptrs = unsafe { &fns as *const fn_ptrs };
-pub const ZSTD_WINDOWLOG_MAX_32: std::ffi::c_int = unsafe { 30 as std::ffi::c_int };
-pub const ZSTD_WINDOWLOG_MAX_64: std::ffi::c_int = unsafe { 31 as std::ffi::c_int };
+pub const ZSTD_WINDOWLOG_MAX_32: std::ffi::c_int = 30 as std::ffi::c_int;
+pub const ZSTD_WINDOWLOG_MAX_64: std::ffi::c_int = 31 as std::ffi::c_int;
 #[no_mangle]
 pub unsafe extern "C" fn test_zstd() -> U64 {
     return (if ::core::mem::size_of::<zstd_platform_dependent_type>() as usize == 4 as usize {
@@ -392,7 +386,7 @@ pub unsafe extern "C" fn test_switch(mut x: std::ffi::c_int) -> std::ffi::c_int 
     }
     return 0 as std::ffi::c_int;
 }
-pub const silk_int16_MIN: std::ffi::c_int = unsafe { 0x8000 as std::ffi::c_int };
+pub const silk_int16_MIN: std::ffi::c_int = 0x8000 as std::ffi::c_int;
 #[no_mangle]
 pub unsafe extern "C" fn test_silk_int16_MIN() -> std::ffi::c_int {
     let mut _null: std::ffi::c_char =


### PR DESCRIPTION
Atop #1306, as I'd rather not regress all const translations to be `unsafe` in master now that we translate const macros by default.