### PR TITLE
ci: don't cache apt pkgs for `c2rust-testsuite` since `dpkg-query` doesn't work correctly

### DIFF
--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -91,27 +91,27 @@ jobs:
       run:  rustup component add rustfmt-preview rustc-dev
 
     - name: Provision Debian Packages
-      uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: |
-          build-essential
-          libbrotli-dev
-          libclang-${{ matrix.clang-version }}-dev
-          libgcrypt20
-          libreadline-dev
-          libidn2-dev
-          libldap2-dev
-          liblzma-dev
-          libnghttp2-dev
-          libpcre3-dev
-          libpsl-dev
-          librtmp-dev
-          libtool
-          libzstd-dev
-          python3-setuptools
-          python3-wheel
-          rcs
-          zlib1g-dev
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get -qq install    \
+            build-essential         \
+            libbrotli-dev           \
+            libclang-${{ matrix.clang-version }}-dev \
+            libgcrypt20             \
+            libreadline-dev         \
+            libidn2-dev             \
+            libldap2-dev            \
+            liblzma-dev             \
+            libnghttp2-dev          \
+            libpcre3-dev            \
+            libpsl-dev              \
+            librtmp-dev             \
+            libtool                 \
+            libzstd-dev             \
+            python3-setuptools      \
+            python3-wheel           \
+            rcs                     \
+            zlib1g-dev
 
     # installs intercept-build to $HOME/.local/bin
     - name: Provision Python Packages


### PR DESCRIPTION
See https://github.com/awalsh128/cache-apt-pkgs-action?tab=readme-ov-file#caveats.  We `dpkg-query` all of the packages to ensure they're installed, but this doesn't work with `cache-apt-pkgs-action`.  We don't actually need to query these, but it's simpler to just revert this and have CI be much slower.