### PR TITLE
transpile: Use enum for `current_block` labels

### DIFF
--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -22,19 +22,16 @@ use crate::diagnostics::TranslationResult;
 use crate::rust_ast::{self, SpanExt};
 use c2rust_ast_printer::pprust;
 use proc_macro2::Span;
-use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeSet;
 use std::fmt::{Debug, Display, Formatter};
 use std::fs::File;
 use std::hash::Hash;
-use std::hash::Hasher;
 use std::io::Write;
 use std::ops::Deref;
 use std::ops::Index;
 use std::rc::Rc;
 use std::{fmt, io};
-use syn::Lit;
-use syn::{spanned::Spanned, Arm, Expr, Pat, Stmt};
+use syn::{spanned::Spanned, Arm, Expr, Ident, Pat, Stmt};
 
 use failure::format_err;
 use indexmap::indexset;
@@ -97,27 +94,12 @@ impl Label {
         String::from(self.pretty_print().trim_start_matches('\''))
     }
 
-    fn to_num_expr(&self) -> Box<Expr> {
-        let mut s = DefaultHasher::new();
-        self.hash(&mut s);
-        let as_num = s.finish();
-
-        mk().lit_expr(as_num as u128)
-    }
-
-    fn to_string_expr(&self) -> Box<Expr> {
-        mk().lit_expr(self.debug_print())
-    }
-
-    fn to_int_lit(&self) -> Lit {
-        let mut s = DefaultHasher::new();
-        self.hash(&mut s);
-        let as_num = s.finish();
-        mk().int_lit(as_num as u128, "")
-    }
-
-    fn to_string_lit(&self) -> Lit {
-        mk().str_lit(&self.debug_print())
+    pub(crate) fn to_variant_ident(&self) -> Ident {
+        mk().ident(match self {
+            Label::FromC(_, Some(s)) => format!("{}", s.as_ref()),
+            Label::FromC(CStmtId(label_id), None) => format!("C_{}", label_id),
+            Label::Synthetic(syn_id) => format!("S_{}", syn_id),
+        })
     }
 }
 

