### PR TITLE
transpile: Add snapshot tests for wide strings

### DIFF
--- a/c2rust-transpile/tests/snapshots/arrays.c
+++ b/c2rust-transpile/tests/snapshots/arrays.c
@@ -35,15 +35,6 @@ void entry(void) {
     char *char_lit_ptr = "abc";
     char (*char_lit_array_ptr)[4] = &"abc";
 
-// TODO re-enable after #1266 adds portable support for translating `wchar_t`.
-#if 0
-    wchar_t wide1[] = L"x";
-
-    wchar_t wide2[3] = L"x";
-
-    wchar_t wide3[1] = L"xy";
-#endif
-
     // Test that we can get the address of the element past the end of the array
     char *past_end = &static_char_array[sizeof(static_char_array)];
     past_end = &static_char_ptr[8];

--- a/c2rust-transpile/tests/snapshots/os-specific/wide_strings.c
+++ b/c2rust-transpile/tests/snapshots/os-specific/wide_strings.c
@@ -1,0 +1,18 @@
+#include <wchar.h>
+
+wchar_t static_array[] = L"x";
+wchar_t static_array_longer[3] = L"x";
+wchar_t static_array_shorter[1] = L"xy";
+// Currently broken, see #1571
+// const wchar_t *static_ptr = L"x";
+
+void func() {
+    wchar_t array[] = L"x";
+    wchar_t array_longer[3] = L"x";
+    wchar_t array_shorter[1] = L"xy";
+
+    // Currently broken, see #1571
+    // const wchar_t *ptr = L"x";
+
+    size_t len = wcslen(array);
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@wide_strings.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@wide_strings.c.snap
@@ -1,0 +1,38 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/os-specific/wide_strings.linux.rs
+input_file: c2rust-transpile/tests/snapshots/os-specific/wide_strings.c
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![feature(raw_ref_op)]
+extern "C" {
+    fn wcslen(__s: *const wchar_t) -> ::core::ffi::c_ulong;
+}
+pub type size_t = usize;
+pub type wchar_t = ::libc::wchar_t;
+#[no_mangle]
+pub static mut static_array: [wchar_t; 2] =
+    unsafe { ::core::mem::transmute::<[u8; 8], [wchar_t; 2]>(*b"x\0\0\0\0\0\0\0") };
+#[no_mangle]
+pub static mut static_array_longer: [wchar_t; 3] =
+    unsafe { ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0") };
+#[no_mangle]
+pub static mut static_array_shorter: [wchar_t; 1] =
+    unsafe { ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0") };
+#[no_mangle]
+pub unsafe extern "C" fn func() {
+    let mut array: [wchar_t; 2] =
+        ::core::mem::transmute::<[u8; 8], [wchar_t; 2]>(*b"x\0\0\0\0\0\0\0");
+    let mut array_longer: [wchar_t; 3] =
+        ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0");
+    let mut array_shorter: [wchar_t; 1] =
+        ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0");
+    let mut len: size_t = wcslen(&raw mut array as *mut wchar_t) as size_t;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@wide_strings.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@wide_strings.c.snap
@@ -1,0 +1,40 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/os-specific/wide_strings.macos.rs
+input_file: c2rust-transpile/tests/snapshots/os-specific/wide_strings.c
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![feature(raw_ref_op)]
+extern "C" {
+    fn wcslen(_: *const wchar_t) -> ::core::ffi::c_ulong;
+}
+pub type __darwin_size_t = usize;
+pub type __darwin_wchar_t = ::libc::wchar_t;
+pub type size_t = __darwin_size_t;
+pub type wchar_t = __darwin_wchar_t;
+#[no_mangle]
+pub static mut static_array: [wchar_t; 2] =
+    unsafe { ::core::mem::transmute::<[u8; 8], [wchar_t; 2]>(*b"x\0\0\0\0\0\0\0") };
+#[no_mangle]
+pub static mut static_array_longer: [wchar_t; 3] =
+    unsafe { ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0") };
+#[no_mangle]
+pub static mut static_array_shorter: [wchar_t; 1] =
+    unsafe { ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0") };
+#[no_mangle]
+pub unsafe extern "C" fn func() {
+    let mut array: [wchar_t; 2] =
+        ::core::mem::transmute::<[u8; 8], [wchar_t; 2]>(*b"x\0\0\0\0\0\0\0");
+    let mut array_longer: [wchar_t; 3] =
+        ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0");
+    let mut array_shorter: [wchar_t; 1] =
+        ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0");
+    let mut len: size_t = wcslen(&raw mut array as *mut wchar_t) as size_t;
+}


### PR DESCRIPTION
The test is os-specific, because the size of `wchar_t` is 2 rather than 4 on Windows. There are no Windows tests (yet) but this way it's prepared for that eventuality. And also makes it clear that portably translating wide strings is still a TODO.

EDIT: Actually it appears that even Linux and MacOS differ here? Hmm...