### PR TITLE
transpile: update `insta` to `1.43.2` for the fix to `INSTA_GLOB_FILTER` so that the snapshot file is correctly resolved

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.43.1"
+version = "1.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
 dependencies = [
  "console",
  "globset",

--- a/c2rust-transpile/Cargo.toml
+++ b/c2rust-transpile/Cargo.toml
@@ -44,4 +44,4 @@ tempfile = "3.5.0"
 llvm-static = ["c2rust-ast-exporter/llvm-static"]
 
 [dev-dependencies]
-insta = { version = "1.15", features = ["glob"] }
+insta = { version = "1.43.2", features = ["glob"] }

--- a/pdg/Cargo.toml
+++ b/pdg/Cargo.toml
@@ -30,7 +30,7 @@ clap = { version = "3.2", features = ["derive"] }
 c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.20.0" }
 
 [dev-dependencies]
-insta = "1.43.1"
+insta = "1.43.2"
 
 [package.metadata.rust-analyzer] 
 rustc_private = true


### PR DESCRIPTION
`INSTA_GLOB_FILTER` conveniently lets you run things like `INSTA_GLOB_FILTER=*/macros.c cargo test -p c2rust-transpile` to only test `macros.c`.  However, previously, limiting the filter to a single snapshot messed up how the snapshot file path was calculated, resulting in a different snapshot (https://github.com/mitsuhiko/insta/issues/785).  Now this is fixed by https://github.com/mitsuhiko/insta/pull/786, so this just updates to the latest `insta` version, which includes this fix.