### PR TITLE
transpile: tests: ignore `.c_decls.json` from snapshot tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ polonius_cache/
 
 # Outputs of c2rust-transpile snapshot tests
 c2rust-transpile/tests/snapshots/**/*.rs
+c2rust-transpile/tests/snapshots/**/*.c_decls.json
+c2rust-transpile/tests/c_decls_snapshots/**/*.rs
+c2rust-transpile/tests/c_decls_snapshots/**/*.c_decls.json


### PR DESCRIPTION
These were added in #1622, but we forgot to add them to the `.gitignore`.