### PR TITLE
transpile: fix variadics in edition 2024

### DIFF
--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -6,6 +6,7 @@ use crate::translator::variadic::mk_va_list_ty;
 use crate::TranspilerConfig;
 use crate::{CrateSet, ExternCrate};
 use c2rust_ast_builder::{mk, properties::*};
+use c2rust_rust_tools::RustEdition;
 use failure::format_err;
 use indexmap::IndexSet;
 use std::collections::{HashMap, HashSet};
@@ -19,6 +20,7 @@ enum FieldKey {
 }
 
 pub struct TypeConverter {
+    pub edition: RustEdition,
     pub translate_valist: bool,
     renamer: Renamer<CDeclId>,
     fields: HashMap<CDeclId, Renamer<FieldKey>>,
@@ -136,6 +138,7 @@ pub const RESERVED_NAMES: [&str; 100] = [
 impl TypeConverter {
     pub fn new(tcfg: &TranspilerConfig) -> TypeConverter {
         TypeConverter {
+            edition: tcfg.edition,
             translate_valist: tcfg.translate_valist,
             renamer: Renamer::new(&RESERVED_NAMES),
             fields: HashMap::new(),
@@ -313,7 +316,7 @@ impl TypeConverter {
         ctype: CTypeId,
     ) -> TranslationResult<Box<Type>> {
         if self.translate_valist && ctxt.is_va_list(ctype) {
-            return Ok(mk_va_list_ty(None));
+            return Ok(mk_va_list_ty(self.edition, None));
         }
 
         match ctxt.index(ctype).kind {

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -360,7 +360,7 @@ impl<'c> Translation<'c> {
             "__builtin_va_end" => {
                 if ctx.is_unused() && args.len() == 1 {
                     if let Some(_va_id) = self.match_vaend(args[0]) {
-                        // nothing to do since `VaListImpl`s get `Drop`'ed.
+                        // nothing to do since the translated Rust `va_list` values get `Drop`'ed.
                         return Ok(WithStmts::new_val(self.panic("va_end stub")));
                     }
                 }

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -32,7 +32,7 @@ use crate::rust_ast::item_store::ItemStore;
 use crate::rust_ast::set_span::SetSpan;
 use crate::rust_ast::{pos_to_span, SpanExt};
 use crate::translator::named_references::NamedReference;
-use crate::translator::variadic::{mk_va_list_ty, mk_va_list_copy};
+use crate::translator::variadic::{mk_va_list_copy, mk_va_list_ty};
 use c2rust_ast_builder::{mk, properties::*, Builder};
 use c2rust_ast_printer::pprust;
 
@@ -2894,9 +2894,9 @@ impl<'c> Translation<'c> {
                     .unwrap_or_else(|| panic!("Failed to insert variable '{}'", ident));
 
                 if self.ast_context.is_va_list(typ.ctype) {
-                    // translate `va_list` variables to `VaListImpl`s and omit the initializer.
+                    // Translate `va_list` variables to the current Rust `va_list` type and omit the initializer.
                     let pat_mut = mk().mutbl().ident_pat(rust_name);
-                    let ty = mk_va_list_ty(None);
+                    let ty = mk_va_list_ty(self.tcfg.edition, None);
                     let local_mut = mk().local(pat_mut, Some(ty), None);
 
                     return Ok(cfg::DeclStmtInfo::new(
@@ -4136,7 +4136,7 @@ impl<'c> Translation<'c> {
         {
             // No `override_ty` to avoid unwanted casting.
             val = self.convert_expr(ctx, expr_id, None)?;
-            val = val.map(mk_va_list_copy);
+            val = val.map(|val| mk_va_list_copy(self.tcfg.edition, val));
         } else {
             val = self.convert_expr(ctx, expr_id, override_ty)?;
         }

--- a/c2rust-transpile/src/translator/structs_unions.rs
+++ b/c2rust-transpile/src/translator/structs_unions.rs
@@ -859,7 +859,7 @@ impl<'a> Translation<'a> {
                 // TODO: handle or panic on structs with more than one va_list?
                 let is_va_list = self.ast_context.is_va_list(ctype);
                 let mut ty = if is_va_list {
-                    mk_va_list_ty(Some("a"))
+                    mk_va_list_ty(self.tcfg.edition, Some("a"))
                 } else {
                     self.convert_type(ctype)?
                 };

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -22,7 +22,15 @@ macro_rules! match_or {
     };
 }
 
-pub fn mk_va_list_ty(lifetime: Option<&str>) -> Box<Type> {
+pub fn mk_va_list_ty(edition: RustEdition, lifetime: Option<&str>) -> Box<Type> {
+    // This was updated in <https://github.com/rust-lang/rust/pull/141980>,
+    // first changed in `nightly-2025-12-07`.
+    // `VaListImpl` was removed.
+    let name = if edition < Edition2024 {
+        "VaListImpl"
+    } else {
+        "VaList"
+    };
     let lifetime_args = match lifetime {
         None => vec![],
         Some(lifetime) => vec![mk().lifetime(lifetime)],
@@ -30,12 +38,20 @@ pub fn mk_va_list_ty(lifetime: Option<&str>) -> Box<Type> {
     mk().abs_path_ty(vec![
         mk().path_segment("core"),
         mk().path_segment("ffi"),
-        mk().path_segment_with_args("VaListImpl", mk().angle_bracketed_args(lifetime_args)),
+        mk().path_segment_with_args(name, mk().angle_bracketed_args(lifetime_args)),
     ])
 }
 
-pub fn mk_va_list_copy(va_list: Box<Expr>) -> Box<Expr> {
-    mk().method_call_expr(va_list, "as_va_list", vec![])
+pub fn mk_va_list_copy(edition: RustEdition, va_list: Box<Expr>) -> Box<Expr> {
+    // This was updated in <https://github.com/rust-lang/rust/pull/141980>,
+    // first changed in `nightly-2025-12-07`.
+    // `VaListImpl` was removed and `.as_va_list()` was replaced with `.clone()`.
+    let name = if edition < Edition2024 {
+        "as_va_list"
+    } else {
+        "clone"
+    };
+    mk().method_call_expr(va_list, name, vec![])
 }
 
 impl<'c> Translation<'c> {
@@ -248,7 +264,7 @@ impl<'c> Translation<'c> {
     /// Update the current function context by
     /// * enabling the C variadics feature
     /// * naming the Rust function argument that corresponds to the ellipsis in the original C function
-    /// * building a list of variable declarations to be translated into `VaListImpl`s.
+    /// * building a list of variable declarations to be translated into the current Rust `va_list` type.
     ///
     /// Returns the name of the `VaList` function argument for convenience.
     pub fn register_va_decls(&self, body: CStmtId) -> String {

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -468,7 +468,6 @@ fn test_wide_strings() {
 #[test]
 fn test_varargs() {
     transpile("varargs.c")
-        .expect_compile_error_edition_2024(cfg!(target_os = "linux"))
         .arch_specific(true)
         .os_specific(true)
         .run();

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2024.x86_64.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2024.x86_64.linux.snap
@@ -33,7 +33,7 @@ pub type size_t = usize;
 #[derive()]
 #[repr(C)]
 pub struct vastruct<'a> {
-    pub args: ::core::ffi::VaListImpl<'a>,
+    pub args: ::core::ffi::VaList<'a>,
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn call_printf() {
@@ -48,20 +48,20 @@ pub unsafe extern "C" fn my_vprintf(
     mut format: *const ::core::ffi::c_char,
     mut ap: ::core::ffi::VaList,
 ) {
-    vprintf(format, ap.as_va_list());
+    vprintf(format, ap.clone());
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn call_vprintf(
     mut format: *const ::core::ffi::c_char,
     mut c2rust_args: ...
 ) {
-    let mut ap: ::core::ffi::VaListImpl;
+    let mut ap: ::core::ffi::VaList;
     ap = c2rust_args.clone();
-    my_vprintf(format, ap.as_va_list());
+    my_vprintf(format, ap.clone());
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn my_printf(mut fmt: *const ::core::ffi::c_char, mut c2rust_args: ...) {
-    let mut ap: ::core::ffi::VaListImpl;
+    let mut ap: ::core::ffi::VaList;
     ap = c2rust_args.clone();
     while *fmt != 0 {
         match *fmt as ::core::ffi::c_int {
@@ -100,12 +100,12 @@ pub unsafe extern "C" fn my_printf(mut fmt: *const ::core::ffi::c_char, mut c2ru
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn simple_vacopy(mut fmt: *const ::core::ffi::c_char, mut c2rust_args: ...) {
-    let mut ap: ::core::ffi::VaListImpl;
-    let mut aq: ::core::ffi::VaListImpl;
+    let mut ap: ::core::ffi::VaList;
+    let mut aq: ::core::ffi::VaList;
     ap = c2rust_args.clone();
     aq = ap.clone();
-    vprintf(fmt, ap.as_va_list());
-    vprintf(fmt, aq.as_va_list());
+    vprintf(fmt, ap.clone());
+    vprintf(fmt, aq.clone());
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn valist_struct_member(
@@ -120,8 +120,8 @@ pub unsafe extern "C" fn valist_struct_member(
     };
     a.args = c2rust_args.clone();
     b.args = a.args.clone();
-    vprintf(fmt, a.args.as_va_list());
-    vprintf(fmt, b.args.as_va_list());
+    vprintf(fmt, a.args.clone());
+    vprintf(fmt, b.args.clone());
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn valist_struct_pointer_member(
@@ -138,19 +138,19 @@ pub unsafe extern "C" fn valist_struct_pointer_member(
     let mut q: *mut vastruct = &raw mut b;
     (*p).args = c2rust_args.clone();
     (*q).args = (*p).args.clone();
-    vprintf(fmt, (*p).args.as_va_list());
-    vprintf(fmt, (*q).args.as_va_list());
+    vprintf(fmt, (*p).args.clone());
+    vprintf(fmt, (*q).args.clone());
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn restart_valist(mut fmt: *const ::core::ffi::c_char, mut c2rust_args: ...) {
-    let mut ap: ::core::ffi::VaListImpl;
+    let mut ap: ::core::ffi::VaList;
     ap = c2rust_args.clone();
-    vprintf(fmt, ap.as_va_list());
+    vprintf(fmt, ap.clone());
     ap = c2rust_args.clone();
-    vprintf(fmt, ap.as_va_list());
+    vprintf(fmt, ap.clone());
 }
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn print_int(mut ap: *mut ::core::ffi::VaListImpl) {
+pub unsafe extern "C" fn print_int(mut ap: *mut ::core::ffi::VaList) {
     printf(
         b"%d\0".as_ptr() as *const ::core::ffi::c_char,
         (*ap).arg::<::core::ffi::c_int>(),
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn print_int(mut ap: *mut ::core::ffi::VaListImpl) {
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn borrowed_valist(mut count: size_t, mut c2rust_args: ...) {
-    let mut ap: ::core::ffi::VaListImpl;
+    let mut ap: ::core::ffi::VaList;
     ap = c2rust_args.clone();
     while count > 0 as size_t {
         print_int(&raw mut ap);

--- a/tests/unit/items/Cargo.toml
+++ b/tests/unit/items/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "items-tests"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]

--- a/tests/unit/items/src/test_fn_attrs.rs
+++ b/tests/unit/items/src/test_fn_attrs.rs
@@ -164,7 +164,7 @@ unsafe extern "C" fn rust_gnu_inline_non_canonical_definition_extern
         let aliased_fn_syntax = |public| {
             format!(
                 r#"
-extern "C" {{
+unsafe extern "C" {{
     #[link_name = "inline_extern"]
     {}fn aliased_fn();
 "#,

--- a/tests/unit/items/src/test_functions.rs
+++ b/tests/unit/items/src/test_functions.rs
@@ -1,7 +1,7 @@
 use crate::functions::rust_coreutils_static_assert;
 
 #[link(name = "test")]
-extern "C" {
+unsafe extern "C" {
     fn coreutils_static_assert();
 }
 

--- a/tests/unit/items/src/test_linking.rs
+++ b/tests/unit/items/src/test_linking.rs
@@ -2,7 +2,7 @@ use crate::linking::{rust_l, rust_w};
 use std::ffi::c_int;
 
 #[link(name = "test")]
-extern "C" {
+unsafe extern "C" {
     fn l() -> c_int;
 
     fn w() -> c_int;

--- a/tests/unit/items/src/test_noop.rs
+++ b/tests/unit/items/src/test_noop.rs
@@ -4,7 +4,7 @@ use crate::noop::rust_noop;
 use std::ffi::c_int;
 
 #[link(name = "test")]
-extern "C" {
+unsafe extern "C" {
     fn noop();
 
     fn nofnargs() -> c_int;

--- a/tests/unit/items/src/test_varargs.rs
+++ b/tests/unit/items/src/test_varargs.rs
@@ -13,14 +13,14 @@ use std::ffi::c_char;
 use std::ffi::CString;
 
 #[link(name = "test")]
-extern "C" {
+unsafe extern "C" {
     fn call_printf();
 }
 
 // See #1281. Varargs don't yet work on aarch64.
 #[cfg(not(target_arch = "aarch64"))]
 #[link(name = "test")]
-extern "C" {
+unsafe extern "C" {
     fn call_vprintf(_: *const c_char, ...);
 
     fn my_printf(_: *const c_char, ...);


### PR DESCRIPTION
`VaListImpl` was removed by https://github.com/rust-lang/rust/pull/141980 in `nightly-2025-12-07`, so for the `nightly-2026-03-03` we're using for `--edition 2024`, we need to switch from `VaListImpl` to `VaList` and from `.as_va_list()` to `.clone()`.  However, this isn't a change strictly tied to the edition change, but just `rustc` changing over time, so we may want to introduce a `--nightly-toolchain` or similar argument in addition to `--edition` to control this, in case `nightly-2025-12-06` with `--edition 2024` is desired, for example.  This is also true of a bunch of other changes, like
* `#![feature(stdsimd)]` split/stabilized
* `#![feature(raw_ref_op)]` stabilized
* `#![feature(label_break_value)]` stabilized
* `#![feature(asm)]` stabilized
* `core::intrinsics::pref_align_of` removed
* atomic `core::intrinsics` changed
* `[profile.release] strip = "debuginfo"` made the default