### PR TITLE
transpile: Avoid unnecessary parentheses around calls or fields

### DIFF
--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-aarch64@vm_x86.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-aarch64@vm_x86.c.snap
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn VM_CallCompiled(
         as *mut ::core::ffi::c_int) = 0 as ::core::ffi::c_int;
     *(&mut *image.offset(programStack as isize) as *mut byte as *mut ::core::ffi::c_int) =
         -(1 as ::core::ffi::c_int);
-    entryPoint = ((*vm).codeBase).offset((*vm).entryOfs as isize);
+    entryPoint = (*vm).codeBase.offset((*vm).entryOfs as isize);
     opStack =
         (stack.as_mut_ptr() as *mut ::core::ffi::c_int).offset(16 as ::core::ffi::c_int as isize);
     *opStack = 0 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-x86_64@vm_x86.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-x86_64@vm_x86.c.snap
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn VM_CallCompiled(
         as *mut ::core::ffi::c_int) = 0 as ::core::ffi::c_int;
     *(&mut *image.offset(programStack as isize) as *mut byte as *mut ::core::ffi::c_int) =
         -(1 as ::core::ffi::c_int);
-    entryPoint = ((*vm).codeBase).offset((*vm).entryOfs as isize);
+    entryPoint = (*vm).codeBase.offset((*vm).entryOfs as isize);
     opStack =
         (stack.as_mut_ptr() as *mut ::core::ffi::c_int).offset(16 as ::core::ffi::c_int as isize);
     *opStack = 0 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
@@ -48,10 +48,10 @@ pub unsafe extern "C" fn unary_with_side_effect() {
         unsafe extern "C" fn() -> ::core::ffi::c_int,
     >(side_effect)() as isize) as *const ::core::ffi::c_char;
     *arr[side_effect() as usize];
-    arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(1);
-    arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(-1);
-    arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(1);
-    arr[side_effect() as usize] = (arr[side_effect() as usize]).offset(-1);
+    arr[side_effect() as usize] = arr[side_effect() as usize].offset(1);
+    arr[side_effect() as usize] = arr[side_effect() as usize].offset(-1);
+    arr[side_effect() as usize] = arr[side_effect() as usize].offset(1);
+    arr[side_effect() as usize] = arr[side_effect() as usize].offset(-1);
 }
 #[no_mangle]
 pub unsafe extern "C" fn compound_literal() {


### PR DESCRIPTION
This adds some exceptions to avoid unncessary parentheses in expressions of the form `a.b.c()`, `a().b()`, `a().b` or `a[b].c()`.