### PR TITLE
Fix nix dev

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,15 +37,14 @@
           };
         };
 
-        myLLVM = pkgs.llvmPackages_18;
-        myStdenv = pkgs.clang18Stdenv;
+        myLLVM = pkgs.llvmPackages;
+        myStdenv = pkgs.clangStdenv;
 
         rustPlatform = pkgs.makeRustPlatform {
           cargo = fenixToolchain;
           rustc = fenixToolchain;
         };
-        env = with pkgs; {
-          LIBCLANG_PATH = "${myLLVM.libclang.lib}/lib";
+        env = {
           CMAKE_LLVM_DIR = "${myLLVM.libllvm.dev}/lib/cmake/llvm";
           CMAKE_CLANG_DIR = "${myLLVM.libclang.dev}/lib/cmake/clang";
           LLVM_CONFIG_PATH = "${myLLVM.libllvm.dev}/bin/llvm-config";
@@ -100,6 +99,7 @@
               ];
 
               buildInputs = with pkgs; [
+                curl.dev
                 rustPlatform.bindgenHook
                 myStdenv.cc
                 myLLVM.libclang
@@ -110,6 +110,7 @@
                 openssl
                 zlib
                 fenixToolchain
+                z3.dev
               ];
 
               cargoLock = {


### PR DESCRIPTION
I was unable to build _c2rust_ and _c2rust-refactor_ without modifying the flake. This change increases LLVM tools to v19.