### PR TITLE
transpile: Translate null pointers with `ptr::null[_mut]`

### DIFF
--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-aarch64@vm_x86.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-aarch64@vm_x86.c.snap
@@ -28,11 +28,11 @@ pub unsafe extern "C" fn VM_CallCompiled(
     mut args: *mut ::core::ffi::c_int,
 ) -> ::core::ffi::c_int {
     let mut stack: [byte; 271] = [0; 271];
-    let mut entryPoint: *mut ::core::ffi::c_void = 0 as *mut ::core::ffi::c_void;
+    let mut entryPoint: *mut ::core::ffi::c_void = ::core::ptr::null_mut::<::core::ffi::c_void>();
     let mut programStack: ::core::ffi::c_int = 0;
     let mut stackOnEntry: ::core::ffi::c_int = 0;
-    let mut image: *mut byte = 0 as *mut byte;
-    let mut opStack: *mut ::core::ffi::c_int = 0 as *mut ::core::ffi::c_int;
+    let mut image: *mut byte = ::core::ptr::null_mut::<byte>();
+    let mut opStack: *mut ::core::ffi::c_int = ::core::ptr::null_mut::<::core::ffi::c_int>();
     let mut opStackOfs: ::core::ffi::c_int = 0;
     let mut arg: ::core::ffi::c_int = 0;
     let mut currentVM: *mut vm_t = vm;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-x86_64@vm_x86.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-x86_64@vm_x86.c.snap
@@ -30,11 +30,11 @@ pub unsafe extern "C" fn VM_CallCompiled(
     mut args: *mut ::core::ffi::c_int,
 ) -> ::core::ffi::c_int {
     let mut stack: [byte; 271] = [0; 271];
-    let mut entryPoint: *mut ::core::ffi::c_void = 0 as *mut ::core::ffi::c_void;
+    let mut entryPoint: *mut ::core::ffi::c_void = ::core::ptr::null_mut::<::core::ffi::c_void>();
     let mut programStack: ::core::ffi::c_int = 0;
     let mut stackOnEntry: ::core::ffi::c_int = 0;
-    let mut image: *mut byte = 0 as *mut byte;
-    let mut opStack: *mut ::core::ffi::c_int = 0 as *mut ::core::ffi::c_int;
+    let mut image: *mut byte = ::core::ptr::null_mut::<byte>();
+    let mut opStack: *mut ::core::ffi::c_int = ::core::ptr::null_mut::<::core::ffi::c_int>();
     let mut opStackOfs: ::core::ffi::c_int = 0;
     let mut arg: ::core::ffi::c_int = 0;
     let mut currentVM: *mut vm_t = vm;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@alloca.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@alloca.c.snap
@@ -19,8 +19,8 @@ pub unsafe extern "C" fn alloca_sum(
     mut val2: ::core::ffi::c_int,
 ) -> ::core::ffi::c_int {
     let mut alloca_allocations: Vec<Vec<u8>> = Vec::new();
-    let mut alloca1: *mut ::core::ffi::c_int = 0 as *mut ::core::ffi::c_int;
-    let mut alloca2: *mut ::core::ffi::c_int = 0 as *mut ::core::ffi::c_int;
+    let mut alloca1: *mut ::core::ffi::c_int = ::core::ptr::null_mut::<::core::ffi::c_int>();
+    let mut alloca2: *mut ::core::ffi::c_int = ::core::ptr::null_mut::<::core::ffi::c_int>();
     if TRUE != 0 {
         alloca_allocations.push(::std::vec::from_elem(
             0,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn entry() {
     let mut int_too_short: [::core::ffi::c_int; 16] = [0 as ::core::ffi::c_int; 16];
     int_too_short[15 as ::core::ffi::c_int as usize] += 9 as ::core::ffi::c_int;
     let mut struct_init_too_short: [C2RustUnnamed_0; 1] = [C2RustUnnamed_0 {
-        x: 0 as *mut ::core::ffi::c_char,
+        x: ::core::ptr::null_mut::<::core::ffi::c_char>(),
         y: 0,
     }; 1];
     struct_init_too_short[0 as ::core::ffi::c_int as usize].y += 9 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.snap
@@ -19,7 +19,7 @@ pub struct Scope {
 #[no_mangle]
 pub static mut scope: *mut Scope = &{
     let mut init = Scope {
-        next: 0 as *const Scope as *mut Scope,
+        next: ::core::ptr::null::<Scope>() as *mut Scope,
     };
     init
 } as *const Scope as *mut Scope;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn unary_without_side_effect() {
 }
 #[no_mangle]
 pub unsafe extern "C" fn unary_with_side_effect() {
-    let mut arr: [*mut ::core::ffi::c_char; 1] = [0 as *mut ::core::ffi::c_char];
+    let mut arr: [*mut ::core::ffi::c_char; 1] = [::core::ptr::null_mut::<::core::ffi::c_char>()];
     -side_effect();
     side_effect();
     !side_effect();

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -240,7 +240,7 @@ static mut global_static_const_mixed_arithmetic: ::core::ffi::c_float =
         - true_0 as ::core::ffi::c_double) as ::core::ffi::c_float;
 static mut global_static_const_parens: ::core::ffi::c_int = PARENS;
 static mut global_static_const_ptr_arithmetic: *const ::core::ffi::c_char =
-    0 as *const ::core::ffi::c_char;
+    ::core::ptr::null::<::core::ffi::c_char>();
 static mut global_static_const_widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
 static mut global_static_const_narrowing_cast: ::core::ffi::c_char =
     LITERAL_INT as ::core::ffi::c_char;
@@ -254,7 +254,7 @@ static mut global_static_const_str_concatenation: [::core::ffi::c_char; 18] = un
 static mut global_static_const_builtin: ::core::ffi::c_int =
     (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
 static mut global_static_const_ref_indexing: *const ::core::ffi::c_char =
-    0 as *const ::core::ffi::c_char;
+    ::core::ptr::null::<::core::ffi::c_char>();
 static mut global_static_const_ref_struct: *const S = &LITERAL_STRUCT as *const S as *mut S;
 static mut global_static_const_ternary: ::core::ffi::c_int = 0;
 static mut global_static_const_member: ::core::ffi::c_int = 0;
@@ -313,7 +313,7 @@ pub static mut global_const_mixed_arithmetic: ::core::ffi::c_float =
 pub static mut global_const_parens: ::core::ffi::c_int = PARENS;
 #[no_mangle]
 pub static mut global_const_ptr_arithmetic: *const ::core::ffi::c_char =
-    0 as *const ::core::ffi::c_char;
+    ::core::ptr::null::<::core::ffi::c_char>();
 #[no_mangle]
 pub static mut global_const_widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
 #[no_mangle]
@@ -335,7 +335,7 @@ pub static mut global_const_builtin: ::core::ffi::c_int =
     (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
 #[no_mangle]
 pub static mut global_const_ref_indexing: *const ::core::ffi::c_char =
-    0 as *const ::core::ffi::c_char;
+    ::core::ptr::null::<::core::ffi::c_char>();
 #[no_mangle]
 pub static mut global_const_ref_struct: *const S = &LITERAL_STRUCT as *const S as *mut S;
 #[no_mangle]
@@ -363,7 +363,7 @@ pub unsafe extern "C" fn reference_define() -> ::core::ffi::c_int {
 #[no_mangle]
 pub static mut fns: fn_ptrs = {
     let mut init = fn_ptrs {
-        v: 0 as *const ::core::ffi::c_void as *mut ::core::ffi::c_void,
+        v: ::core::ptr::null::<::core::ffi::c_void>() as *mut ::core::ffi::c_void,
         fn1: None,
         fn2: None,
     };

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
@@ -68,8 +68,8 @@ pub unsafe extern "C" fn array_extra_braces() {
 pub unsafe extern "C" fn array_of_ptrs() {
     let mut _s: [*const ::core::ffi::c_char; 3] = [
         b"hello\0" as *const u8 as *const ::core::ffi::c_char,
-        0 as *const ::core::ffi::c_char,
-        0 as *const ::core::ffi::c_char,
+        ::core::ptr::null::<::core::ffi::c_char>(),
+        ::core::ptr::null::<::core::ffi::c_char>(),
     ];
 }
 #[no_mangle]


### PR DESCRIPTION
* Depends on #1478.
* Fixes #202.

This is more idiomatic, and is also necessary for supporting strict(er) provenance in the future.