### PR TITLE
transpile: search for `llvm-config-21` and `llvm-config-20`

### DIFF
--- a/c2rust-build-paths/src/lib.rs
+++ b/c2rust-build-paths/src/lib.rs
@@ -91,6 +91,8 @@ pub fn find_llvm_config() -> Option<PathBuf> {
         .or_else(|| {
             // In PATH
             [
+                "llvm-config-21",
+                "llvm-config-20",
                 "llvm-config-19",
                 "llvm-config-18",
                 "llvm-config-17",
@@ -107,6 +109,8 @@ pub fn find_llvm_config() -> Option<PathBuf> {
                 "llvm-config-7.0",
                 "llvm-config",
                 // Homebrew install locations on Intel macOS
+                "/usr/local/opt/llvm@21/bin/llvm-config",
+                "/usr/local/opt/llvm@20/bin/llvm-config",
                 "/usr/local/opt/llvm@19/bin/llvm-config",
                 "/usr/local/opt/llvm@18/bin/llvm-config",
                 "/usr/local/opt/llvm@17/bin/llvm-config",
@@ -121,6 +125,8 @@ pub fn find_llvm_config() -> Option<PathBuf> {
                 "/usr/local/opt/llvm@8/bin/llvm-config",
                 "/usr/local/opt/llvm/bin/llvm-config",
                 // Homebrew install locations on Apple Silicon macOS
+                "/opt/homebrew/opt/llvm@21/bin/llvm-config",
+                "/opt/homebrew/opt/llvm@20/bin/llvm-config",
                 "/opt/homebrew/opt/llvm@19/bin/llvm-config",
                 "/opt/homebrew/opt/llvm@18/bin/llvm-config",
                 "/opt/homebrew/opt/llvm@17/bin/llvm-config",


### PR DESCRIPTION
We support LLVM 21 and 20 now, so we should also search for their `llvm-config`s like we do for the other versions.