### PR TITLE
transpile: simplify and fix comparing `SrcLoc`s by include paths

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -155,13 +155,17 @@ struct SrcLocInclude<'a> {
     include_path: &'a [SrcLoc],
 }
 
+impl SrcLocInclude<'_> {
+    fn cmp_iter<'a>(&'a self) -> impl Iterator<Item = SrcLoc> + 'a {
+        // See docs on `Self` for why this is the right comparison.
+        let Self { loc, include_path } = *self;
+        include_path.iter().copied().chain([loc])
+    }
+}
+
 impl PartialOrd for SrcLocInclude<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let a = self;
-        let b = other;
-        let a = a.include_path.iter().copied().chain([a.loc]);
-        let b = b.include_path.iter().copied().chain([b.loc]);
-        Some(a.cmp(b))
+        Some(self.cmp_iter().cmp(other.cmp_iter()))
     }
 }
 


### PR DESCRIPTION
* Fixes #1126.

@spernsteiner, I'm pretty sure you were right about your suggestion in https://github.com/immunant/c2rust/issues/1126#issuecomment-3730132058.

Include paths are set up such that `include_path.first()` is in the main/root file we're transpiling, the root include, while `include_path.last()` is the final include, with that path containing the definition.  Thus, comparing with the definition's location at the end of the include path produces a natural ordering for the `SrcLoc`s should be trivially total (as long as the include paths are well-formed; they didn't use to be) as we're comparing two equivalent things (`include_path.iter().copied().chain([loc])`.