### PR TITLE
Fix error code reporting for test suite failures

### DIFF
--- a/tests/integration/tests/__init__.py
+++ b/tests/integration/tests/__init__.py
@@ -238,9 +238,8 @@ def run_tests(conf: Config, generated_scripts: set[Path]):
         return TestResult(test=test, passed=passed, time=time)
 
     with ThreadPoolExecutor() as executor:
-        results = executor.map(run, tests)
+        results = list(executor.map(run, tests))
 
-    results = [result for result in results]
     for result in results:
         print(f"{result.test.name} took {result.time}")
     if not all(result.passed for result in results):


### PR DESCRIPTION
Looks like the issue is that when we did `for result in results` it emptied the iterator, so when we then did the `if not all(result.passed for result in results)` check it didn't actually look at any test results. Seems like pulling the test results into a list first fixes the issue.

I branched this off from before https://github.com/immunant/c2rust/pull/1515 so that we can verify that CI actually reports the failures now. I'll rebase onto master after that's confirmed.