### PR TITLE
transpile: update dependencies in generated `Cargo.toml`

### DIFF
--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -182,8 +182,12 @@ impl ExternCrateDetails {
 impl From<ExternCrate> for ExternCrateDetails {
     fn from(extern_crate: ExternCrate) -> Self {
         match extern_crate {
-            ExternCrate::C2RustBitfields => Self::new("c2rust-bitfields", "0.21", true),
-            ExternCrate::C2RustAsmCasts => Self::new("c2rust-asm-casts", "0.21", true),
+            ExternCrate::C2RustBitfields => {
+                Self::new("c2rust-bitfields", env!("CARGO_PKG_VERSION"), true)
+            }
+            ExternCrate::C2RustAsmCasts => {
+                Self::new("c2rust-asm-casts", env!("CARGO_PKG_VERSION"), true)
+            }
             ExternCrate::F128 => Self::new("f128", "0.2", false),
             ExternCrate::NumTraits => Self::new("num-traits", "0.2", true),
             ExternCrate::Memoffset => Self::new("memoffset", "0.5", true),


### PR DESCRIPTION
These have been missed for a long time, so we've been using 6-year-old versions this whole time.