### PR TITLE
Support python 3.12 in test suite runner

### DIFF
--- a/tests/integration/tests/templates.py
+++ b/tests/integration/tests/templates.py
@@ -102,14 +102,14 @@ def render_script(template: str, out_path: str, params: Dict):
     os.chmod(out_path, stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)
 
 
-def autogen_cargo(conf_file, yaml: Dict) -> Generator[Path]:
+def autogen_cargo(conf_file, yaml: Dict) -> Generator[Path, None, None]:
     """
     Yield generated paths.
     """
 
     def render_stage(
         stage_conf: Mapping[str, Any] | None, filename: str
-    ) -> Generator[Path]:
+    ) -> Generator[Path, None, None]:
         """
         Yield generated paths.
         """
@@ -139,7 +139,7 @@ def autogen_cargo(conf_file, yaml: Dict) -> Generator[Path]:
         yield from render_stage(yaml.get(key), fname)
 
 
-def autogen_refactor(conf_file, yaml: Dict) -> Generator[str]:
+def autogen_refactor(conf_file, yaml: Dict) -> Generator[str, None, None]:
     """
     Yield generated paths.
     """
@@ -170,7 +170,7 @@ def autogen_refactor(conf_file, yaml: Dict) -> Generator[str]:
                 yield Path(out_path)
 
 
-def autogen_transpile(conf_file, yaml: Dict) -> Generator[Path]:
+def autogen_transpile(conf_file, yaml: Dict) -> Generator[Path, None, None]:
     """
     Yield generated paths.
     """
@@ -202,7 +202,7 @@ def autogen_transpile(conf_file, yaml: Dict) -> Generator[Path]:
             yield Path(out_path)
 
 
-def autogen(conf: Config) -> Generator[Path]:
+def autogen(conf: Config) -> Generator[Path, None, None]:
     """
     Yield generated paths.
     """


### PR DESCRIPTION
The `Generator` class takes 3 type arguments, but in python 3.13 it became possible to just specify the first one and the other 2 would default to `None`. Explicitly adding the `None` arguments allows this to also work on python 3.12.

One of my work machines is on a version of Ubuntu that has 3.12 installed and it looks like it'd be mildly painful to install 3.13. Seems like it'd be reasonable to support 3.12 here, unless there's some reason that'd be a bad idea.