### PR TITLE
transpile: actually fix `SrcLoc` sorting by fixing include path `fileid`s

### DIFF
--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -257,7 +257,7 @@ fn has_packed_attribute(attrs: Vec<Value>) -> bool {
 
 impl ConversionContext {
     /// Create a new 'ConversionContext' seeded with top-level nodes from an 'AstContext'.
-    pub fn new(untyped_context: &AstContext) -> ConversionContext {
+    pub fn new(input_path: &Path, untyped_context: &AstContext) -> ConversionContext {
         let mut invalid_clang_ast = false;
 
         // This starts out as all of the top-level nodes, which we expect to be 'DECL's
@@ -323,7 +323,7 @@ impl ConversionContext {
             id_mapper: IdMapper::new(),
             processed_nodes: HashMap::new(),
             visit_as,
-            typed_context: TypedAstContext::new(&untyped_context.files),
+            typed_context: TypedAstContext::new(input_path, &untyped_context.files),
             invalid_clang_ast,
         };
 

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -143,6 +143,7 @@ impl TypedAstContext {
     // TODO: build the TypedAstContext during initialization, rather than
     // building an empty one and filling it later.
     pub fn new(clang_files: &[SrcFile]) -> TypedAstContext {
+        // Deduplicate paths, converting clang `fileid`s to our `FileId`s.
         let mut files: Vec<SrcFile> = vec![];
         let mut file_map: Vec<FileId> = vec![];
         for file in clang_files {

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -143,20 +143,8 @@ impl TypedAstContext {
     // TODO: build the TypedAstContext during initialization, rather than
     // building an empty one and filling it later.
     pub fn new(clang_files: &[SrcFile]) -> TypedAstContext {
-        // Deduplicate paths, converting clang `fileid`s to our `FileId`s.
-        let mut files: Vec<SrcFile> = vec![];
-        let mut file_map: Vec<FileId> = vec![];
-        for file in clang_files {
-            if let Some(existing) = files.iter().position(|f| f.path == file.path) {
-                file_map.push(existing);
-            } else {
-                file_map.push(files.len());
-                files.push(file.clone());
-            }
-        }
-
         let mut include_map = vec![];
-        for (mut fileid, mut cur) in files.iter().enumerate() {
+        for (mut fileid, mut cur) in clang_files.iter().enumerate() {
             let mut include_path = vec![];
             while let Some(include_loc) = &cur.include_loc {
                 include_path.push(SrcLoc {
@@ -169,6 +157,18 @@ impl TypedAstContext {
             }
             include_path.reverse();
             include_map.push(include_path);
+        }
+
+        // Deduplicate paths, converting clang `fileid`s to our `FileId`s.
+        let mut files: Vec<SrcFile> = vec![];
+        let mut file_map: Vec<FileId> = vec![];
+        for file in clang_files {
+            if let Some(existing) = files.iter().position(|f| f.path == file.path) {
+                file_map.push(existing);
+            } else {
+                file_map.push(files.len());
+                files.push(file.clone());
+            }
         }
 
         TypedAstContext {

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -155,7 +155,7 @@ impl TypedAstContext {
         }
 
         let mut include_map = vec![];
-        for (fileid, mut cur) in files.iter().enumerate() {
+        for (mut fileid, mut cur) in files.iter().enumerate() {
             let mut include_path = vec![];
             while let Some(include_loc) = &cur.include_loc {
                 include_path.push(SrcLoc {
@@ -163,7 +163,8 @@ impl TypedAstContext {
                     line: include_loc.line,
                     column: include_loc.column,
                 });
-                cur = &clang_files[include_loc.fileid as usize];
+                fileid = include_loc.fileid as usize;
+                cur = &clang_files[fileid];
             }
             include_path.reverse();
             include_map.push(include_path);

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -540,7 +540,7 @@ fn transpile_single(
 
     // Convert this into a typed AST
     let typed_context = {
-        let conv = ConversionContext::new(&untyped_context);
+        let conv = ConversionContext::new(input_path, &untyped_context);
         if conv.invalid_clang_ast && tcfg.fail_on_error {
             panic!("Clang AST was invalid");
         }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -34,8 +34,8 @@ pub type zstd_platform_dependent_type = core::ffi::c_long;
 pub struct ntlmdata {
     pub target_info_len: core::ffi::c_uint,
 }
-pub const UINTPTR_MAX: core::ffi::c_ulong = 18446744073709551615 as core::ffi::c_ulong;
 pub const true_0: core::ffi::c_int = 1 as core::ffi::c_int;
+pub const UINTPTR_MAX: core::ffi::c_ulong = 18446744073709551615 as core::ffi::c_ulong;
 pub const LITERAL_INT: core::ffi::c_int = 0xffff as core::ffi::c_int;
 pub const LITERAL_BOOL: core::ffi::c_int = true_0;
 pub const LITERAL_FLOAT: core::ffi::c_double = 3.14f64;


### PR DESCRIPTION
* Fixes #1126.

This (I believe 🤞) should actually fix `SrcLoc` sorting.  It came up as an issue again when `libxml2` was enabled in `c2rust-testsuite`, as it would fail on `stable` due to the non-total (non-transitive) `SrcLoc` order.

Digging into this, the root cause was that our include paths were messed up, and we were relying on those invariants in `fn compare_src_locs` even though they weren't being upheld.

There were two things wrong that I found.  One was that we weren't updating `fileid` in the loop that calculates the include path, so all of the `fileid`s in an include path were the same, with only the last one (it's reversed) being correct.  And second (I'm not sure if this was uncovered in testing), we were using the index into `files` as the `fileid`.  `fileid` is the clang `fileid`, which is an index into the non-deduplicated by path `clang_files`, while `FileId` (a `type` alias, not a newtype) is an index into `files`.  We were iterating over `files`, getting its `FileId` indices, and using that as the clang `fileid` field of `SrcLoc`, which is incorrect if any of the `SrcFile`s were deduplicated by path.

After fixing this, I also pass down the `input_path` to check the invariants.  All of the include paths should start with an include from the input/main file.  This was obviously not the case previously when things were messed up.

Now that this is fixed, we also fix `SrcLoc` sorting in general, which we can see in the `macros.c` snapshot.  `true` from `stdbool.h` is `#include`d first, before `UINTPTR_MAX` from `stdint.h`, and now it correctly emits `true_0` before `UINTPTR_MAX`.