### PR TITLE
transpile: Always explicitly reference `current_block` values

### DIFF
--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -2,7 +2,8 @@
 
 use super::*;
 use log::warn;
-use syn::{spanned::Spanned as _, ExprBinary, ExprBreak, ExprIf, ExprUnary, Stmt};
+use proc_macro2::TokenStream;
+use syn::{spanned::Spanned as _, ExprBinary, ExprBreak, ExprIf, ExprUnary, MacroDelimiter, Stmt};
 
 use crate::rust_ast::{comment_store, set_span::SetSpan, BytePos, SpanExt};
 
@@ -649,28 +650,12 @@ fn process_cfg(
                 S::mk_loop(Some(label.clone()), body)
             }
 
-            Multiple { entries, branches } => {
-                // If we have entries that aren't one of our branches, our `then` case needs to
-                // be empty so that we fall through to the next structure. Otherwise we pull off
-                // the first branch as the `then` case in order to satisfy the exhaustiveness
-                // requirement for the generated `match`.
-                let mut branch_entries = branches.keys();
-                let then = if entries.iter().all(|entry| branches.contains_key(entry)) {
-                    let then_entry = branch_entries
-                        .next()
-                        .expect("There must be at least one branch");
-                    process_cfg(
-                        &branches[then_entry],
-                        cfg_info,
-                        &next_entries,
-                        loop_context,
-                        break_targets,
-                    )?
-                } else {
-                    S::empty()
-                };
-
-                let cases = branch_entries
+            Multiple {
+                entries: _,
+                branches,
+            } => {
+                let cases = branches
+                    .keys()
                     .map(|entry| {
                         let stmts = process_cfg(
                             &branches[entry],
@@ -683,7 +668,27 @@ fn process_cfg(
                     })
                     .collect::<TranslationResult<_>>()?;
 
-                S::mk_goto_table(cases, Some(then))
+                let then = if cfg_info
+                    .checked_entries
+                    .iter()
+                    .all(|entry| branches.contains_key(entry))
+                {
+                    // If the branches cover all the enum variants in `checked_entries`, then the
+                    // `match` is exhaustive and we don't need a "then" branch.
+                    None
+                } else {
+                    // Otherwise, the branches *should* at least cover all of our entries, so there
+                    // should be no other possible cases. Mark the "then" branch as unreachable.
+                    // See https://github.com/immunant/c2rust/pull/1556#discussion_r3874230125
+                    let unreachable_call = mk().mac_expr(mk().mac(
+                        mk().path(vec!["unreachable"]),
+                        TokenStream::new(),
+                        MacroDelimiter::Paren(Default::default()),
+                    ));
+                    Some(S::mk_singleton(mk().expr_stmt(unreachable_call)))
+                };
+
+                S::mk_goto_table(cases, then)
             }
         };
 

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -165,7 +165,10 @@ fn cleanup_labels(
             for (_, case) in cases {
                 cleanup_labels(case, current_loop, encountered_labels);
             }
-            cleanup_labels(then, current_loop, encountered_labels);
+
+            if let Some(then) = then {
+                cleanup_labels(then, current_loop, encountered_labels);
+            }
         }
         Empty | Singleton(_) | Goto(_) => {}
     }
@@ -208,7 +211,10 @@ fn merge_labels(ast: &mut StructuredAST<Box<Expr>, Pat, Label, Stmt>, old: &Labe
             for (_, case) in cases {
                 merge_labels(case, old, new);
             }
-            merge_labels(then, old, new);
+
+            if let Some(then) = then {
+                merge_labels(then, old, new);
+            }
         }
         Exit(_, None) | Empty | Singleton(_) | Goto(_) => {}
     }
