### PR TITLE
postprocess: add `--enable-llm`/`$C2RUST_POSTPROCESS_ENABLE_LLM` to make LLM usage explicitly opt-in

### DIFF
--- a/c2rust-postprocess/postprocess/__init__.py
+++ b/c2rust-postprocess/postprocess/__init__.py
@@ -4,7 +4,8 @@ c2rust-postprocess: Transfer comments from C functions to Rust functions using L
 
 import argparse
 import logging
-from argparse import BooleanOptionalAction
+import os
+from argparse import ArgumentTypeError, BooleanOptionalAction
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -20,6 +21,20 @@ from postprocess.transforms import (
     CommentTransfer,
 )
 from postprocess.utils import existing_file
+
+
+def parse_booly(arg: str) -> bool:
+    """
+    Parse a "booly"/bool-like value, meant for CLI args and environment variables.
+    """
+
+    match arg.lower():
+        case "true" | "1" | "yes" | "y":
+            return True
+        case "false" | "0" | "no" | "n" | "":
+            return False
+        case _:
+            raise ArgumentTypeError(f"booly value expected, got '{arg}'")
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
@@ -66,6 +81,20 @@ def build_arg_parser() -> argparse.ArgumentParser:
         required=False,
         default="gemini-3-flash-preview",
         help="ID of the LLM model to use (default: gemini-3-flash-preview)",
+    )
+
+    # Explicitly require opt-in to LLM usage.
+    # This can be set via an environment variable to a "booly" value
+    # or via a CLI argument.
+    enable_llm_env_var = "C2RUST_POSTPROCESS_ENABLE_LLM"
+    enable_llm_default = parse_booly(os.getenv(enable_llm_env_var) or "")
+    parser.add_argument(
+        "--enable-llm",
+        default=enable_llm_default,
+        required=False,
+        action=BooleanOptionalAction,
+        help="explicitly opt into LLM usage"
+        f" (can also set {enable_llm_env_var}, default: {enable_llm_default})",
     )
 
     parser.add_argument(
@@ -129,7 +158,7 @@ def main(argv: Sequence[str] | None = None):
         if not args.update_cache:
             cache = FrozenCache(cache)
 
-        model = get_model(args.llm_model)
+        model = get_model(args.llm_model) if args.enable_llm else MockGenerativeModel()
 
         # TODO: instantiate transform(s) based on command line args
         xform = CommentTransfer(cache, model)


### PR DESCRIPTION
We had discussed adding a `$C2RUST_POSTPROCESS_LLM_MODEL` environment variable to make LLM usage explicitly opt-in, but having it be the model argument meant that we couldn't set a default for it, which is convenient, so I added a boolean `--enable-llm`/`$C2RUST_POSTPROCESS_ENABLE_LLM` arg instead.  I also renamed `--model-id` to `--llm-model` to be more explicit about LLM usage there as well.  If specifying the specific model is important to make explicit, though, I could switch to that version instead, though.