### PR TITLE
Include libc dependency only when needed

### DIFF
--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -308,6 +308,7 @@ impl<'c> Translation<'c> {
                             mk().block(vec![mk().expr_stmt(minus_one)]),
                             Some(mk().lit_expr(mk().int_lit(0, "isize"))),
                         );
+                        self.use_crate(ExternCrate::Libc);
                         let size_t = mk().path_ty(vec!["libc", "size_t"]);
                         mk().cast_expr(if_expr, size_t)
                     }))
@@ -752,6 +753,7 @@ impl<'c> Translation<'c> {
         arg_types: &[LibcFnArgType],
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let name = &builtin_name[10..];
+        self.use_crate(ExternCrate::Libc);
         let mem = mk().path_expr(vec!["libc", name]);
         let args = self.convert_exprs(ctx.used(), args, None)?;
         args.and_then(|args| {
@@ -765,13 +767,13 @@ impl<'c> Translation<'c> {
                 ))
                 .context(TranslationErrorKind::Generic))?
             }
-            let size_t = || mk().path_ty(vec!["libc", "size_t"]);
             let args_casted = args
                 .into_iter()
                 .zip(arg_types)
                 .map(|(arg, &ty)| {
                     if ty == LibcFnArgType::Size {
-                        mk().cast_expr(arg, size_t())
+                        self.use_crate(ExternCrate::Libc);
+                        mk().cast_expr(arg, mk().path_ty(vec!["libc", "size_t"]))
                     } else {
                         arg
                     }


### PR DESCRIPTION
* Fixes #1362

Since most C types are now imported from `std::ffi`, there is less need to always include the `libc` library. This changes it so that it's only included when actually needed.

To implement this, `TypeConverter` now tracks external crates, separately from `Translator`. The two lists are merged afterwards. While working on this, I also spotted a bug that `f128` wasn't being included from `TypeConverter` and a few other places, so I included fixes for that as well.