### PR TITLE
Fix z3 in CI for restored c2rust-refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
       - name: cargo test --release --workspace
         run: |
           export RUSTFLAGS="-D warnings"
+          # add homebrew library path for z3
+          export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-L/opt/homebrew/lib -Clink-arg=-Wl,-rpath,/opt/homebrew/lib"
           export RUSTDOCFLAGS="-D warnings"
           cargo test --release --workspace
       - name: Test translator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
             librtmp-dev
             libssl-dev
             libtool
+            libz3-dev
             llvm
             llvm-dev
             luarocks


### PR DESCRIPTION
I think this requires less fiddly setup with newer versions of the `z3` crate, but we can't use those because they switch to the 2024 edition, which our pinned nightly from 2023 doesn't know about.