### PR TITLE
postprocess: run on a whole dir at once, searching for `*.c_decls.json` files

### DIFF
--- a/c2rust-postprocess/postprocess/__init__.py
+++ b/c2rust-postprocess/postprocess/__init__.py
@@ -114,7 +114,7 @@ def main(argv: Sequence[str] | None = None):
 
         # TODO: instantiate transform(s) based on command line args
         xform = CommentTransfer(cache, model)
-        xform.transfer_comments(
+        xform.transfer_comments_dir(
             root_rust_source_file=args.root_rust_source_file,
             ident_filter=args.ident_filter,
             update_rust=args.update_rust,


### PR DESCRIPTION
Previously, we took a root rust source file (like `lib.rs` or `main.rs`). This is because tools like `merge-rust` use that.  But the comment transferer works on any `*.rs` file with a corresponding `*.c_decls.json`, so we weren't always giving the rust tools the right root source file. Also, this only worked for running on a single file.

Now we take a root source file and search for `*.c_decls.json`s in its directory, passing the root source file to `merge-rust` and the individual `*.rs`s to the comment transferer. This isn't always perfect, as `mod` declarations can reference other files not in the directory hierarchy, but to get that exact search, we'd have to parse the Rust. This should be a good enough approximation for now. Also, this should be better for handling conditional compilation.