### PR TITLE
ci: keep `RUSTFLAGS` consistent to not rebuild everything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: cargo fmt --check
         run: |
-          export RUSTFLAGS="-D warnings"
+          export RUSTFLAGS="$RUSTFLAGS -D warnings"
           export RUSTDOCFLAGS="-D warnings"
           cargo fmt --check
 
@@ -95,23 +95,21 @@ jobs:
           # `bash` needed b/c macOS ships with bash 3, which doesn't support arrays properly.
           brew install -q ninja gpg llvm@${{ matrix.clang-version }} bash z3
           echo "Z3_SYS_Z3_HEADER=/opt/homebrew/include/z3.h" >> $GITHUB_ENV
+          # It's important that we keep `RUSTFLAGS` consistent between different steps
+          # so that we don't have to rebuild everything.
+          echo "RUSTFLAGS=-Clink-arg=-L/opt/homebrew/lib -Clink-arg=-Wl,-rpath,/opt/homebrew/lib" >> $GITHUB_ENV
+          
 
       - name: cargo build --release
         run: |
-          export RUSTFLAGS="-D warnings"
+          export RUSTFLAGS="$RUSTFLAGS -D warnings"
           export RUSTDOCFLAGS="-D warnings"
           # Don't build with `--all-features` as `--all-features` includes `--features llvm-static`,
           # which we don't want to test here (see https://github.com/immunant/c2rust/issues/500).
           cargo build --release
       - name: cargo test --release --workspace
         run: |
-          export RUSTFLAGS="-D warnings"
-          # add homebrew library path for z3; z3-sys 0.9.4 supports the
-          # Z3_LIBRARY_PATH_OVERRIDE environment variable that would let
-          # us override the library path, but that crate version is too new
-          # for nightly-2022-08-08 (requires 2024 edition). On our nightly rustc
-          # on Mac OS, we have to pass in the exact library path directly to RUSTFLAGS.
-          export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-L/opt/homebrew/lib -Clink-arg=-Wl,-rpath,/opt/homebrew/lib"
+          export RUSTFLAGS="$RUSTFLAGS -D warnings"
           export RUSTDOCFLAGS="-D warnings"
           cargo test --release --workspace
       - name: Test translator


### PR DESCRIPTION
`RUSTFLAGS` was being changed only in the `cargo test` step to link z3. This meant that `cargo build` was thrown out and redone, making everything take way longer. This moves the z3 addition to `RUSTFLAGS` to where we install `z3` and also only sets it for macOS, where it's needed (for brew).