### PR TITLE
refactor: set `rustc_private = true` in `Cargo.toml` for `rust-analyzer`

### DIFF
--- a/c2rust-refactor/Cargo.toml
+++ b/c2rust-refactor/Cargo.toml
@@ -46,3 +46,6 @@ rand = "0.7"
 [features]
 default = []
 profile = ["flame", "flamer"]
+
+[package.metadata.rust-analyzer]
+rustc_private = true


### PR DESCRIPTION
We already have this for the other crates that use `#![feature(rustc_private)]`, but didn't add it yet for `c2rust-refactor`.