### PR TITLE
ci: remove `scan-build` install

### DIFF
--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -52,10 +52,6 @@ jobs:
 
     - run: uv python install
 
-    - name: Install Python Packages
-      run: |
-        uv tool install scan-build # for `intercept-build`
-
     - uses: Swatinem/rust-cache@v2
       with:
         cache-workspace-crates: true


### PR DESCRIPTION
This is now redundant after https://github.com/immunant/c2rust-testsuite/pull/28.