### PR TITLE
transpile: Add detection of `va_list` based on builtin typedef

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4601,7 +4601,7 @@ impl<'c> Translation<'c> {
                 // and to be a pointer as a function argument we would get
                 // spurious casts when trying to treat it like a VaList which
                 // has reference semantics.
-                if self.ast_context.is_va_list(target_cty.ctype) {
+                if self.ast_context.is_va_list(source_cty.ctype) {
                     return Ok(val);
                 }
 


### PR DESCRIPTION
Related issues:
- #1353
- #1281
- #246

The code had an unused `is_builtin_va_list` function sitting around for years, so I cleaned it up and made it work correctly. This fixes the issue for me when transpiling x86-32 code, but I can't say if this fixes the issues that others have been having, for example on ARM.

As noted in an old comment, `is_builtin_va_list` may be all that's needed and `is_va_list_struct` could be superfluous here. But I'm not able to verify that, so for now I've left them both in.