### PR TITLE
ci: enable new `libmcs` test from c2rust-testsuite

### DIFF
--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -119,7 +119,7 @@ jobs:
         export C2RUST_DIR=$PWD
         # Needs to be run from `testsuite/` (or further inside)
         # to correctly load the `pyproject.toml`.
-        (cd testsuite && ./test.py curl json-c lua nginx zstd libxml2 python2)
+        (cd testsuite && ./test.py curl json-c lua nginx zstd libxml2 python2 libmcs)
 
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This was just added in https://github.com/immunant/c2rust-testsuite/pull/23, but it needs this change in the `c2rust` repo to actually test it in CI.