### PR TITLE
tests: Print stderr too on unit test failure

### DIFF
--- a/scripts/test_translator.py
+++ b/scripts/test_translator.py
@@ -540,6 +540,7 @@ class TestDirectory:
 
             self.print_status(Colors.FAIL, "FAILED", "test {}".format(lib_file_path_short))
             sys.stdout.write('\n')
+            sys.stdout.write(stderr)
             sys.stdout.write(stdout)
         else:
             for line in stdout.split("\n"):


### PR DESCRIPTION
If the test fails during `cargo test` execution, then the error output is on stdout. But if the test source file fails to compile, `cargo test` writes to stderr. Stderr was not being printed, so you would just have a failed test with no information about what went wrong.