### PR TITLE
transpile: Move some stuff into `struct` module

### DIFF
--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -290,21 +290,7 @@ impl<'c> Translation<'c> {
                 }
             }
             CTypeKind::Struct(struct_id) => {
-                let mut literal = self.convert_struct_literal(ctx, struct_id, ids.as_ref());
-                if self.ast_context.has_inner_struct_decl(struct_id) {
-                    // If the structure is split into an outer/inner,
-                    // wrap the inner initializer using the outer structure
-                    let outer_name = self
-                        .type_converter
-                        .borrow()
-                        .resolve_decl_name(struct_id)
-                        .unwrap();
-
-                    let outer_path = mk().path_expr(vec![outer_name]);
-                    literal = literal
-                        .map(|lit_ws| lit_ws.map(|lit| mk().call_expr(outer_path, vec![lit])));
-                };
-                literal
+                self.convert_struct_literal(ctx, struct_id, ids.as_ref())
             }
             CTypeKind::Union(union_id) => {
                 self.convert_union_literal(ctx, union_id, ids.as_ref(), ty, opt_union_field_id)

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4763,16 +4763,13 @@ impl<'c> Translation<'c> {
                 fields: Some(ref fields),
                 platform_byte_size,
                 ..
-            } => {
-                let name = self.resolve_decl_inner_name(name_decl_id);
-                self.convert_struct_zero_initializer(
-                    name,
-                    decl_id,
-                    fields,
-                    platform_byte_size,
-                    is_static,
-                )?
-            }
+            } => self.convert_struct_zero_initializer(
+                decl_id,
+                name_decl_id,
+                fields,
+                platform_byte_size,
+                is_static,
+            )?,
 
             CDeclKind::Struct { fields: None, .. } => {
                 return Err(TranslationError::generic(


### PR DESCRIPTION
Moving some things into the `struct` module that were previously in the `translator` and `literals` modules. Helps to keep things organised hopefully.