### PR TITLE
Change VisitEnumDecl to TraverseDecl

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -2537,7 +2537,7 @@ void TypeEncoder::VisitEnumType(const EnumType *T) {
         cbor_encode_uint(local, uintptr_t(ed));
     });
 
-    if (ed != nullptr) astEncoder->VisitEnumDecl(ed);
+    if (ed != nullptr) astEncoder->TraverseDecl(ed);
 }
 
 void TypeEncoder::VisitRecordType(const RecordType *T) {

--- a/c2rust-transpile/tests/snapshots/exprs.c
+++ b/c2rust-transpile/tests/snapshots/exprs.c
@@ -33,3 +33,8 @@ void unary_with_side_effect(){
     arr[side_effect()]++;
     arr[side_effect()]--;
 }
+
+void compound_literal(){
+    /// https://github.com/immunant/c2rust/issues/1234
+    int i = (enum {A, B, C}){1};
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
@@ -15,6 +15,10 @@ input_file: c2rust-transpile/tests/snapshots/exprs.c
 extern "C" {
     fn puts(str: *const std::ffi::c_char) -> std::ffi::c_int;
 }
+pub type C2RustUnnamed = std::ffi::c_uint;
+pub const C: C2RustUnnamed = 2;
+pub const B: C2RustUnnamed = 1;
+pub const A: C2RustUnnamed = 0;
 unsafe extern "C" fn side_effect() -> std::ffi::c_int {
     puts(b"the return of side effect\0" as *const u8 as *const std::ffi::c_char);
     return 10 as std::ffi::c_int;
@@ -49,4 +53,8 @@ pub unsafe extern "C" fn unary_with_side_effect() {
     arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(-1);
     arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(1);
     arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(-1);
+}
+#[no_mangle]
+pub unsafe extern "C" fn compound_literal() {
+    let mut i: std::ffi::c_int = B as std::ffi::c_int;
 }


### PR DESCRIPTION
The C AST exporter was not correctly traversing the children of anonymous enum declarations inside compound literals. This caused the transpiler to panic with an "invalid Clang AST" error. calling TraverseDecl will make it to visit the children too.

credit to @google-labs-jules for solutions

* fixes #1234 