### PR TITLE
c2rust-refactor: Structurally match types more conservatively by comparing visibility

### DIFF
--- a/c2rust-refactor/src/transform/reorganize_definitions.rs
+++ b/c2rust-refactor/src/transform/reorganize_definitions.rs
@@ -455,7 +455,7 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
 
                         _ => {
                             if let Some(decl_ty) = self.cx.opt_node_type(decl.id) {
-                                self.cx.structural_eq_tys(decl_ty, self.cx.ty_ctxt().type_of(def_id))
+                                self.cx.structural_eq_tys_with_vis(decl_ty, self.cx.ty_ctxt().type_of(def_id))
                             } else {
                                 false
                             }
@@ -491,7 +491,7 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
                                     let export_static_ty = self.cx.ty_ctxt().type_of(def_id);
                                     let foreign_def_id = self.cx.node_def_id(foreign.id);
                                     let foreign_static_ty = self.cx.ty_ctxt().type_of(foreign_def_id);
-                                    self.cx.structural_eq_tys(export_static_ty, foreign_static_ty)
+                                    self.cx.structural_eq_tys_with_vis(export_static_ty, foreign_static_ty)
                                 } else {
                                     false
                                 }


### PR DESCRIPTION
This fixes issues where reorganize_definitions would match internal structure definitions like statvfs against the types in libc which keep some fields as private:

```
    pub struct statvfs {
        pub f_bsize: c_ulong,
        pub f_frsize: c_ulong,
        pub f_blocks: crate::fsblkcnt_t,
        pub f_bfree: crate::fsblkcnt_t,
        pub f_bavail: crate::fsblkcnt_t,
        pub f_files: crate::fsfilcnt_t,
        pub f_ffree: crate::fsfilcnt_t,
        pub f_favail: crate::fsfilcnt_t,
        pub f_fsid: c_ulong,
        pub f_flag: c_ulong,
        pub f_namemax: c_ulong,
        __f_spare: [c_int; 6],
    }
```