### PR TITLE
transpile: Allow `clippy::missing_safety_doc` in generated code

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -1332,7 +1332,14 @@ fn arrange_header(t: &Translation, is_binary: bool) -> (Vec<syn::Attribute>, Vec
         for (key, mut values) in pragmas {
             values.sort_unstable();
             // generate #[key(values)]
-            let meta = mk().meta_list(vec![key], values);
+            let args: Vec<_> = values
+                .into_iter()
+                .map(|path_str| {
+                    let path_vec: Vec<_> = path_str.split("::").collect();
+                    mk().meta_path(path_vec)
+                })
+                .collect();
+            let meta = mk().meta_list(vec![key], args);
             let attr = mk().attribute(AttrStyle::Inner(Default::default()), meta);
             out_attrs.push(attr);
         }
@@ -1550,6 +1557,7 @@ impl<'c> Translation<'c> {
         features.extend(self.type_converter.borrow().features_used());
 
         let mut allow = vec![
+            "clippy::missing_safety_doc",
             "non_upper_case_globals",
             "non_camel_case_types",
             "non_snake_case",

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@irreducible.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@irreducible.c.snap
@@ -4,6 +4,7 @@ expression: cat tests/snapshots/os-specific/irreducible.linux.rs
 input_file: c2rust-transpile/tests/snapshots/os-specific/irreducible.c
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@switch.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@switch.c.snap
@@ -4,6 +4,7 @@ expression: cat tests/snapshots/os-specific/switch.linux.rs
 input_file: c2rust-transpile/tests/snapshots/os-specific/switch.c
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@irreducible.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@irreducible.c.snap
@@ -4,6 +4,7 @@ expression: cat tests/snapshots/os-specific/irreducible.linux.rs
 input_file: c2rust-transpile/tests/snapshots/os-specific/irreducible.c
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@switch.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@switch.c.snap
@@ -4,6 +4,7 @@ expression: cat tests/snapshots/os-specific/switch.macos.rs
 input_file: c2rust-transpile/tests/snapshots/os-specific/switch.c
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@alloca.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@alloca.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/alloca.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@alloca.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@alloca.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/alloca.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arrays.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arrays.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2021.aarch64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2021.aarch64.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-specific/asm.2024.aarch64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2021.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2021.x86_64.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-specific/asm.2021.x86_64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2024.aarch64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2024.aarch64.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-specific/asm.2024.aarch64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2024.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2024.x86_64.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-specific/asm.2024.x86_64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2021.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/atomics.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2024.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/atomics.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@bitfields.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@bitfields.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/bitfields.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@bitfields.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@bitfields.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/bitfields.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2021.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/bool.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2024.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/bool.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@call_only_once.c.2021.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@call_only_once.c.2021.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/call_only_once.2021.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@call_only_once.c.2021.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@call_only_once.c.2021.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/call_only_once.2021.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@call_only_once.c.2024.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@call_only_once.c.2024.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/call_only_once.2024.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@call_only_once.c.2024.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@call_only_once.c.2024.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/call_only_once.2024.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/compound_literals.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/compound_literals.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/empty_init.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/empty_init.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/exprs.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/exprs.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.c.2021.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.c.2021.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/f128.c.2021.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.c.2021.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.c.2021.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/f128.c.2021.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.c.2024.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.c.2024.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/f128.c.2024.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.c.2024.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.c.2024.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/f128.c.2024.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@factorial.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@factorial.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/factorial.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@factorial.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@factorial.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/factorial.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@fn_attrs.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@fn_attrs.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/fn_attrs.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@fn_attrs.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@fn_attrs.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/fn_attrs.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/gotos.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/gotos.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@if_else.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@if_else.c.snap
@@ -4,6 +4,7 @@ expression: cat tests/snapshots/if_else.rs
 input_file: c2rust-transpile/tests/snapshots/if_else.c
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@incomplete_arrays.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@incomplete_arrays.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/incomplete_arrays.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@incomplete_arrays.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@incomplete_arrays.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/incomplete_arrays.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@insertion.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@insertion.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/insertion.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@insertion.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@insertion.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/insertion.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@keywords.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@keywords.c.2021.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/keywords.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@keywords.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@keywords.c.2024.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/keywords.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2021.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/lift_const.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2024.snap
@@ -4,6 +4,7 @@ assertion_line: 135
 expression: cat tests/snapshots/lift_const.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@loops.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@loops.c.snap
@@ -4,6 +4,7 @@ expression: cat tests/snapshots/loops.rs
 input_file: c2rust-transpile/tests/snapshots/loops.c
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/macrocase.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/macrocase.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/macros.2021.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/macros.2021.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/macros.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/macros.2024.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/macros.2024.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/macros.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@main_fn.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@main_fn.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/main_fn.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@main_fn.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@main_fn.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/main_fn.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@out_of_range_lit.c.2021.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@out_of_range_lit.c.2021.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/out_of_range_lit.2021.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@out_of_range_lit.c.2021.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@out_of_range_lit.c.2021.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/out_of_range_lit.2021.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@out_of_range_lit.c.2024.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@out_of_range_lit.c.2024.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/out_of_range_lit.2024.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@out_of_range_lit.c.2024.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@out_of_range_lit.c.2024.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/out_of_range_lit.2024.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@predefined.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@predefined.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/predefined.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@predefined.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@predefined.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/predefined.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@records.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@records.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/records.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@records.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@records.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/records.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@ref_ub.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@ref_ub.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/ref_ub.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@ref_ub.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@ref_ub.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/ref_ub.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rnd.c.2021.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rnd.c.2021.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/rnd.2021.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rnd.c.2021.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rnd.c.2021.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/rnd.2021.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rnd.c.2024.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rnd.c.2024.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/rnd.2024.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rnd.c.2024.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rnd.c.2024.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/rnd.2024.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/rotate.2021.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/rotate.2021.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/rotate.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/rotate.2024.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/rotate.2024.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/rotate.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/scalar_init.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/scalar_init.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@sigign.c.2021.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@sigign.c.2021.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/sigign.2021.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@sigign.c.2021.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@sigign.c.2021.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/sigign.2021.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@sigign.c.2024.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@sigign.c.2024.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/sigign.2024.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@sigign.c.2024.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@sigign.c.2024.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/sigign.2024.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@spin.c.2021.aarch64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@spin.c.2021.aarch64.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-specific/spin.2021.aarch64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@spin.c.2021.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@spin.c.2021.x86_64.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-specific/spin.2021.x86_64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@spin.c.2024.aarch64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@spin.c.2024.aarch64.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-specific/spin.2024.aarch64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@spin.c.2024.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@spin.c.2024.x86_64.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-specific/spin.2024.x86_64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@static_assert.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@static_assert.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/static_assert.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@static_assert.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@static_assert.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/static_assert.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.2021.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/str_init.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@str_init.c.2024.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/str_init.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@typedefidx.c.2021.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@typedefidx.c.2021.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/typedefidx.2021.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@typedefidx.c.2021.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@typedefidx.c.2021.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/typedefidx.2021.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@typedefidx.c.2024.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@typedefidx.c.2024.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/typedefidx.2024.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@typedefidx.c.2024.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@typedefidx.c.2024.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/typedefidx.2024.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@types.c.2021.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@types.c.2021.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/types.2021.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@types.c.2021.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@types.c.2021.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/types.2021.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@types.c.2024.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@types.c.2024.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/types.2024.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@types.c.2024.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@types.c.2024.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/types.2024.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2021.aarch64.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2021.aarch64.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-os-specific/varargs.2021.aarch64.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2021.x86_64.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2021.x86_64.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-os-specific/varargs.2021.x86_64.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2024.aarch64.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2024.aarch64.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-os-specific/varargs.2024.aarch64.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2024.x86_64.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2024.x86_64.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-os-specific/varargs.2024.x86_64.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2021.aarch64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2021.aarch64.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-specific/vm_x86.2021.aarch64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2021.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2021.x86_64.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/arch-specific/vm_x86.2021.x86_64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2024.aarch64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2024.aarch64.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/arch-specific/vm_x86.2024.aarch64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2024.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2024.x86_64.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/arch-specific/vm_x86.2024.x86_64.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
@@ -4,6 +4,7 @@ assertion_line: 134
 expression: cat tests/snapshots/volatile.2021.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
@@ -4,6 +4,7 @@ assertion_line: 135
 expression: cat tests/snapshots/volatile.2024.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/wide_strings.2021.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/wide_strings.2021.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.linux.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/wide_strings.2024.linux.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.macos.snap
@@ -3,6 +3,7 @@ source: c2rust-transpile/tests/snapshots.rs
 expression: cat tests/snapshots/os-specific/wide_strings.2024.macos.rs
 ---
 #![allow(
+    clippy::missing_safety_doc,
     dead_code,
     non_camel_case_types,
     non_snake_case,


### PR DESCRIPTION
Allows the `unused_imports` and `clippy::missing_safety_doc` in all generated code. There's always a lot of these which makes it harder to see genuine warnings.