### PR TITLE
ci: run `testsuite/test.py` from inside `testsuite` so that the `pyproject.toml` is loaded correctly

### DIFF
--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -121,7 +121,9 @@ jobs:
         export PATH=$PWD/target/release:$HOME/.local/bin:$PATH
         echo "PATH=$PATH"
         export C2RUST_DIR=$PWD
-        ./testsuite/test.py curl json-c lua nginx zstd libxml2 python2
+        # Needs to be run from `testsuite/` (or further inside)
+        # to correctly load the `pyproject.toml`.
+        (cd testsuite && ./test.py curl json-c lua nginx zstd libxml2 python2)
 
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This should fix the errors in https://github.com/immunant/c2rust-testsuite/actions/runs/19446554243/job/55642381389?pr=29, which was loading the wrong Python version because it wasn't using the `pyproject.toml`.