### PR TITLE
transpile: Dedup keywords

### DIFF
--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -29,118 +29,12 @@ pub struct TypeConverter {
     extern_crates: CrateSet,
 }
 
-pub const RESERVED_NAMES: [&str; 100] = [
-    // Keywords currently in use
-    "as",
-    "async",
-    "await",
-    "break",
-    "const",
-    "continue",
-    "crate",
-    "dyn",
-    "else",
-    "enum",
-    "extern",
-    "false",
-    "fn",
-    "for",
-    "if",
-    "impl",
-    "in",
-    "let",
-    "loop",
-    "match",
-    "mod",
-    "move",
-    "mut",
-    "pub",
-    "ref",
-    "return",
-    "self",
-    "Self",
-    "static",
-    "struct",
-    "super",
-    "trait",
-    "true",
-    "type",
-    "unsafe",
-    "use",
-    "where",
-    "while",
-    // Keywords reserved for future use
-    "abstract",
-    "become",
-    "box",
-    "do",
-    "final",
-    "gen",
-    "macro",
-    "override",
-    "priv",
-    "try",
-    "typeof",
-    "unsized",
-    "virtual",
-    "yield",
-    // Types exported in prelude
-    "Copy",
-    "Send",
-    "Sized",
-    "Sync",
-    "Drop",
-    "Fn",
-    "FnMut",
-    "FnOnce",
-    "Box",
-    "ToOwned",
-    "Clone",
-    "PartialEq",
-    "PartialOrd",
-    "Eq",
-    "Ord",
-    "AsRef",
-    "AsMut",
-    "Into",
-    "From",
-    "Default",
-    "Iterator",
-    "Extend",
-    "IntoIterator",
-    "DoubleEndedIterator",
-    "ExactSizeIterator",
-    "Option",
-    "Result",
-    "SliceConcatExt",
-    "String",
-    "ToString",
-    "Vec",
-    "bool",
-    "char",
-    "f32",
-    "f64",
-    "i8",
-    "i16",
-    "i32",
-    "i64",
-    "i128",
-    "isize",
-    "u8",
-    "u16",
-    "u32",
-    "u64",
-    "u128",
-    "usize",
-    "str",
-];
-
 impl TypeConverter {
     pub fn new(tcfg: &TranspilerConfig) -> TypeConverter {
         TypeConverter {
             edition: tcfg.edition,
             translate_valist: tcfg.translate_valist,
-            renamer: Renamer::new(&RESERVED_NAMES),
+            renamer: Renamer::type_namespace(),
             fields: HashMap::new(),
             suffix_names: HashMap::new(),
             features: HashSet::new(),
@@ -197,7 +91,7 @@ impl TypeConverter {
 
         self.fields
             .entry(record_id)
-            .or_insert_with(|| Renamer::new(&RESERVED_NAMES))
+            .or_insert_with(|| Renamer::keywords())
             .insert(FieldKey::Field(field_id), name)
             .expect("Field already declared")
     }
@@ -206,7 +100,7 @@ impl TypeConverter {
         let field = self
             .fields
             .entry(record_id)
-            .or_insert_with(|| Renamer::new(&RESERVED_NAMES));
+            .or_insert_with(|| Renamer::keywords());
         let key = FieldKey::Padding(padding_idx);
         if let Some(name) = field.get(&key) {
             name

--- a/c2rust-transpile/src/lib.rs
+++ b/c2rust-transpile/src/lib.rs
@@ -20,6 +20,7 @@ use std::process::Command;
 use std::{env, io};
 
 use crate::compile_cmds::CompileCmd;
+use crate::renamer::RUST_KEYWORDS;
 use c2rust_rust_tools::{rustfmt, RustEdition};
 use failure::{format_err, Error};
 use itertools::Itertools;
@@ -36,7 +37,6 @@ use c2rust_ast_exporter as ast_exporter;
 
 use crate::build_files::{emit_build_files, get_build_dir, CrateConfig};
 use crate::compile_cmds::get_compile_commands;
-use crate::convert_type::RESERVED_NAMES;
 pub use crate::translator::ReplaceMode;
 use std::prelude::v1::Vec;
 
@@ -248,7 +248,7 @@ fn str_to_ident_checked(s: &str, check_reserved: bool) -> String {
     let s = str_to_ident(s);
 
     // make sure the name does not clash with keywords
-    if check_reserved && RESERVED_NAMES.contains(&s.as_str()) {
+    if check_reserved && RUST_KEYWORDS.contains(&s.as_str()) {
         format!("r#{}", s)
     } else {
         s

--- a/c2rust-transpile/src/renamer.rs
+++ b/c2rust-transpile/src/renamer.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
-use std::iter::FromIterator;
 
 struct Scope<T> {
     name_map: HashMap<T, String>,
@@ -37,6 +36,125 @@ impl<T: Clone + Eq + Hash> Scope<T> {
     }
 }
 
+// Keywords obtained from https://doc.rust-lang.org/reference/keywords.html
+#[rustfmt::skip] // Preserve one keyword per line.
+pub const RUST_KEYWORDS: &[&str] = &[
+    // Strict keywords
+    "as",
+    "async", // 2018 Edition
+    "await", // 2018 Edition
+    "break",
+    "const",
+    "continue",
+    "crate",
+    "dyn", // 2018 Edition
+    "else",
+    "enum",
+    "extern",
+    "false",
+    "fn",
+    "for",
+    "if",
+    "impl",
+    "in",
+    "let",
+    "loop",
+    "match",
+    "mod",
+    "move",
+    "mut",
+    "pub",
+    "ref",
+    "return",
+    "self",
+    "Self",
+    "static",
+    "struct",
+    "super",
+    "trait",
+    "true",
+    "type",
+    "unsafe",
+    "use",
+    "where",
+    "while",
+    // Reserved keywords
+    "abstract",
+    "become",
+    "box",
+    "do",
+    "final",
+    "gen", // 2024 Edition
+    "macro",
+    "override",
+    "priv",
+    "try", // 2018 Edition
+    "typeof",
+    "unsized",
+    "virtual",
+    "yield",
+];
+
+const PRELUDE_TYPE_NAMESPACE: &[&str] = &[
+    "Copy",
+    "Send",
+    "Sized",
+    "Sync",
+    "Drop",
+    "Fn",
+    "FnMut",
+    "FnOnce",
+    "Box",
+    "ToOwned",
+    "Clone",
+    "PartialEq",
+    "PartialOrd",
+    "Eq",
+    "Ord",
+    "AsRef",
+    "AsMut",
+    "Into",
+    "From",
+    "Default",
+    "Iterator",
+    "Extend",
+    "IntoIterator",
+    "DoubleEndedIterator",
+    "ExactSizeIterator",
+    "Option",
+    "Result",
+    "SliceConcatExt",
+    "String",
+    "ToString",
+    "Vec",
+    "bool",
+    "char",
+    "f32",
+    "f64",
+    "i8",
+    "i16",
+    "i32",
+    "i64",
+    "i128",
+    "isize",
+    "u8",
+    "u16",
+    "u32",
+    "u64",
+    "u128",
+    "usize",
+    "str",
+];
+
+#[rustfmt::skip] // Preserve one symbol per line.
+const PRELUDE_VALUE_NAMESPACE: &[&str] = &[
+    "drop",
+    "Some",
+    "None",
+    "Ok",
+    "Err",
+];
+
 pub struct Renamer<T> {
     scopes: Vec<Scope<T>>,
     next_fresh: u64,
@@ -46,12 +164,32 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
     /// Creates a new renaming environment with a single, empty scope. The given set of
     /// reserved names will exclude those names from being chosen as the mangled names from
     /// the insert method.
-    pub fn new(reserved_names: &[&str]) -> Self {
-        let set: HashSet<String> = HashSet::from_iter(reserved_names.iter().map(|&x| x.to_owned()));
+    pub fn new(reserved_names: &[&[&str]]) -> Self {
+        let set = reserved_names
+            .iter()
+            .flat_map(|&names| names)
+            .map(|&s| s.to_owned())
+            .collect::<HashSet<_>>();
         Renamer {
             scopes: vec![Scope::new_with_reserved(set)],
             next_fresh: 0,
         }
+    }
+
+    pub fn keywords() -> Self {
+        Renamer::new(&[RUST_KEYWORDS])
+    }
+
+    pub fn type_namespace() -> Self {
+        Renamer::new(&[RUST_KEYWORDS, PRELUDE_TYPE_NAMESPACE])
+    }
+
+    pub fn value_namespace() -> Self {
+        Renamer::new(&[RUST_KEYWORDS, PRELUDE_VALUE_NAMESPACE])
+    }
+
+    pub fn global_value_namespace() -> Self {
+        Renamer::new(&[RUST_KEYWORDS, PRELUDE_VALUE_NAMESPACE, &["main"]])
     }
 
     /// Introduces a new name binding scope
@@ -190,7 +328,7 @@ mod tests {
 
     #[test]
     fn simple() {
-        let mut renamer = Renamer::new(&["reserved"]);
+        let mut renamer = Renamer::new(&[&["reserved"]]);
 
         let one1 = renamer.insert(1, "one").unwrap();
         let one2 = renamer.get(&1).unwrap();

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -1545,19 +1545,8 @@ impl<'c> Translation<'c> {
             type_converter: RefCell::new(type_converter),
             ast_context,
             tcfg,
-            renamer: RefCell::new(Renamer::new(&[
-                // Keywords currently in use
-                "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false",
-                "fn", "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut",
-                "pub", "ref", "return", "Self", "self", "static", "struct", "super", "trait",
-                "true", "type", "unsafe", "use", "where", "while", "dyn",
-                // Keywords reserved for future use
-                "abstract", "alignof", "become", "box", "do", "final", "macro", "offsetof",
-                "override", "priv", "proc", "pure", "sizeof", "typeof", "unsized", "virtual",
-                "async", "try", "yield", // Prevent use for other reasons
-                "main",  // prelude names
-                "drop", "Some", "None", "Ok", "Err",
-            ])),
+            // TODO: Use Renamer::value_namespace() for most renamings.
+            renamer: RefCell::new(Renamer::global_value_namespace()),
             zero_inits: RefCell::new(IndexMap::new()),
             function_context: RefCell::new(FuncContext::new()),
             potential_flexible_array_members: RefCell::new(IndexSet::new()),

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -9,7 +9,7 @@ use c2rust_rust_tools::sanitize_file_name;
 use c2rust_rust_tools::RustEdition;
 use c2rust_rust_tools::RustEdition::Edition2021;
 use c2rust_rust_tools::RustEdition::Edition2024;
-use c2rust_transpile::convert_type::RESERVED_NAMES;
+use c2rust_transpile::renamer::RUST_KEYWORDS;
 use c2rust_transpile::ReplaceMode;
 use c2rust_transpile::TranspilerConfig;
 use itertools::Itertools;
@@ -196,6 +196,7 @@ impl<'a> TranspileTest<'a> {
         }
     }
 
+    #[allow(unused)] // TODO remove once used
     pub fn expect_compile_error_edition_2024(
         self,
         expect_compile_error_edition_2024: bool,
@@ -279,12 +280,9 @@ fn generate_keywords_test() {
         "break", "const", "continue", "else", "enum", "extern", "for", "if", "return", "static",
         "struct", "while", "do", "typeof", "char",
     ];
-    // These don't work yet.  We need to fix these.
-    let broken_rust_keywords = ["await"];
-    let mut c_code = RESERVED_NAMES
+    let mut c_code = RUST_KEYWORDS
         .into_iter()
         .filter(|keyword| !c_keywords.contains(keyword))
-        .filter(|keyword| !broken_rust_keywords.contains(keyword))
         .map(|name| format!("void {name}(void) {{}}"))
         .join("\n\n");
     c_code.push_str("\n");
@@ -352,9 +350,7 @@ fn test_insertion() {
 #[test]
 fn test_keywords() {
     generate_keywords_test();
-    transpile("keywords.c")
-        .expect_compile_error_edition_2024(true)
-        .run();
+    transpile("keywords.c").run();
 }
 
 #[test]

--- a/c2rust-transpile/tests/snapshots/keywords.c
+++ b/c2rust-transpile/tests/snapshots/keywords.c
@@ -2,6 +2,8 @@ void as(void) {}
 
 void async(void) {}
 
+void await(void) {}
+
 void crate(void) {}
 
 void dyn(void) {}
@@ -71,97 +73,3 @@ void unsized(void) {}
 void virtual(void) {}
 
 void yield(void) {}
-
-void Copy(void) {}
-
-void Send(void) {}
-
-void Sized(void) {}
-
-void Sync(void) {}
-
-void Drop(void) {}
-
-void Fn(void) {}
-
-void FnMut(void) {}
-
-void FnOnce(void) {}
-
-void Box(void) {}
-
-void ToOwned(void) {}
-
-void Clone(void) {}
-
-void PartialEq(void) {}
-
-void PartialOrd(void) {}
-
-void Eq(void) {}
-
-void Ord(void) {}
-
-void AsRef(void) {}
-
-void AsMut(void) {}
-
-void Into(void) {}
-
-void From(void) {}
-
-void Default(void) {}
-
-void Iterator(void) {}
-
-void Extend(void) {}
-
-void IntoIterator(void) {}
-
-void DoubleEndedIterator(void) {}
-
-void ExactSizeIterator(void) {}
-
-void Option(void) {}
-
-void Result(void) {}
-
-void SliceConcatExt(void) {}
-
-void String(void) {}
-
-void ToString(void) {}
-
-void Vec(void) {}
-
-void bool(void) {}
-
-void f32(void) {}
-
-void f64(void) {}
-
-void i8(void) {}
-
-void i16(void) {}
-
-void i32(void) {}
-
-void i64(void) {}
-
-void i128(void) {}
-
-void isize(void) {}
-
-void u8(void) {}
-
-void u16(void) {}
-
-void u32(void) {}
-
-void u64(void) {}
-
-void u128(void) {}
-
-void usize(void) {}
-
-void str(void) {}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@keywords.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@keywords.c.2021.snap
@@ -15,6 +15,8 @@ expression: cat tests/snapshots/keywords.2021.rs
 pub unsafe extern "C" fn as_0() {}
 #[export_name = "async"]
 pub unsafe extern "C" fn async_0() {}
+#[export_name = "await"]
+pub unsafe extern "C" fn await_0() {}
 #[export_name = "crate"]
 pub unsafe extern "C" fn crate_0() {}
 #[export_name = "dyn"]
@@ -69,8 +71,8 @@ pub unsafe extern "C" fn become_0() {}
 pub unsafe extern "C" fn box_0() {}
 #[export_name = "final"]
 pub unsafe extern "C" fn final_0() {}
-#[no_mangle]
-pub unsafe extern "C" fn gen() {}
+#[export_name = "gen"]
+pub unsafe extern "C" fn gen_0() {}
 #[export_name = "macro"]
 pub unsafe extern "C" fn macro_0() {}
 #[export_name = "override"]
@@ -85,97 +87,3 @@ pub unsafe extern "C" fn unsized_0() {}
 pub unsafe extern "C" fn virtual_0() {}
 #[export_name = "yield"]
 pub unsafe extern "C" fn yield_0() {}
-#[no_mangle]
-pub unsafe extern "C" fn Copy() {}
-#[no_mangle]
-pub unsafe extern "C" fn Send() {}
-#[no_mangle]
-pub unsafe extern "C" fn Sized() {}
-#[no_mangle]
-pub unsafe extern "C" fn Sync() {}
-#[no_mangle]
-pub unsafe extern "C" fn Drop() {}
-#[no_mangle]
-pub unsafe extern "C" fn Fn() {}
-#[no_mangle]
-pub unsafe extern "C" fn FnMut() {}
-#[no_mangle]
-pub unsafe extern "C" fn FnOnce() {}
-#[no_mangle]
-pub unsafe extern "C" fn Box() {}
-#[no_mangle]
-pub unsafe extern "C" fn ToOwned() {}
-#[no_mangle]
-pub unsafe extern "C" fn Clone() {}
-#[no_mangle]
-pub unsafe extern "C" fn PartialEq() {}
-#[no_mangle]
-pub unsafe extern "C" fn PartialOrd() {}
-#[no_mangle]
-pub unsafe extern "C" fn Eq() {}
-#[no_mangle]
-pub unsafe extern "C" fn Ord() {}
-#[no_mangle]
-pub unsafe extern "C" fn AsRef() {}
-#[no_mangle]
-pub unsafe extern "C" fn AsMut() {}
-#[no_mangle]
-pub unsafe extern "C" fn Into() {}
-#[no_mangle]
-pub unsafe extern "C" fn From() {}
-#[no_mangle]
-pub unsafe extern "C" fn Default() {}
-#[no_mangle]
-pub unsafe extern "C" fn Iterator() {}
-#[no_mangle]
-pub unsafe extern "C" fn Extend() {}
-#[no_mangle]
-pub unsafe extern "C" fn IntoIterator() {}
-#[no_mangle]
-pub unsafe extern "C" fn DoubleEndedIterator() {}
-#[no_mangle]
-pub unsafe extern "C" fn ExactSizeIterator() {}
-#[no_mangle]
-pub unsafe extern "C" fn Option() {}
-#[no_mangle]
-pub unsafe extern "C" fn Result() {}
-#[no_mangle]
-pub unsafe extern "C" fn SliceConcatExt() {}
-#[no_mangle]
-pub unsafe extern "C" fn String() {}
-#[no_mangle]
-pub unsafe extern "C" fn ToString() {}
-#[no_mangle]
-pub unsafe extern "C" fn Vec() {}
-#[no_mangle]
-pub unsafe extern "C" fn bool() {}
-#[no_mangle]
-pub unsafe extern "C" fn f32() {}
-#[no_mangle]
-pub unsafe extern "C" fn f64() {}
-#[no_mangle]
-pub unsafe extern "C" fn i8() {}
-#[no_mangle]
-pub unsafe extern "C" fn i16() {}
-#[no_mangle]
-pub unsafe extern "C" fn i32() {}
-#[no_mangle]
-pub unsafe extern "C" fn i64() {}
-#[no_mangle]
-pub unsafe extern "C" fn i128() {}
-#[no_mangle]
-pub unsafe extern "C" fn isize() {}
-#[no_mangle]
-pub unsafe extern "C" fn u8() {}
-#[no_mangle]
-pub unsafe extern "C" fn u16() {}
-#[no_mangle]
-pub unsafe extern "C" fn u32() {}
-#[no_mangle]
-pub unsafe extern "C" fn u64() {}
-#[no_mangle]
-pub unsafe extern "C" fn u128() {}
-#[no_mangle]
-pub unsafe extern "C" fn usize() {}
-#[no_mangle]
-pub unsafe extern "C" fn str() {}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@keywords.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@keywords.c.2024.snap
@@ -15,6 +15,8 @@ expression: cat tests/snapshots/keywords.2024.rs
 pub unsafe extern "C" fn as_0() {}
 #[unsafe(export_name = "async")]
 pub unsafe extern "C" fn async_0() {}
+#[unsafe(export_name = "await")]
+pub unsafe extern "C" fn await_0() {}
 #[unsafe(export_name = "crate")]
 pub unsafe extern "C" fn crate_0() {}
 #[unsafe(export_name = "dyn")]
@@ -69,8 +71,8 @@ pub unsafe extern "C" fn become_0() {}
 pub unsafe extern "C" fn box_0() {}
 #[unsafe(export_name = "final")]
 pub unsafe extern "C" fn final_0() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn gen() {}
+#[unsafe(export_name = "gen")]
+pub unsafe extern "C" fn gen_0() {}
 #[unsafe(export_name = "macro")]
 pub unsafe extern "C" fn macro_0() {}
 #[unsafe(export_name = "override")]
@@ -85,97 +87,3 @@ pub unsafe extern "C" fn unsized_0() {}
 pub unsafe extern "C" fn virtual_0() {}
 #[unsafe(export_name = "yield")]
 pub unsafe extern "C" fn yield_0() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Copy() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Send() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Sized() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Sync() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Drop() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Fn() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn FnMut() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn FnOnce() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Box() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn ToOwned() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Clone() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn PartialEq() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn PartialOrd() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Eq() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Ord() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn AsRef() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn AsMut() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Into() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn From() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Default() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Iterator() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Extend() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn IntoIterator() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn DoubleEndedIterator() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn ExactSizeIterator() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Option() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Result() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn SliceConcatExt() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn String() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn ToString() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn Vec() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn bool() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn f32() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn f64() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn i8() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn i16() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn i32() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn i64() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn i128() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn isize() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn u8() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn u16() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn u32() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn u64() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn u128() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn usize() {}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn str() {}


### PR DESCRIPTION
This change extracts keywords into `c2rust-transpile::RUST_KEYWORDS` and reduces the amount of renaming in a few places. If I have understood the code correctly, `RESERVED_NAMES` should have only been used when renaming types, but it was also being used when renaming field names and module names.