### PR TITLE
refactor: configure `cargo`

### DIFF
--- a/c2rust-refactor/src/lib.rs
+++ b/c2rust-refactor/src/lib.rs
@@ -248,7 +248,20 @@ fn get_rustc_cargo_args(target_type: CargoTarget) -> Vec<RustcArgs> {
     use cargo_util::ProcessBuilder;
     use std::sync::Mutex;
 
-    let config = Config::default().unwrap();
+    let mut config = Config::default().unwrap();
+    config
+        .configure(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            &Default::default(),
+            Default::default(),
+            Default::default(),
+        )
+        .unwrap();
     config.shell().set_verbosity(Verbosity::Quiet);
     let mode = CompileMode::Check { test: false };
     let mut compile_opts = CompileOptions::new(&config, mode).unwrap();


### PR DESCRIPTION
Without this, `cargo` never tries to load any of the settings from `.cargo/config.toml`, etc.  For example, it doesn't load the `[unstable] sparse-registry = true` in `config.toml` set by crisp, which is what is causing the hang in `cargo refactor` in crisp.