### PR TITLE
properly handle `ASTEntryTag::TagStaticAssertDecl` conversion

### DIFF
--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -184,16 +184,7 @@ fn immediate_decl_children(kind: &CDeclKind) -> Vec<SomeId> {
         Field { typ, .. } => intos![typ.ctype],
         MacroObject { .. } | MacroFunction { .. } => vec![],
         NonCanonicalDecl { canonical_decl } => intos![canonical_decl],
-        StaticAssert {
-            assert_expr,
-            message,
-        } => {
-            if let Some(message) = message {
-                intos![assert_expr, message]
-            } else {
-                intos![assert_expr]
-            }
-        }
+        StaticAssert { assert_expr, .. } => intos![assert_expr],
     }
 }
 

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1151,7 +1151,7 @@ pub enum CDeclKind {
 
     StaticAssert {
         assert_expr: CExprId,
-        message: Option<CExprId>,
+        message: Option<String>,
     },
 }
 

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@static_assert.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@static_assert.c.snap
@@ -1,0 +1,16 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/static_assert.rs
+input_file: c2rust-transpile/tests/snapshots/static_assert.c
+---
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#[no_mangle]
+pub unsafe extern "C" fn static_assert() {}

--- a/c2rust-transpile/tests/snapshots/static_assert.c
+++ b/c2rust-transpile/tests/snapshots/static_assert.c
@@ -1,0 +1,4 @@
+void static_assert() {
+    _Static_assert (1);
+    _Static_assert (1, "Expression evaluates to false");
+}


### PR DESCRIPTION
visit children nodes in StaticAssertDecl, so all children exprs will be inserted in `ast_context.c_exprs`. without visiting it, we will get panic  'no entry found for key' when translator try to convert `_Static_assert`.

* Fixes #1332.