### PR TITLE
ast-exporter: fix crash on cast of empty initializer

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -590,6 +590,7 @@ class TranslateASTVisitor final
     }
 
     bool evaluateConstantInt(Expr *E, APSInt &constant) {
+        assert(E != nullptr);
         auto value = getIntegerConstantExpr(*E, *Context);
 
         if (value) {
@@ -605,7 +606,9 @@ class TranslateASTVisitor final
 #if CLANG_VERSION_MAJOR < 8
             constant = eval_result;
 #else
-            constant = eval_result.Val.getInt();
+            if (hasValue) {
+                constant = eval_result.Val.getInt();
+            }
 #endif // CLANG_VERSION_MAJOR
             return hasValue;
         }

--- a/c2rust-transpile/tests/snapshots/empty_init.c
+++ b/c2rust-transpile/tests/snapshots/empty_init.c
@@ -1,0 +1,6 @@
+typedef struct Scope Scope;
+struct Scope {
+  Scope *next;
+};
+
+Scope *scope = &(Scope){};

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.snap
@@ -1,0 +1,25 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/empty_init.rs
+input_file: c2rust-transpile/tests/snapshots/empty_init.c
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Scope {
+    pub next: *mut Scope,
+}
+#[no_mangle]
+pub static mut scope: *mut Scope = &{
+    let mut init = Scope {
+        next: 0 as *const Scope as *mut Scope,
+    };
+    init
+} as *const Scope as *mut Scope;


### PR DESCRIPTION
- Fixes #1140.