### PR TITLE
refactor: Fix transform casts from non-unit to unit types

### DIFF
--- a/c2rust-refactor/src/transform/externs.rs
+++ b/c2rust-refactor/src/transform/externs.rs
@@ -187,6 +187,13 @@ fn make_cast<'a, 'tcx>(
 
     if needs_transmute {
         mk().call_expr(mk().path_expr(vec!["", "core", "mem", "transmute"]), vec![expr])
+    } else if ty.is_unit() {
+        // `{ let _ = expr; }` since the context expects a unit tuple.
+        // `let` is technically a statement but its value is `()` which
+        // is exactly what we need.
+        mk().block_expr(mk().block(vec![
+            mk().local_stmt(P(mk().local(mk().wild_pat(), None::<P<ast::Ty>>, Some(expr)))),
+        ]))
     } else {
         let expr = if let ExprKind::AddrOf(_, mutability, _) = expr.kind {
             // We have to cast to *T where &T is the type of expr before casting


### PR DESCRIPTION
* Fixes #1560.

Fixes the example from #1560 by emitting the following pattern:
```rust
    {
        let _ = crate::app::src::rng::randombytes(
            &raw mut seed as *mut ::core::ffi::c_uchar,
            (3 as ::core::ffi::c_int * crate::params_sphincs_haraka_128s_h::SPX_N)
                as ::core::ffi::c_ulonglong,
        );
        ()
    };
```