--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -11,8 +11,8 @@ pub fn structured_cfg(
     root: &[Structure<Stmt>],
     cfg_info: &CfgInfo,
     comment_store: &mut comment_store::CommentStore,
-    current_block: Box<Expr>,
-    debug_labels: bool,
+    current_block_enum: Ident,
+    current_block_variable: Box<Expr>,
 ) -> TranslationResult<Vec<Stmt>> {
     let loop_context = LoopContext::default();
     let mut ast = process_cfg(
@@ -28,8 +28,8 @@ pub fn structured_cfg(
     cleanup_labels(&mut ast, &None, &mut IndexSet::new());
 
     let s = StructureState {
-        debug_labels,
-        current_block,
+        current_block_enum,
+        current_block_variable,
     };
     let (stmts, _span) = s.to_stmt(ast, comment_store);
 
@@ -740,8 +740,8 @@ fn process_cfg(
 }
 
 struct StructureState {
-    debug_labels: bool,
-    current_block: Box<Expr>,
+    current_block_enum: Ident,
+    current_block_variable: Box<Expr>,
 }
 
 /// Returns a `Span` between the beginning of `span` or `other`, whichever is
@@ -842,14 +842,10 @@ impl StructureState {
 
             Goto(to) => {
                 // Assign to `c2rust_current_block` the next label we want to go to.
-
-                let lbl_expr = if self.debug_labels {
-                    to.to_string_expr()
-                } else {
-                    to.to_num_expr()
-                };
-                mk().span(span)
-                    .semi_stmt(mk().assign_expr(self.current_block.clone(), lbl_expr))
+                let path = vec![self.current_block_enum.clone(), to.to_variant_ident()];
+                let expr =
+                    mk().assign_expr(self.current_block_variable.clone(), mk().path_expr(path));
+                mk().span(span).semi_stmt(expr)
             }
 
             Match(cond, cases) => {
@@ -941,13 +937,13 @@ impl StructureState {
                     .into_iter()
                     .map(|(lbl, stmts)| -> Arm {
                         let (stmts, stmts_span) = self.to_stmt(stmts, comment_store);
-
-                        let lbl_lit = if self.debug_labels {
-                            lbl.to_string_lit()
-                        } else {
-                            lbl.to_int_lit()
+                        let pat = {
+                            let path = mk().path(vec![
+                                self.current_block_enum.clone(),
+                                lbl.to_variant_ident(),
+                            ]);
+                            mk().path_pat(path, None)
                         };
-                        let pat = mk().lit_pat(lbl_lit);
                         let body = mk().block_expr(mk().span(stmts_span).block(stmts));
                         mk().arm(pat, None, body)
                     })
@@ -961,7 +957,7 @@ impl StructureState {
                     mk().block_expr(mk().span(then_span).block(then)),
                 ));
 
-                let e = mk().match_expr(self.current_block.clone(), arms);
+                let e = mk().match_expr(self.current_block_variable.clone(), arms);
 
                 mk().span(span).expr_stmt(e)
             }

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -78,7 +78,6 @@ pub struct TranspilerConfig {
     pub incremental_relooper: bool,
     pub fail_on_multiple: bool,
     pub filter: Option<Regex>,
-    pub debug_relooper_labels: bool,
     pub prefix_function_names: Option<String>,
     pub translate_asm: bool,
     pub use_c_loop_info: bool,

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -80,7 +80,6 @@ pub struct TranspilerConfig {
     pub incremental_relooper: bool,
     pub fail_on_multiple: bool,
     pub filter: Option<Regex>,
-    pub debug_relooper_labels: bool,
     pub cross_checks: bool,
     pub cross_check_backend: String,
     pub cross_check_configs: Vec<String>,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -19,7 +19,7 @@ use serde_derive::Serialize;
 use syn::spanned::Spanned as _;
 use syn::{
     AttrStyle, BareVariadic, BinOp, Block, Expr, ExprBinary, ExprBlock, ExprBreak, ExprCast,
-    ExprParen, ExprReturn, ExprUnary, FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro,
+    ExprParen, ExprReturn, ExprUnary, Fields, FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro,
     ForeignItemStatic, ForeignItemType, Ident, Item, ItemConst, ItemEnum, ItemExternCrate, ItemFn,
     ItemForeignMod, ItemImpl, ItemMacro, ItemMod, ItemStatic, ItemStruct, ItemTrait,
     ItemTraitAlias, ItemType, ItemUnion, ItemUse, Lit, MacroDelimiter, PathSegment, ReturnType,
@@ -2407,26 +2407,31 @@ impl<'c> Translation<'c> {
         let mut cfg_info = cfg::structures::CfgInfo::default();
         cfg::structures::gather_cfg_info(&relooped, &mut cfg_info);
 
-        let current_block_ident = self
+        let current_block_enum = self
+            .renamer
+            .borrow_mut()
+            .pick_name("C2Rust_Block", Namespaces::types());
+        let current_block_variable = self
             .renamer
             .borrow_mut()
             .pick_name("c2rust_current_block", Namespaces::values());
-        let current_block = mk().ident_expr(&current_block_ident);
         let mut stmts: Vec<Stmt> = lifted_stmts;
         if !cfg_info.checked_entries.is_empty() {
             if self.tcfg.fail_on_multiple {
                 panic!("Uses of `c2rust_current_block' are illegal with `--fail-on-multiple'.");
             }
 
-            let current_block_ty = if self.tcfg.debug_relooper_labels {
-                mk().ref_lt_ty("static", mk().path_ty(vec!["str"]))
-            } else {
-                mk().path_ty(vec!["u64"])
-            };
+            let variants = cfg_info
+                .checked_entries
+                .iter()
+                .map(|lbl| mk().variant(lbl.to_variant_ident(), Fields::Unit))
+                .collect();
+            let item = mk().enum_item(&current_block_enum, variants);
+            stmts.push(mk().item_stmt(item));
 
             let local = mk().local(
-                mk().mutbl().ident_pat(current_block_ident),
-                Some(current_block_ty),
+                mk().mutbl().ident_pat(&current_block_variable),
+                Some(mk().ident_ty(&current_block_enum)),
                 None,
             );
             stmts.push(mk().local_stmt(Box::new(local)))
@@ -2436,8 +2441,8 @@ impl<'c> Translation<'c> {
             &relooped,
             &cfg_info,
             &mut self.comment_store.borrow_mut(),
-            current_block,
-            self.tcfg.debug_relooper_labels,
+            mk().ident(current_block_enum),
+            mk().ident_expr(current_block_variable),
         )?);
         Ok(stmts)
     }

--- a/c2rust-transpile/tests/common/mod.rs
+++ b/c2rust-transpile/tests/common/mod.rs
@@ -18,7 +18,6 @@ pub fn config(edition: RustEdition) -> TranspilerConfig {
         incremental_relooper: true,
         fail_on_multiple: false,
         filter: None,
-        debug_relooper_labels: false,
         cross_checks: false,
         cross_check_backend: Default::default(),
         cross_check_configs: Default::default(),

--- a/c2rust-transpile/tests/module_paths.rs
+++ b/c2rust-transpile/tests/module_paths.rs
@@ -21,7 +21,6 @@ fn config(output_dir: PathBuf) -> TranspilerConfig {
         incremental_relooper: true,
         fail_on_multiple: false,
         filter: None,
-        debug_relooper_labels: false,
         cross_checks: false,
         cross_check_backend: Default::default(),
         cross_check_configs: Default::default(),

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -20,7 +20,6 @@ fn config() -> TranspilerConfig {
         incremental_relooper: true,
         fail_on_multiple: false,
         filter: None,
-        debug_relooper_labels: false,
         prefix_function_names: None,
         translate_asm: true,
         use_c_loop_info: true,

--- a/c2rust-transpile/tests/snapshots/gotos.c
+++ b/c2rust-transpile/tests/snapshots/gotos.c
@@ -121,3 +121,26 @@ also_bad:
 common:
     return x + 10;
 }
+
+int nested_irreducible(int x, int start_with_error) {
+    if (x < 0) {
+        if (start_with_error)
+            goto exit;
+    }
+    if (start_with_error)
+        goto error;
+    goto next;
+
+next:
+    if (x == 1)
+        goto error;
+    x -= 1;
+
+error:
+    if (x > 0)
+        goto next;
+    goto exit;
+
+exit:
+    return x;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.clang15.snap
@@ -126,3 +126,42 @@ pub unsafe extern "C" fn multi_goto_error_common(mut x: ::core::ffi::c_int) -> :
     }
     return x + 10 as ::core::ffi::c_int;
 }
+#[no_mangle]
+pub unsafe extern "C" fn nested_irreducible(
+    mut x: ::core::ffi::c_int,
+    mut start_with_error: ::core::ffi::c_int,
+) -> ::core::ffi::c_int {
+    let mut c2rust_current_block: u64;
+    '_exit: {
+        if x < 0 as ::core::ffi::c_int {
+            if start_with_error != 0 {
+                break '_exit;
+            }
+        }
+        if start_with_error != 0 {
+            c2rust_current_block = 11406321539332183563;
+        } else {
+            c2rust_current_block = 16095097497300269400;
+        }
+        loop {
+            match c2rust_current_block {
+                11406321539332183563 => {
+                    if x > 0 as ::core::ffi::c_int {
+                        c2rust_current_block = 16095097497300269400;
+                    } else {
+                        break '_exit;
+                    }
+                }
+                _ => {
+                    if x == 1 as ::core::ffi::c_int {
+                        c2rust_current_block = 11406321539332183563;
+                        continue;
+                    }
+                    x -= 1 as ::core::ffi::c_int;
+                    c2rust_current_block = 11406321539332183563;
+                }
+            }
+        }
+    }
+    return x;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.clang15.snap
@@ -131,7 +131,11 @@ pub unsafe extern "C" fn nested_irreducible(
     mut x: ::core::ffi::c_int,
     mut start_with_error: ::core::ffi::c_int,
 ) -> ::core::ffi::c_int {
-    let mut c2rust_current_block: u64;
+    enum C2Rust_Block {
+        error,
+        next,
+    }
+    let mut c2rust_current_block: C2Rust_Block;
     '_exit: {
         if x < 0 as ::core::ffi::c_int {
             if start_with_error != 0 {
@@ -139,26 +143,26 @@ pub unsafe extern "C" fn nested_irreducible(
             }
         }
         if start_with_error != 0 {
-            c2rust_current_block = 11406321539332183563;
+            c2rust_current_block = C2Rust_Block::error;
         } else {
-            c2rust_current_block = 16095097497300269400;
+            c2rust_current_block = C2Rust_Block::next;
         }
         loop {
             match c2rust_current_block {
-                11406321539332183563 => {
+                C2Rust_Block::error => {
                     if x > 0 as ::core::ffi::c_int {
-                        c2rust_current_block = 16095097497300269400;
+                        c2rust_current_block = C2Rust_Block::next;
                     } else {
                         break '_exit;
                     }
                 }
                 _ => {
                     if x == 1 as ::core::ffi::c_int {
-                        c2rust_current_block = 11406321539332183563;
+                        c2rust_current_block = C2Rust_Block::error;
                         continue;
                     }
                     x -= 1 as ::core::ffi::c_int;
-                    c2rust_current_block = 11406321539332183563;
+                    c2rust_current_block = C2Rust_Block::error;
                 }
             }
         }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.clang15.snap
@@ -127,3 +127,42 @@ pub unsafe extern "C" fn multi_goto_error_common(mut x: ::core::ffi::c_int) -> :
     }
     return x + 10 as ::core::ffi::c_int;
 }
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn nested_irreducible(
+    mut x: ::core::ffi::c_int,
+    mut start_with_error: ::core::ffi::c_int,
+) -> ::core::ffi::c_int {
+    let mut c2rust_current_block: u64;
+    '_exit: {
+        if x < 0 as ::core::ffi::c_int {
+            if start_with_error != 0 {
+                break '_exit;
+            }
+        }
+        if start_with_error != 0 {
+            c2rust_current_block = 11406321539332183563;
+        } else {
+            c2rust_current_block = 16095097497300269400;
+        }
+        loop {
+            match c2rust_current_block {
+                11406321539332183563 => {
+                    if x > 0 as ::core::ffi::c_int {
+                        c2rust_current_block = 16095097497300269400;
+                    } else {
+                        break '_exit;
+                    }
+                }
+                _ => {
+                    if x == 1 as ::core::ffi::c_int {
+                        c2rust_current_block = 11406321539332183563;
+                        continue;
+                    }
+                    x -= 1 as ::core::ffi::c_int;
+                    c2rust_current_block = 11406321539332183563;
+                }
+            }
+        }
+    }
+    return x;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.clang15.snap
@@ -132,7 +132,11 @@ pub unsafe extern "C" fn nested_irreducible(
     mut x: ::core::ffi::c_int,
     mut start_with_error: ::core::ffi::c_int,
 ) -> ::core::ffi::c_int {
-    let mut c2rust_current_block: u64;
+    enum C2Rust_Block {
+        error,
+        next,
+    }
+    let mut c2rust_current_block: C2Rust_Block;
     '_exit: {
         if x < 0 as ::core::ffi::c_int {
             if start_with_error != 0 {
@@ -140,26 +144,26 @@ pub unsafe extern "C" fn nested_irreducible(
             }
         }
         if start_with_error != 0 {
-            c2rust_current_block = 11406321539332183563;
+            c2rust_current_block = C2Rust_Block::error;
         } else {
-            c2rust_current_block = 16095097497300269400;
+            c2rust_current_block = C2Rust_Block::next;
         }
         loop {
             match c2rust_current_block {
-                11406321539332183563 => {
+                C2Rust_Block::error => {
                     if x > 0 as ::core::ffi::c_int {
-                        c2rust_current_block = 16095097497300269400;
+                        c2rust_current_block = C2Rust_Block::next;
                     } else {
                         break '_exit;
                     }
                 }
                 _ => {
                     if x == 1 as ::core::ffi::c_int {
-                        c2rust_current_block = 11406321539332183563;
+                        c2rust_current_block = C2Rust_Block::error;
                         continue;
                     }
                     x -= 1 as ::core::ffi::c_int;
-                    c2rust_current_block = 11406321539332183563;
+                    c2rust_current_block = C2Rust_Block::error;
                 }
             }
         }

--- a/c2rust/src/bin/c2rust-transpile.rs
+++ b/c2rust/src/bin/c2rust-transpile.rs
@@ -85,10 +85,6 @@ struct Args {
     #[clap(long = "ddump-structures")]
     dump_structures: bool,
 
-    /// Generate readable 'current_block' values in relooper
-    #[clap(long = "ddebug-labels")]
-    debug_labels: bool,
-
     /// Path to compile_commands.json, or a list of source files
     #[clap(parse(from_os_str), multiple_values = true)]
     compile_commands: Vec<PathBuf>,
@@ -221,7 +217,6 @@ fn main() {
         fail_on_error: args.fail_on_error,
         fail_on_multiple: args.fail_on_multiple,
         filter: args.filter,
-        debug_relooper_labels: args.debug_labels,
         prefix_function_names: args.prefix_function_names,
 
         // We used to guard asm translation with a command-line

--- a/c2rust/src/bin/c2rust-transpile.rs
+++ b/c2rust/src/bin/c2rust-transpile.rs
@@ -86,10 +86,6 @@ struct Args {
     #[clap(long = "ddump-structures")]
     dump_structures: bool,
 
-    /// Generate readable 'c2rust_current_block' values in relooper
-    #[clap(long = "ddebug-labels")]
-    debug_labels: bool,
-
     /// Path to compile_commands.json, or a list of source files
     #[clap(parse(from_os_str), multiple_values = true)]
     compile_commands: Vec<PathBuf>,
@@ -284,7 +280,6 @@ fn main() {
         fail_on_error: args.fail_on_error,
         fail_on_multiple: args.fail_on_multiple,
         filter: args.filter,
-        debug_relooper_labels: args.debug_labels,
         cross_checks: args.cross_checks,
         cross_check_backend: args.cross_check_backend.into(),
         cross_check_configs: args.cross_check_config,


### PR DESCRIPTION
- Fixes #1523

The enum variants now suffice for debugging purposes, so I've removed the `debug_labels` command line option.