### PR TITLE
cleanup AST builder functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ version = "0.20.0"
 name = "c2rust-ast-builder"
 version = "0.20.0"
 dependencies = [
+ "itertools",
  "proc-macro2",
  "syn 2.0.101",
 ]

--- a/c2rust-ast-builder/Cargo.toml
+++ b/c2rust-ast-builder/Cargo.toml
@@ -12,5 +12,6 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+itertools = "0.10.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"]}
 syn = { version = "2.0", features = ["full", "extra-traits", "printing", "clone-impls"]}

--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -161,6 +161,23 @@ fn punct_box<T, P: Default>(x: Vec<Box<T>>) -> Punctuated<T, P> {
     Punctuated::from_iter(x.into_iter().map(|x| *x))
 }
 
+fn comma_separated<T, F>(items: Vec<T>, f: F) -> TokenStream
+where
+    F: Fn(&mut TokenStream, T),
+{
+    let mut tokens = TokenStream::new();
+    let mut first = true;
+    for item in items {
+        if !first {
+            TokenTree::Punct(Punct::new(',', Spacing::Alone)).to_tokens(&mut tokens);
+        } else {
+            first = false;
+        }
+        f(&mut tokens, item);
+    }
+    tokens
+}
+
 pub trait Make<T> {
     fn make(self, mk: &Builder) -> T;
 }
@@ -208,28 +225,6 @@ impl<'a> Make<Path> for &'a str {
     }
 }
 
