### PR TITLE
transpile: Split off new pointers.rs module

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -28,7 +28,6 @@ use crate::rust_ast::item_store::ItemStore;
 use crate::rust_ast::set_span::SetSpan;
 use crate::rust_ast::{pos_to_span, SpanExt};
 use crate::translator::named_references::NamedReference;
-use crate::translator::pointers::pointer_offset;
 use c2rust_ast_builder::{mk, properties::*, Builder};
 use c2rust_ast_printer::pprust;
 


### PR DESCRIPTION
Working with pointer-related stuff, I found that related code was kinda scattered all over, making it difficult to find at times. This creates a new pointers.rs module, moves some existing functions there, and creates new functions to wrap some other bits of code. I've tried to not make too many semantic changes.

In `convert_assignment_operator_with_rhs` there was a bit of dead code that I removed. Since `AssignAdd` and `AssignSubtract` are handled by the match arms, the `if` that checks for them below a second time wasn't doing anything (and it did the same thing anyway).