### PR TITLE
ci: Add runner name to rust-cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-workspace-crates: true
+          # Add the runner name to the cache key because we have
+          # multiple Linux runners with different versions of the
+          # system libraries and we do not want to mix them up.
+          key: "${{ matrix.runner }}"
 
       # Run after `rust-cache` so that this is cached.
       - name: Install Rust toolchains


### PR DESCRIPTION
This fixes errors caused by reusing Ubuntu 24.04 binaries on the older 22.04 image with older libraries like glibc:
```
   Compiling z3-sys v0.8.1
error: failed to run custom build command for `z3-sys v0.8.1`

Caused by:
  process didn't exit successfully: `/home/runner/work/c2rust/c2rust/target/release/build/z3-sys-29b81b2e035745ff/build-script-build` (exit status: 1)
  --- stderr
  /home/runner/work/c2rust/c2rust/target/release/build/z3-sys-29b81b2e035745ff/build-script-build: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /home/runner/work/c2rust/c2rust/target/release/build/z3-sys-29b81b2e035745ff/build-script-build)
```