### PR TITLE
transpile: Rework `is_va_list` for better accuracy

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4998,16 +4998,16 @@ impl<'c> Translation<'c> {
         ty_id: CTypeId,
         is_static: bool,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let resolved_ty_id = self.ast_context.resolve_type_id(ty_id);
-        let resolved_ty = &self.ast_context.index(resolved_ty_id).kind;
-
-        if self.ast_context.is_va_list(resolved_ty_id) {
+        if self.ast_context.is_va_list(ty_id) {
             // generate MaybeUninit::uninit().assume_init()
             let path = vec!["core", "mem", "MaybeUninit", "uninit"];
             let call = mk().call_expr(mk().abs_path_expr(path), vec![]);
             let call = mk().method_call_expr(call, "assume_init", vec![]);
             return Ok(WithStmts::new_val(call));
         }
+
+        let resolved_ty_id = self.ast_context.resolve_type_id(ty_id);
+        let resolved_ty = &self.ast_context.index(resolved_ty_id).kind;
 
         if resolved_ty.is_bool() {
             Ok(WithStmts::new_val(mk().lit_expr(mk().bool_lit(false))))


### PR DESCRIPTION
* Fixes #1353.

This reworks the implementation of `is_va_list`, so that it is more accurate (less false positives/negatives). It's split into two subfunctions, one that detects `va_list` based on the `__builtin_va_list` typedef, and the other that detects based on the architecture-specific struct definition. Both methods have situations in which they don't work, so they are used together.

This has been confirmed to work on:
- Linux x86-64
- Linux x86-32 (was previously broken)

MacOS aarch64 is still failing if I enable it, because things like `va_start` seem to be unimplemented. Testing for Linux aarch64 will depend on #1283.