-impl<'a> Make<Visibility> for &'a str {
-    fn make(self, mk_: &Builder) -> Visibility {
-        match self {
-            "pub" => Visibility::Public(Token![pub](mk_.span)),
-            "priv" | "" | "inherit" => Visibility::Inherited,
-            "pub(crate)" => Visibility::Restricted(VisRestricted {
-                pub_token: Token![pub](mk_.span),
-                paren_token: token::Paren(mk_.span),
-                in_token: None,
-                path: Box::new(mk().path("crate")),
-            }),
-            "pub(super)" => Visibility::Restricted(VisRestricted {
-                pub_token: Token![pub](mk_.span),
-                paren_token: token::Paren(mk_.span),
-                in_token: None,
-                path: Box::new(mk().path("super")),
-            }),
-            _ => panic!("unrecognized string for Visibility: {:?}", self),
-        }
-    }
-}
-
 impl<'a> Make<Abi> for &'a str {
     fn make(self, mk: &Builder) -> Abi {
         Abi {
@@ -249,47 +244,6 @@ impl<'a> Make<Extern> for &'a str {
 impl Make<Extern> for Abi {
     fn make(self, _mk: &Builder) -> Extern {
         Extern::Explicit(self.name.to_token_stream().to_string())
-    }
-}
-
-impl<'a> Make<Mutability> for &'a str {
-    fn make(self, _mk: &Builder) -> Mutability {
-        match self {
-            "" | "imm" | "immut" | "immutable" => Mutability::Immutable,
-            "mut" | "mutable" => Mutability::Mutable,
-            _ => panic!("unrecognized string for Mutability: {:?}", self),
-        }
-    }
-}
-
-impl<'a> Make<Unsafety> for &'a str {
-    fn make(self, _mk: &Builder) -> Unsafety {
-        match self {
-            "" | "safe" | "normal" => Unsafety::Normal,
-            "unsafe" => Unsafety::Unsafe,
-            _ => panic!("unrecognized string for Unsafety: {:?}", self),
-        }
-    }
-}
-
-impl<'a> Make<Constness> for &'a str {
-    fn make(self, _mk: &Builder) -> Constness {
-        match self {
-            "" | "normal" | "not-const" => Constness::NotConst,
-            "const" => Constness::Const,
-            _ => panic!("unrecognized string for Constness: {:?}", self),
-        }
-    }
-}
-
-impl<'a> Make<UnOp> for &'a str {
-    fn make(self, _mk: &Builder) -> UnOp {
-        match self {
-            "deref" | "*" => UnOp::Deref(Default::default()),
-            "not" | "!" => UnOp::Not(Default::default()),
-            "neg" | "-" => UnOp::Neg(Default::default()),
-            _ => panic!("unrecognized string for UnOp: {:?}", self),
-        }
     }
 }
 
@@ -330,94 +284,35 @@ impl Make<TokenStream> for Vec<TokenTree> {
     }
 }
 
-impl Make<TokenStream> for Vec<String> {
-    fn make(self, _mk: &Builder) -> TokenStream {
-        let mut tokens = vec![];
-        let mut first = true;
-
-        for s in self {
-            if !first {
-                tokens.push(TokenTree::Punct(Punct::new(',', Spacing::Alone)));
-            } else {
-                first = false;
-            }
-
-            tokens.push(TokenTree::Ident(Ident::new(&s, Span::call_site())));
-        }
-
-        tokens.into_iter().collect::<TokenStream>()
-    }
-}
-
 impl Make<TokenStream> for Vec<&str> {
     fn make(self, _mk: &Builder) -> TokenStream {
-        let mut tokens = vec![];
-        let mut first = true;
-
-        for s in self {
-            if !first {
-                tokens.push(TokenTree::Punct(Punct::new(',', Spacing::Alone)));
-            } else {
-                first = false;
-            }
-
-            tokens.push(TokenTree::Ident(Ident::new(s, Span::call_site())));
-        }
-
-        tokens.into_iter().collect::<TokenStream>()
+        comma_separated(self, |tokens, s| {
+            let tt = TokenTree::Ident(Ident::new(s, Span::call_site()));
+            tt.to_tokens(tokens);
+        })
     }
 }
 
 impl Make<TokenStream> for Vec<u64> {
     fn make(self, _mk: &Builder) -> TokenStream {
-        let mut tokens = vec![];
-        let mut first = true;
-
-        for s in self {
-            if !first {
-                tokens.push(TokenTree::Punct(Punct::new(',', Spacing::Alone)));
-            } else {
-                first = false;
-            }
-
-            tokens.push(TokenTree::Literal(Literal::u64_unsuffixed(s)));
-        }
-
-        tokens.into_iter().collect::<TokenStream>()
+        comma_separated(self, |tokens, s| {
+            let tt = TokenTree::Literal(Literal::u64_unsuffixed(s));
+            tt.to_tokens(tokens);
+        })
     }
 }
 
 impl Make<TokenStream> for Vec<Meta> {
     fn make(self, _mk: &Builder) -> TokenStream {
-        let mut tokens = TokenStream::new();
-
-        let mut first = true;
-
-        for meta in self {
-            if !first {
-                let tt = TokenTree::Punct(Punct::new(',', Spacing::Alone));
-
-                tokens.extend(vec![tt]);
-            } else {
-                first = false;
-            }
-
-            meta.to_tokens(&mut tokens);
-        }
-
-        tokens
+        comma_separated(self, |tokens, s| {
+            s.to_tokens(tokens);
+        })
     }
 }
 
 impl Make<PathArguments> for AngleBracketedGenericArguments {
     fn make(self, _mk: &Builder) -> PathArguments {
         PathArguments::AngleBracketed(self)
-    }
-}
-
-impl Make<PathArguments> for ParenthesizedGenericArguments {
-    fn make(self, _mk: &Builder) -> PathArguments {
-        PathArguments::Parenthesized(self)
     }
 }
 
@@ -658,14 +553,6 @@ impl Builder {
         PathSegment {
             ident: identifier,
             arguments: args,
-        }
-    }
-
-    pub fn parenthesized_args(self, tys: Vec<Box<Type>>) -> ParenthesizedGenericArguments {
-        ParenthesizedGenericArguments {
-            paren_token: token::Paren(self.span),
-            inputs: punct_box(tys),
-            output: ReturnType::Default,
         }
     }
 

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -667,12 +667,13 @@ impl StructureState {
 ///   * Negating something of the form `!<expr>` produces `<expr>`
 ///
 fn not(bool_expr: &Expr) -> Box<Expr> {
+    use syn::UnOp;
     match *bool_expr {
         Expr::Unary(ExprUnary {
-            op: syn::UnOp::Not(_),
+            op: UnOp::Not(_),
             ref expr,
             ..
         }) => Box::new(unparen(expr).clone()),
-        _ => mk().unary_expr("!", Box::new(bool_expr.clone())),
+        _ => mk().unary_expr(UnOp::Not(Default::default()), Box::new(bool_expr.clone())),
     }
 }

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -108,7 +108,7 @@ impl<'c> Translation<'c> {
                         // Fallback for characters outside of the valid Unicode range
                         if (val as i32) < 0 {
                             mk().unary_expr(
-                                "-",
+                                UnOp::Neg(Default::default()),
                                 mk().lit_expr(
                                     mk().int_lit((val as i32).unsigned_abs() as u128, "i32"),
                                 ),
@@ -170,7 +170,7 @@ impl<'c> Translation<'c> {
                 Ok(WithStmts::new_unsafe_val(transmute_expr(
                     mk().array_ty(u8_ty, width_lit),
                     self.convert_type(ty.ctype)?,
-                    mk().unary_expr("*", mk().lit_expr(val)),
+                    mk().unary_expr(UnOp::Deref(Default::default()), mk().lit_expr(val)),
                 )))
             }
         }


### PR DESCRIPTION
- remove unused function & impl
  - `impl<'a> Make<Unsafety> for &'a str`
  - `impl<'a> Make<Constness> for &'a str`
  - `impl Make<TokenStream> for Vec<String>`
  - `impl Make<PathArguments> for ParenthesizedGenericArguments`
  - `fn parenthesized_args`
- refactor `mk().vis()` usage so we can remove `impl<'a> Make<Visibility> for &'a str`
- refactor `mk().set_mutbl()` usage so we can remove `impl<'a> Make<Mutability> for &'a str`
- refactor `mk().unary_expr()` usage so we can remove `impl<'a> Make<UnOp> for &'a str`
- unify `impl Make<TokenStream> for Vec<&str>`, `impl Make<TokenStream> for Vec<u64>`, and `impl Make<TokenStream> for Vec<Meta>` functionality to use `fn comma_separated`