### PR TITLE
Fix type error in generated Rust when indexing typedef'd pointers

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3957,7 +3957,15 @@ impl<'c> Translation<'c> {
                                 };
 
                             let mul = self.compute_size_of_expr(pointee_type_id.ctype);
-                            Ok(pointer_offset(lhs, rhs, mul, false, true))
+                            let mut val = pointer_offset(lhs, rhs, mul, false, true);
+                            // if the context wants a different type, add a cast
+                            if let Some(expected_ty) = override_ty {
+                                if expected_ty != pointee_type_id {
+                                    val =
+                                        mk().cast_expr(val, self.convert_type(expected_ty.ctype)?);
+                                }
+                            }
+                            Ok(val)
                         })
                     }
                 })

--- a/c2rust-transpile/tests/snapshots/os-specific/typedefidx.c
+++ b/c2rust-transpile/tests/snapshots/os-specific/typedefidx.c
@@ -1,0 +1,6 @@
+#include <stddef.h>
+#include <stdint.h>
+
+void index_typedef(uint64_t *arr) {
+    size_t foo3 = arr[25];
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@typedefidx.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@typedefidx.c.snap
@@ -1,0 +1,20 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/os-specific/typedefidx.linux.rs
+input_file: c2rust-transpile/tests/snapshots/os-specific/typedefidx.c
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+pub type size_t = usize;
+pub type __uint64_t = u64;
+pub type uint64_t = __uint64_t;
+#[no_mangle]
+pub unsafe extern "C" fn index_typedef(mut arr: *mut uint64_t) {
+    let mut foo3: size_t = *arr.offset(25 as ::core::ffi::c_int as isize) as size_t;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@typedefidx.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@typedefidx.c.snap
@@ -1,0 +1,20 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/os-specific/typedefidx.macos.rs
+input_file: c2rust-transpile/tests/snapshots/os-specific/typedefidx.c
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+pub type __darwin_size_t = usize;
+pub type size_t = __darwin_size_t;
+pub type uint64_t = u64;
+#[no_mangle]
+pub unsafe extern "C" fn index_typedef(mut arr: *mut uint64_t) {
+    let mut foo3: size_t = *arr.offset(25 as ::core::ffi::c_int as isize) as size_t;
+}


### PR DESCRIPTION
This happens when we index a pointer to one portable type and the result is treated as a different one. In C they're compatible without Clang even including an implicit cast node in the AST, but when we translate to distinct types such as `u64` and `usize`, the generated Rust will contain a type error. We can avoid this by simply adding a cast if necessary.