### PR TITLE
transpile: tests: snapshots: fix vm_x86.c snapshot test

### DIFF
--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-aarch64@vm_x86.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-aarch64@vm_x86.c.snap
@@ -5,7 +5,6 @@ input_file: c2rust-transpile/tests/snapshots/arch-specific/vm_x86.c
 ---
 #![allow(
     dead_code,
-    mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
     non_upper_case_globals,
@@ -22,7 +21,7 @@ pub struct vm_t {
     pub instructionPointers: *mut std::ffi::c_ulong,
 }
 pub type byte = std::ffi::c_uchar;
-pub const MAX_VMMAIN_ARGS: std::ffi::c_int = unsafe { 50 as std::ffi::c_int };
+pub const MAX_VMMAIN_ARGS: std::ffi::c_int = 50 as std::ffi::c_int;
 #[no_mangle]
 pub unsafe extern "C" fn VM_CallCompiled(
     mut vm: *mut vm_t,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-x86_64@vm_x86.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-x86_64@vm_x86.c.snap
@@ -5,7 +5,6 @@ input_file: c2rust-transpile/tests/snapshots/arch-specific/vm_x86.c
 ---
 #![allow(
     dead_code,
-    mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
     non_upper_case_globals,
@@ -24,7 +23,7 @@ pub struct vm_t {
     pub instructionPointers: *mut std::ffi::c_ulong,
 }
 pub type byte = std::ffi::c_uchar;
-pub const MAX_VMMAIN_ARGS: std::ffi::c_int = unsafe { 50 as std::ffi::c_int };
+pub const MAX_VMMAIN_ARGS: std::ffi::c_int = 50 as std::ffi::c_int;
 #[no_mangle]
 pub unsafe extern "C" fn VM_CallCompiled(
     mut vm: *mut vm_t,


### PR DESCRIPTION
CI on this ran before #1339 merged; as a result, the snapshot as landed is out of date.