### PR TITLE
postprocess: add `--update-rust` so we can avoid updating in-place for tests

### DIFF
--- a/c2rust-postprocess/postprocess/__init__.py
+++ b/c2rust-postprocess/postprocess/__init__.py
@@ -4,6 +4,7 @@ c2rust-postprocess: Transfer comments from C functions to Rust functions using L
 
 import argparse
 import logging
+from argparse import BooleanOptionalAction
 from collections.abc import Sequence
 
 from google.genai import types
@@ -63,6 +64,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Enable or disable caching of LLM responses (default: enabled)",
     )
 
+    parser.add_argument(
+        "--update-rust",
+        required=False,
+        default=True,
+        action=BooleanOptionalAction,
+        help="Update the Rust in-place",
+    )
+
     # TODO: add option to select model
     # TODO: add option to configure cache
     # TODO: add option to select what transforms to apply
@@ -105,7 +114,11 @@ def main(argv: Sequence[str] | None = None):
 
         # TODO: instantiate transform(s) based on command line args
         xform = CommentTransfer(cache, model)
-        xform.transfer_comments(args.root_rust_source_file, args.ident_filter)
+        xform.transfer_comments(
+            root_rust_source_file=args.root_rust_source_file,
+            ident_filter=args.ident_filter,
+            update_rust=args.update_rust,
+        )
 
         return 0
     except KeyboardInterrupt:

--- a/c2rust-postprocess/postprocess/transforms.py
+++ b/c2rust-postprocess/postprocess/transforms.py
@@ -55,7 +55,10 @@ class CommentTransfer:
         self.model = model
 
     def transfer_comments(
-        self, root_rust_source_file: Path, ident_filter: str | None = None
+        self,
+        root_rust_source_file: Path,
+        ident_filter: str | None = None,
+        update_rust: bool = True,
     ) -> None:
         pattern = re.compile(ident_filter) if ident_filter else None
 
@@ -156,4 +159,9 @@ class CommentTransfer:
 
             print(get_highlighted_rust(rust_fn))
 
-            update_rust_definition(root_rust_source_file, prompt.identifier, rust_fn)
+            if update_rust:
+                update_rust_definition(
+                    root_rust_source_file=root_rust_source_file,
+                    identifier=prompt.identifier,
+                    new_definition=rust_fn,
+                )

--- a/c2rust-postprocess/tests/test_definitions.py
+++ b/c2rust-postprocess/tests/test_definitions.py
@@ -87,4 +87,4 @@ def test_c_function_splitting(generate_compile_commands_for_qsort, transpile_qso
 def test_comment_insertion_qsort():
     qsort_rs = Path(__file__).parent / "examples/qsort.rs"
     qsort_rs = qsort_rs.relative_to(Path.cwd())
-    main([str(qsort_rs)])
+    main([str(qsort_rs), "--no-update-rust"])


### PR DESCRIPTION
This makes testing a lot simpler and idempotent.