### PR TITLE
transpile: Configure generated `Cargo.toml` to strip debug info

### DIFF
--- a/c2rust-transpile/src/build_files/Cargo.toml.hbs
+++ b/c2rust-transpile/src/build_files/Cargo.toml.hbs
@@ -55,3 +55,6 @@ features = ["libc-hash", "fixed-length-array-hash"]
 version = "*"
 {{~/if}}
 {{~/if}}
+
+[profile.release]
+strip = "debuginfo"


### PR DESCRIPTION
Looks like with the toolchain we're on binaries have debug info by default, which results in very large binaries even in release builds. This PR updates our `Cargo.toml` template to include `strip = "debuginfo"` for the release profile. I've tested this against a hello world binary and confirmed that this reduces the release binary size from ~4 MB to ~300 KB.