### PR TITLE
refactor: Fix ordering of snapshot tests

### DIFF
--- a/c2rust-refactor/tests/snapshots.rs
+++ b/c2rust-refactor/tests/snapshots.rs
@@ -60,6 +60,8 @@ fn test_refactor(command: &str) {
     test_refactor_named(command, &format!("{command}.rs"));
 }
 
+// NOTE: Tests should be listed in alphabetical order.
+
 #[test]
 fn test_convert_exits() {
     test_refactor("convert_exits");


### PR DESCRIPTION
I added a comment in there about what the expected ordering is. It would be nice if copilot would see that and chastise us if we put any tests in the wrong order, but idk if it'll actually do that. At the least it's a reminder to me for the next time I add refactor tests.