### PR TITLE
transpile: remove unused Handlebars inputs `reorganize_definitions` and `translate_valist`

### DIFF
--- a/c2rust-transpile/src/build_files/mod.rs
+++ b/c2rust-transpile/src/build_files/mod.rs
@@ -265,8 +265,6 @@ fn emit_lib_rs(
     let rs_xcheck_backend = tcfg.cross_check_backend.replace('-', "_");
     let json = json!({
         "lib_rs_file": file_name,
-        "reorganize_definitions": tcfg.reorganize_definitions,
-        "translate_valist": tcfg.translate_valist,
         "cross_checks": tcfg.cross_checks,
         "cross_check_backend": rs_xcheck_backend,
         "plugin_args": plugin_args,


### PR DESCRIPTION
`reorganize_definitions` was removed (noted here: https://github.com/immunant/c2rust/pull/1640#discussion_r2934439912) and `translate_valist` appears to be unused, too.