### PR TITLE
Dont write unused unary expr when operator is increment/decrement

### DIFF
--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -1034,13 +1034,19 @@ impl<'c> Translation<'c> {
             }
         }?;
 
-        // Unused unary operators (`-foo()`) may have side effects, so we need
-        // to add them to stmts.
-        if ctx.is_unused() {
+        // Some unused unary operators (`-foo()`) may have side effects, so we need
+        // to add them to stmts when name is not increment/decrement operator.
+        if ctx.is_unused()
+            && !matches!(
+                name,
+                c_ast::UnOp::PreDecrement
+                    | c_ast::UnOp::PreIncrement
+                    | c_ast::UnOp::PostDecrement
+                    | c_ast::UnOp::PostIncrement
+            )
+        {
             let v = unary.clone().into_value();
-            unary
-                .stmts_mut()
-                .push(Stmt::Expr(*v, Some(Default::default())));
+            unary.add_stmt(mk().semi_stmt(v));
         }
         Ok(unary)
     }

--- a/c2rust-transpile/tests/snapshots/exprs.c
+++ b/c2rust-transpile/tests/snapshots/exprs.c
@@ -1,0 +1,35 @@
+int puts(const char *str);
+
+static int side_effect(){
+    puts("the return of side effect");
+    return 10;
+}
+
+void unary_without_side_effect(){
+    int i = 5;
+    -i;
+    +i;
+    ~i;
+    !i;
+    &i;
+    *&i;
+    i++;
+    i--;
+    --i;
+    ++i;
+}
+
+void unary_with_side_effect(){
+    char* arr[1] = {0};
+
+    -side_effect();
+    +side_effect();
+    ~side_effect();
+    !side_effect();
+    &""[side_effect()];
+    *arr[side_effect()];
+    ++arr[side_effect()];
+    --arr[side_effect()];
+    arr[side_effect()]++;
+    arr[side_effect()]--;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
@@ -29,13 +29,9 @@ pub unsafe extern "C" fn unary_without_side_effect() {
     &mut i;
     i;
     i += 1;
-    i;
     i -= 1;
-    i;
     i -= 1;
-    i;
     i += 1;
-    i;
 }
 #[no_mangle]
 pub unsafe extern "C" fn unary_with_side_effect() {
@@ -50,11 +46,7 @@ pub unsafe extern "C" fn unary_with_side_effect() {
     >(side_effect)() as isize) as *const std::ffi::c_char;
     *arr[side_effect() as usize];
     arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(1);
-    arr[side_effect() as usize];
     arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(-1);
-    arr[side_effect() as usize];
     arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(1);
-    arr[side_effect() as usize];
     arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(-1);
-    arr[side_effect() as usize];
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
@@ -1,0 +1,60 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/exprs.rs
+input_file: c2rust-transpile/tests/snapshots/exprs.c
+---
+#![allow(
+    dead_code,
+    mutable_transmutes,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+extern "C" {
+    fn puts(str: *const std::ffi::c_char) -> std::ffi::c_int;
+}
+unsafe extern "C" fn side_effect() -> std::ffi::c_int {
+    puts(b"the return of side effect\0" as *const u8 as *const std::ffi::c_char);
+    return 10 as std::ffi::c_int;
+}
+#[no_mangle]
+pub unsafe extern "C" fn unary_without_side_effect() {
+    let mut i: std::ffi::c_int = 5 as std::ffi::c_int;
+    -i;
+    i;
+    !i;
+    (i == 0) as std::ffi::c_int;
+    &mut i;
+    i;
+    i += 1;
+    i;
+    i -= 1;
+    i;
+    i -= 1;
+    i;
+    i += 1;
+    i;
+}
+#[no_mangle]
+pub unsafe extern "C" fn unary_with_side_effect() {
+    let mut arr: [*mut std::ffi::c_char; 1] = [0 as *mut std::ffi::c_char];
+    -side_effect();
+    side_effect();
+    !side_effect();
+    (side_effect() == 0) as std::ffi::c_int;
+    &*(b"\0" as *const u8 as *const std::ffi::c_char).offset(::core::mem::transmute::<
+        unsafe extern "C" fn() -> std::ffi::c_int,
+        unsafe extern "C" fn() -> std::ffi::c_int,
+    >(side_effect)() as isize) as *const std::ffi::c_char;
+    *arr[side_effect() as usize];
+    arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(1);
+    arr[side_effect() as usize];
+    arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(-1);
+    arr[side_effect() as usize];
+    arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(1);
+    arr[side_effect() as usize];
+    arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(-1);
+    arr[side_effect() as usize];
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@factorial.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@factorial.c.snap
@@ -19,7 +19,6 @@ pub unsafe extern "C" fn factorial(mut n: std::ffi::c_ushort) -> std::ffi::c_ush
     while (i as std::ffi::c_int) < n as std::ffi::c_int {
         result = (result as std::ffi::c_int * i as std::ffi::c_int) as std::ffi::c_ushort;
         i = i.wrapping_add(1);
-        i;
     }
     return result;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.snap
@@ -1,6 +1,5 @@
 ---
 source: c2rust-transpile/tests/snapshots.rs
-assertion_line: 67
 expression: cat tests/snapshots/gotos.rs
 input_file: c2rust-transpile/tests/snapshots/gotos.c
 ---
@@ -19,8 +18,6 @@ pub unsafe extern "C" fn sum(mut count: std::ffi::c_int) -> std::ffi::c_int {
     while !(count <= 0 as std::ffi::c_int) {
         x += count;
         count -= 1;
-        count;
     }
     return x;
 }
-

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@insertion.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@insertion.c.snap
@@ -21,10 +21,8 @@ pub unsafe extern "C" fn insertion_sort(n: std::ffi::c_int, p: *mut std::ffi::c_
         while j > 0 as std::ffi::c_int && *p.offset((j - 1 as std::ffi::c_int) as isize) > tmp {
             *p.offset(j as isize) = *p.offset((j - 1 as std::ffi::c_int) as isize);
             j -= 1;
-            j;
         }
         *p.offset(j as isize) = tmp;
         i += 1;
-        i;
     }
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -407,12 +407,10 @@ pub unsafe extern "C" fn stmt_expr_inc() -> std::ffi::c_int {
     ({
         *b += 1;
         *b;
-        *b;
         *b
     });
     return ({
         *b += 1;
-        *b;
         *b
     });
 }


### PR DESCRIPTION
currently, c2rust transpiled this code
```c
void increment(){
    int i = 5;
    i++;
    i--;
    --i;
    ++i;
}
```
to this
```rust
#[no_mangle]
pub unsafe extern "C" fn increment() {
    let mut i: std::ffi::c_int = 5 as std::ffi::c_int;
    i += 1;
    i;
    i -= 1;
    i;
    i -= 1;
    i;
    i += 1;
    i;
}
```
which contain useless `i` expression. this is because UnaryExpr can contain side effect expression which cannot be ignored, ~~however not all unary expr can contain side effects. this pull request limit to only Negate , Plus, Complement, and Not~~ . However we can limit it to only expr which is not pure.