### PR TITLE
transpile: update generated nightly to `nightly-2023-04-15` (1.70.0) for `syn v2.0.107` and `cargo`'s sparse registry

### DIFF
--- a/c2rust-transpile/src/build_files/generated-rust-toolchain.toml
+++ b/c2rust-transpile/src/build_files/generated-rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-08-08"
+channel = "nightly-2023-04-15" # 1.70 (1.68 for syn v2.0, 1.70 for sparse registry)
 components = ["rustfmt"]

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -120,7 +120,7 @@ fn transpile(platform: Option<&str>, c_path: &Path) {
     let rlib_path = format!("lib{crate_name}.rlib");
     let status = Command::new("rustc")
         .args([
-            "+nightly-2022-08-08",
+            "+nightly-2023-04-15",
             "--crate-type",
             "lib",
             "--edition",


### PR DESCRIPTION
`c2rust-bitfields-derive` depends on `syn v2.0`.  Without a `Cargo.lock`, like in transpiled projects (as opposed to `c2rust` itself), this will resolve to `syn v2.0.107`, which requires Rust 1.68, but the generated `rust-toolchain.toml` uses Rust 1.65 (the same as our own nightly).  This is currently breaking CI for the `c2rust-instrument` tests, and will also break CI for `c2rust-testsuite` once #1418 lands (a bug fix).

Furthermore, the old git-based registry fetching is extremely slow in CI, so when #1227 lands and switches to stable, we also want Rust 1.70 for `cargo`'s sparse registry.  Due to stable crates now building on stable but testing their output on nightly, it is very difficult to correctly cache.
Updating the nightly of their output to the earliest to have the sparse registry should fix this.

The combination of this, #1418, #1419, #1420, and #1421 has been tested to work on `libxml2`:

```sh
cargo build --release
(cd ../c2rust-testsuite/tests/libxml2/repo/ &&
    $OLDPWD/target/release/c2rust-refactor --cargo --rewrite-mode inplace --lib reorganize_definitions
)
```