### PR TITLE
refactor: declare `transform` `mod`s outside macros so `cargo fmt` can discover them

### DIFF
--- a/c2rust-refactor/src/transform/char_literals.rs
+++ b/c2rust-refactor/src/transform/char_literals.rs
@@ -1,28 +1,28 @@
-use rustc_ast::*;
 use rustc_ast::ptr::P;
+use rustc_ast::*;
 
 use crate::ast_builder::mk;
 use crate::command::{CommandState, Registry};
-use crate::RefactorCtxt;
 use crate::driver::{self, Phase};
-use crate::matcher::{Bindings, BindingType, MatchCtxt, Subst, mut_visit_match_with};
+use crate::matcher::{mut_visit_match_with, BindingType, Bindings, MatchCtxt, Subst};
 use crate::transform::Transform;
+use crate::RefactorCtxt;
 
 /// # `char_literals` Command
-/// 
+///
 /// Obsolete - the translator now does this automatically.
-/// 
+///
 /// Usage: `char_literals`
-/// 
+///
 /// Replace integer literals cast to `libc::c_char` with actual char literals.
 /// For example, replaces `65 as libc::c_char` with `'A' as libc::c_char`.
-struct CharLits {
-}
+struct CharLits {}
 
 impl Transform for CharLits {
-    fn min_phase(&self) -> Phase { Phase::Phase2 }
+    fn min_phase(&self) -> Phase {
+        Phase::Phase2
+    }
     fn transform(&self, krate: &mut Crate, st: &CommandState, cx: &RefactorCtxt) {
-
         let pattern = driver::parse_expr(cx.session(), "__number as libc::c_char");
         let mut mcx = MatchCtxt::new(st, cx);
         mcx.set_type("__number", BindingType::Expr);
@@ -45,5 +45,5 @@ impl Transform for CharLits {
 pub fn register_commands(reg: &mut Registry) {
     use super::mk;
 
-    reg.register("char_literals", |_args| mk(CharLits{}))
+    reg.register("char_literals", |_args| mk(CharLits {}))
 }

--- a/c2rust-refactor/src/transform/mod.rs
+++ b/c2rust-refactor/src/transform/mod.rs
@@ -7,6 +7,36 @@ use crate::command::{Command, CommandState, RefactorState, Registry};
 use crate::driver::Phase;
 use crate::RefactorCtxt;
 
+// `cargo fmt` doesn't expand macros, so if we declare modules inside a macro,
+// they won't be formatted because `cargo fmt` won't find them.
+
+pub mod canonicalize_refs;
+pub mod casts;
+pub mod char_literals;
+pub mod control_flow;
+pub mod exits;
+pub mod externs;
+pub mod format;
+pub mod funcs;
+pub mod generics;
+// TODO: this is disabled because it uses Subst for AssocItem
+// pub mod ionize;
+pub mod items;
+// TODO: this is disabled for now because it depends on analysis/runtime
+// pub mod lifetime_analysis;
+pub mod linkage;
+pub mod literals;
+pub mod math;
+pub mod ownership;
+pub mod paths;
+pub mod reorganize_definitions;
+pub mod retype;
+pub mod rewrite;
+pub mod statics;
+pub mod structs;
+pub mod test;
+pub mod vars;
+
 /// An AST transformation that can be applied to a crate.
 pub trait Transform {
     /// Apply the transformation.
@@ -40,8 +70,6 @@ fn mk<T: Transform + 'static>(t: T) -> Box<dyn Command> {
 
 macro_rules! transform_modules {
     ($($name:ident,)*) => {
-        $( pub mod $name; )*
-
         pub fn register_commands(reg: &mut Registry) {
             $( $name::register_commands(reg); )*
         }
@@ -58,11 +86,11 @@ transform_modules! {
     format,
     funcs,
     generics,
-    //TODO: this is disabled because it uses Subst for AssocItem
-    //ionize,
+    // TODO: this is disabled because it uses Subst for AssocItem
+    // ionize,
     items,
     // TODO: this is disabled for now because it depends on analysis/runtime
-    //lifetime_analysis,
+    // lifetime_analysis,
     linkage,
     literals,
     math,

--- a/c2rust-refactor/src/transform/paths.rs
+++ b/c2rust-refactor/src/transform/paths.rs
@@ -1,5 +1,5 @@
-use crate::ast_manip::visit_nodes;
 use crate::ast_manip::util::{namespace, UseInfo};
+use crate::ast_manip::visit_nodes;
 use crate::command::{CommandState, Registry};
 use crate::path_edit::fold_resolved_paths_with_id;
 use crate::transform::Transform;


### PR DESCRIPTION
While reviewing one of @Rua's PR that had a lot of formatting changes in the commit, I realized there were unformatted files in `c2rust-refactor`.  Not having them formatted makes reviewing harder, and format on save has to be disabled for them to avoid formatting if we want to have sane diffs.  The cause is `cargo fmt` doesn't expand macros when discovering modules and we declare `c2rust_refactor::transform::*` modules in a macro.  We can simply hoist them out of the macro and repeat them once, which doesn't seem that bad.  This is done in `c2rust-refactor/src/transform/mod.rs` (probably only this file needs to be reviewed, not the formatted files).

Also, I believe it's not just `cargo fmt` that's affected.  Any `cargo` command that isn't invoking `rustc`, which does do macro expansion, won't discover these modules and will just miss them, likely silently.