### PR TITLE
transpile: remove `~` in `Cargo.toml.hbs` causing trailing whitespace to be removed

### DIFF
--- a/c2rust-transpile/src/build_files/Cargo.toml.hbs
+++ b/c2rust-transpile/src/build_files/Cargo.toml.hbs
@@ -32,7 +32,7 @@ path = "{{path}}"
 name = "{{name}}"
 {{/each}}
 [dependencies]
-{{#each dependencies~}}
+{{#each dependencies}}
 {{this.name}} = "{{this.version}}"
 {{/each}}
 


### PR DESCRIPTION
I think this was probably a typo in the `Cargo.toml.hbs` template.  The `~` means strip trailing whitespace, causing us to emit things like `c2rust-bitfields= "0.3"` instead of `c2rust-bitfields = "0.3"`, which is what `c2rust-testsuite` matches on:

https://github.com/immunant/c2rust-testsuite/blob/5b5a098a39d5431383f46410b838e24321a4cb25/tests/templates.py#L31-L32
```sh
    sed --in-place --regexp-extended "s|c2rust-bitfields = \"([0-9.]+)\"|c2rust-bitfields = { version = \"\1\", path = \"$C2RUST_DIR/c2rust-bitfields\" }|" "$SCRIPT_DIR/repo/Cargo.toml"
    sed --in-place --regexp-extended "s|c2rust-asm-casts = \"([0-9.]+)\"|c2rust-asm-casts = { version = \"\1\", path = \"$C2RUST_DIR/c2rust-asm-casts\" }|" "$SCRIPT_DIR/repo/Cargo.toml"
```
