### PR TITLE
transpile: support `CastKind::ArrayToPointerDecay`s in `--translate-const-macros conservative`

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -649,7 +649,6 @@ impl TypedAstContext {
             // TODO `f128` is not yet handled, as we should eventually
             // switch to the (currently unstable) `f128` primitive type (#1262).
             Binary(_, _, lhs, rhs, _, _) => is_const(lhs) && is_const(rhs),
-            ImplicitCast(_, _, CastKind::ArrayToPointerDecay, _, _) => false, // TODO disabled for now as tests are broken
             // `as` casts are always `const`.
             ImplicitCast(_, expr, _, _, _) => is_const(expr),
             // `as` casts are always `const`.

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -2330,6 +2330,17 @@ impl CTypeKind {
         };
         Some(ty)
     }
+
+    /// Return the element type of a pointer or array
+    pub fn element_ty(&self) -> Option<CTypeId> {
+        Some(match *self {
+            Self::Pointer(ty) => ty.ctype,
+            Self::ConstantArray(ty, _) => ty,
+            Self::IncompleteArray(ty) => ty,
+            Self::VariableArray(ty, _) => ty,
+            _ => return None,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2934,10 +2934,10 @@ impl<'c> Translation<'c> {
             return Ok(mk().path_expr(vec!["None"]));
         }
 
-        let pointee = match self.ast_context.resolve_type(type_id).kind {
-            CTypeKind::Pointer(pointee) => pointee,
-            _ => return Err(TranslationError::generic("null_ptr requires a pointer")),
-        };
+        let pointee = self
+            .ast_context
+            .get_pointee_qual_type(type_id)
+            .ok_or(TranslationError::generic("null_ptr requires a pointer"))?;
         let ty = self.convert_type(type_id)?;
         let mut zero = mk().lit_expr(mk().int_unsuffixed_lit(0));
         if is_static && !pointee.qualifiers.is_const {
@@ -4485,10 +4485,10 @@ impl<'c> Translation<'c> {
                     return Ok(val);
                 }
 
-                let pointee = match self.ast_context.resolve_type(ty.ctype).kind {
-                    CTypeKind::Pointer(pointee) => pointee,
-                    _ => panic!("Dereferencing a non-pointer"),
-                };
+                let pointee = self
+                    .ast_context
+                    .get_pointee_qual_type(ty.ctype)
+                    .unwrap_or_else(|| panic!("dereferencing a non-pointer"));
 
                 let is_const = pointee.qualifiers.is_const;
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4293,15 +4293,15 @@ impl<'c> Translation<'c> {
     fn convert_cast(
         &self,
         ctx: ExprContext,
-        source_ty: CQualTypeId,
-        ty: CQualTypeId,
+        source_cty: CQualTypeId,
+        target_cty: CQualTypeId,
         val: WithStmts<Box<Expr>>,
         expr: Option<CExprId>,
         kind: Option<CastKind>,
         opt_field_id: Option<CFieldId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let source_ty_kind = &self.ast_context.resolve_type(source_ty.ctype).kind;
-        let target_ty_kind = &self.ast_context.resolve_type(ty.ctype).kind;
+        let source_ty_kind = &self.ast_context.resolve_type(source_cty.ctype).kind;
+        let target_ty_kind = &self.ast_context.resolve_type(target_cty.ctype).kind;
 
         if source_ty_kind == target_ty_kind {
             return Ok(val);
@@ -4382,24 +4382,26 @@ impl<'c> Translation<'c> {
         match kind {
             CastKind::BitCast | CastKind::NoOp => {
                 val.and_then(|x| {
-                    if self.ast_context.is_function_pointer(ty.ctype)
-                        || self.ast_context.is_function_pointer(source_ty.ctype)
+                    if self.ast_context.is_function_pointer(target_cty.ctype)
+                        || self.ast_context.is_function_pointer(source_cty.ctype)
                     {
-                        let source_ty = self.convert_type(source_ty.ctype)?;
-                        let target_ty = self.convert_type(ty.ctype)?;
+                        let source_ty = self.convert_type(source_cty.ctype)?;
+                        let target_ty = self.convert_type(target_cty.ctype)?;
                         Ok(WithStmts::new_unsafe_val(transmute_expr(
                             source_ty, target_ty, x,
                         )))
                     } else {
                         // Normal case
-                        let target_ty = self.convert_type(ty.ctype)?;
+                        let target_ty = self.convert_type(target_cty.ctype)?;
                         Ok(WithStmts::new_val(mk().cast_expr(x, target_ty)))
                     }
                 })
             }
 
-            CastKind::IntegralToPointer if self.ast_context.is_function_pointer(ty.ctype) => {
-                let target_ty = self.convert_type(ty.ctype)?;
+            CastKind::IntegralToPointer
+                if self.ast_context.is_function_pointer(target_cty.ctype) =>
+            {
+                let target_ty = self.convert_type(target_cty.ctype)?;
                 val.and_then(|x| {
                     let intptr_t = mk().path_ty(vec!["libc", "intptr_t"]);
                     let intptr = mk().cast_expr(x, intptr_t.clone());
@@ -4415,13 +4417,10 @@ impl<'c> Translation<'c> {
             | CastKind::FloatingCast
             | CastKind::FloatingToIntegral
             | CastKind::IntegralToFloating => {
-                let target_ty = self.convert_type(ty.ctype)?;
-                let target_ty_ctype = &self.ast_context.resolve_type(ty.ctype).kind;
+                let target_ty = self.convert_type(target_cty.ctype)?;
+                let source_ty = self.convert_type(source_cty.ctype)?;
 
-                let source_ty_ctype_id = source_ty.ctype;
-
-                let source_ty = self.convert_type(source_ty_ctype_id)?;
-                if let CTypeKind::LongDouble = target_ty_ctype {
+                if let CTypeKind::LongDouble = target_ty_kind {
                     if ctx.is_const {
                         return Err(format_translation_err!(
                                 None,
@@ -4433,21 +4432,28 @@ impl<'c> Translation<'c> {
 
                     let fn_path = mk().path_expr(vec!["f128", "f128", "new"]);
                     Ok(val.map(|val| mk().call_expr(fn_path, vec![val])))
-                } else if let CTypeKind::LongDouble = self.ast_context[source_ty_ctype_id].kind {
-                    self.f128_cast_to(val, target_ty_ctype)
-                } else if let &CTypeKind::Enum(enum_decl_id) = target_ty_ctype {
+                } else if let CTypeKind::LongDouble = self.ast_context[source_cty.ctype].kind {
+                    self.f128_cast_to(val, target_ty_kind)
+                } else if let &CTypeKind::Enum(enum_decl_id) = target_ty_kind {
                     // Casts targeting `enum` types...
                     let expr =
                         expr.ok_or_else(|| format_err!("Casts to enums require a C ExprId"))?;
-                    Ok(self.enum_cast(ty.ctype, enum_decl_id, expr, val, source_ty, target_ty))
-                } else if target_ty_ctype.is_floating_type() && source_ty_kind.is_bool() {
+                    Ok(self.enum_cast(
+                        target_cty.ctype,
+                        enum_decl_id,
+                        expr,
+                        val,
+                        source_ty,
+                        target_ty,
+                    ))
+                } else if target_ty_kind.is_floating_type() && source_ty_kind.is_bool() {
                     val.and_then(|x| {
                         Ok(WithStmts::new_val(mk().cast_expr(
                             mk().cast_expr(x, mk().path_ty(vec!["u8"])),
                             target_ty,
                         )))
                     })
-                } else if target_ty_ctype.is_pointer() && source_ty_kind.is_bool() {
+                } else if target_ty_kind.is_pointer() && source_ty_kind.is_bool() {
                     val.and_then(|x| {
                         Ok(WithStmts::new_val(mk().cast_expr(
                             mk().cast_expr(x, mk().path_ty(vec!["libc", "size_t"])),
@@ -4458,7 +4464,7 @@ impl<'c> Translation<'c> {
                     // Other numeric casts translate to Rust `as` casts,
                     // unless the cast is to a function pointer then use `transmute`.
                     val.and_then(|x| {
-                        if self.ast_context.is_function_pointer(source_ty_ctype_id) {
+                        if self.ast_context.is_function_pointer(source_cty.ctype) {
                             Ok(WithStmts::new_unsafe_val(transmute_expr(
                                 source_ty, target_ty, x,
                             )))
@@ -4481,13 +4487,13 @@ impl<'c> Translation<'c> {
                 // and to be a pointer as a function argument we would get
                 // spurious casts when trying to treat it like a VaList which
                 // has reference semantics.
-                if self.ast_context.is_va_list(ty.ctype) {
+                if self.ast_context.is_va_list(target_cty.ctype) {
                     return Ok(val);
                 }
 
                 let pointee = self
                     .ast_context
-                    .get_pointee_qual_type(ty.ctype)
+                    .get_pointee_qual_type(target_cty.ctype)
                     .unwrap_or_else(|| panic!("dereferencing a non-pointer"));
 
                 let is_const = pointee.qualifiers.is_const;
@@ -4495,7 +4501,7 @@ impl<'c> Translation<'c> {
                 let expr_kind = expr.map(|e| &self.ast_context.index(e).kind);
                 match expr_kind {
                     Some(&CExprKind::Literal(_, CLiteral::String(ref bytes, 1))) if is_const => {
-                        let target_ty = self.convert_type(ty.ctype)?;
+                        let target_ty = self.convert_type(target_cty.ctype)?;
 
                         let mut bytes = bytes.to_owned();
                         bytes.push(0);
@@ -4507,9 +4513,7 @@ impl<'c> Translation<'c> {
                     }
                     _ => {
                         // Variable length arrays are already represented as pointers.
-                        if let CTypeKind::VariableArray(..) =
-                            self.ast_context.resolve_type(source_ty.ctype).kind
-                        {
+                        if let CTypeKind::VariableArray(..) = source_ty_kind {
                             Ok(val)
                         } else {
                             let method = if is_const || ctx.is_static {
@@ -4538,7 +4542,9 @@ impl<'c> Translation<'c> {
 
             CastKind::NullToPointer => {
                 assert!(val.stmts().is_empty());
-                Ok(WithStmts::new_val(self.null_ptr(ty.ctype, ctx.is_static)?))
+                Ok(WithStmts::new_val(
+                    self.null_ptr(target_cty.ctype, ctx.is_static)?,
+                ))
             }
 
             CastKind::ToUnion => {
@@ -4567,7 +4573,7 @@ impl<'c> Translation<'c> {
                 if let Some(expr) = expr {
                     self.convert_condition(ctx, true, expr)
                 } else {
-                    Ok(val.map(|e| self.match_bool(true, source_ty.ctype, e)))
+                    Ok(val.map(|e| self.match_bool(true, source_cty.ctype, e)))
                 }
             }
 

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@macros.c.snap
@@ -31,11 +31,13 @@ pub unsafe extern "C" fn size_of_const() -> std::ffi::c_int {
     return SIZE as std::ffi::c_int;
 }
 pub const SIZE: usize = unsafe { ::core::mem::size_of::<[std::ffi::c_int; 10]>() };
+pub const POS: [std::ffi::c_char; 3] =
+    unsafe { *::core::mem::transmute::<&[u8; 3], &[std::ffi::c_char; 3]>(b"\"]\0") };
 #[no_mangle]
 pub unsafe extern "C" fn memcpy_str_literal(mut out: *mut std::ffi::c_char) {
     memcpy(
         out as *mut std::ffi::c_void,
-        b"\"]\0" as *const u8 as *const std::ffi::c_char as *const std::ffi::c_void,
+        POS.as_ptr() as *const std::ffi::c_void,
         (::core::mem::size_of::<[std::ffi::c_char; 3]>() as size_t)
             .wrapping_div(::core::mem::size_of::<std::ffi::c_char>() as size_t)
             .wrapping_sub(1 as size_t)

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@macros.c.snap
@@ -32,11 +32,13 @@ pub unsafe extern "C" fn size_of_const() -> std::ffi::c_int {
     return SIZE as std::ffi::c_int;
 }
 pub const SIZE: usize = unsafe { ::core::mem::size_of::<[std::ffi::c_int; 10]>() };
+pub const POS: [std::ffi::c_char; 3] =
+    unsafe { *::core::mem::transmute::<&[u8; 3], &[std::ffi::c_char; 3]>(b"\"]\0") };
 #[no_mangle]
 pub unsafe extern "C" fn memcpy_str_literal(mut out: *mut std::ffi::c_char) {
     memcpy(
         out as *mut std::ffi::c_void,
-        b"\"]\0" as *const u8 as *const std::ffi::c_char as *const std::ffi::c_void,
+        POS.as_ptr() as *const std::ffi::c_void,
         (::core::mem::size_of::<[std::ffi::c_char; 3]>() as size_t)
             .wrapping_div(::core::mem::size_of::<std::ffi::c_char>() as size_t)
             .wrapping_sub(1 as size_t)

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -36,6 +36,8 @@ pub const LITERAL_INT: std::ffi::c_int = unsafe { 0xffff as std::ffi::c_int };
 pub const LITERAL_BOOL: std::ffi::c_int = unsafe { true_0 };
 pub const LITERAL_FLOAT: std::ffi::c_double = unsafe { 3.14f64 };
 pub const LITERAL_CHAR: std::ffi::c_int = unsafe { 'x' as i32 };
+pub const LITERAL_STR: [std::ffi::c_char; 6] =
+    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
 pub const LITERAL_STRUCT: S = unsafe {
     {
         let mut init = S {
@@ -48,6 +50,8 @@ pub const NESTED_INT: std::ffi::c_int = unsafe { LITERAL_INT };
 pub const NESTED_BOOL: std::ffi::c_int = unsafe { 1 as std::ffi::c_int };
 pub const NESTED_FLOAT: std::ffi::c_double = unsafe { LITERAL_FLOAT };
 pub const NESTED_CHAR: std::ffi::c_int = unsafe { 'x' as i32 };
+pub const NESTED_STR: [std::ffi::c_char; 6] =
+    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
 pub const NESTED_STRUCT: S = unsafe {
     {
         let mut init = S {
@@ -57,6 +61,12 @@ pub const NESTED_STRUCT: S = unsafe {
     }
 };
 pub const PARENS: std::ffi::c_int = unsafe { NESTED_INT * (LITERAL_CHAR + true_0) };
+pub const PTR_ARITHMETIC: *const std::ffi::c_char = unsafe {
+    LITERAL_STR
+        .as_ptr()
+        .offset(5 as std::ffi::c_int as isize)
+        .offset(-(3 as std::ffi::c_int as isize))
+};
 pub const WIDENING_CAST: std::ffi::c_int = unsafe { LITERAL_INT };
 pub const CONVERSION_CAST: std::ffi::c_int = unsafe { LITERAL_INT };
 pub const STMT_EXPR: std::ffi::c_float = unsafe {
@@ -82,10 +92,8 @@ pub unsafe extern "C" fn local_muts() {
     let mut literal_bool: bool = LITERAL_BOOL != 0;
     let mut literal_float: std::ffi::c_float = LITERAL_FLOAT as std::ffi::c_float;
     let mut literal_char: std::ffi::c_char = LITERAL_CHAR as std::ffi::c_char;
-    let mut literal_str_ptr: *const std::ffi::c_char =
-        b"hello\0" as *const u8 as *const std::ffi::c_char;
-    let mut literal_str: [std::ffi::c_char; 6] =
-        *::core::mem::transmute::<&[u8; 6], &mut [std::ffi::c_char; 6]>(b"hello\0");
+    let mut literal_str_ptr: *const std::ffi::c_char = LITERAL_STR.as_ptr();
+    let mut literal_str: [std::ffi::c_char; 6] = LITERAL_STR;
     let mut literal_array: [std::ffi::c_int; 3] = [
         1 as std::ffi::c_int,
         2 as std::ffi::c_int,
@@ -96,10 +104,8 @@ pub unsafe extern "C" fn local_muts() {
     let mut nested_bool: bool = NESTED_BOOL != 0;
     let mut nested_float: std::ffi::c_float = NESTED_FLOAT as std::ffi::c_float;
     let mut nested_char: std::ffi::c_char = NESTED_CHAR as std::ffi::c_char;
-    let mut nested_str_ptr: *const std::ffi::c_char =
-        b"hello\0" as *const u8 as *const std::ffi::c_char;
-    let mut nested_str: [std::ffi::c_char; 6] =
-        *::core::mem::transmute::<&[u8; 6], &mut [std::ffi::c_char; 6]>(b"hello\0");
+    let mut nested_str_ptr: *const std::ffi::c_char = NESTED_STR.as_ptr();
+    let mut nested_str: [std::ffi::c_char; 6] = NESTED_STR;
     let mut nested_array: [std::ffi::c_int; 3] = [
         1 as std::ffi::c_int,
         2 as std::ffi::c_int,
@@ -111,10 +117,7 @@ pub unsafe extern "C" fn local_muts() {
         (LITERAL_INT as std::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as std::ffi::c_double
             - true_0 as std::ffi::c_double) as std::ffi::c_float;
     let mut parens: std::ffi::c_int = PARENS;
-    let mut ptr_arithmetic: *const std::ffi::c_char = (b"hello\0" as *const u8
-        as *const std::ffi::c_char)
-        .offset(5 as std::ffi::c_int as isize)
-        .offset(-(3 as std::ffi::c_int as isize));
+    let mut ptr_arithmetic: *const std::ffi::c_char = PTR_ARITHMETIC;
     let mut widening_cast: std::ffi::c_ulonglong = WIDENING_CAST as std::ffi::c_ulonglong;
     let mut narrowing_cast: std::ffi::c_char = LITERAL_INT as std::ffi::c_char;
     let mut conversion_cast: std::ffi::c_double = CONVERSION_CAST as std::ffi::c_double;
@@ -126,9 +129,10 @@ pub unsafe extern "C" fn local_muts() {
     let mut str_concatenation: [std::ffi::c_char; 18] =
         *::core::mem::transmute::<&[u8; 18], &mut [std::ffi::c_char; 18]>(b"hello hello world\0");
     let mut builtin: std::ffi::c_int = (LITERAL_INT as std::ffi::c_uint).leading_zeros() as i32;
-    let mut ref_indexing: *const std::ffi::c_char =
-        &*(b"hello\0" as *const u8 as *const std::ffi::c_char)
-            .offset(LITERAL_FLOAT as std::ffi::c_int as isize) as *const std::ffi::c_char;
+    let mut ref_indexing: *const std::ffi::c_char = &*NESTED_STR
+        .as_ptr()
+        .offset(LITERAL_FLOAT as std::ffi::c_int as isize)
+        as *const std::ffi::c_char;
     let mut ref_struct: *const S = &mut LITERAL_STRUCT as *mut S;
     let mut ternary: std::ffi::c_int = if LITERAL_BOOL != 0 {
         1 as std::ffi::c_int
@@ -144,10 +148,8 @@ pub unsafe extern "C" fn local_consts() {
     let literal_bool: bool = LITERAL_BOOL != 0;
     let literal_float: std::ffi::c_float = LITERAL_FLOAT as std::ffi::c_float;
     let literal_char: std::ffi::c_char = LITERAL_CHAR as std::ffi::c_char;
-    let literal_str_ptr: *const std::ffi::c_char =
-        b"hello\0" as *const u8 as *const std::ffi::c_char;
-    let literal_str: [std::ffi::c_char; 6] =
-        *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0");
+    let literal_str_ptr: *const std::ffi::c_char = LITERAL_STR.as_ptr();
+    let literal_str: [std::ffi::c_char; 6] = LITERAL_STR;
     let literal_array: [std::ffi::c_int; 3] = [
         1 as std::ffi::c_int,
         2 as std::ffi::c_int,
@@ -158,10 +160,8 @@ pub unsafe extern "C" fn local_consts() {
     let nested_bool: bool = NESTED_BOOL != 0;
     let nested_float: std::ffi::c_float = NESTED_FLOAT as std::ffi::c_float;
     let nested_char: std::ffi::c_char = NESTED_CHAR as std::ffi::c_char;
-    let nested_str_ptr: *const std::ffi::c_char =
-        b"hello\0" as *const u8 as *const std::ffi::c_char;
-    let nested_str: [std::ffi::c_char; 6] =
-        *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0");
+    let nested_str_ptr: *const std::ffi::c_char = NESTED_STR.as_ptr();
+    let nested_str: [std::ffi::c_char; 6] = NESTED_STR;
     let nested_array: [std::ffi::c_int; 3] = [
         1 as std::ffi::c_int,
         2 as std::ffi::c_int,
@@ -173,10 +173,7 @@ pub unsafe extern "C" fn local_consts() {
         (LITERAL_INT as std::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as std::ffi::c_double
             - true_0 as std::ffi::c_double) as std::ffi::c_float;
     let parens: std::ffi::c_int = PARENS;
-    let ptr_arithmetic: *const std::ffi::c_char = (b"hello\0" as *const u8
-        as *const std::ffi::c_char)
-        .offset(5 as std::ffi::c_int as isize)
-        .offset(-(3 as std::ffi::c_int as isize));
+    let ptr_arithmetic: *const std::ffi::c_char = PTR_ARITHMETIC;
     let widening_cast: std::ffi::c_ulonglong = WIDENING_CAST as std::ffi::c_ulonglong;
     let narrowing_cast: std::ffi::c_char = LITERAL_INT as std::ffi::c_char;
     let conversion_cast: std::ffi::c_double = CONVERSION_CAST as std::ffi::c_double;
@@ -188,9 +185,10 @@ pub unsafe extern "C" fn local_consts() {
     let str_concatenation: [std::ffi::c_char; 18] =
         *::core::mem::transmute::<&[u8; 18], &[std::ffi::c_char; 18]>(b"hello hello world\0");
     let builtin: std::ffi::c_int = (LITERAL_INT as std::ffi::c_uint).leading_zeros() as i32;
-    let ref_indexing: *const std::ffi::c_char =
-        &*(b"hello\0" as *const u8 as *const std::ffi::c_char)
-            .offset(LITERAL_FLOAT as std::ffi::c_int as isize) as *const std::ffi::c_char;
+    let ref_indexing: *const std::ffi::c_char = &*NESTED_STR
+        .as_ptr()
+        .offset(LITERAL_FLOAT as std::ffi::c_int as isize)
+        as *const std::ffi::c_char;
     let ref_struct: *const S = &mut LITERAL_STRUCT as *mut S;
     let ternary: std::ffi::c_int = if LITERAL_BOOL != 0 {
         1 as std::ffi::c_int
@@ -205,10 +203,8 @@ static mut global_static_const_literal_bool: bool = LITERAL_BOOL != 0;
 static mut global_static_const_literal_float: std::ffi::c_float =
     LITERAL_FLOAT as std::ffi::c_float;
 static mut global_static_const_literal_char: std::ffi::c_char = LITERAL_CHAR as std::ffi::c_char;
-static mut global_static_const_literal_str_ptr: *const std::ffi::c_char =
-    b"hello\0" as *const u8 as *const std::ffi::c_char;
-static mut global_static_const_literal_str: [std::ffi::c_char; 6] =
-    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
+static mut global_static_const_literal_str_ptr: *const std::ffi::c_char = LITERAL_STR.as_ptr();
+static mut global_static_const_literal_str: [std::ffi::c_char; 6] = LITERAL_STR;
 static mut global_static_const_literal_array: [std::ffi::c_int; 3] = [
     1 as std::ffi::c_int,
     2 as std::ffi::c_int,
@@ -219,10 +215,8 @@ static mut global_static_const_nested_int: std::ffi::c_int = NESTED_INT;
 static mut global_static_const_nested_bool: bool = NESTED_BOOL != 0;
 static mut global_static_const_nested_float: std::ffi::c_float = NESTED_FLOAT as std::ffi::c_float;
 static mut global_static_const_nested_char: std::ffi::c_char = NESTED_CHAR as std::ffi::c_char;
-static mut global_static_const_nested_str_ptr: *const std::ffi::c_char =
-    b"hello\0" as *const u8 as *const std::ffi::c_char;
-static mut global_static_const_nested_str: [std::ffi::c_char; 6] =
-    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
+static mut global_static_const_nested_str_ptr: *const std::ffi::c_char = NESTED_STR.as_ptr();
+static mut global_static_const_nested_str: [std::ffi::c_char; 6] = NESTED_STR;
 static mut global_static_const_nested_array: [std::ffi::c_int; 3] = [
     1 as std::ffi::c_int,
     2 as std::ffi::c_int,
@@ -265,11 +259,9 @@ pub static mut global_const_literal_float: std::ffi::c_float = LITERAL_FLOAT as 
 #[no_mangle]
 pub static mut global_const_literal_char: std::ffi::c_char = LITERAL_CHAR as std::ffi::c_char;
 #[no_mangle]
-pub static mut global_const_literal_str_ptr: *const std::ffi::c_char =
-    b"hello\0" as *const u8 as *const std::ffi::c_char;
+pub static mut global_const_literal_str_ptr: *const std::ffi::c_char = LITERAL_STR.as_ptr();
 #[no_mangle]
-pub static mut global_const_literal_str: [std::ffi::c_char; 6] =
-    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
+pub static mut global_const_literal_str: [std::ffi::c_char; 6] = LITERAL_STR;
 #[no_mangle]
 pub static mut global_const_literal_array: [std::ffi::c_int; 3] = [
     1 as std::ffi::c_int,
@@ -287,11 +279,9 @@ pub static mut global_const_nested_float: std::ffi::c_float = NESTED_FLOAT as st
 #[no_mangle]
 pub static mut global_const_nested_char: std::ffi::c_char = NESTED_CHAR as std::ffi::c_char;
 #[no_mangle]
-pub static mut global_const_nested_str_ptr: *const std::ffi::c_char =
-    b"hello\0" as *const u8 as *const std::ffi::c_char;
+pub static mut global_const_nested_str_ptr: *const std::ffi::c_char = NESTED_STR.as_ptr();
 #[no_mangle]
-pub static mut global_const_nested_str: [std::ffi::c_char; 6] =
-    unsafe { *::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0") };
+pub static mut global_const_nested_str: [std::ffi::c_char; 6] = NESTED_STR;
 #[no_mangle]
 pub static mut global_const_nested_array: [std::ffi::c_int; 3] = [
     1 as std::ffi::c_int,
@@ -429,13 +419,12 @@ pub unsafe extern "C" fn use_portable_type(mut len: uintptr_t) -> bool {
     return len <= (UINTPTR_MAX as uintptr_t).wrapping_div(2 as uintptr_t);
 }
 unsafe extern "C" fn run_static_initializers() {
-    global_static_const_ptr_arithmetic = (b"hello\0" as *const u8 as *const std::ffi::c_char)
-        .offset(5 as std::ffi::c_int as isize)
-        .offset(-(3 as std::ffi::c_int as isize));
+    global_static_const_ptr_arithmetic = PTR_ARITHMETIC;
     global_static_const_indexing =
         (*::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0"))
             [LITERAL_FLOAT as std::ffi::c_int as usize];
-    global_static_const_ref_indexing = &*(b"hello\0" as *const u8 as *const std::ffi::c_char)
+    global_static_const_ref_indexing = &*NESTED_STR
+        .as_ptr()
         .offset(LITERAL_FLOAT as std::ffi::c_int as isize)
         as *const std::ffi::c_char;
     global_static_const_ternary = if LITERAL_BOOL != 0 {
@@ -444,13 +433,12 @@ unsafe extern "C" fn run_static_initializers() {
         2 as std::ffi::c_int
     };
     global_static_const_member = LITERAL_STRUCT.i;
-    global_const_ptr_arithmetic = (b"hello\0" as *const u8 as *const std::ffi::c_char)
-        .offset(5 as std::ffi::c_int as isize)
-        .offset(-(3 as std::ffi::c_int as isize));
+    global_const_ptr_arithmetic = PTR_ARITHMETIC;
     global_const_indexing =
         (*::core::mem::transmute::<&[u8; 6], &[std::ffi::c_char; 6]>(b"hello\0"))
             [LITERAL_FLOAT as std::ffi::c_int as usize];
-    global_const_ref_indexing = &*(b"hello\0" as *const u8 as *const std::ffi::c_char)
+    global_const_ref_indexing = &*NESTED_STR
+        .as_ptr()
         .offset(LITERAL_FLOAT as std::ffi::c_int as isize)
         as *const std::ffi::c_char;
     global_const_ternary = if LITERAL_BOOL != 0 {


### PR DESCRIPTION
* Fixes #1348.

This is done by adding a ptr cast to the target pointer type if the element types aren't the same, where the element type is like the pointee type, but also includes array types that will decay to pointers.  `fn CTypeKind::element_ty` is added for that.

I also cleaned up some stuff in `fn convert_cast`, as the naming was pretty irregular, repetitive, and confusing.