### PR TITLE
transpile: const macros: skip `DeclRef`s

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3338,6 +3338,15 @@ impl<'c> Translation<'c> {
                     .ok_or_else(|| format_err!("Missing declref {:?}", decl_id))?
                     .kind;
                 if ctx.is_const {
+                    // TODO Determining which declarations have been declared within the scope of the const macro expr
+                    // vs. which are out-of-scope of the const macro is non-trivial,
+                    // so for now, we don't allow const macros referencing any declarations.
+                    return Err(format_translation_err!(
+                        self.ast_context.display_loc(src_loc),
+                        "Cannot yet refer to declarations in a const expr",
+                    ));
+
+                    #[allow(unreachable_code)] // TODO temporary (see above).
                     if let CDeclKind::Variable {
                         has_static_duration: true,
                         ..

--- a/c2rust-transpile/tests/snapshots/macros.c
+++ b/c2rust-transpile/tests/snapshots/macros.c
@@ -386,3 +386,22 @@ int local_fn(void) { return 1234; }
 int use_local_value(void) { return LOCAL_VALUE; }
 
 bool use_portable_type(uintptr_t len) { return len <= UINTPTR_MAX / 2; }
+
+// From `curl`'s `curl_ntlm_core.c`.
+
+struct ntlmdata {
+  unsigned int target_info_len;
+};
+
+// Should not translate since it references an out-of-scope `ntlm` variable.
+#define NTLMv2_BLOB_LEN (44 - 16 + ntlm->target_info_len + 4)
+
+unsigned int ntlm_v2_blob_len(struct ntlmdata *ntlm) { return NTLMv2_BLOB_LEN; }
+
+// The variable `i` lacks an initializer, but is still declared within the macro,
+// so it should be translated like `STMT_EXPR` is.
+#define LATE_INIT_VAR ({ int i; i = 1; i; })
+
+int late_init_var() {
+  return LATE_INIT_VAR;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -29,6 +29,11 @@ pub struct fn_ptrs {
     pub fn2: Option<unsafe extern "C" fn(core::ffi::c_int) -> core::ffi::c_int>,
 }
 pub type zstd_platform_dependent_type = core::ffi::c_long;
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ntlmdata {
+    pub target_info_len: core::ffi::c_uint,
+}
 pub const UINTPTR_MAX: core::ffi::c_ulong = 18446744073709551615 as core::ffi::c_ulong;
 pub const true_0: core::ffi::c_int = 1 as core::ffi::c_int;
 pub const LITERAL_INT: core::ffi::c_int = 0xffff as core::ffi::c_int;
@@ -58,19 +63,6 @@ pub const PTR_ARITHMETIC: *const core::ffi::c_char = unsafe {
 };
 pub const WIDENING_CAST: core::ffi::c_ulonglong = LITERAL_INT as core::ffi::c_ulonglong;
 pub const CONVERSION_CAST: core::ffi::c_double = LITERAL_INT as core::ffi::c_double;
-pub const STMT_EXPR: core::ffi::c_float = ({
-    let mut builtin: core::ffi::c_int = (LITERAL_INT as core::ffi::c_uint).leading_zeros() as i32;
-    let mut indexing: core::ffi::c_char = NESTED_STR[LITERAL_FLOAT as core::ffi::c_int as usize];
-    let mut mixed: core::ffi::c_float =
-        (LITERAL_INT as core::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as core::ffi::c_double
-            - true_0 as core::ffi::c_double) as core::ffi::c_float;
-    let mut i: core::ffi::c_int = 0 as core::ffi::c_int;
-    while i < builtin {
-        mixed += indexing as core::ffi::c_float;
-        i += 1;
-    }
-    mixed
-});
 #[no_mangle]
 pub unsafe extern "C" fn local_muts() {
     let mut literal_int: core::ffi::c_int = LITERAL_INT;
@@ -123,7 +115,22 @@ pub unsafe extern "C" fn local_muts() {
         2 as core::ffi::c_int
     };
     let mut member: core::ffi::c_int = LITERAL_STRUCT.i;
-    let mut stmt_expr: core::ffi::c_float = STMT_EXPR;
+    let mut stmt_expr: core::ffi::c_float = ({
+        let mut builtin_0: core::ffi::c_int =
+            (LITERAL_INT as core::ffi::c_uint).leading_zeros() as i32;
+        let mut indexing_0: core::ffi::c_char =
+            NESTED_STR[LITERAL_FLOAT as core::ffi::c_int as usize];
+        let mut mixed: core::ffi::c_float = (LITERAL_INT as core::ffi::c_double
+            + NESTED_FLOAT * LITERAL_CHAR as core::ffi::c_double
+            - true_0 as core::ffi::c_double)
+            as core::ffi::c_float;
+        let mut i: core::ffi::c_int = 0 as core::ffi::c_int;
+        while i < builtin_0 {
+            mixed += indexing_0 as core::ffi::c_float;
+            i += 1;
+        }
+        mixed
+    });
 }
 #[no_mangle]
 pub unsafe extern "C" fn local_consts() {
@@ -177,7 +184,22 @@ pub unsafe extern "C" fn local_consts() {
         2 as core::ffi::c_int
     };
     let member: core::ffi::c_int = LITERAL_STRUCT.i;
-    let stmt_expr: core::ffi::c_float = STMT_EXPR;
+    let stmt_expr: core::ffi::c_float = ({
+        let mut builtin_0: core::ffi::c_int =
+            (LITERAL_INT as core::ffi::c_uint).leading_zeros() as i32;
+        let mut indexing_0: core::ffi::c_char =
+            NESTED_STR[LITERAL_FLOAT as core::ffi::c_int as usize];
+        let mut mixed: core::ffi::c_float = (LITERAL_INT as core::ffi::c_double
+            + NESTED_FLOAT * LITERAL_CHAR as core::ffi::c_double
+            - true_0 as core::ffi::c_double)
+            as core::ffi::c_float;
+        let mut i: core::ffi::c_int = 0 as core::ffi::c_int;
+        while i < builtin_0 {
+            mixed += indexing_0 as core::ffi::c_float;
+            i += 1;
+        }
+        mixed
+    });
 }
 static mut global_static_const_literal_int: core::ffi::c_int = LITERAL_INT;
 static mut global_static_const_literal_bool: bool = LITERAL_BOOL != 0;
@@ -392,6 +414,20 @@ pub unsafe extern "C" fn use_local_value() -> core::ffi::c_int {
 #[no_mangle]
 pub unsafe extern "C" fn use_portable_type(mut len: uintptr_t) -> bool {
     return len <= (UINTPTR_MAX as uintptr_t).wrapping_div(2 as uintptr_t);
+}
+#[no_mangle]
+pub unsafe extern "C" fn ntlm_v2_blob_len(mut ntlm: *mut ntlmdata) -> core::ffi::c_uint {
+    return ((44 as core::ffi::c_int - 16 as core::ffi::c_int) as core::ffi::c_uint)
+        .wrapping_add((*ntlm).target_info_len)
+        .wrapping_add(4 as core::ffi::c_uint);
+}
+#[no_mangle]
+pub unsafe extern "C" fn late_init_var() -> core::ffi::c_int {
+    return ({
+        let mut i: core::ffi::c_int = 0;
+        i = 1 as core::ffi::c_int;
+        i
+    });
 }
 unsafe extern "C" fn run_static_initializers() {
     global_static_const_ptr_arithmetic = PTR_ARITHMETIC;


### PR DESCRIPTION
Determining which declarations have been declared within the scope of the const macro expr vs. which are out-of-scope of the const macro is non-trivial, so for now, we don't allow const macros referencing any declarations.

This should fix some of the issues surfaced in #1371 when the order of top-level decl being converted was changed.