### PR TITLE
ci: set `C2RUST_DIR` for `c2rust-testsuite` so that current versions of c2rust crates are used

### DIFF
--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -135,6 +135,7 @@ jobs:
         find testsuite -type f -name compile_commands.json -delete
         export PATH=$PWD/target/release:$HOME/.local/bin:$PATH
         echo "PATH=$PATH"
+        export C2RUST_DIR=$PWD
         python3 testsuite/test.py curl json-c lua nginx zstd libxml2 python2
 
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
The `transpile.gen.sh`s generated by `c2rust-testsuite` use `C2RUST_DIR` to set dependencies in generated `Cargo.toml`s to point to the current `c2rust` directory, allowing it to test with the current version of `c2rust-bitfields` and `c2rust-asm-casts`.

This needs #1419 fixed first, and it should unblock #1408, which depends on the `c2rust-bitfields-derive` fix in #1411.