### PR TITLE
transpile: tests: specify `--edition 2021` for `rustfmt`, too

### DIFF
--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -88,7 +88,12 @@ fn transpile(platform: Option<&str>, c_path: &Path) {
         }
     };
 
-    let status = Command::new("rustfmt").arg(&rs_path).status();
+    let edition = "2021";
+
+    let status = Command::new("rustfmt")
+        .args(["--edition", edition])
+        .arg(&rs_path)
+        .status();
     assert!(status.unwrap().success());
 
     let rs = fs::read_to_string(&rs_path).unwrap();
@@ -119,7 +124,7 @@ fn transpile(platform: Option<&str>, c_path: &Path) {
             "--crate-type",
             "lib",
             "--edition",
-            "2021",
+            edition,
             "--crate-name",
             crate_name,
             "-o",


### PR DESCRIPTION
This is what was breaking https://github.com/immunant/c2rust/pull/1408#issuecomment-3393665108.  @Rua, I think this should fix your issue.  Let me know and you can review this PR.