### PR TITLE
refactor: update to `cargo v0.65`, matching our pinned nightly of Rust 1.65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,7 @@ dependencies = [
  "flamer",
  "indexmap",
  "json",
+ "kstring",
  "libc",
  "log",
  "petgraph",
@@ -501,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.62.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79bc435c2de37f164b5c36420d9e1dd65cd5acbd41b2df10fdc02dbf75ed9efc"
+checksum = "988ba7aa82c0944fd91d119ee24a5c1f865eb2797e0edd90f6c08c7252857ca5"
 dependencies = [
  "anyhow",
  "atty",
@@ -527,6 +528,7 @@ dependencies = [
  "humantime",
  "ignore",
  "im-rc",
+ "indexmap",
  "itertools",
  "jobserver",
  "lazy_static 1.4.0",
@@ -535,8 +537,10 @@ dependencies = [
  "libgit2-sys",
  "log",
  "memchr",
+ "num_cpus",
  "opener",
  "os_info",
+ "pathdiff",
  "percent-encoding",
  "rustc-workspace-hack",
  "rustfix",
@@ -549,7 +553,7 @@ dependencies = [
  "tar",
  "tempfile",
  "termcolor",
- "toml_edit 0.13.4",
+ "toml_edit 0.14.4",
  "unicode-width",
  "unicode-xid",
  "url",
@@ -568,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.1.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51c783163bdf4549820b80968d386c94ed45ed23819c93f59cca7ebd97fe0eb"
+checksum = "e4e0cd00582e110eb8d99de768521d36fce9e24a286babf3cea68824ae09948f"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -1369,6 +1373,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,11 +1551,11 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "kstring"
-version = "1.0.6"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
+checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
 dependencies = [
- "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1717,11 +1727,11 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+checksum = "52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123"
 dependencies = [
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1741,6 +1751,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
 ]
 
 [[package]]
@@ -2405,6 +2425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strip-ansi-escapes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,9 +2615,9 @@ checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 
 [[package]]
 name = "toml_edit"
-version = "0.13.4"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744e9ed5b352340aa47ce033716991b5589e23781acb97cad37d4ea70560f55b"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
 dependencies = [
  "combine",
  "indexmap",

--- a/c2rust-refactor/Cargo.toml
+++ b/c2rust-refactor/Cargo.toml
@@ -18,7 +18,7 @@ libc = "0.2"
 regex = "1.1"
 ena = "0.13"
 indexmap = { version = "1.0.1", features = ["serde-1"] }
-cargo = "0.62"
+cargo = "0.65"
 clap = {version = "2.33", features = ["yaml"]}
 c2rust-analysis-rt = { path = "../analysis/runtime", version = "0.21.0" }
 env_logger = "0.10"
@@ -32,8 +32,9 @@ flamer = { version = "0.4", optional = true }
 failure = "0.1"
 bincode = "1.0.1"
 petgraph = "0.4"
-cargo-util = "0.1.2"
+cargo-util = "0.2.1"
 shlex = "1.3"
+kstring = "=2.0.0" # v2.0.0 has a MSRV of 1.59, while v2.0.1 has a MSRV of 1.73, but we're pinned to 1.65.
 
 [build-dependencies]
 c2rust-build-paths = { path = "../c2rust-build-paths", version = "0.21.0" }

--- a/c2rust-refactor/src/lib.rs
+++ b/c2rust-refactor/src/lib.rs
@@ -283,7 +283,6 @@ fn get_rustc_cargo_args(target_type: CargoTarget) -> Vec<RustcArgs> {
 
             let args = cmd
                 .get_args()
-                .iter()
                 .map(|os| os.to_str().unwrap().to_owned())
                 .collect();
             let mut g = self.pkg_args.lock().unwrap();


### PR DESCRIPTION
Our workspace `Cargo.toml` uses workspace inheritance, which was stabilized in Rust 1.64, so is fine with our pinned nightly of Rust 1.65. But `c2rust-refactor` was using `cargo v0.62` (corresponding to Rust 1.62), so when `c2rust-refactor` was run on a `Cargo.toml` that referenced `c2rust-bitfields` with a relative path to our repo, it broke on this (which #1419 and #1420 fix/enable).

Thus, we need to update to at least `cargo v0.64`, and preferably `v0.65`. `cargo v0.65` depends on `toml_edit v0.14.3`, which depends on `kstring v2.0.0`. By default, `kstring v2.0.1` is selected (since Rust 1.65 doesn't support the MSRV-aware resolver), but it has an MSRV of Rust 1.73, too new.
Luckily, though, `kstring v2.0.0` has an MSRV of Rust 1.59, so we pin it.