### PR TITLE
transpile: Do not emit block and `init` variable for non-bitfield structs

### DIFF
--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.snap
@@ -61,11 +61,8 @@ pub unsafe extern "C" fn entry() {
         y: 0,
     }; 1];
     struct_init_too_short[0 as ::core::ffi::c_int as usize].y += 9 as ::core::ffi::c_int;
-    let mut struct_init_too_long: [C2RustUnnamed; 1] = [{
-        let mut init = C2RustUnnamed {
-            y: 1 as ::core::ffi::c_int,
-        };
-        init
+    let mut struct_init_too_long: [C2RustUnnamed; 1] = [C2RustUnnamed {
+        y: 1 as ::core::ffi::c_int,
     }];
     struct_init_too_long[0 as ::core::ffi::c_int as usize].y += 9 as ::core::ffi::c_int;
     let mut char_with_string: [::core::ffi::c_char; 4] =
@@ -114,20 +111,14 @@ pub unsafe extern "C" fn short_initializer() {
     let mut excess_elements_1: [::core::ffi::c_int; 2] =
         [1 as ::core::ffi::c_int, 2 as ::core::ffi::c_int];
     let mut excess_elements_2: [::core::ffi::c_int; 0] = [0; 0];
-    let mut single_struct: [C2RustUnnamed_2; 1] = [{
-        let mut init = C2RustUnnamed_2 {
-            x: 1 as ::core::ffi::c_short,
-            y: 2 as ::core::ffi::c_int,
-        };
-        init
+    let mut single_struct: [C2RustUnnamed_2; 1] = [C2RustUnnamed_2 {
+        x: 1 as ::core::ffi::c_short,
+        y: 2 as ::core::ffi::c_int,
     }];
     let mut many_struct: [C2RustUnnamed_1; 3] = [
-        {
-            let mut init = C2RustUnnamed_1 {
-                x: 1 as ::core::ffi::c_short,
-                y: 2 as ::core::ffi::c_int,
-            };
-            init
+        C2RustUnnamed_1 {
+            x: 1 as ::core::ffi::c_short,
+            y: 2 as ::core::ffi::c_int,
         },
         C2RustUnnamed_1 { x: 0, y: 0 },
         C2RustUnnamed_1 { x: 0, y: 0 },

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.snap
@@ -17,9 +17,6 @@ pub struct Scope {
     pub next: *mut Scope,
 }
 #[no_mangle]
-pub static mut scope: *mut Scope = &{
-    let mut init = Scope {
-        next: ::core::ptr::null::<Scope>() as *mut Scope,
-    };
-    init
+pub static mut scope: *mut Scope = &Scope {
+    next: ::core::ptr::null::<Scope>() as *mut Scope,
 } as *const Scope as *mut Scope;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.snap
@@ -43,11 +43,8 @@ pub const LITERAL_FLOAT: ::core::ffi::c_double = 3.14f64;
 pub const LITERAL_CHAR: ::core::ffi::c_int = 'x' as i32;
 pub const LITERAL_STR: [::core::ffi::c_char; 6] =
     unsafe { ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0") };
-pub const LITERAL_STRUCT: S = {
-    let mut init = S {
-        i: 5 as ::core::ffi::c_int,
-    };
-    init
+pub const LITERAL_STRUCT: S = S {
+    i: 5 as ::core::ffi::c_int,
 };
 pub const NESTED_INT: ::core::ffi::c_int = LITERAL_INT;
 pub const NESTED_BOOL: ::core::ffi::c_int = LITERAL_BOOL;
@@ -362,13 +359,10 @@ pub unsafe extern "C" fn reference_define() -> ::core::ffi::c_int {
     return x;
 }
 #[no_mangle]
-pub static mut fns: fn_ptrs = {
-    let mut init = fn_ptrs {
-        v: ::core::ptr::null::<::core::ffi::c_void>() as *mut ::core::ffi::c_void,
-        fn1: None,
-        fn2: None,
-    };
-    init
+pub static mut fns: fn_ptrs = fn_ptrs {
+    v: ::core::ptr::null::<::core::ffi::c_void>() as *mut ::core::ffi::c_void,
+    fn1: None,
+    fn2: None,
 };
 #[no_mangle]
 pub static mut p: *const fn_ptrs = unsafe { &raw const fns };

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@ref_ub.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@ref_ub.c.snap
@@ -22,11 +22,8 @@ pub unsafe extern "C" fn dec(mut f: *mut Foo) {
     (*f).len -= 1;
 }
 unsafe fn main_0() -> ::core::ffi::c_int {
-    let mut f: Foo = {
-        let mut init = Foo {
-            len: 5 as ::core::ffi::c_int,
-        };
-        init
+    let mut f: Foo = Foo {
+        len: 5 as ::core::ffi::c_int,
     };
     let mut fp: *mut Foo = &raw mut f;
     dec(fp);

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.snap
@@ -93,28 +93,20 @@ pub unsafe extern "C" fn array_of_arrays_static() {
 #[no_mangle]
 pub unsafe extern "C" fn array_of_arrays_static_struct() {
     static mut _S: s = unsafe {
-        {
-            let mut init = s {
-                entries: [
-                    ::core::mem::transmute::<[u8; 10], [::core::ffi::c_char; 10]>(
-                        *b"hello\0\0\0\0\0",
-                    ),
-                    [0; 10],
-                    [0; 10],
-                ],
-            };
-            init
+        s {
+            entries: [
+                ::core::mem::transmute::<[u8; 10], [::core::ffi::c_char; 10]>(*b"hello\0\0\0\0\0"),
+                [0; 10],
+                [0; 10],
+            ],
         }
     };
 }
 #[no_mangle]
 pub unsafe extern "C" fn curl_alpn_spec() {
-    static mut _ALPN_SPEC_H11: alpn_spec = {
-        let mut init = alpn_spec {
-            entries: [ALPN_HTTP_1_1, [0; 10], [0; 10]],
-            count: 1 as ::core::ffi::c_uint,
-        };
-        init
+    static mut _ALPN_SPEC_H11: alpn_spec = alpn_spec {
+        entries: [ALPN_HTTP_1_1, [0; 10], [0; 10]],
+        count: 1 as ::core::ffi::c_uint,
     };
 }
 pub const ALPN_HTTP_1_1: [::core::ffi::c_char; 10] =


### PR DESCRIPTION
For struct inits, the current generated code looks like
```rust
{
    let mut init = Foo { field1: 0 };
    init
}
```

This syntax is intended to accommodate bitfields, which need their own initialisation statements after the main one. But for normal structs, that isn't necessary. This PR makes it use the struct expression directly in such cases.