### PR TITLE
transpile: support anonymous `struct`/`union`/`enum`s within `struct`s and `union`s

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -2098,9 +2098,16 @@ class TranslateASTVisitor final
         auto loc = D->getLocation();
         std::vector<void *> childIds;
         if (def) {
-            for (auto x : def->fields()) {
-                childIds.push_back(x->getCanonicalDecl());
+            for (auto decl : def->decls()) {
+                auto kind = decl->getKind();
+                // Note: We skip `Decl::Kind::IndirectField`.
+                if (kind == Decl::Kind::Field 
+                    || kind == Decl::Kind::Enum 
+                    || kind == Decl::Kind::Record) {
+                    childIds.push_back(decl->getCanonicalDecl());
+                }
             }
+            
             // Since the RecordDecl D isn't the complete definition,
             // the actual location should be given. This should handle opaque
             // types.

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -556,6 +556,22 @@ impl ConversionContext {
         self.typed_context.target = untyped_context.target.clone();
     }
 
+    /// Visit child nodes of a `RecordDecl` (`struct` or `union`) and collect `FieldDecl` node IDs.
+    fn visit_record_children<'a>(
+        &'a mut self,
+        node: &'a AstNode,
+        new_id: ImporterId,
+    ) -> impl Iterator<Item = CDeclId> + 'a {
+        use self::node_types::*;
+
+        node.children.iter().filter_map(move |id| {
+            let field = id.expect("Record field decl not found");
+            let id = CDeclId(self.visit_node_type(field, FIELD_DECL));
+            self.typed_context.parents.insert(id, CDeclId(new_id));
+            Some(id)
+        })
+    }
+
     /// Visit one node.
     fn visit_node(
         &mut self,
@@ -2245,17 +2261,7 @@ impl ConversionContext {
                         from_value(node.extras[6].clone()).expect("Expected struct alignment");
 
                     let fields: Option<Vec<CDeclId>> = if has_def {
-                        Some(
-                            node.children
-                                .iter()
-                                .map(|id| {
-                                    let field = id.expect("Record field decl not found");
-                                    let id = CDeclId(self.visit_node_type(field, FIELD_DECL));
-                                    self.typed_context.parents.insert(id, CDeclId(new_id));
-                                    id
-                                })
-                                .collect(),
-                        )
+                        Some(self.visit_record_children(node, new_id).collect())
                     } else {
                         None
                     };
@@ -2283,17 +2289,7 @@ impl ConversionContext {
                     let attrs = from_value::<Vec<Value>>(node.extras[2].clone())
                         .expect("Expected attribute array on record");
                     let fields: Option<Vec<CDeclId>> = if has_def {
-                        Some(
-                            node.children
-                                .iter()
-                                .map(|id| {
-                                    let field = id.expect("Record field decl not found");
-                                    let id = CDeclId(self.visit_node_type(field, FIELD_DECL));
-                                    self.typed_context.parents.insert(id, CDeclId(new_id));
-                                    id
-                                })
-                                .collect(),
-                        )
+                        Some(self.visit_record_children(node, new_id).collect())
                     } else {
                         None
                     };

--- a/c2rust-transpile/tests/snapshots/records.c
+++ b/c2rust-transpile/tests/snapshots/records.c
@@ -1,0 +1,60 @@
+// record (struct/union) declaration
+
+struct AnonEnumInStruct {
+    enum {
+        VALUE1,
+        VALUE2
+    };
+};
+
+struct AnonStructInStruct {
+    struct {
+        int some_number;
+    };
+};
+
+struct NestedStructInStruct {
+    struct InsideStruct {
+        int yup;
+    };
+};
+
+union AnonEnumInUnion {
+    enum {
+        VALUE3,
+        VALUE4
+    };
+    int a;
+};
+
+union AnonStructInUnion {
+    struct {
+        int some_number;
+    };
+    int a;
+};
+
+union NestedStructInUnion {
+    struct InsideUnion {
+        int yup;
+    };
+    int a;
+};
+
+void struct_declaration() {
+    int value = VALUE2;
+    struct AnonEnumInStruct a;
+    struct AnonStructInStruct b;
+    b.some_number = 7;
+    struct NestedStructInStruct c;
+    struct InsideStruct d;
+}
+
+void union_declaration() {
+    int value = VALUE4;
+    union AnonEnumInUnion a;
+    union AnonStructInUnion b;
+    b.some_number = 99;
+    union NestedStructInUnion c;
+    struct InsideUnion d;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@records.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@records.c.snap
@@ -1,0 +1,88 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/records.rs
+input_file: c2rust-transpile/tests/snapshots/records.c
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct AnonEnumInStruct {}
+pub type C2RustUnnamed = std::ffi::c_uint;
+pub const VALUE2: C2RustUnnamed = 1;
+pub const VALUE1: C2RustUnnamed = 0;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct AnonStructInStruct {
+    pub c2rust_unnamed: C2RustUnnamed_0,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct C2RustUnnamed_0 {
+    pub some_number: std::ffi::c_int,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct NestedStructInStruct {}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct InsideStruct {
+    pub yup: std::ffi::c_int,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union AnonEnumInUnion {
+    pub a: std::ffi::c_int,
+}
+pub type C2RustUnnamed_1 = std::ffi::c_uint;
+pub const VALUE4: C2RustUnnamed_1 = 1;
+pub const VALUE3: C2RustUnnamed_1 = 0;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union AnonStructInUnion {
+    pub c2rust_unnamed: C2RustUnnamed_2,
+    pub a: std::ffi::c_int,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct C2RustUnnamed_2 {
+    pub some_number: std::ffi::c_int,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub union NestedStructInUnion {
+    pub a: std::ffi::c_int,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct InsideUnion {
+    pub yup: std::ffi::c_int,
+}
+#[no_mangle]
+pub unsafe extern "C" fn struct_declaration() {
+    let mut value: std::ffi::c_int = VALUE2 as std::ffi::c_int;
+    let mut a: AnonEnumInStruct = AnonEnumInStruct {};
+    let mut b: AnonStructInStruct = AnonStructInStruct {
+        c2rust_unnamed: C2RustUnnamed_0 { some_number: 0 },
+    };
+    b.c2rust_unnamed.some_number = 7 as std::ffi::c_int;
+    let mut c: NestedStructInStruct = NestedStructInStruct {};
+    let mut d: InsideStruct = InsideStruct { yup: 0 };
+}
+#[no_mangle]
+pub unsafe extern "C" fn union_declaration() {
+    let mut value: std::ffi::c_int = VALUE4 as std::ffi::c_int;
+    let mut a: AnonEnumInUnion = AnonEnumInUnion { a: 0 };
+    let mut b: AnonStructInUnion = AnonStructInUnion {
+        c2rust_unnamed: C2RustUnnamed_2 { some_number: 0 },
+    };
+    b.c2rust_unnamed.some_number = 99 as std::ffi::c_int;
+    let mut c: NestedStructInUnion = NestedStructInUnion { a: 0 };
+    let mut d: InsideUnion = InsideUnion { yup: 0 };
+}


### PR DESCRIPTION
* Fixes #1233.

`RecordDecl` can have anonymous struct or enum as children so we must collect them so they can have parent in `TypedAstContext`.