### PR TITLE
Narrow const macro `DeclRef` exclusion to only variables

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3338,13 +3338,15 @@ impl<'c> Translation<'c> {
                     .ok_or_else(|| format_err!("Missing declref {:?}", decl_id))?
                     .kind;
                 if ctx.is_const {
-                    // TODO Determining which declarations have been declared within the scope of the const macro expr
-                    // vs. which are out-of-scope of the const macro is non-trivial,
-                    // so for now, we don't allow const macros referencing any declarations.
-                    return Err(format_translation_err!(
-                        self.ast_context.display_loc(src_loc),
-                        "Cannot yet refer to declarations in a const expr",
-                    ));
+                    if let CDeclKind::Variable { .. } = decl {
+                        // TODO Determining which variables have been declared within the scope of the const macro expr
+                        // vs. which are out-of-scope of the const macro is non-trivial,
+                        // so for now, we don't allow const macros referencing any variables.
+                        return Err(format_translation_err!(
+                            self.ast_context.display_loc(src_loc),
+                            "Cannot yet refer to variables in a const expr",
+                        ));
+                    }
 
                     #[allow(unreachable_code)] // TODO temporary (see above).
                     if let CDeclKind::Variable {

--- a/c2rust-transpile/tests/snapshots/macros.c
+++ b/c2rust-transpile/tests/snapshots/macros.c
@@ -405,3 +405,7 @@ unsigned int ntlm_v2_blob_len(struct ntlmdata *ntlm) { return NTLMv2_BLOB_LEN; }
 int late_init_var() {
   return LATE_INIT_VAR;
 }
+
+enum foo { Variant1, };
+#define VARIANT1 Variant1
+enum foo fooval = VARIANT1;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -34,6 +34,8 @@ pub type zstd_platform_dependent_type = core::ffi::c_long;
 pub struct ntlmdata {
     pub target_info_len: core::ffi::c_uint,
 }
+pub type foo = core::ffi::c_uint;
+pub const Variant1: foo = 0;
 pub const UINTPTR_MAX: core::ffi::c_ulong = 18446744073709551615 as core::ffi::c_ulong;
 pub const true_0: core::ffi::c_int = 1 as core::ffi::c_int;
 pub const LITERAL_INT: core::ffi::c_int = 0xffff as core::ffi::c_int;
@@ -429,6 +431,9 @@ pub unsafe extern "C" fn late_init_var() -> core::ffi::c_int {
         i
     });
 }
+pub const VARIANT1: core::ffi::c_int = Variant1 as core::ffi::c_int;
+#[no_mangle]
+pub static mut fooval: foo = VARIANT1 as foo;
 unsafe extern "C" fn run_static_initializers() {
     global_static_const_ptr_arithmetic = PTR_ARITHMETIC;
     global_static_const_indexing = NESTED_STR[LITERAL_FLOAT as core::ffi::c_int as usize];


### PR DESCRIPTION
Mentioning enum variants, etc. in const contexts doesn't have the same scoping problems as variables. This change narrows the exception to const macro translation for `DeclRef`s and makes it more distinct from what #1386 covers.