@@ -262,7 +268,7 @@ pub trait StructuredStatement: Sized {
     /// Make a `goto` table
     fn mk_goto_table(
         cases: Vec<(Self::L, Self)>, // entries in the goto table
-        then: Self,                  // default case of the goto table
+        then: Option<Self>,          // default case of the goto table
     ) -> Self;
 
     /// Make some sort of loop
@@ -330,7 +336,7 @@ pub enum StructuredASTKind<E, P, L, S> {
     ),
     GotoTable(
         Vec<(L, StructuredAST<E, P, L, S>)>,
-        Box<StructuredAST<E, P, L, S>>,
+        Option<Box<StructuredAST<E, P, L, S>>>,
     ),
     Loop(Option<L>, Box<StructuredAST<E, P, L, S>>),
     Block(L, Box<StructuredAST<E, P, L, S>>),
@@ -374,8 +380,8 @@ impl<E, P, L, S> StructuredStatement for StructuredAST<E, P, L, S> {
         dummy_spanned(StructuredASTKind::If(cond, Box::new(then), Box::new(else_)))
     }
 
-    fn mk_goto_table(cases: Vec<(Self::L, Self)>, then: Self) -> Self {
-        dummy_spanned(StructuredASTKind::GotoTable(cases, Box::new(then)))
+    fn mk_goto_table(cases: Vec<(Self::L, Self)>, then: Option<Self>) -> Self {
+        dummy_spanned(StructuredASTKind::GotoTable(cases, then.map(Box::new)))
     }
 
     fn mk_loop(lbl: Option<Self::L>, body: Self) -> Self {
@@ -677,7 +683,7 @@ fn process_cfg(
                     })
                     .collect::<TranslationResult<_>>()?;
 
-                S::mk_goto_table(cases, then)
+                S::mk_goto_table(cases, Some(then))
             }
         };
 
@@ -949,13 +955,15 @@ impl StructureState {
                     })
                     .collect();
 
-                let (then, then_span) = self.to_stmt(*then, comment_store);
+                if let Some(then) = then {
+                    let (then, then_span) = self.to_stmt(*then, comment_store);
 
-                arms.push(mk().arm(
-                    mk().wild_pat(),
-                    None,
-                    mk().block_expr(mk().span(then_span).block(then)),
-                ));
+                    arms.push(mk().arm(
+                        mk().wild_pat(),
+                        None,
+                        mk().block_expr(mk().span(then_span).block(then)),
+                    ));
+                }
 
                 let e = mk().match_expr(self.current_block_variable.clone(), arms);
 

--- a/c2rust-transpile/tests/snapshots/gotos.c
+++ b/c2rust-transpile/tests/snapshots/gotos.c
@@ -144,3 +144,35 @@ error:
 exit:
     return x;
 }
+
+int double_irreducible(int x) {
+    if (x % 2 == 0) {
+        goto l1;
+    } else {
+        goto l2;
+    }
+
+    while (x < 10) {
+l1:
+        x += 1;
+
+l2:
+        x += 1;
+    }
+
+    if (x % 2 == 0) {
+        goto a;
+    } else {
+        goto b;
+    }
+
+    while (x < 10) {
+a:
+        x += 1;
+
+b:
+        x += 1;
+    }
+
+    return x;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.clang15.snap
@@ -169,3 +169,56 @@ pub unsafe extern "C" fn nested_irreducible(
     }
     return x;
 }
