### PR TITLE
bitfields-derive: pin `unicode-ident` to MSRV-compatible version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2699,9 +2700,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-normalization"

--- a/c2rust-bitfields-derive/Cargo.toml
+++ b/c2rust-bitfields-derive/Cargo.toml
@@ -16,6 +16,7 @@ categories.workspace = true
 proc-macro2 = "=1.0.103"
 syn = { version = "=2.0.106", features = ["full"] }
 quote = "=1.0.40"
+unicode-ident = "=1.0.22"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
`unicode-ident` released `v1.0.23` yesterday, which bumped its MSRV to 1.71. Our transpiled code targets 1.70, so this broke it. Very annoying that this happened just a couple days after we release `c2rust` `v0.22.0`, so we'll probably have to do a new `c2rust `v0.23.0` release now.