### PR TITLE
tests: copy `generated-rust-toolchain.toml` to test directories

### DIFF
--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -497,7 +497,7 @@ class TestDirectory:
         # We `c2rust-transpile` `*.c` files individually, so `--emit-build-files` doesn't work
         # (if it's generated, it's in the wrong directory and may be different for each transpiled file).
         # We could also change things to transpile all `*.c` files at once, but that's more involved.
-        generated_rust_toolchain = Path(__file__).parent / "../c2rust-transpile/src/build_files/generated-rust-toolchain.toml"
+        generated_rust_toolchain = Path(c.TRANSPILE_CRATE_DIR) / "src/build_files/generated-rust-toolchain.toml"
         rust_toolchain = Path(self.full_path) / "rust-toolchain.toml"
         rust_toolchain.unlink(missing_ok=True)
         rust_toolchain.symlink_to(generated_rust_toolchain)


### PR DESCRIPTION
In `test_translator.py`, we `c2rust-transpile` `*.c` files individually, so `--emit-build-files` doesn't work as intended, since it'd be used per-file and emit in the wrong directory (in `src/`, not parallel to the `Cargo.toml`).  We could change things to transpile all `*.c` files at once, but that'd be a more involved change.  So we just link `generated-rust-toolchain.toml` to `rust-toolchain.toml`.

This should finally fully fix the CI errors due `c2rust-bitfields-derive` resolving `syn v2.0.107`, which can't build on our pinned nightly.