### PR TITLE
transpile: add support for `CTypeKind::UnaryType`s in `--translate-const-macros conservative`

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -640,12 +640,10 @@ impl TypedAstContext {
             // Unary ops should be `const`.
             // TODO handle `f128` or use the primitive type.
             Unary(_, _, expr, _) => is_const(expr),
-            UnaryType(_, _, _, _) => false, // TODO disabled for now as tests are broken
             // Not sure what a `None` `CExprId` means here
             // or how to detect a `sizeof` of a VLA, which is non-`const`,
             // although it seems we don't handle `sizeof(VLAs)`
             // correctly in macros elsewhere already.
-            #[allow(unreachable_patterns)]
             UnaryType(_, _, expr, _) => expr.map_or(true, is_const),
             // Not sure what a `OffsetOfKind::Variable` means.
             OffsetOf(_, _) => true,

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1,3 +1,5 @@
+use crate::c_ast::iterators::{immediate_children_all_types, NodeVisitor};
+use crate::iterators::{DFNodes, SomeId};
 use c2rust_ast_exporter::clang_ast::LRValue;
 use indexmap::{IndexMap, IndexSet};
 use std::cell::RefCell;
@@ -9,7 +11,13 @@ use std::ops::Index;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
+pub use self::conversion::*;
+pub use self::print::Printer;
 pub use c2rust_ast_exporter::clang_ast::{BuiltinVaListKind, SrcFile, SrcLoc, SrcSpan};
+
+mod conversion;
+pub mod iterators;
+mod print;
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Copy, Clone)]
 pub struct CTypeId(pub u64);
@@ -32,17 +40,6 @@ pub type CRecordId = CDeclId; // Record types need to point to 'DeclKind::Record
 pub type CTypedefId = CDeclId; // Typedef types need to point to 'DeclKind::Typedef'
 pub type CEnumId = CDeclId; // Enum types need to point to 'DeclKind::Enum'
 pub type CEnumConstantId = CDeclId; // Enum's need to point to child 'DeclKind::EnumConstant's
-
-use crate::c_ast::iterators::{immediate_children_all_types, NodeVisitor};
-
-pub use self::conversion::*;
-pub use self::print::Printer;
-
-mod conversion;
-pub mod iterators;
-mod print;
-
-use iterators::{DFNodes, SomeId};
 
 /// AST context containing all of the nodes in the Clang AST
 #[derive(Debug, Clone)]

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -950,13 +950,12 @@ impl TypedAstContext {
                     CExprKind::Paren(_ty, e) => self.ast_context.c_exprs[&e].kind.get_qual_type(),
                     _ => return,
                 };
-                if let (Some(ty), Some(new_ty)) = (
-                    self.ast_context
-                        .c_exprs
-                        .get_mut(&e)
-                        .and_then(|e| e.kind.get_qual_type_mut()),
-                    new_ty,
-                ) {
+                let ty = self
+                    .ast_context
+                    .c_exprs
+                    .get_mut(&e)
+                    .and_then(|e| e.kind.get_qual_type_mut());
+                if let (Some(ty), Some(new_ty)) = (ty, new_ty) {
                     *ty = new_ty;
                 };
             }

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -33,6 +33,8 @@ pub type CTypedefId = CDeclId; // Typedef types need to point to 'DeclKind::Type
 pub type CEnumId = CDeclId; // Enum types need to point to 'DeclKind::Enum'
 pub type CEnumConstantId = CDeclId; // Enum's need to point to child 'DeclKind::EnumConstant's
 
+use crate::c_ast::iterators::{immediate_children_all_types, NodeVisitor};
+
 pub use self::conversion::*;
 pub use self::print::Printer;
 
@@ -888,7 +890,6 @@ impl TypedAstContext {
             ast_context: &'a mut TypedAstContext,
         }
 
