### PR TITLE
cargo: set `[unstable] sparse-registry = true`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[unstable]
+sparse-registry = true # Only needed for cargo versions < 1.68.


### PR DESCRIPTION
I realized I forgot to do this on `c2rust` instead of only CRISP.  We've already successfully set this in crisp (https://github.com/GaloisInc/Tractor-Crisp/pull/44). Since we're pinned to `nightly-2022-08-08` and the sparse registry was still unstable then (but long since stable by now), this lets us use to speed things up a lot.