### PR TITLE
transpile: Do not deref when taking address of array indexing expression

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3791,7 +3791,7 @@ impl<'c> Translation<'c> {
                 .map_err(|e| e.add_loc(self.ast_context.display_loc(src_loc))),
 
             ArraySubscript(_, lhs, rhs, _) => self
-                .convert_array_subscript(ctx, lhs, rhs, override_ty)
+                .convert_array_subscript(ctx, lhs, rhs, override_ty, true)
                 .map_err(|e| e.add_loc(self.ast_context.display_loc(src_loc))),
 
             Call(call_expr_ty, func, ref args) => {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-aarch64@vm_x86.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-aarch64@vm_x86.c.snap
@@ -42,14 +42,14 @@ pub unsafe extern "C" fn VM_CallCompiled(
     programStack -= 8 as ::core::ffi::c_int + 4 as ::core::ffi::c_int * MAX_VMMAIN_ARGS;
     arg = 0 as ::core::ffi::c_int;
     while arg < MAX_VMMAIN_ARGS {
-        *(&mut *image.offset(
+        *(image.offset(
             (programStack + 8 as ::core::ffi::c_int + arg * 4 as ::core::ffi::c_int) as isize,
         ) as *mut byte as *mut ::core::ffi::c_int) = *args.offset(arg as isize);
         arg += 1;
     }
-    *(&mut *image.offset((programStack + 4 as ::core::ffi::c_int) as isize) as *mut byte
+    *(image.offset((programStack + 4 as ::core::ffi::c_int) as isize) as *mut byte
         as *mut ::core::ffi::c_int) = 0 as ::core::ffi::c_int;
-    *(&mut *image.offset(programStack as isize) as *mut byte as *mut ::core::ffi::c_int) =
+    *(image.offset(programStack as isize) as *mut byte as *mut ::core::ffi::c_int) =
         -(1 as ::core::ffi::c_int);
     entryPoint = (*vm).codeBase.offset((*vm).entryOfs as isize);
     opStack =

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-x86_64@vm_x86.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-x86_64@vm_x86.c.snap
@@ -44,14 +44,14 @@ pub unsafe extern "C" fn VM_CallCompiled(
     programStack -= 8 as ::core::ffi::c_int + 4 as ::core::ffi::c_int * MAX_VMMAIN_ARGS;
     arg = 0 as ::core::ffi::c_int;
     while arg < MAX_VMMAIN_ARGS {
-        *(&mut *image.offset(
+        *(image.offset(
             (programStack + 8 as ::core::ffi::c_int + arg * 4 as ::core::ffi::c_int) as isize,
         ) as *mut byte as *mut ::core::ffi::c_int) = *args.offset(arg as isize);
         arg += 1;
     }
-    *(&mut *image.offset((programStack + 4 as ::core::ffi::c_int) as isize) as *mut byte
+    *(image.offset((programStack + 4 as ::core::ffi::c_int) as isize) as *mut byte
         as *mut ::core::ffi::c_int) = 0 as ::core::ffi::c_int;
-    *(&mut *image.offset(programStack as isize) as *mut byte as *mut ::core::ffi::c_int) =
+    *(image.offset(programStack as isize) as *mut byte as *mut ::core::ffi::c_int) =
         -(1 as ::core::ffi::c_int);
     entryPoint = (*vm).codeBase.offset((*vm).entryOfs as isize);
     opStack =

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
@@ -97,12 +97,11 @@ pub unsafe extern "C" fn entry() {
     let mut char_lit_array_ptr: *mut [::core::ffi::c_char; 4] = b"abc\0" as *const [u8; 4]
         as *const [::core::ffi::c_char; 4]
         as *mut [::core::ffi::c_char; 4];
-    let mut past_end: *mut ::core::ffi::c_char = &mut *static_char_array
+    let mut past_end: *mut ::core::ffi::c_char = static_char_array
         .as_mut_ptr()
         .offset(::core::mem::size_of::<[::core::ffi::c_char; 9]>() as isize)
         as *mut ::core::ffi::c_char;
-    past_end =
-        &mut *static_char_ptr.offset(8 as ::core::ffi::c_int as isize) as *mut ::core::ffi::c_char;
+    past_end = static_char_ptr.offset(8 as ::core::ffi::c_int as isize) as *mut ::core::ffi::c_char;
 }
 #[no_mangle]
 pub unsafe extern "C" fn short_initializer() {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn unary_with_side_effect() {
     side_effect();
     !side_effect();
     (side_effect() == 0) as ::core::ffi::c_int;
-    &*(b"\0" as *const u8 as *const ::core::ffi::c_char).offset(::core::mem::transmute::<
+    (b"\0" as *const u8 as *const ::core::ffi::c_char).offset(::core::mem::transmute::<
         unsafe extern "C" fn() -> ::core::ffi::c_int,
         unsafe extern "C" fn() -> ::core::ffi::c_int,
     >(side_effect)() as isize) as *const ::core::ffi::c_char;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -107,7 +107,7 @@ pub unsafe extern "C" fn local_muts() {
         ::core::mem::transmute::<[u8; 18], [::core::ffi::c_char; 18]>(*b"hello hello world\0");
     let mut builtin: ::core::ffi::c_int =
         (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
-    let mut ref_indexing: *const ::core::ffi::c_char = &*NESTED_STR
+    let mut ref_indexing: *const ::core::ffi::c_char = NESTED_STR
         .as_ptr()
         .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;
@@ -177,7 +177,7 @@ pub unsafe extern "C" fn local_consts() {
     let str_concatenation: [::core::ffi::c_char; 18] =
         ::core::mem::transmute::<[u8; 18], [::core::ffi::c_char; 18]>(*b"hello hello world\0");
     let builtin: ::core::ffi::c_int = (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
-    let ref_indexing: *const ::core::ffi::c_char = &*NESTED_STR
+    let ref_indexing: *const ::core::ffi::c_char = NESTED_STR
         .as_ptr()
         .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;
@@ -446,7 +446,7 @@ pub unsafe extern "C" fn late_init_var() -> ::core::ffi::c_int {
 unsafe extern "C" fn run_static_initializers() {
     global_static_const_ptr_arithmetic = PTR_ARITHMETIC;
     global_static_const_indexing = NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
-    global_static_const_ref_indexing = &*NESTED_STR
+    global_static_const_ref_indexing = NESTED_STR
         .as_ptr()
         .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;
@@ -458,7 +458,7 @@ unsafe extern "C" fn run_static_initializers() {
     global_static_const_member = LITERAL_STRUCT.i;
     global_const_ptr_arithmetic = PTR_ARITHMETIC;
     global_const_indexing = NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
-    global_const_ref_indexing = &*NESTED_STR
+    global_const_ref_indexing = NESTED_STR
         .as_ptr()
         .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;


### PR DESCRIPTION
- Fixes #303.

I'm not sure what should be done in the case of a `Deref`/`ArraySubscript` nested inside an  `ArrayToPointerDecay`. In such a case it might also be neater to avoid a deref, but I don't know if it's required by C.