-        use iterators::{immediate_children_all_types, NodeVisitor};
         impl<'a> NodeVisitor for BubbleExprTypes<'a> {
             fn children(&mut self, id: SomeId) -> Vec<SomeId> {
                 immediate_children_all_types(self.ast_context, id)

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -948,6 +948,19 @@ impl TypedAstContext {
                         self.ast_context.c_exprs[&e].kind.get_qual_type().unwrap(),
                     ),
                     CExprKind::Paren(_ty, e) => self.ast_context.c_exprs[&e].kind.get_qual_type(),
+                    CExprKind::UnaryType(_, op, _, _) => {
+                        // All of these `UnTypeOp`s should return `size_t`.
+                        let kind = match op {
+                            UnTypeOp::SizeOf => CTypeKind::Size,
+                            UnTypeOp::AlignOf => CTypeKind::Size,
+                            UnTypeOp::PreferredAlignOf => CTypeKind::Size,
+                        };
+                        let ty = self
+                            .ast_context
+                            .type_for_kind(&kind)
+                            .expect("CTypeKind::Size should be size_t");
+                        Some(CQualTypeId::new(ty))
+                    }
                     _ => return,
                 };
                 let ty = self

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@macros.c.snap
@@ -28,8 +28,9 @@ pub unsafe extern "C" fn errno_is_error() -> bool {
 #[no_mangle]
 pub unsafe extern "C" fn size_of_const() -> std::ffi::c_int {
     let mut a: [std::ffi::c_int; 10] = [0; 10];
-    return ::core::mem::size_of::<[std::ffi::c_int; 10]>() as std::ffi::c_int;
+    return SIZE as std::ffi::c_int;
 }
+pub const SIZE: usize = unsafe { ::core::mem::size_of::<[std::ffi::c_int; 10]>() };
 #[no_mangle]
 pub unsafe extern "C" fn memcpy_str_literal(mut out: *mut std::ffi::c_char) {
     memcpy(

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@macros.c.snap
@@ -29,8 +29,9 @@ pub unsafe extern "C" fn errno_is_error() -> bool {
 #[no_mangle]
 pub unsafe extern "C" fn size_of_const() -> std::ffi::c_int {
     let mut a: [std::ffi::c_int; 10] = [0; 10];
-    return ::core::mem::size_of::<[std::ffi::c_int; 10]>() as std::ffi::c_int;
+    return SIZE as std::ffi::c_int;
 }
+pub const SIZE: usize = unsafe { ::core::mem::size_of::<[std::ffi::c_int; 10]>() };
 #[no_mangle]
 pub unsafe extern "C" fn memcpy_str_literal(mut out: *mut std::ffi::c_char) {
     memcpy(

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -372,9 +372,7 @@ pub const ZSTD_WINDOWLOG_MAX_32: std::ffi::c_int = unsafe { 30 as std::ffi::c_in
 pub const ZSTD_WINDOWLOG_MAX_64: std::ffi::c_int = unsafe { 31 as std::ffi::c_int };
 #[no_mangle]
 pub unsafe extern "C" fn test_zstd() -> U64 {
-    return (if ::core::mem::size_of::<zstd_platform_dependent_type>() as std::ffi::c_ulong
-        == 4 as std::ffi::c_ulong
-    {
+    return (if ::core::mem::size_of::<zstd_platform_dependent_type>() as usize == 4 as usize {
         ZSTD_WINDOWLOG_MAX_32
     } else {
         ZSTD_WINDOWLOG_MAX_64


### PR DESCRIPTION
* Fixes #1345.

This adds support for `CTypeKind::UnaryType` in `--translate-const-macros conservative`.  Previously, these `UnaryType`s received the non-portable type of `c_ulong`, which failed to compile since their Rust translations like `mem::size_of` return `usize`.  On the C side, `sizeof` expressions are indeed supposed to have type `size_t`, so they should get the portable type `CTypeKind::Size`.  This adds this type in `fn bubble_expr_types`, which might not be the right place to do so, since that's currently for fixing up the types from clang 15.  This type fix could instead be moved to a separate pass as well.  In doing so, I also cleaned up some minor stuff in `fn bubble_expr_types`, which should be easier to review if you ignore whitespace changes.