### PR TITLE
Allow empty include paths

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -207,8 +207,10 @@ impl TypedAstContext {
         if cfg!(debug_assertions) {
             if let Some(root_include) = includes.first() {
                 let file_id = self.file_map[root_include.fileid as usize];
-                let file = &self.files[file_id];
-                assert_eq!(file.path.as_deref(), Some(self.main_file.as_path()));
+                // headers included via `-include` will not have an include path
+                if let Some(path) = self.get_file_path(file_id) {
+                    assert_eq!(path, self.main_file.as_path());
+                }
             }
         }
         includes


### PR DESCRIPTION
Given `main.c`
```c
int main() {
  assert(0);
  return 0;
}
```
and `header.h`:
```
void assert(int x);
````

and `compile_commands.json` derived from 

```clang -c -include header.h main.c```

`c2rust transpile compile_commands.json` panics in `TypedAstContext::include_path` because the include path for `header.h` is `None`.

This PR fixes the panic by first checking if the root include is not `None`. 
