### PR TITLE
transpile: Run `rustfmt` on generated .rs files

### DIFF
--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -226,7 +226,10 @@ fn emit_build_rs(
     let output = reg.render("build.rs", &json).unwrap();
     let output_path = build_dir.join("build.rs");
     let path = maybe_write_to_file(&output_path, output, tcfg.overwrite_existing)?;
-    rustfmt(&output_path, build_dir);
+
+    if !tcfg.disable_rustfmt {
+        rustfmt(&output_path, build_dir);
+    }
 
     Some(path)
 }
@@ -256,7 +259,10 @@ fn emit_lib_rs(
     let output_path = build_dir.join(file_name);
     let output = reg.render("lib.rs", &json).unwrap();
     let path = maybe_write_to_file(&output_path, output, tcfg.overwrite_existing)?;
-    rustfmt(&output_path, build_dir);
+
+    if !tcfg.disable_rustfmt {
+        rustfmt(&output_path, build_dir);
+    }
 
     Some(path)
 }

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -39,6 +39,7 @@ fn config() -> TranspilerConfig {
         output_dir: None,
         translate_const_macros: Default::default(),
         translate_fn_macros: Default::default(),
+        disable_rustfmt: false,
         disable_refactoring: false,
         preserve_unused_functions: false,
         log_level: log::LevelFilter::Warn,

--- a/c2rust/src/bin/c2rust-transpile.rs
+++ b/c2rust/src/bin/c2rust-transpile.rs
@@ -145,6 +145,10 @@ struct Args {
     #[clap(long)]
     emit_no_std: bool,
 
+    /// Disable running rustfmt after translation
+    #[clap(long)]
+    disable_rustfmt: bool,
+
     /// Disable running refactoring tool after translation
     #[clap(long)]
     disable_refactoring: bool,
@@ -232,6 +236,7 @@ fn main() {
 
         translate_const_macros: args.translate_const_macros.into(),
         translate_fn_macros: args.translate_fn_macros.into(),
+        disable_rustfmt: args.disable_rustfmt,
         disable_refactoring: args.disable_refactoring,
         preserve_unused_functions: args.preserve_unused_functions,
 


### PR DESCRIPTION
- Fixes #742.

Rather than running `cargo fmt`, this runs the `rustfmt` binary directly so that it can be used on individual files, and also when there are no build files.