### PR TITLE
transpile, analyze: remove `#![feature(label_break_value)]`, stabilized in Rust 1.65 (our current nightly)

### DIFF
--- a/c2rust-analyze/tests/filecheck/alloc.rs
+++ b/c2rust-analyze/tests/filecheck/alloc.rs
@@ -1,5 +1,4 @@
 #![feature(extern_types)]
-#![feature(label_break_value)]
 #![feature(rustc_private)]
 #![feature(c_variadic)]
 #![allow(non_upper_case_globals)]

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -2130,7 +2130,6 @@ impl CfgBuilder {
             || !IncCleanup::new(in_tail, brk_lbl.clone()).remove_tail_expr(&mut stmts);
 
         if has_fallthrough && need_block && use_brk_lbl {
-            translator.use_feature("label_break_value");
             let block_body = mk().block(stmts);
             let block: Box<Expr> = mk().labelled_block_expr(block_body, brk_lbl.pretty_print());
             stmts = vec![mk().expr_stmt(block)]

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4335,10 +4335,7 @@ impl<'c> Translation<'c> {
 
                             return Ok(WithStmts::new(stmts, val));
                         }
-                        _ => {
-                            self.use_feature("label_break_value");
-                            stmts.push(stmt)
-                        }
+                        _ => stmts.push(stmt),
                     }
                 }
 

--- a/tests/gotos/src/test_translation_only.rs
+++ b/tests/gotos/src/test_translation_only.rs
@@ -1,5 +1,3 @@
-//! feature_label_break_value
-
 use crate::jump_into_loop::rust_jump_into_loop;
 use crate::label_break_trigger::rust_triggers_label_break;
 

--- a/tests/misc/src/test_sizeofs.rs
+++ b/tests/misc/src/test_sizeofs.rs
@@ -1,4 +1,4 @@
-//! feature_core_intrinsics, feature_label_break_value
+//! feature_core_intrinsics
 
 use crate::sizeofs::rust_sizeofs;
 use std::ffi::{c_int, c_uint};


### PR DESCRIPTION
* Fixes #731.