### PR TITLE
transpile: Avoid some identity transmutes for function pointers

### DIFF
--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.snap
@@ -44,10 +44,8 @@ pub unsafe extern "C" fn unary_with_side_effect() {
     side_effect();
     !side_effect();
     (side_effect() == 0) as ::core::ffi::c_int;
-    (b"\0" as *const u8 as *const ::core::ffi::c_char).offset(::core::mem::transmute::<
-        unsafe extern "C" fn() -> ::core::ffi::c_int,
-        unsafe extern "C" fn() -> ::core::ffi::c_int,
-    >(side_effect)() as isize) as *const ::core::ffi::c_char;
+    (b"\0" as *const u8 as *const ::core::ffi::c_char).offset(side_effect() as isize)
+        as *const ::core::ffi::c_char;
     *arr[side_effect() as usize];
     arr[side_effect() as usize] = arr[side_effect() as usize].offset(1);
     arr[side_effect() as usize] = arr[side_effect() as usize].offset(-1);


### PR DESCRIPTION
I noticed that in some cases, a transmute would be added between a K&R style function declaration using `()` as the parameters, and a full type with `(void)` as the parameters. Since both of those are translated to the same Rust type, you'd end up with pointless transmute. This PR gates the transmute to only happen if the two Rust types actually differ.