+#[no_mangle]
+pub unsafe extern "C" fn double_irreducible(mut x: ::core::ffi::c_int) -> ::core::ffi::c_int {
+    enum C2Rust_Block {
+        l1,
+        l2,
+        a,
+        b,
+    }
+    let mut c2rust_current_block: C2Rust_Block;
+    if x % 2 as ::core::ffi::c_int == 0 as ::core::ffi::c_int {
+        c2rust_current_block = C2Rust_Block::l1;
+    } else {
+        c2rust_current_block = C2Rust_Block::l2;
+    }
+    loop {
+        match c2rust_current_block {
+            C2Rust_Block::l1 => {
+                x += 1 as ::core::ffi::c_int;
+                c2rust_current_block = C2Rust_Block::l2;
+            }
+            _ => {
+                x += 1 as ::core::ffi::c_int;
+                if x < 10 as ::core::ffi::c_int {
+                    c2rust_current_block = C2Rust_Block::l1;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    if x % 2 as ::core::ffi::c_int == 0 as ::core::ffi::c_int {
+        c2rust_current_block = C2Rust_Block::a;
+    } else {
+        c2rust_current_block = C2Rust_Block::b;
+    }
+    loop {
+        match c2rust_current_block {
+            C2Rust_Block::a => {
+                x += 1 as ::core::ffi::c_int;
+                c2rust_current_block = C2Rust_Block::b;
+            }
+            _ => {
+                x += 1 as ::core::ffi::c_int;
+                if x < 10 as ::core::ffi::c_int {
+                    c2rust_current_block = C2Rust_Block::a;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    return x;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.clang15.snap
@@ -149,20 +149,20 @@ pub unsafe extern "C" fn nested_irreducible(
         }
         loop {
             match c2rust_current_block {
-                C2Rust_Block::error => {
-                    if x > 0 as ::core::ffi::c_int {
-                        c2rust_current_block = C2Rust_Block::next;
-                    } else {
-                        break '_exit;
-                    }
-                }
-                _ => {
+                C2Rust_Block::next => {
                     if x == 1 as ::core::ffi::c_int {
                         c2rust_current_block = C2Rust_Block::error;
                         continue;
                     }
                     x -= 1 as ::core::ffi::c_int;
                     c2rust_current_block = C2Rust_Block::error;
+                }
+                C2Rust_Block::error => {
+                    if x > 0 as ::core::ffi::c_int {
+                        c2rust_current_block = C2Rust_Block::next;
+                    } else {
+                        break '_exit;
+                    }
                 }
             }
         }
@@ -185,11 +185,7 @@ pub unsafe extern "C" fn double_irreducible(mut x: ::core::ffi::c_int) -> ::core
     }
     loop {
         match c2rust_current_block {
-            C2Rust_Block::l1 => {
-                x += 1 as ::core::ffi::c_int;
-                c2rust_current_block = C2Rust_Block::l2;
-            }
-            _ => {
+            C2Rust_Block::l2 => {
                 x += 1 as ::core::ffi::c_int;
                 if x < 10 as ::core::ffi::c_int {
                     c2rust_current_block = C2Rust_Block::l1;
@@ -197,6 +193,11 @@ pub unsafe extern "C" fn double_irreducible(mut x: ::core::ffi::c_int) -> ::core
                     break;
                 }
             }
+            C2Rust_Block::l1 => {
+                x += 1 as ::core::ffi::c_int;
+                c2rust_current_block = C2Rust_Block::l2;
+            }
+            _ => unreachable!(),
         }
     }
     if x % 2 as ::core::ffi::c_int == 0 as ::core::ffi::c_int {
@@ -206,11 +207,7 @@ pub unsafe extern "C" fn double_irreducible(mut x: ::core::ffi::c_int) -> ::core
     }
     loop {
         match c2rust_current_block {
-            C2Rust_Block::a => {
-                x += 1 as ::core::ffi::c_int;
-                c2rust_current_block = C2Rust_Block::b;
-            }
-            _ => {
+            C2Rust_Block::b => {
                 x += 1 as ::core::ffi::c_int;
                 if x < 10 as ::core::ffi::c_int {
                     c2rust_current_block = C2Rust_Block::a;
@@ -218,6 +215,11 @@ pub unsafe extern "C" fn double_irreducible(mut x: ::core::ffi::c_int) -> ::core
                     break;
                 }
             }
+            C2Rust_Block::a => {
+                x += 1 as ::core::ffi::c_int;
+                c2rust_current_block = C2Rust_Block::b;
+            }
+            _ => unreachable!(),
         }
     }
     return x;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.clang15.snap
@@ -150,20 +150,20 @@ pub unsafe extern "C" fn nested_irreducible(
         }
         loop {
             match c2rust_current_block {
-                C2Rust_Block::error => {
-                    if x > 0 as ::core::ffi::c_int {
-                        c2rust_current_block = C2Rust_Block::next;
-                    } else {
-                        break '_exit;
-                    }
-                }
-                _ => {
+                C2Rust_Block::next => {
                     if x == 1 as ::core::ffi::c_int {
                         c2rust_current_block = C2Rust_Block::error;
                         continue;
                     }
                     x -= 1 as ::core::ffi::c_int;
                     c2rust_current_block = C2Rust_Block::error;
+                }
+                C2Rust_Block::error => {
+                    if x > 0 as ::core::ffi::c_int {
+                        c2rust_current_block = C2Rust_Block::next;
+                    } else {
+                        break '_exit;
+                    }
                 }
             }
         }
@@ -186,11 +186,7 @@ pub unsafe extern "C" fn double_irreducible(mut x: ::core::ffi::c_int) -> ::core
     }
     loop {
         match c2rust_current_block {
-            C2Rust_Block::l1 => {
-                x += 1 as ::core::ffi::c_int;
-                c2rust_current_block = C2Rust_Block::l2;
-            }
-            _ => {
+            C2Rust_Block::l2 => {
                 x += 1 as ::core::ffi::c_int;
                 if x < 10 as ::core::ffi::c_int {
                     c2rust_current_block = C2Rust_Block::l1;
@@ -198,6 +194,11 @@ pub unsafe extern "C" fn double_irreducible(mut x: ::core::ffi::c_int) -> ::core
                     break;
                 }
             }
+            C2Rust_Block::l1 => {
+                x += 1 as ::core::ffi::c_int;
+                c2rust_current_block = C2Rust_Block::l2;
+            }
+            _ => unreachable!(),
         }
     }
     if x % 2 as ::core::ffi::c_int == 0 as ::core::ffi::c_int {
@@ -207,11 +208,7 @@ pub unsafe extern "C" fn double_irreducible(mut x: ::core::ffi::c_int) -> ::core
     }
     loop {
         match c2rust_current_block {
-            C2Rust_Block::a => {
-                x += 1 as ::core::ffi::c_int;
-                c2rust_current_block = C2Rust_Block::b;
-            }
-            _ => {
+            C2Rust_Block::b => {
                 x += 1 as ::core::ffi::c_int;
                 if x < 10 as ::core::ffi::c_int {
                     c2rust_current_block = C2Rust_Block::a;
@@ -219,6 +216,11 @@ pub unsafe extern "C" fn double_irreducible(mut x: ::core::ffi::c_int) -> ::core
                     break;
                 }
             }
+            C2Rust_Block::a => {
+                x += 1 as ::core::ffi::c_int;
+                c2rust_current_block = C2Rust_Block::b;
+            }
+            _ => unreachable!(),
         }
     }
     return x;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.clang15.snap
@@ -170,3 +170,56 @@ pub unsafe extern "C" fn nested_irreducible(
     }
     return x;
 }
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn double_irreducible(mut x: ::core::ffi::c_int) -> ::core::ffi::c_int {
+    enum C2Rust_Block {
+        l1,
+        l2,
+        a,
+        b,
+    }
+    let mut c2rust_current_block: C2Rust_Block;
+    if x % 2 as ::core::ffi::c_int == 0 as ::core::ffi::c_int {
+        c2rust_current_block = C2Rust_Block::l1;
+    } else {
+        c2rust_current_block = C2Rust_Block::l2;
+    }
+    loop {
+        match c2rust_current_block {
+            C2Rust_Block::l1 => {
+                x += 1 as ::core::ffi::c_int;
+                c2rust_current_block = C2Rust_Block::l2;
+            }
+            _ => {
+                x += 1 as ::core::ffi::c_int;
+                if x < 10 as ::core::ffi::c_int {
+                    c2rust_current_block = C2Rust_Block::l1;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    if x % 2 as ::core::ffi::c_int == 0 as ::core::ffi::c_int {
+        c2rust_current_block = C2Rust_Block::a;
+    } else {
+        c2rust_current_block = C2Rust_Block::b;
+    }
+    loop {
+        match c2rust_current_block {
+            C2Rust_Block::a => {
+                x += 1 as ::core::ffi::c_int;
+                c2rust_current_block = C2Rust_Block::b;
+            }
+            _ => {
+                x += 1 as ::core::ffi::c_int;
+                if x < 10 as ::core::ffi::c_int {
+                    c2rust_current_block = C2Rust_Block::a;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+    return x;
+}


### PR DESCRIPTION
- Depends on #1523
- Fixes #1522

I've assumed here that the `entries` field of `Structure::Multiple` is exhaustive. Thus all labels in `entries` minus those in `branches` should be those that were previously covered by the wildcard pattern, and any other values are unreachable. I don't know if that's the case or not; if not, then this may turn out much harder to implement, as I don't know where to recover the missing labels from.