### PR TITLE
refactor: Don't require `#[no_mangle]` when converting libc funcs

### DIFF
--- a/c2rust-refactor/src/ast_manip/visit_node.rs
+++ b/c2rust-refactor/src/ast_manip/visit_node.rs
@@ -190,9 +190,6 @@ where
     });
 
     visit_nodes(target, |fi: &ForeignItem| {
-        if !crate::util::contains_name(&fi.attrs, sym::no_mangle) {
-            return;
-        }
         let ForeignItemKind::Fn(_) = fi.kind else {
             return;
         };

--- a/c2rust-refactor/tests/snapshots/convert_exits.rs
+++ b/c2rust-refactor/tests/snapshots/convert_exits.rs
@@ -1,9 +1,7 @@
 #![allow(unused)]
 
 extern "C" {
-    #[no_mangle]
     fn abort() -> !;
-    #[no_mangle]
     fn exit(status: i32) -> !;
 }
 

--- a/c2rust-refactor/tests/snapshots/convert_exits_skip.rs
+++ b/c2rust-refactor/tests/snapshots/convert_exits_skip.rs
@@ -1,9 +1,7 @@
 #![allow(unused)]
 
 extern "C" {
-    #[no_mangle]
     fn abort() -> !;
-    #[no_mangle]
     fn exit(status: i32) -> !;
 }
 

--- a/c2rust-refactor/tests/snapshots/convert_math_funcs.rs
+++ b/c2rust-refactor/tests/snapshots/convert_math_funcs.rs
@@ -1,61 +1,33 @@
 #![allow(unused)]
 
 extern "C" {
-    #[no_mangle]
     fn sin(x: f64) -> f64;
-    #[no_mangle]
     fn sinf(x: f32) -> f32;
-    #[no_mangle]
     fn cos(x: f64) -> f64;
-    #[no_mangle]
     fn tan(x: f64) -> f64;
-    #[no_mangle]
     fn asin(x: f64) -> f64;
-    #[no_mangle]
     fn acos(x: f64) -> f64;
-    #[no_mangle]
     fn atan(x: f64) -> f64;
-    #[no_mangle]
     fn sinh(x: f64) -> f64;
-    #[no_mangle]
     fn cosh(x: f64) -> f64;
-    #[no_mangle]
     fn tanh(x: f64) -> f64;
-    #[no_mangle]
     fn sqrt(x: f64) -> f64;
-    #[no_mangle]
     fn pow(x: f64, y: f64) -> f64;
-    #[no_mangle]
     fn log(x: f64) -> f64;
-    #[no_mangle]
     fn exp(x: f64) -> f64;
-    #[no_mangle]
     fn fabs(x: f64) -> f64;
-    #[no_mangle]
     fn abs(x: i32) -> i32;
-    #[no_mangle]
     fn labs(x: i64) -> i64;
-    #[no_mangle]
     fn llabs(x: i64) -> i64;
-    #[no_mangle]
     fn floor(x: f64) -> f64;
-    #[no_mangle]
     fn floorf(x: f32) -> f32;
-    #[no_mangle]
     fn ceil(x: f64) -> f64;
-    #[no_mangle]
     fn ceilf(x: f32) -> f32;
-    #[no_mangle]
     fn round(x: f64) -> f64;
-    #[no_mangle]
     fn trunc(x: f64) -> f64;
-    #[no_mangle]
     fn truncf(x: f32) -> f32;
-    #[no_mangle]
     fn atan2(y: f64, x: f64) -> f64;
-    #[no_mangle]
     fn hypot(x: f64, y: f64) -> f64;
-    #[no_mangle]
     fn fmax(x: f64, y: f64) -> f64;
 }
 

--- a/c2rust-refactor/tests/snapshots/convert_math_skip.rs
+++ b/c2rust-refactor/tests/snapshots/convert_math_skip.rs
@@ -11,7 +11,6 @@ mod custom_math {
     }
 }
 extern "C" {
-    #[no_mangle]
     fn sin(x: f64) -> f64;
 }
 

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-convert_exits-convert_exits_skip.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-convert_exits-convert_exits_skip.rs.snap
@@ -5,9 +5,7 @@ expression: c2rust-refactor convert_exits --rewrite-mode alongside -- tests/snap
 #![allow(unused)]
 
 extern "C" {
-    #[no_mangle]
     fn abort() -> !;
-    #[no_mangle]
     fn exit(status: i32) -> !;
 }
 

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-convert_exits.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-convert_exits.rs.snap
@@ -5,9 +5,7 @@ expression: c2rust-refactor convert_exits --rewrite-mode alongside -- tests/snap
 #![allow(unused)]
 
 extern "C" {
-    #[no_mangle]
     fn abort() -> !;
-    #[no_mangle]
     fn exit(status: i32) -> !;
 }
 

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-convert_math_funcs-convert_math_skip.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-convert_math_funcs-convert_math_skip.rs.snap
@@ -15,7 +15,6 @@ mod custom_math {
     }
 }
 extern "C" {
-    #[no_mangle]
     fn sin(x: f64) -> f64;
 }
 

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-convert_math_funcs.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-convert_math_funcs.rs.snap
@@ -5,61 +5,33 @@ expression: c2rust-refactor convert_math_funcs --rewrite-mode alongside -- tests
 #![allow(unused)]
 
 extern "C" {
-    #[no_mangle]
     fn sin(x: f64) -> f64;
-    #[no_mangle]
     fn sinf(x: f32) -> f32;
-    #[no_mangle]
     fn cos(x: f64) -> f64;
-    #[no_mangle]
     fn tan(x: f64) -> f64;
-    #[no_mangle]
     fn asin(x: f64) -> f64;
-    #[no_mangle]
     fn acos(x: f64) -> f64;
-    #[no_mangle]
     fn atan(x: f64) -> f64;
-    #[no_mangle]
     fn sinh(x: f64) -> f64;
-    #[no_mangle]
     fn cosh(x: f64) -> f64;
-    #[no_mangle]
     fn tanh(x: f64) -> f64;
-    #[no_mangle]
     fn sqrt(x: f64) -> f64;
-    #[no_mangle]
     fn pow(x: f64, y: f64) -> f64;
-    #[no_mangle]
     fn log(x: f64) -> f64;
-    #[no_mangle]
     fn exp(x: f64) -> f64;
-    #[no_mangle]
     fn fabs(x: f64) -> f64;
-    #[no_mangle]
     fn abs(x: i32) -> i32;
-    #[no_mangle]
     fn labs(x: i64) -> i64;
-    #[no_mangle]
     fn llabs(x: i64) -> i64;
-    #[no_mangle]
     fn floor(x: f64) -> f64;
-    #[no_mangle]
     fn floorf(x: f32) -> f32;
-    #[no_mangle]
     fn ceil(x: f64) -> f64;
-    #[no_mangle]
     fn ceilf(x: f32) -> f32;
-    #[no_mangle]
     fn round(x: f64) -> f64;
-    #[no_mangle]
     fn trunc(x: f64) -> f64;
-    #[no_mangle]
     fn truncf(x: f32) -> f32;
-    #[no_mangle]
     fn atan2(y: f64, x: f64) -> f64;
-    #[no_mangle]
     fn hypot(x: f64, y: f64) -> f64;
-    #[no_mangle]
     fn fmax(x: f64, y: f64) -> f64;
 }
 


### PR DESCRIPTION
Turns out we don't generate `#[no_mangle]` attributes in the `extern "C"` blocks because extern decls are automatically no-mangle. This updates the logic in `visit_foreign_fns` to not require `#[no_mangle]`, and updates the tests accordingly.