### PR TITLE
transpile: Compute and store `override_ty`s ahead of time

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1383,6 +1383,18 @@ impl TypedAstContext {
             _ => false,
         }
     }
+
+    /// Same as the `Index` trait, but doesn't bypass `Paren`.
+    pub fn index_expr_raw(&self, index: CExprId) -> &CExpr {
+        static BADEXPR: CExpr = Located {
+            loc: None,
+            kind: CExprKind::BadExpr,
+        };
+        match self.c_exprs.get(&index) {
+            None => &BADEXPR,
+            Some(e) => e,
+        }
+    }
 }
 
 impl CommentContext {

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1366,6 +1366,23 @@ impl TypedAstContext {
         }
         false
     }
+
+    /// Return whether the literal can be directly translated as this type.
+    pub fn literal_matches_ty(&self, lit: &CLiteral, ty: CQualTypeId, is_negated: bool) -> bool {
+        let ty_kind = &self.resolve_type(ty.ctype).kind;
+        match *lit {
+            CLiteral::Integer(value, _) | CLiteral::Character(value)
+                if ty_kind.is_integral_type() && !ty_kind.is_bool() =>
+            {
+                ty_kind.guaranteed_integer_in_range(value)
+                    && (!is_negated || ty_kind.is_signed_integral_type())
+            }
+            CLiteral::Floating(value, _) if ty_kind.is_floating_type() => {
+                ty_kind.guaranteed_float_in_range(value)
+            }
+            _ => false,
+        }
+    }
 }
 
 impl CommentContext {

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -616,9 +616,7 @@ impl Cfg<Label, StmtOrDecl> {
                         wip.body.push(StmtOrDecl::Stmt(mk().semi_stmt(ret_expr)));
                     }
                     ImplicitReturnType::StmtExpr(ctx, expr_id, brk_label) => {
-                        let (stmts, val) = translator
-                            .convert_expr(ctx, expr_id, None)?
-                            .discard_unsafe();
+                        let (stmts, val) = translator.convert_expr(ctx, expr_id)?.discard_unsafe();
 
                         wip.body.extend(stmts.into_iter().map(StmtOrDecl::Stmt));
                         wip.body.push(StmtOrDecl::Stmt(mk().semi_stmt(
@@ -1420,7 +1418,7 @@ impl CfgBuilder {
             }
 
             CStmtKind::Return(expr) => {
-                let val = match expr.map(|i| translator.convert_expr(ctx.used(), i, ret_ty)) {
+                let val = match expr.map(|i| translator.convert_expr(ctx.used(), i)) {
                     Some(r) => Some(r?),
                     None => None,
                 };
@@ -1684,9 +1682,8 @@ impl CfgBuilder {
                     match increment {
                         None => slf.add_block(incr_entry, BasicBlock::new_jump(cond_entry)),
                         Some(incr) => {
-                            let incr_stmts = translator
-                                .convert_expr(ctx.unused(), incr, None)?
-                                .into_stmts();
+                            let incr_stmts =
+                                translator.convert_expr(ctx.unused(), incr)?.into_stmts();
                             let mut incr_wip = slf.new_wip_block(incr_entry);
                             incr_wip.extend(incr_stmts);
                             slf.add_wip_block(incr_wip, Jump(cond_entry));
@@ -1797,11 +1794,7 @@ impl CfgBuilder {
                 match blk_or_wip {
                     Ok(blk) => Ok(blk),
                     Err(mut wip) => {
-                        wip.extend(
-                            translator
-                                .convert_expr(ctx.unused(), expr, None)?
-                                .into_stmts(),
-                        );
+                        wip.extend(translator.convert_expr(ctx.unused(), expr)?.into_stmts());
 
                         // If we can tell the expression is going to diverge, there is no falling through to
                         // the next block.
@@ -1861,7 +1854,7 @@ impl CfgBuilder {
                 let branch = match translator.ast_context.index(resolved).kind {
                     CExprKind::Literal(..) | CExprKind::ConstantExpr(_, _, Some(_)) => {
                         match translator
-                            .convert_expr(ctx.used(), resolved, None)?
+                            .convert_expr(ctx.used(), resolved)?
                             .to_pure_expr()
                         {
                             Some(expr) => match *expr {
@@ -1939,7 +1932,7 @@ impl CfgBuilder {
 
                 // Convert the condition
                 let (stmts, val) = translator
-                    .convert_expr(ctx.used(), scrutinee, None)?
+                    .convert_expr(ctx.used(), scrutinee)?
                     .discard_unsafe();
                 wip.extend(stmts);
 

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -874,7 +874,7 @@ impl<'c> Translation<'c> {
 
             // First, convert output expr if present
             let out_expr = if let Some((output_idx, out_expr)) = operand.out_expr {
-                let mut out_expr = self.convert_expr(ctx.used(), out_expr, None)?;
+                let mut out_expr = self.convert_expr(ctx.used(), out_expr)?;
                 stmts.append(out_expr.stmts_mut());
                 let mut out_expr = out_expr.into_value();
 
@@ -921,7 +921,7 @@ impl<'c> Translation<'c> {
 
             // Then, handle input expr if present
             let in_expr = if let Some((input_idx, in_expr)) = operand.in_expr {
-                let mut in_expr = self.convert_expr(ctx.used(), in_expr, None)?;
+                let mut in_expr = self.convert_expr(ctx.used(), in_expr)?;
                 stmts.append(in_expr.stmts_mut());
                 let mut in_expr = in_expr.into_value();
 

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -144,14 +144,14 @@ impl<'c> Translation<'c> {
         val2_id: Option<CExprId>,
         weak_id: Option<CExprId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let ptr = self.convert_expr(ctx.used(), ptr_id, None)?;
+        let ptr = self.convert_expr(ctx.used(), ptr_id)?;
         let order = self.convert_memordering(order_id);
         let val1 = val1_id
-            .map(|x| self.convert_expr(ctx.used(), x, None))
+            .map(|x| self.convert_expr(ctx.used(), x))
             .transpose()?;
         let order_fail = order_fail_id.and_then(|x| self.convert_memordering(x));
         let val2 = val2_id
-            .map(|x| self.convert_expr(ctx.used(), x, None))
+            .map(|x| self.convert_expr(ctx.used(), x))
             .transpose()?;
         let weak = weak_id.and_then(|x| self.convert_constant_bool(x));
 
@@ -237,7 +237,7 @@ impl<'c> Translation<'c> {
                     if name == "__atomic_exchange" {
                         // LLVM stores the ret pointer in the order_fail slot
                         order_fail_id
-                            .map(|x| self.convert_expr(ctx.used(), x, None))
+                            .map(|x| self.convert_expr(ctx.used(), x))
                             .transpose()?
                             .expect("__atomic_exchange must have a ret pointer argument")
                             .and_then_try(|ret| {

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -32,8 +32,8 @@ impl<'c> Translation<'c> {
         rotate_method_name: &'static str,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         // Emit `arg0.{method_name}(arg1)`
-        let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
-        let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
+        let arg0 = self.convert_expr(ctx.used(), args[0])?;
+        let arg1 = self.convert_expr(ctx.used(), args[1])?;
         arg0.zip(arg1).and_then_try(|(arg0, arg1)| {
             let arg1 = mk().cast_expr(arg1, mk().path_ty(vec!["u32"]));
             let method_call_expr = mk().method_call_expr(arg0, rotate_method_name, vec![arg1]);
@@ -115,7 +115,7 @@ impl<'c> Translation<'c> {
             "__builtin_signbit" | "__builtin_signbitf" | "__builtin_signbitl" => {
                 self.import_num_traits(args[0])?;
 
-                let val = self.convert_expr(ctx.used(), args[0], None)?;
+                let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|v| {
                     let val = mk().method_call_expr(v, "is_sign_negative", vec![]);
 
@@ -123,7 +123,7 @@ impl<'c> Translation<'c> {
                 }))
             }
             "__builtin_ffs" | "__builtin_ffsl" | "__builtin_ffsll" => {
-                let val = self.convert_expr(ctx.used(), args[0], None)?;
+                let val = self.convert_expr(ctx.used(), args[0])?;
 
                 Ok(val.map(|x| {
                     let add = BinOp::Add(Default::default());
@@ -140,33 +140,33 @@ impl<'c> Translation<'c> {
                 }))
             }
             "__builtin_clz" | "__builtin_clzl" | "__builtin_clzll" => {
-                let val = self.convert_expr(ctx.used(), args[0], None)?;
+                let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|x| {
                     let zeros = mk().method_call_expr(x, "leading_zeros", vec![]);
                     mk().cast_expr(zeros, mk().path_ty(vec!["i32"]))
                 }))
             }
             "__builtin_ctz" | "__builtin_ctzl" | "__builtin_ctzll" => {
-                let val = self.convert_expr(ctx.used(), args[0], None)?;
+                let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|x| {
                     let zeros = mk().method_call_expr(x, "trailing_zeros", vec![]);
                     mk().cast_expr(zeros, mk().path_ty(vec!["i32"]))
                 }))
             }
             "__builtin_bswap16" | "__builtin_bswap32" | "__builtin_bswap64" => {
-                let val = self.convert_expr(ctx.used(), args[0], None)?;
+                let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|x| mk().method_call_expr(x, "swap_bytes", vec![])))
             }
             "__builtin_fabs" | "__builtin_fabsf" | "__builtin_fabsl" => {
                 self.import_num_traits(args[0])?;
 
-                let val = self.convert_expr(ctx.used(), args[0], None)?;
+                let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|x| mk().method_call_expr(x, "abs", vec![])))
             }
             "__builtin_isfinite" | "__builtin_isnan" => {
                 self.import_num_traits(args[0])?;
 
-                let val = self.convert_expr(ctx.used(), args[0], None)?;
+                let val = self.convert_expr(ctx.used(), args[0])?;
 
                 let seg = match builtin_name {
                     "__builtin_isfinite" => "is_finite",
@@ -182,7 +182,7 @@ impl<'c> Translation<'c> {
                 self.import_num_traits(args[0])?;
 
                 // isinf_sign(x) -> fabs(x) == infinity ? (signbit(x) ? -1 : 1) : 0
-                let val = self.convert_expr(ctx.used(), args[0], None)?;
+                let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|x| {
                     let inner_cond = mk().method_call_expr(x.clone(), "is_sign_positive", vec![]);
                     let one = mk().lit_expr(mk().int_lit(1, ""));
@@ -201,18 +201,18 @@ impl<'c> Translation<'c> {
                 // https://github.com/llvm-mirror/llvm/blob/master/lib/CodeGen/IntrinsicLowering.cpp#L470
                 Ok(WithStmts::new_val(mk().lit_expr(mk().int_lit(1, "i32"))))
             }
-            "__builtin_expect" => self.convert_expr(ctx.used(), args[0], None),
+            "__builtin_expect" => self.convert_expr(ctx.used(), args[0]),
 
             "__builtin_popcount" | "__builtin_popcountl" | "__builtin_popcountll" => {
-                let val = self.convert_expr(ctx.used(), args[0], None)?;
+                let val = self.convert_expr(ctx.used(), args[0])?;
                 Ok(val.map(|x| {
                     let zeros = mk().method_call_expr(x, "count_ones", vec![]);
                     mk().cast_expr(zeros, mk().path_ty(vec!["i32"]))
                 }))
             }
             "__builtin_bzero" => {
-                let ptr_stmts = self.convert_expr(ctx.used(), args[0], None)?;
-                let n_stmts = self.convert_expr(ctx.used(), args[1], None)?;
+                let ptr_stmts = self.convert_expr(ctx.used(), args[0])?;
+                let n_stmts = self.convert_expr(ctx.used(), args[1])?;
                 let write_bytes = mk().abs_path_expr(vec!["core", "ptr", "write_bytes"]);
                 let zero = mk().lit_expr(mk().int_lit(0, "u8"));
                 Ok(ptr_stmts.and_then(|ptr| {
@@ -223,7 +223,7 @@ impl<'c> Translation<'c> {
             // If the target does not support data prefetch, the address expression is evaluated if
             // it includes side effects but no other code is generated and GCC does not issue a warning.
             // void __builtin_prefetch (const void *addr, ...);
-            "__builtin_prefetch" => self.convert_expr(ctx.unused(), args[0], None),
+            "__builtin_prefetch" => self.convert_expr(ctx.unused(), args[0]),
 
             "__builtin_memcpy" | "__builtin_memcmp" | "__builtin_memmove" | "__builtin_strncmp"
             | "__builtin_strncpy" | "__builtin_strncat" => self.convert_libc_fns(
@@ -301,8 +301,8 @@ impl<'c> Translation<'c> {
                 // We can't convert this to Rust, but it should be safe to always return -1/0
                 // (depending on the value of `type`), so we emit the following:
                 // `(if (type & 2) == 0 { -1isize } else { 0isize }) as libc::size_t`
-                let ptr_arg = self.convert_expr(ctx.unused(), args[0], None)?;
-                let type_arg = self.convert_expr(ctx.used(), args[1], None)?;
+                let ptr_arg = self.convert_expr(ctx.unused(), args[0])?;
+                let type_arg = self.convert_expr(ctx.used(), args[1])?;
                 Ok(ptr_arg.and_then(|_| {
                     type_arg.map(|type_arg| {
                         let type_and_2 = mk().binary_expr(
@@ -332,7 +332,7 @@ impl<'c> Translation<'c> {
                 if ctx.is_unused() && args.len() == 2 {
                     if let Some(va_id) = self.match_vastart(args[0]) {
                         if self.ast_context.get_decl(&va_id).is_some() {
-                            let dst = self.convert_expr(ctx.used(), args[0], None)?;
+                            let dst = self.convert_expr(ctx.used(), args[0])?;
                             let fn_ctx = self.function_context.borrow();
                             let src = fn_ctx.get_va_list_arg_name();
 
@@ -353,8 +353,8 @@ impl<'c> Translation<'c> {
             "__builtin_va_copy" => {
                 if ctx.is_unused() && args.len() == 2 {
                     if let Some((_dst_va_id, _src_va_id)) = self.match_vacopy(args[0], args[1]) {
-                        let dst = self.convert_expr(ctx.used(), args[0], None)?;
-                        let src = self.convert_expr(ctx.used(), args[1], None)?;
+                        let dst = self.convert_expr(ctx.used(), args[0])?;
+                        let src = self.convert_expr(ctx.used(), args[1])?;
 
                         let call_expr = mk().method_call_expr(src.to_expr(), "clone", vec![]);
                         let assign_expr = mk().assign_expr(dst.to_expr(), call_expr);
@@ -379,7 +379,7 @@ impl<'c> Translation<'c> {
             }
 
             "__builtin_alloca" => {
-                let count = self.convert_expr(ctx.used(), args[0], None)?;
+                let count = self.convert_expr(ctx.used(), args[0])?;
                 Ok(count.and_then(|count| {
                     // Get `alloca` allocation storage.
                     let mut fn_ctx = self.function_context.borrow_mut();
@@ -426,7 +426,7 @@ impl<'c> Translation<'c> {
                 } else {
                     warn!("{builtin_name} has no Rust equivalent; emitting null pointer");
                 }
-                let level = self.convert_expr(ctx.unused(), args[0], None)?;
+                let level = self.convert_expr(ctx.unused(), args[0])?;
                 Ok(level.and_then(|_| {
                     let void_ty = mk().abs_path_ty(vec!["core", "ffi", "c_void"]);
                     let type_args = mk().angle_bracketed_args(vec![void_ty]);
@@ -447,7 +447,7 @@ impl<'c> Translation<'c> {
                 // architectures (only used to mask/unmask hardware-specific
                 // bits like the ARM Thumb mode bit). Pass the argument
                 // through unchanged.
-                self.convert_expr(ctx, args[0], None)
+                self.convert_expr(ctx, args[0])
             }
 
             "__builtin_ia32_pause" => {
@@ -495,9 +495,9 @@ impl<'c> Translation<'c> {
             | "__sync_bool_compare_and_swap_4"
             | "__sync_bool_compare_and_swap_8"
             | "__sync_bool_compare_and_swap_16" => {
-                let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
-                let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
-                let arg2 = self.convert_expr(ctx.used(), args[2], None)?;
+                let arg0 = self.convert_expr(ctx.used(), args[0])?;
+                let arg1 = self.convert_expr(ctx.used(), args[1])?;
+                let arg2 = self.convert_expr(ctx.used(), args[2])?;
                 arg0.zip(arg1)
                     .zip(arg2)
                     .and_then_try(|((arg0, arg1), arg2)| {
@@ -532,8 +532,8 @@ impl<'c> Translation<'c> {
             | "__sync_lock_test_and_set_16" => {
                 // Emit `atomic_xchg_acquire(arg0, arg1)`
                 let atomic_func = self.atomic_intrinsic_expr("xchg", &[Acquire]);
-                let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
-                let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
+                let arg0 = self.convert_expr(ctx.used(), args[0])?;
+                let arg1 = self.convert_expr(ctx.used(), args[1])?;
                 arg0.zip(arg1).and_then_try(|(arg0, arg1)| {
                     let call_expr = mk().call_expr(atomic_func, vec![arg0, arg1]);
                     self.convert_side_effects_expr(
@@ -551,7 +551,7 @@ impl<'c> Translation<'c> {
             | "__sync_lock_release_16" => {
                 // Emit `atomic_store_release(arg0, 0)`
                 let atomic_func = self.atomic_intrinsic_expr("store", &[Release]);
-                let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
+                let arg0 = self.convert_expr(ctx.used(), args[0])?;
                 arg0.and_then_try(|arg0| {
                     let zero = mk().lit_expr(mk().int_lit(0, ""));
                     let call_expr = mk().call_expr(atomic_func, vec![arg0, zero]);
@@ -564,7 +564,7 @@ impl<'c> Translation<'c> {
             }
             // There's currently no way to replicate this functionality in Rust, so we just
             // pass the ptr input param in its place.
-            "__builtin_assume_aligned" => Ok(self.convert_expr(ctx.used(), args[0], None)?),
+            "__builtin_assume_aligned" => Ok(self.convert_expr(ctx.used(), args[0])?),
             // Skip over, there's no way to implement it in Rust
             "__builtin_unwind_init" => Ok(WithStmts::new_val(self.panic_or_err("no value"))),
             "__builtin_unreachable" => Ok(WithStmts::new(
@@ -588,8 +588,8 @@ impl<'c> Translation<'c> {
 
             _ => {
                 if let Some(atomic_op) = CAtomicBinOp::from_sync_builtin_fn(builtin_name) {
-                    let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
-                    let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
+                    let arg0 = self.convert_expr(ctx.used(), args[0])?;
+                    let arg1 = self.convert_expr(ctx.used(), args[1])?;
                     let arg1_type_id = self.ast_context[args[1]]
                         .kind
                         .get_qual_type()
@@ -638,7 +638,7 @@ impl<'c> Translation<'c> {
         method_name: &str,
         args: &[CExprId],
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let args = self.convert_exprs(ctx.used(), args, None)?;
+        let args = self.convert_exprs(ctx.used(), args)?;
         args.and_then_try(|args| {
             let [a, b, c]: [_; 3] = args
                 .try_into()
@@ -678,7 +678,7 @@ impl<'c> Translation<'c> {
         let name = &builtin_name[10..];
         self.use_crate(ExternCrate::Libc);
         let mem = mk().abs_path_expr(vec!["libc", name]);
-        let args = self.convert_exprs(ctx.used(), args, None)?;
+        let args = self.convert_exprs(ctx.used(), args)?;
         args.and_then_try(|args| {
             if args.len() != arg_types.len() {
                 // This should not generally happen, as the C frontend checks these first

--- a/c2rust-transpile/src/translator/context.rs
+++ b/c2rust-transpile/src/translator/context.rs
@@ -1,0 +1,458 @@
+use crate::c_ast::iterators::{immediate_children_all_types, NodeVisitor, SomeId};
+use crate::c_ast::{
+    CBinOp, CDeclId, CDeclKind, CExprId, CExprKind, CQualTypeId, CStmtId, CStmtKind, CTypeKind,
+    CUnOp, CastKind, TypedAstContext,
+};
+use crate::translator::simd::simd_fn_from_builtin_fn;
+use std::collections::{HashMap, HashSet};
+
+pub struct ContextVisitor<'a> {
+    ast_context: &'a TypedAstContext,
+
+    /// Whether an expression is within a conditional context, meaning that it is in a context
+    /// where a Rust `bool` will be expected.
+    expr_is_condition: HashSet<CExprId>,
+
+    /// Whether an expression is the argument of an SIMD function call.
+    expr_is_simd_arg: HashSet<CExprId>,
+
+    /// Override for the type of an expression.
+    pub expr_override_types: HashMap<CExprId, CQualTypeId>,
+
+    /// The stack of functions that is currently being processed.
+    in_function: Vec<CDeclId>,
+}
+
+impl<'a> ContextVisitor<'a> {
+    pub fn new(ast_context: &'a TypedAstContext) -> Self {
+        Self {
+            ast_context,
+            expr_is_condition: HashSet::new(),
+            expr_is_simd_arg: HashSet::new(),
+            expr_override_types: HashMap::new(),
+            in_function: Vec::new(),
+        }
+    }
+
+    pub fn visit(&mut self, c_decls_top: &[CDeclId]) {
+        for &decl in c_decls_top {
+            self.visit_tree(SomeId::Decl(decl));
+        }
+    }
+
+    fn pre_stmt(&mut self, stmt: CStmtId) {
+        match self.ast_context[stmt].kind {
+            CStmtKind::Return(Some(expr)) => {
+                let func_id = match self.in_function.last() {
+                    Some(&func_id) => func_id,
+                    None => return,
+                };
+                let func_ty = match self.ast_context[func_id].kind {
+                    CDeclKind::Function { typ, .. } => typ,
+                    _ => return,
+                };
+                let return_ty = match self.ast_context.resolve_type(func_ty).kind {
+                    CTypeKind::Function(return_ty, _, _, false, _) => return_ty,
+                    _ => return,
+                };
+
+                self.expr_override_types.insert(expr, return_ty);
+            }
+
+            CStmtKind::If {
+                scrutinee: condition,
+                ..
+            }
+            | CStmtKind::While { condition, .. }
+            | CStmtKind::DoWhile { condition, .. }
+            | CStmtKind::ForLoop {
+                condition: Some(condition),
+                ..
+            } => {
+                self.expr_is_condition.insert(condition);
+            }
+
+            _ => {}
+        }
+    }
+
+    fn pre_expr(&mut self, parent_expr: CExprId) {
+        let expr_override_type = self.expr_override_types.get(&parent_expr).copied();
+        let expr_is_condition = self.expr_is_condition.contains(&parent_expr);
+        let expr_is_simd_arg = self.expr_is_simd_arg.contains(&parent_expr);
+
+        let expr_kind = &self.ast_context.index_expr_raw(parent_expr).kind;
+
+        match *expr_kind {
+            CExprKind::Literal(..) => {}
+
+            CExprKind::Unary(ty, op, arg, _) => match op {
+                CUnOp::Plus | CUnOp::Negate | CUnOp::Complement | CUnOp::Extension => {
+                    let cqual_type = expr_override_type.unwrap_or(ty);
+                    self.expr_override_types.insert(arg, cqual_type);
+                }
+
+                CUnOp::Not => {
+                    self.expr_is_condition.insert(arg);
+                }
+
+                CUnOp::AddressOf
+                | CUnOp::Deref
+                | CUnOp::PostIncrement
+                | CUnOp::PreIncrement
+                | CUnOp::PostDecrement
+                | CUnOp::PreDecrement
+                | CUnOp::Real
+                | CUnOp::Imag
+                | CUnOp::Coawait => {}
+            },
+
+            CExprKind::UnaryType(..) => {}
+            CExprKind::OffsetOf(..) => {}
+
+            CExprKind::Binary(ty, op, lhs, rhs, _, _) => {
+                match op {
+                    CBinOp::Comma => {
+                        let expr_type_id = expr_override_type.unwrap_or(ty);
+                        self.expr_override_types.insert(rhs, expr_type_id);
+                    }
+
+                    CBinOp::And | CBinOp::Or => {
+                        self.expr_is_condition.insert(lhs);
+                        self.expr_is_condition.insert(rhs);
+                    }
+
+                    CBinOp::AssignAdd
+                    | CBinOp::AssignSubtract
+                    | CBinOp::AssignMultiply
+                    | CBinOp::AssignDivide
+                    | CBinOp::AssignModulus
+                    | CBinOp::AssignBitXor
+                    | CBinOp::AssignShiftLeft
+                    | CBinOp::AssignShiftRight
+                    | CBinOp::AssignBitOr
+                    | CBinOp::AssignBitAnd
+                    | CBinOp::Assign => {}
+
+                    // Operands of == and != have no override for null pointer comparisons,
+                    // because only the non-null operand is converted.
+                    CBinOp::EqualEqual | CBinOp::NotEqual
+                        if expr_is_condition
+                            && (self.ast_context.is_null_expr(lhs)
+                                || self.ast_context.is_null_expr(rhs)) => {}
+
+                    _ => {
+                        let expr_type_id = expr_override_type.unwrap_or(ty);
+
+                        let lhs_kind = &self.ast_context[lhs].kind;
+                        let mut lhs_type_id = match lhs_kind.get_qual_type() {
+                            Some(ty) => ty,
+                            None => return,
+                        };
+                        let rhs_kind = &self.ast_context[rhs].kind;
+                        let mut rhs_type_id = match rhs_kind.get_qual_type() {
+                            Some(ty) => ty,
+                            None => return,
+                        };
+
+                        // If this operation will (in Rust) take args of the same type, then
+                        // propagate our expected type down to the translation of our argument
+                        // expressions.
+                        let lhs_resolved_ty = self.ast_context.resolve_type(lhs_type_id.ctype);
+                        let rhs_resolved_ty = self.ast_context.resolve_type(rhs_type_id.ctype);
+                        let expr_ty_kind = &self.ast_context[expr_type_id.ctype].kind;
+
+                        // Addition and subtraction can accept one pointer argument for .offset(),
+                        // in which case we don't want to homogenize arg types.
+                        if !lhs_resolved_ty.kind.is_pointer()
+                            && !rhs_resolved_ty.kind.is_pointer()
+                            && !expr_ty_kind.is_pointer()
+                        {
+                            if op.all_types_same() {
+                                // Ops like division and bitxor accept inputs of their expected
+                                // result type.
+                                lhs_type_id = expr_type_id;
+                                rhs_type_id = expr_type_id;
+                            } else if op.input_types_same()
+                                && lhs_resolved_ty.kind != rhs_resolved_ty.kind
+                            {
+                                if CTypeKind::PULLBACK_KINDS.contains(&lhs_resolved_ty.kind) {
+                                    rhs_type_id = lhs_type_id;
+                                } else {
+                                    lhs_type_id = rhs_type_id;
+                                }
+                            } else if matches!(op, CBinOp::ShiftLeft | CBinOp::ShiftRight) {
+                                lhs_type_id = expr_type_id;
+                            }
+                        }
+
+                        self.expr_override_types.insert(lhs, lhs_type_id);
+                        self.expr_override_types.insert(rhs, rhs_type_id);
+                    }
+                }
+            }
+
+            CExprKind::ImplicitCast(ty, expr, kind, _, _)
+            | CExprKind::ExplicitCast(ty, expr, kind, _, _) => {
+                let is_explicit = matches!(expr_kind, CExprKind::ExplicitCast(..));
+
+                if expr_is_simd_arg && !is_explicit && matches!(kind, CastKind::IntegralCast) {
+                    return;
+                }
+
+                if matches!(
+                    kind,
+                    CastKind::IntegralToBoolean
+                        | CastKind::FloatingToBoolean
+                        | CastKind::PointerToBoolean
+                ) {
+                    self.expr_is_condition.insert(expr);
+                }
+
+                let child_expr_kind = &self.ast_context[expr].kind;
+                let target_ty = expr_override_type.unwrap_or(ty);
+
+                if !is_explicit {
+                    let mut literal_expr_kind = child_expr_kind;
+                    let mut is_negated = false;
+
+                    if let &CExprKind::Unary(_, CUnOp::Negate, subexpr_id, _) = literal_expr_kind {
+                        literal_expr_kind = &self.ast_context[subexpr_id].kind;
+                        is_negated = true;
+                    }
+
+                    if let CExprKind::Literal(_, lit) = literal_expr_kind {
+                        if self
+                            .ast_context
+                            .literal_matches_ty(lit, target_ty, is_negated)
+                        {
+                            self.expr_override_types.insert(expr, target_ty);
+                        }
+                    }
+
+                    if let Some(expr_override_type) = expr_override_type {
+                        if kind == CastKind::LValueToRValue {
+                            let source_ty = match self.ast_context[expr].kind.get_qual_type() {
+                                Some(ty) => ty,
+                                None => return,
+                            };
+
+                            if source_ty.ctype != expr_override_type.ctype {
+                                self.expr_override_types.insert(expr, expr_override_type);
+                            }
+                        }
+                    }
+                }
+            }
+
+            CExprKind::ConstantExpr(ty, expr, _) => {
+                self.expr_override_types.insert(expr, ty);
+            }
+
+            CExprKind::DeclRef(..) => {}
+
+            CExprKind::Call(_, func, ref args) => {
+                if let CExprKind::ImplicitCast(_, fexp, CastKind::BuiltinFnToFnPtr, _, _) =
+                    self.ast_context[func].kind
+                {
+                    let CExprKind::DeclRef(_, decl_id, _) = self.ast_context[fexp].kind else {
+                        return;
+                    };
+                    let CDeclKind::Function {
+                        name: ref builtin_name,
+                        ..
+                    } = self.ast_context[decl_id].kind
+                    else {
+                        return;
+                    };
+
+                    if simd_fn_from_builtin_fn(builtin_name).is_some() {
+                        for &arg in args {
+                            self.expr_is_simd_arg.insert(arg);
+                        }
+                    }
+
+                    return;
+                }
+
+                // Try to get the Variable decl directly,
+                // or fall back to querying the function pointer type.
+                let tys_of_params = if let Some(CDeclKind::Function { parameters, .. }) =
+                    self.ast_context.fn_declref_decl(func)
+                {
+                    self.ast_context.tys_of_params(parameters)
+                } else {
+                    self.ast_context[func]
+                        .kind
+                        .get_type()
+                        .and_then(|fn_ptr_qty| self.ast_context.get_pointee_qual_type(fn_ptr_qty))
+                        .and_then(
+                            |fn_qty| match self.ast_context.resolve_type(fn_qty.ctype).kind {
+                                CTypeKind::Function(_, ref param_tys, ..) => {
+                                    Some(param_tys.clone())
+                                }
+                                _ => None,
+                            },
+                        )
+                };
+
+                if let Some(tys_of_params) = tys_of_params {
+                    for (&arg, param_ty) in args.iter().zip(tys_of_params) {
+                        if !(self.ast_context[arg].kind.get_qual_type())
+                            .map_or(false, |qtype| self.ast_context.is_va_list(qtype.ctype))
+                        {
+                            self.expr_override_types.insert(arg, param_ty);
+                        }
+                    }
+                }
+            }
+
+            CExprKind::Member(..) => {}
+            CExprKind::ArraySubscript(..) => {}
+
+            CExprKind::Conditional(ty, _, lhs, rhs) => {
+                self.expr_is_condition.insert(lhs);
+
+                self.expr_override_types
+                    .insert(lhs, expr_override_type.unwrap_or(ty));
+                self.expr_override_types
+                    .insert(rhs, expr_override_type.unwrap_or(ty));
+            }
+
+            CExprKind::BinaryConditional(_, condition, _) => {
+                self.expr_is_condition.insert(condition);
+            }
+
+            CExprKind::InitList(ty, ref exprs, _, _) => {
+                match self.ast_context.resolve_type(ty.ctype).kind {
+                    CTypeKind::Struct(struct_id) => {
+                        let field_decl_ids = match self.ast_context[struct_id].kind {
+                            CDeclKind::Struct {
+                                fields: Some(ref fields),
+                                ..
+                            } => fields,
+                            _ => return,
+                        };
+
+                        let field_info_iter = field_decl_ids.iter().filter_map(|&field_id| {
+                            match self.ast_context[field_id].kind {
+                                CDeclKind::Field {
+                                    bitfield_width: Some(0),
+                                    ..
+                                } => None,
+                                CDeclKind::Field { typ, .. } => Some(typ),
+                                _ => None,
+                            }
+                        });
+
+                        for (&expr, typ) in exprs.iter().zip(field_info_iter) {
+                            self.expr_override_types.insert(expr, typ);
+                        }
+                    }
+
+                    _ => {}
+                }
+            }
+
+            CExprKind::ImplicitValueInit(..) => {}
+
+            CExprKind::Paren(_, expr) => {
+                if expr_is_condition {
+                    self.expr_is_condition.insert(expr);
+                }
+
+                if expr_is_simd_arg {
+                    self.expr_is_simd_arg.insert(expr);
+                }
+
+                if let Some(expr_override_type) = expr_override_type {
+                    self.expr_override_types.insert(expr, expr_override_type);
+                }
+            }
+
+            CExprKind::CompoundLiteral(_, expr) => {
+                if let Some(expr_override_type) = expr_override_type {
+                    self.expr_override_types.insert(expr, expr_override_type);
+                }
+            }
+
+            CExprKind::Predefined(_, expr) => {
+                if let Some(expr_override_type) = expr_override_type {
+                    self.expr_override_types.insert(expr, expr_override_type);
+                }
+            }
+
+            CExprKind::Statements(..) => {}
+            CExprKind::VAArg(..) => {}
+            CExprKind::ShuffleVector(..) => {}
+            CExprKind::ConvertVector(..) => {}
+            CExprKind::DesignatedInitExpr(..) => {}
+
+            CExprKind::Choose(_, _, lhs, rhs, _) => {
+                if let Some(expr_override_type) = expr_override_type {
+                    self.expr_override_types.insert(lhs, expr_override_type);
+                    self.expr_override_types.insert(rhs, expr_override_type);
+                }
+            }
+
+            CExprKind::Atomic { .. } => {}
+            CExprKind::BadExpr => {}
+        }
+    }
+
+    fn pre_decl(&mut self, decl: CDeclId) {
+        match self.ast_context[decl].kind {
+            CDeclKind::Function { .. } => {
+                self.in_function.push(decl);
+            }
+
+            CDeclKind::Variable {
+                typ,
+                initializer: Some(initializer),
+                ..
+            } => {
+                self.expr_override_types.insert(initializer, typ);
+            }
+
+            _ => {}
+        }
+    }
+
+    fn post_decl(&mut self, decl: CDeclId) {
+        match self.ast_context[decl].kind {
+            CDeclKind::Function { .. } => {
+                if matches!(self.in_function.last(), Some(&func) if func == decl) {
+                    self.in_function.pop();
+                }
+            }
+
+            _ => {}
+        }
+    }
+}
+
+impl<'a> NodeVisitor for ContextVisitor<'a> {
+    fn children(&mut self, id: SomeId) -> Vec<SomeId> {
+        immediate_children_all_types(self.ast_context, id)
+    }
+
+    fn pre(&mut self, id: SomeId) -> bool {
+        match id {
+            SomeId::Stmt(stmt) => self.pre_stmt(stmt),
+            SomeId::Expr(expr) => self.pre_expr(expr),
+            SomeId::Decl(decl) => self.pre_decl(decl),
+            SomeId::Type(_) => {}
+        }
+
+        true
+    }
+
+    fn post(&mut self, id: SomeId) {
+        match id {
+            SomeId::Stmt(_stmt) => {}
+            SomeId::Expr(_expr) => {}
+            SomeId::Decl(decl) => self.post_decl(decl),
+            SomeId::Type(_) => {}
+        }
+    }
+}

--- a/c2rust-transpile/src/translator/enums.rs
+++ b/c2rust-transpile/src/translator/enums.rs
@@ -97,7 +97,7 @@ impl<'c> Translation<'c> {
                     if self.is_variant_of_enum(enum_id, enum_constant_id) =>
                 {
                     // `enum`s shouldn't need portable `override_ty`s.
-                    let expr_is_macro = self.expr_is_expanded_macro(ctx, expr, None);
+                    let expr_is_macro = self.expr_is_expanded_macro(ctx, expr);
 
                     // If this DeclRef expanded to a const macro, we actually need to insert a cast,
                     // because the translation of a const macro skips implicit casts in its context.

--- a/c2rust-transpile/src/translator/functions.rs
+++ b/c2rust-transpile/src/translator/functions.rs
@@ -376,14 +376,6 @@ impl<'c> Translation<'c> {
             _ => false,
         };
 
-        let mut arg_tys = if let Some(CDeclKind::Function { parameters, .. }) =
-            self.ast_context.fn_declref_decl(func)
-        {
-            self.ast_context.tys_of_params(parameters)
-        } else {
-            None
-        };
-
         let func = match self.ast_context[func].kind {
             // Direct function call
             CExprKind::ImplicitCast(_, fexp, CastKind::FunctionToPointerDecay, _, _)
@@ -391,7 +383,7 @@ impl<'c> Translation<'c> {
             // callee is a declref
             if matches!(self.ast_context[fexp].kind, CExprKind::DeclRef(..)) =>
                 {
-                    self.convert_expr(ctx.used(), fexp, None)?
+                    self.convert_expr(ctx.used(), fexp)?
                 }
 
             // Builtin function call
@@ -401,7 +393,7 @@ impl<'c> Translation<'c> {
 
             // Function pointer call
             _ => {
-                let callee = self.convert_expr(ctx.used(), func, None)?;
+                let callee = self.convert_expr(ctx.used(), func)?;
                 let make_fn_ty = |ret_ty: Box<Type>| {
                     let ret_ty = match *ret_ty {
                         Type::Tuple(TypeTuple { elems: ref v, .. }) if v.is_empty() => ReturnType::Default,
@@ -432,8 +424,7 @@ impl<'c> Translation<'c> {
                             transmute_expr(mk().infer_ty(), target_ty, fn_ptr)
                         }).set_unsafe()
                     }
-                    Some(CTypeKind::Function(_, ty_arg_tys, ..)) => {
-                        arg_tys = Some(ty_arg_tys.clone());
+                    Some(CTypeKind::Function(..)) => {
                         // Normal function pointer
                         callee.map(unwrap_function_pointer)
                     }
@@ -449,7 +440,7 @@ impl<'c> Translation<'c> {
             // We want to decay refs only when function is variadic
             ctx.decay_ref = DecayRef::from(is_variadic);
 
-            let args = self.convert_call_args(ctx.used(), args, arg_tys.as_deref(), is_variadic)?;
+            let args = self.convert_call_args(ctx.used(), args)?;
 
             let mut call_expr = args.map(|args| mk().call_expr(func, args));
             if let Some(expected_ty) = override_ty {
@@ -478,23 +469,10 @@ impl<'c> Translation<'c> {
         &self,
         ctx: ExprContext,
         exprs: &[CExprId],
-        arg_tys: Option<&[CQualTypeId]>,
-        is_variadic: bool,
     ) -> TranslationResult<WithStmts<Vec<Box<Expr>>>> {
-        let arg_tys = if let Some(arg_tys) = arg_tys {
-            if !is_variadic {
-                assert!(arg_tys.len() == exprs.len());
-            }
-
-            arg_tys
-        } else {
-            &[]
-        };
-
         exprs
             .iter()
-            .enumerate()
-            .map(|(n, arg)| self.convert_call_arg(ctx, *arg, arg_tys.get(n).copied()))
+            .map(|arg| self.convert_call_arg(ctx, *arg))
             .collect()
     }
 
@@ -503,18 +481,16 @@ impl<'c> Translation<'c> {
         &self,
         ctx: ExprContext,
         expr_id: CExprId,
-        override_ty: Option<CQualTypeId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let mut val;
 
         if (self.ast_context.index(expr_id).kind.get_qual_type())
             .map_or(false, |qtype| self.ast_context.is_va_list(qtype.ctype))
         {
-            // No `override_ty` to avoid unwanted casting.
-            val = self.convert_expr(ctx, expr_id, None)?;
+            val = self.convert_expr(ctx, expr_id)?;
             val = val.map(|val| mk_va_list_copy(self.tcfg.edition, val));
         } else {
-            val = self.convert_expr(ctx, expr_id, override_ty)?;
+            val = self.convert_expr(ctx, expr_id)?;
         }
 
         Ok(val)

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -31,23 +31,6 @@ impl<'c> Translation<'c> {
         Ok(mk().cast_expr(expr, target_ty))
     }
 
-    /// Return whether the literal can be directly translated as this type.
-    pub fn literal_matches_ty(&self, lit: &CLiteral, ty: CQualTypeId, is_negated: bool) -> bool {
-        let ty_kind = &self.ast_context.resolve_type(ty.ctype).kind;
-        match *lit {
-            CLiteral::Integer(value, _) | CLiteral::Character(value)
-                if ty_kind.is_integral_type() && !ty_kind.is_bool() =>
-            {
-                ty_kind.guaranteed_integer_in_range(value)
-                    && (!is_negated || ty_kind.is_signed_integral_type())
-            }
-            CLiteral::Floating(value, _) if ty_kind.is_floating_type() => {
-                ty_kind.guaranteed_float_in_range(value)
-            }
-            _ => false,
-        }
-    }
-
     /// Convert a C literal expression to a Rust expression
     pub fn convert_literal(
         &self,

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -150,7 +150,7 @@ impl<'c> Translation<'c> {
         // C compound literals are lvalues, but equivalent Rust expressions generally are not.
         // So if an address is needed, store it in an intermediate variable first.
         if !ctx.needs_address() || ctx.expanding_macro.is_some() {
-            return self.convert_expr(ctx, val, override_ty);
+            return self.convert_expr(ctx, val);
         }
 
         let fresh_name = self.renamer.borrow_mut().fresh();
@@ -158,7 +158,7 @@ impl<'c> Translation<'c> {
 
         // Translate the expression to be assigned to the fresh variable.
         // It will be assigned by value, so we don't need its address anymore.
-        let val = self.convert_expr(ctx.set_needs_address(false), val, override_ty)?;
+        let val = self.convert_expr(ctx.set_needs_address(false), val)?;
 
         // If we are translating a static variable,
         // then the fresh variable should also be static.
@@ -206,7 +206,7 @@ impl<'c> Translation<'c> {
                 // Convert all of the provided initializer values
 
                 let to_array_element = |id: CExprId| -> TranslationResult<_> {
-                    self.convert_expr(ctx.used(), id, None)?.try_map(|x| {
+                    self.convert_expr(ctx.used(), id)?.try_map(|x| {
                         // Array literals require all of their elements to be
                         // the correct type; they will not use implicit casts to
                         // change mut to const. This becomes a problem when an
@@ -270,7 +270,7 @@ impl<'c> Translation<'c> {
                         // * `ptr_extra_braces`
                         // * `array_of_ptrs`
                         // * `array_of_arrays`
-                        self.convert_expr(ctx.used(), single, None)
+                        self.convert_expr(ctx.used(), single)
                     }
                     &[single] if is_zero_literal(single) && n > 1 => {
                         // This was likely a C array of the form `int x[16] = { 0 }`.
@@ -305,7 +305,7 @@ impl<'c> Translation<'c> {
             }
             ref kind if kind.is_scalar() => {
                 if let Some(&first) = ids.first() {
-                    self.convert_expr(ctx.used(), first, None)
+                    self.convert_expr(ctx.used(), first)
                 } else {
                     self.implicit_default_expr(ctx.used(), ty.ctype)
                 }

--- a/c2rust-transpile/src/translator/macros.rs
+++ b/c2rust-transpile/src/translator/macros.rs
@@ -74,8 +74,8 @@ impl<'c> Translation<'c> {
             .try_fold::<Option<(WithStmts<Box<Expr>>, CTypeId)>, _, _>(None, |canonical, &id| {
                 self.can_convert_const_macro_expansion(id)?;
 
+                let expr = self.convert_expr(ctx, id)?;
                 let override_ty = self.expr_override_types.get(&id).copied();
-                let expr = self.convert_expr(ctx, id, override_ty)?;
                 let ty = override_ty
                     .or_else(|| self.ast_context[id].kind.get_qual_type())
                     .ok_or_else(|| format_err!("Invalid expression type"))?

--- a/c2rust-transpile/src/translator/macros.rs
+++ b/c2rust-transpile/src/translator/macros.rs
@@ -149,7 +149,6 @@ impl<'c> Translation<'c> {
         &self,
         ctx: ExprContext,
         expr_id: CExprId,
-        override_ty: Option<CQualTypeId>,
     ) -> TranslationResult<Option<WithStmts<Box<Expr>>>> {
         let macros = match self.ast_context.macro_invocations.get(&expr_id) {
             Some(macros) => macros.as_slice(),
@@ -202,6 +201,7 @@ impl<'c> Translation<'c> {
         // determined by the surrounding context.
         // Since the expansion sites are expecting a particular type, we need to cast it here
         // if it differs from the `const` type.
+        let override_ty = self.expr_override_types.get(&expr_id).copied();
         let expr_ty = override_ty.or_else(|| self.ast_context[expr_id].kind.get_qual_type());
         if let Some(expr_ty) = expr_ty {
             self.convert_cast(
@@ -250,14 +250,9 @@ impl<'c> Translation<'c> {
         ))))
     }
 
-    pub fn expr_is_expanded_macro(
-        &self,
-        ctx: ExprContext,
-        expr_id: CExprId,
-        override_ty: Option<CQualTypeId>,
-    ) -> bool {
+    pub fn expr_is_expanded_macro(&self, ctx: ExprContext, expr_id: CExprId) -> bool {
         matches!(
-            self.convert_const_macro_expansion(ctx, expr_id, override_ty),
+            self.convert_const_macro_expansion(ctx, expr_id),
             Ok(Some(_))
         )
     }

--- a/c2rust-transpile/src/translator/macros.rs
+++ b/c2rust-transpile/src/translator/macros.rs
@@ -74,11 +74,12 @@ impl<'c> Translation<'c> {
             .try_fold::<Option<(WithStmts<Box<Expr>>, CTypeId)>, _, _>(None, |canonical, &id| {
                 self.can_convert_const_macro_expansion(id)?;
 
-                let ty = self.ast_context[id]
-                    .kind
-                    .get_type()
-                    .ok_or_else(|| format_err!("Invalid expression type"))?;
-                let expr = self.convert_expr(ctx, id, None)?;
+                let override_ty = self.expr_override_types.get(&id).copied();
+                let expr = self.convert_expr(ctx, id, override_ty)?;
+                let ty = override_ty
+                    .or_else(|| self.ast_context[id].kind.get_qual_type())
+                    .ok_or_else(|| format_err!("Invalid expression type"))?
+                    .ctype;
 
                 // Join ty and cur_ty to the smaller of the two types. If the
                 // types are not cast-compatible, abort the fold.
@@ -196,13 +197,12 @@ impl<'c> Translation<'c> {
 
         let val = WithStmts::new_val(mk().path_expr(vec![rust_name]));
 
-        let expr_kind = &self.ast_context[expr_id].kind;
-        // TODO We'd like to get rid of this cast eventually (see #1321).
-        // Currently, const macros do not get the correct `override_ty` themselves,
-        // so they aren't declared with the correct portable type,
-        // but its uses are expecting the correct portable type,
-        // so we need to cast it to the `override_ty` here.
-        let expr_ty = override_ty.or_else(|| expr_kind.get_qual_type());
+        // Rust `const` variables have a single consistent type, determined by
+        // `recreate_const_macro_from_expansions`, while in C each macro expansion has its own type,
+        // determined by the surrounding context.
+        // Since the expansion sites are expecting a particular type, we need to cast it here
+        // if it differs from the `const` type.
+        let expr_ty = override_ty.or_else(|| self.ast_context[expr_id].kind.get_qual_type());
         if let Some(expr_ty) = expr_ty {
             self.convert_cast(
                 ctx,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -30,6 +30,7 @@ use crate::rust_ast::comment_store::CommentStore;
 use crate::rust_ast::item_store::ItemStore;
 use crate::rust_ast::set_span::SetSpan;
 use crate::rust_ast::{pos_to_span, SpanExt};
+use crate::translator::context::ContextVisitor;
 use crate::translator::named_references::NamedReference;
 use crate::translator::variadic::{mk_va_list_copy, mk_va_list_ty};
 use c2rust_ast_builder::{mk, properties::*, Builder};
@@ -49,6 +50,7 @@ mod assembly;
 mod atomics;
 mod builtins;
 mod comments;
+mod context;
 mod enums;
 mod functions;
 mod literals;
@@ -271,6 +273,11 @@ pub struct Translation<'c> {
     // Translation environment
     pub ast_context: TypedAstContext,
     pub tcfg: &'c TranspilerConfig,
+
+    /// The type expected by the surrounding expression context.
+    /// This can be different from the type of the AST node itself
+    /// and in many cases should override it.
+    pub expr_override_types: HashMap<CExprId, CQualTypeId>,
 
     // Accumulated outputs
     pub features: RefCell<IndexSet<&'static str>>,
@@ -721,6 +728,8 @@ pub fn translate(
         // binary and unary operators' expr types agree with their argument types
         // in the presence of typedefs.
         t.ast_context.bubble_expr_types();
+
+        t.set_contexts();
 
         enum Name<'a> {
             Var(&'a str),
@@ -1503,6 +1512,7 @@ impl<'c> Translation<'c> {
             type_converter: RefCell::new(type_converter),
             ast_context,
             tcfg,
+            expr_override_types: HashMap::new(),
             // TODO: Use Renamer::value_namespace() for most renamings.
             renamer: RefCell::new(Renamer::global_value_namespace()),
             zero_inits: RefCell::new(IndexMap::new()),
@@ -1520,6 +1530,13 @@ impl<'c> Translation<'c> {
             extern_crates: RefCell::new(IndexSet::new()),
             cur_file: Default::default(),
         }
+    }
+
+    fn set_contexts(&mut self) {
+        let mut visitor = ContextVisitor::new(&self.ast_context);
+        visitor.visit(&self.ast_context.c_decls_top);
+
+        self.expr_override_types = visitor.expr_override_types;
     }
 
     fn use_crate(&self, extern_crate: ExternCrate) {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2289,7 +2289,7 @@ impl<'c> Translation<'c> {
             }
 
             CExprKind::Literal(_, ref literal @ CLiteral::Integer(0 | 1, _))
-                if !self.expr_is_expanded_macro(ctx, cond_id, None) =>
+                if !self.expr_is_expanded_macro(ctx, cond_id) =>
             {
                 // If there is a literal `0` or `1` here, translate them directly rather than
                 // with a comparison. But not if they're inside a macro; we want to keep that.
@@ -2947,7 +2947,7 @@ impl<'c> Translation<'c> {
 
         let override_ty = self.expr_override_types.get(&expr_id).copied();
 
-        if let Some(converted) = self.convert_const_macro_expansion(ctx, expr_id, override_ty)? {
+        if let Some(converted) = self.convert_const_macro_expansion(ctx, expr_id)? {
             return Ok(converted);
         }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2254,7 +2254,7 @@ impl<'c> Translation<'c> {
 
         let null_pointer_case =
             |ptr: CExprId, is_null: bool| -> TranslationResult<WithStmts<Box<Expr>>> {
-                let val = self.convert_expr(ctx.used().decay_ref(), ptr, None)?;
+                let val = self.convert_expr(ctx.used().decay_ref(), ptr)?;
                 let ptr_type = self.ast_context[ptr]
                     .kind
                     .get_type()
@@ -2307,7 +2307,7 @@ impl<'c> Translation<'c> {
                 // in https://github.com/rust-lang/rust/issues/53772, you cant compare a reference (lhs) to
                 // a ptr (rhs) (even though the reverse works!). We could also be smarter here and just
                 // specify Yes for that particular case, given enough analysis.
-                let val = self.convert_expr(ctx.used().decay_ref(), cond_id, None)?;
+                let val = self.convert_expr(ctx.used().decay_ref(), cond_id)?;
                 val.try_map(|e| self.match_bool(ctx, target, ty_id, e))
             }
         }
@@ -2629,7 +2629,7 @@ impl<'c> Translation<'c> {
         typ: CQualTypeId,
     ) -> TranslationResult<ConvertedVariable> {
         let init = match initializer {
-            Some(x) => self.convert_expr(ctx.used(), x, Some(typ)),
+            Some(x) => self.convert_expr(ctx.used(), x),
             None => self.implicit_default_expr(ctx, typ.ctype),
         };
 
@@ -2788,24 +2788,22 @@ impl<'c> Translation<'c> {
                     type_id = elt;
 
                     // Convert this expression
-                    let expr = self
-                        .convert_expr(ctx.used(), expr_id, None)?
-                        .and_then(|expr| {
-                            let name = self
-                                .renamer
-                                .borrow_mut()
-                                .insert(CDeclId(expr_id.0), "vla")
-                                .unwrap(); // try using declref name?
-                                           // TODO: store the name corresponding to expr_id
+                    let expr = self.convert_expr(ctx.used(), expr_id)?.and_then(|expr| {
+                        let name = self
+                            .renamer
+                            .borrow_mut()
+                            .insert(CDeclId(expr_id.0), "vla")
+                            .unwrap(); // try using declref name?
+                                       // TODO: store the name corresponding to expr_id
 
-                            let local = mk().local(
-                                mk().ident_pat(name),
-                                None,
-                                Some(mk().cast_expr(expr, mk().path_ty(vec!["usize"]))),
-                            );
+                        let local = mk().local(
+                            mk().ident_pat(name),
+                            None,
+                            Some(mk().cast_expr(expr, mk().path_ty(vec!["usize"]))),
+                        );
 
-                            WithStmts::new(vec![mk().local_stmt(Box::new(local))], ())
-                        });
+                        WithStmts::new(vec![mk().local_stmt(Box::new(local))], ())
+                    });
 
                     stmts.extend(expr.into_stmts());
                 }
@@ -2829,7 +2827,7 @@ impl<'c> Translation<'c> {
 
             let elts = self.compute_size_of_type(ctx, elts, override_ty)?;
             return elts.and_then_try(|lhs| {
-                let len = self.convert_expr(ctx.used().not_static(), len, override_ty)?;
+                let len = self.convert_expr(ctx.used().not_static(), len)?;
                 Ok(len.map(|len| {
                     let rhs = cast_int(len, "usize", true);
                     mk().binary_expr(BinOp::Mul(Default::default()), lhs, rhs)
@@ -2911,13 +2909,10 @@ impl<'c> Translation<'c> {
         &self,
         ctx: ExprContext,
         exprs: &[CExprId],
-        arg_tys: Option<&[CQualTypeId]>,
     ) -> TranslationResult<WithStmts<Vec<Box<Expr>>>> {
-        assert!(arg_tys.map(|tys| tys.len() == exprs.len()).unwrap_or(true));
         exprs
             .iter()
-            .enumerate()
-            .map(|(n, arg)| self.convert_expr(ctx, *arg, arg_tys.map(|tys| tys[n])))
+            .map(|arg| self.convert_expr(ctx, *arg))
             .collect()
     }
 
@@ -2938,7 +2933,6 @@ impl<'c> Translation<'c> {
         &self,
         mut ctx: ExprContext,
         expr_id: CExprId,
-        override_ty: Option<CQualTypeId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let Located {
             loc: src_loc,
@@ -2950,6 +2944,8 @@ impl<'c> Translation<'c> {
             expr_id,
             self.ast_context[expr_id]
         );
+
+        let override_ty = self.expr_override_types.get(&expr_id).copied();
 
         if let Some(converted) = self.convert_const_macro_expansion(ctx, expr_id, override_ty)? {
             return Ok(converted);
@@ -3011,11 +3007,11 @@ impl<'c> Translation<'c> {
                 Ok(result)
             }
 
-            ConstantExpr(ty, child, value) => {
+            ConstantExpr(_ty, child, value) => {
                 if let Some(constant) = value {
                     self.convert_constant(constant).map(WithStmts::new_val)
                 } else {
-                    self.convert_expr(ctx, child, Some(ty))
+                    self.convert_expr(ctx, child)
                 }
             }
 
@@ -3182,7 +3178,7 @@ impl<'c> Translation<'c> {
 
                     // Index Expr
                     let expr = self
-                        .convert_expr(ctx, *expr_id, None)?
+                        .convert_expr(ctx, *expr_id)?
                         .to_pure_expr()
                         .ok_or_else(|| {
                             format_err!("Expected Variable offsetof to be a side-effect free")
@@ -3262,12 +3258,12 @@ impl<'c> Translation<'c> {
                             .ast_context
                             .literal_matches_ty(lit, target_ty, is_negated)
                         {
-                            return self.convert_expr(ctx, expr, Some(target_ty));
+                            return self.convert_expr(ctx, expr);
                         }
                     }
                 }
 
-                let mut val = self.convert_expr(ctx, expr, None)?;
+                let mut val = self.convert_expr(ctx, expr)?;
 
                 if is_explicit {
                     let stmts = self.compute_variable_array_sizes(ctx, ty.ctype)?;
@@ -3322,11 +3318,11 @@ impl<'c> Translation<'c> {
                 self.convert_unary_operator(ctx, op, override_ty.unwrap_or(type_id), arg)
             }
 
-            Conditional(ty, cond, lhs, rhs) => {
+            Conditional(_ty, cond, lhs, rhs) => {
                 let cond = self.convert_condition(ctx, true, cond)?;
 
-                let lhs = self.convert_expr(ctx, lhs, Some(override_ty.unwrap_or(ty)))?;
-                let rhs = self.convert_expr(ctx, rhs, Some(override_ty.unwrap_or(ty)))?;
+                let lhs = self.convert_expr(ctx, lhs)?;
+                let rhs = self.convert_expr(ctx, rhs)?;
 
                 if ctx.is_unused() {
                     let is_unsafe = lhs.is_unsafe() || rhs.is_unsafe();
@@ -3363,7 +3359,7 @@ impl<'c> Translation<'c> {
             BinaryConditional(ty, lhs, rhs) => {
                 if ctx.is_unused() {
                     let mut lhs = self.convert_condition(ctx, false, lhs)?;
-                    let rhs = self.convert_expr(ctx, rhs, None)?;
+                    let rhs = self.convert_expr(ctx, rhs)?;
                     lhs = lhs.merge_unsafe(rhs.is_unsafe());
 
                     Ok(lhs.and_then(|val| {
@@ -3387,7 +3383,7 @@ impl<'c> Translation<'c> {
                             let ite = mk().ifte_expr(
                                 cond,
                                 mk().block(vec![mk().expr_stmt(lhs_val)]),
-                                Some(self.convert_expr(ctx, rhs, None)?.to_expr()),
+                                Some(self.convert_expr(ctx, rhs)?.to_expr()),
                             );
                             Ok(ite)
                         },
@@ -3419,7 +3415,7 @@ impl<'c> Translation<'c> {
                 self.convert_member_expr(ctx, qual_ty, expr, decl, kind, lrvalue, override_ty)
             }
 
-            Paren(_, val) => self.convert_expr(ctx, val, override_ty),
+            Paren(_, val) => self.convert_expr(ctx, val),
 
             CompoundLiteral(qty, val) => self.convert_compound_literal(ctx, qty, val, override_ty),
 
@@ -3429,7 +3425,7 @@ impl<'c> Translation<'c> {
 
             ImplicitValueInit(ty) => self.implicit_default_expr(ctx, ty.ctype),
 
-            Predefined(_, val_id) => self.convert_expr(ctx, val_id, override_ty),
+            Predefined(_, val_id) => self.convert_expr(ctx, val_id),
 
             Statements(_, compound_stmt_id) => {
                 self.convert_statement_expression(ctx, compound_stmt_id)
@@ -3439,9 +3435,9 @@ impl<'c> Translation<'c> {
 
             Choose(_, _cond, lhs, rhs, is_cond_true) => {
                 let chosen_expr = if is_cond_true {
-                    self.convert_expr(ctx, lhs, override_ty)?
+                    self.convert_expr(ctx, lhs)?
                 } else {
-                    self.convert_expr(ctx, rhs, override_ty)?
+                    self.convert_expr(ctx, rhs)?
                 };
 
                 // TODO: Support compile-time choice between lhs and rhs based on cond.

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3241,7 +3241,10 @@ impl<'c> Translation<'c> {
                     }
 
                     if let CExprKind::Literal(_, lit) = literal_expr_kind {
-                        if self.literal_matches_ty(lit, target_ty, is_negated) {
+                        if self
+                            .ast_context
+                            .literal_matches_ty(lit, target_ty, is_negated)
+                        {
                             return self.convert_expr(ctx, expr, Some(target_ty));
                         }
                     }

--- a/c2rust-transpile/src/translator/named_references.rs
+++ b/c2rust-transpile/src/translator/named_references.rs
@@ -107,7 +107,7 @@ impl<'c> Translation<'c> {
             .get_qual_type()
             .ok_or_else(|| format_err!("bad reference type"))?;
         let read = |write| self.read(reference_ty, write);
-        let reference = self.convert_expr(ctx.used(), reference, Some(reference_ty))?;
+        let reference = self.convert_expr(ctx.used(), reference)?;
         reference.and_then_try(|reference| {
             if !uses_read && is_lvalue(&reference) {
                 Ok(WithStmts::new_val(NamedReference {

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -838,7 +838,7 @@ impl<'c> Translation<'c> {
         if let (&CExprKind::Literal(_, CLiteral::Integer(val, base)), false, false) = (
             &self.ast_context[arg_id].kind,
             is_unsigned_integral_type,
-            self.expr_is_expanded_macro(ctx, arg_id, Some(expr_type_id)),
+            self.expr_is_expanded_macro(ctx, arg_id),
         ) {
             // If we are negating a literal, generate a negated literal directly.
             // This will create an expression like `-1 as ty` without parentheses,

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -25,8 +25,8 @@ impl<'c> Translation<'c> {
         match op {
             Comma => {
                 // The value of the LHS of a comma expression is always discarded
-                self.convert_expr(ctx.unused(), lhs, None)?
-                    .and_then_try(|_| self.convert_expr(ctx, rhs, Some(expr_type_id)))
+                self.convert_expr(ctx.unused(), lhs)?
+                    .and_then_try(|_| self.convert_expr(ctx, rhs))
             }
 
             op if op.is_logical() => {
@@ -122,8 +122,8 @@ impl<'c> Translation<'c> {
 
                 if ctx.is_unused() {
                     Ok(self
-                        .convert_expr(ctx, lhs, Some(lhs_type_id))?
-                        .and_then_try(|_| self.convert_expr(ctx, rhs, Some(rhs_type_id)))?
+                        .convert_expr(ctx, lhs)?
+                        .and_then_try(|_| self.convert_expr(ctx, rhs))?
                         .map(|_| self.panic_or_err("Binary expression is not supposed to be used")))
                 } else {
                     let rhs_ctx = ctx;
@@ -145,7 +145,7 @@ impl<'c> Translation<'c> {
                         let is_null = op == CBinOp::EqualEqual;
 
                         if self.ast_context.is_null_expr(lhs) {
-                            let val = self.convert_expr(rhs_ctx, rhs, Some(rhs_type_id))?;
+                            let val = self.convert_expr(rhs_ctx, rhs)?;
                             let val = val.try_map(|rhs_rs| {
                                 self.convert_pointer_is_null(
                                     ctx,
@@ -156,7 +156,7 @@ impl<'c> Translation<'c> {
                             })?;
                             return Ok(val.map(bool_to_int));
                         } else if self.ast_context.is_null_expr(rhs) {
-                            let val = self.convert_expr(ctx, lhs, Some(lhs_type_id))?;
+                            let val = self.convert_expr(ctx, lhs)?;
                             let val = val.try_map(|lhs_rs| {
                                 self.convert_pointer_is_null(
                                     ctx,
@@ -169,8 +169,8 @@ impl<'c> Translation<'c> {
                         }
                     }
 
-                    let lhs_val = self.convert_expr(ctx, lhs, Some(lhs_type_id))?;
-                    let rhs_val = self.convert_expr(rhs_ctx, rhs, Some(rhs_type_id))?;
+                    let lhs_val = self.convert_expr(ctx, lhs)?;
+                    let rhs_val = self.convert_expr(rhs_ctx, rhs)?;
 
                     lhs_val.zip(rhs_val).and_then_try(|(lhs_val, rhs_val)| {
                         self.convert_binary_operator(
@@ -276,7 +276,7 @@ impl<'c> Translation<'c> {
             .ok_or_else(|| format_err!("bad initial lhs type"))?;
 
         // First, translate the rhs. Then, if it must match the lhs but doesn't, add a cast.
-        let mut rhs_translation = self.convert_expr(ctx.used(), rhs, Some(rhs_type_id))?;
+        let mut rhs_translation = self.convert_expr(ctx.used(), rhs)?;
         let lhs_rhs_types_must_match = {
             let lhs_resolved_ty = &self.ast_context.resolve_type(lhs_type_id.ctype);
             let rhs_resolved_ty = &self.ast_context.resolve_type(rhs_type_id.ctype);
@@ -781,11 +781,11 @@ impl<'c> Translation<'c> {
                 self.convert_post_increment(ctx, cqual_type, CBinOp::AssignSubtract, arg)
             }
             CUnOp::Deref => self.convert_deref(ctx, cqual_type, arg),
-            CUnOp::Plus => self.convert_expr(ctx.used(), arg, Some(cqual_type)), // promotion is explicit in the clang AST
+            CUnOp::Plus => self.convert_expr(ctx.used(), arg), // promotion is explicit in the clang AST
 
             CUnOp::Negate => self.convert_negate_operator(ctx, cqual_type, arg),
             CUnOp::Complement => Ok(self
-                .convert_expr(ctx.used(), arg, Some(cqual_type))?
+                .convert_expr(ctx.used(), arg)?
                 .map(|a| mk().unary_expr(UnOp::Not(Default::default()), a))),
 
             CUnOp::Not => {
@@ -793,7 +793,7 @@ impl<'c> Translation<'c> {
                 Ok(val.map(|x| mk().cast_expr(x, mk().abs_path_ty(vec!["core", "ffi", "c_int"]))))
             }
             CUnOp::Extension => {
-                let arg = self.convert_expr(ctx, arg, Some(cqual_type))?;
+                let arg = self.convert_expr(ctx, arg)?;
                 Ok(arg)
             }
             CUnOp::Real | CUnOp::Imag | CUnOp::Coawait => {
@@ -846,7 +846,7 @@ impl<'c> Translation<'c> {
             let val = self.mk_int_lit(expr_type_id, val, base, true)?;
             Ok(WithStmts::new_val(val))
         } else {
-            let val = self.convert_expr(ctx.used(), arg_id, Some(expr_type_id))?;
+            let val = self.convert_expr(ctx.used(), arg_id)?;
             let val = val.map(|val| {
                 if is_unsigned_integral_type {
                     wrapping_neg_expr(val)

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -27,9 +27,7 @@ impl<'c> Translation<'c> {
 
         match arg_kind {
             // C99 6.5.3.2 para 4
-            CExprKind::Unary(_, CUnOp::Deref, target, _) => {
-                return self.convert_expr(ctx, *target, None)
-            }
+            CExprKind::Unary(_, CUnOp::Deref, target, _) => return self.convert_expr(ctx, *target),
             // Array subscript functions as a deref too.
             &CExprKind::ArraySubscript(_, lhs, rhs, _) => {
                 return self.convert_array_subscript(
@@ -48,7 +46,7 @@ impl<'c> Translation<'c> {
             _ => (),
         }
 
-        let val = self.convert_expr(ctx.used().set_needs_address(true), arg, None)?;
+        let val = self.convert_expr(ctx.used().set_needs_address(true), arg)?;
 
         // & becomes a no-op when applied to a function.
         if self.ast_context.is_function_pointer(cqual_type.ctype) {
@@ -201,10 +199,10 @@ impl<'c> Translation<'c> {
         let arg_expr_kind = &self.ast_context.index(arg).kind;
 
         if let &CExprKind::Unary(_, CUnOp::AddressOf, arg, _) = arg_expr_kind {
-            return self.convert_expr(ctx.used(), arg, None);
+            return self.convert_expr(ctx.used(), arg);
         }
 
-        self.convert_expr(ctx.used(), arg, None)?
+        self.convert_expr(ctx.used(), arg)?
             .try_map(|val: Box<Expr>| {
                 if let CTypeKind::Function(..) =
                     self.ast_context.resolve_type(cqual_type.ctype).kind
@@ -258,7 +256,7 @@ impl<'c> Translation<'c> {
             ));
         }
 
-        let rhs = self.convert_expr(ctx.used(), rhs, None)?;
+        let rhs = self.convert_expr(ctx.used(), rhs)?;
         rhs.and_then_try(|rhs| {
             let simple_index_array = if ctx.needs_address() {
                 // We can't necessarily index into an array if we're using
@@ -307,7 +305,7 @@ impl<'c> Translation<'c> {
                     ref other => panic!("Unexpected array type {:?}", other),
                 };
 
-                let lhs = self.convert_expr(ctx.used(), arr, None)?;
+                let lhs = self.convert_expr(ctx.used(), arr)?;
                 Ok(lhs.and_then(|lhs| {
                     // stmts.extend(lhs.stmts_mut());
                     // is_unsafe = is_unsafe || lhs.is_unsafe();
@@ -321,7 +319,7 @@ impl<'c> Translation<'c> {
                 }))
             } else {
                 // LHS must be ref decayed for the offset method call's self param
-                let lhs = self.convert_expr(ctx.used().decay_ref(), lhs, None)?;
+                let lhs = self.convert_expr(ctx.used().decay_ref(), lhs)?;
                 lhs.and_then_try(|lhs| {
                     // stmts.extend(lhs.stmts_mut());
                     // is_unsafe = is_unsafe || lhs.is_unsafe();

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -104,7 +104,7 @@ impl<'c> Translation<'c> {
             .ast_context
             .get_pointee_qual_type(pointer_cty.ctype)
             .ok_or_else(|| TranslationError::generic("Address-of should return a pointer"))?;
-        let arg_is_macro = arg.map_or(false, |arg| self.expr_is_expanded_macro(ctx, arg, None));
+        let arg_is_macro = arg.map_or(false, |arg| self.expr_is_expanded_macro(ctx, arg));
 
         let mut needs_cast = false;
         let mut ref_cast_pointee_ty = None;

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -222,7 +222,7 @@ impl<'c> Translation<'c> {
                 .map(|arg| self.clean_int_or_vector_param(*arg)),
         );
 
-        let param_translation = self.convert_exprs(ctx.used(), &processed_args, None)?;
+        let param_translation = self.convert_exprs(ctx.used(), &processed_args)?;
         Ok(param_translation.and_then(|call_params| {
             let call = mk().call_expr(mk().ident_expr(fn_name), call_params);
 
@@ -292,7 +292,7 @@ impl<'c> Translation<'c> {
         ctype: CTypeId,
         len: usize,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let param_translation = self.convert_exprs(ctx, ids, None)?;
+        let param_translation = self.convert_exprs(ctx, ids)?;
         param_translation.and_then_try(|mut params| {
             let mut is_unsafe = false;
 
@@ -383,11 +383,8 @@ impl<'c> Translation<'c> {
         }
 
         let mask_expr_id = self.get_shuffle_vector_mask(&child_expr_ids[2..])?;
-        let param_translation = self.convert_exprs(
-            ctx.used(),
-            &[first_expr_id, second_expr_id, mask_expr_id],
-            None,
-        )?;
+        let param_translation =
+            self.convert_exprs(ctx.used(), &[first_expr_id, second_expr_id, mask_expr_id])?;
         param_translation.and_then_try(|params| {
             let [first, second, third]: [_; 3] = params
                 .try_into()

--- a/c2rust-transpile/src/translator/structs_unions.rs
+++ b/c2rust-transpile/src/translator/structs_unions.rs
@@ -492,8 +492,8 @@ impl<'a> Translation<'a> {
                     let field = init.map(|init| mk().field(field_name, init));
                     fields.push(field);
                 }
-                Both(field_id, (field_name, ty, bitfield_width, use_inner_type)) => {
-                    let mut expr = self.convert_expr(ctx.used(), *field_id, Some(ty))?;
+                Both(field_id, (field_name, _ty, bitfield_width, use_inner_type)) => {
+                    let mut expr = self.convert_expr(ctx.used(), *field_id)?;
 
                     if use_inner_type {
                         // See comment above
@@ -585,7 +585,7 @@ impl<'a> Translation<'a> {
                         let val = if ids.is_empty() {
                             self.implicit_default_expr(ctx, field_ty.ctype)?
                         } else {
-                            self.convert_expr(ctx.used(), ids[0], None)?
+                            self.convert_expr(ctx.used(), ids[0])?
                         };
 
                         Ok(val.map(|v| {
@@ -988,20 +988,20 @@ impl<'a> Translation<'a> {
         override_ty: Option<CQualTypeId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         if ctx.is_unused() {
-            return self.convert_expr(ctx, expr, None);
+            return self.convert_expr(ctx, expr);
         }
 
         let mut val = match kind {
-            MemberKind::Dot => self.convert_expr(ctx, expr, None)?,
+            MemberKind::Dot => self.convert_expr(ctx, expr)?,
             MemberKind::Arrow => {
                 if let CExprKind::Unary(_, CUnOp::AddressOf, subexpr_id, _) =
                     self.ast_context[expr].kind
                 {
                     // Special-case the `(&x)->field` pattern
                     // Convert it directly into `x.field`
-                    self.convert_expr(ctx, subexpr_id, None)?
+                    self.convert_expr(ctx, subexpr_id)?
                 } else {
-                    let val = self.convert_expr(ctx, expr, None)?;
+                    let val = self.convert_expr(ctx, expr)?;
                     val.map(|v| mk().unary_expr(UnOp::Deref(Default::default()), v))
                 }
             }

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -176,7 +176,7 @@ impl<'c> Translation<'c> {
         val_id: CExprId,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         if self.tcfg.translate_valist {
-            let val = self.convert_expr(ctx.used(), val_id, None)?;
+            let val = self.convert_expr(ctx.used(), val_id)?;
 
             // The current implementation of the C-variadics feature doesn't allow us to
             // return `Option<fn(...) -> _>` from `VaList::arg`, so we detect function pointers

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.clang15.snap
@@ -36,11 +36,11 @@ pub struct ntlmdata {
     pub target_info_len: ::core::ffi::c_uint,
 }
 pub const true_0: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
-pub const UINTPTR_MAX: ::core::ffi::c_ulong = 18446744073709551615 as ::core::ffi::c_ulong;
+pub const UINTPTR_MAX: uintptr_t = 18446744073709551615 as uintptr_t;
 pub const LITERAL_INT: ::core::ffi::c_int = 0xffff as ::core::ffi::c_int;
 pub const LITERAL_BOOL: ::core::ffi::c_int = true_0;
-pub const LITERAL_FLOAT: ::core::ffi::c_double = 3.14f64;
-pub const LITERAL_CHAR: ::core::ffi::c_int = 'x' as ::core::ffi::c_int;
+pub const LITERAL_FLOAT: ::core::ffi::c_float = 3.14f32;
+pub const LITERAL_CHAR: ::core::ffi::c_char = 'x' as ::core::ffi::c_char;
 pub const LITERAL_STR: [::core::ffi::c_char; 6] =
     unsafe { ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0") };
 pub const LITERAL_STRUCT: S = S {
@@ -48,11 +48,11 @@ pub const LITERAL_STRUCT: S = S {
 };
 pub const NESTED_INT: ::core::ffi::c_int = LITERAL_INT;
 pub const NESTED_BOOL: ::core::ffi::c_int = LITERAL_BOOL;
-pub const NESTED_FLOAT: ::core::ffi::c_double = LITERAL_FLOAT;
-pub const NESTED_CHAR: ::core::ffi::c_int = LITERAL_CHAR;
+pub const NESTED_FLOAT: ::core::ffi::c_float = LITERAL_FLOAT;
+pub const NESTED_CHAR: ::core::ffi::c_char = LITERAL_CHAR;
 pub const NESTED_STR: [::core::ffi::c_char; 6] = LITERAL_STR;
 pub const NESTED_STRUCT: S = LITERAL_STRUCT;
-pub const PARENS: ::core::ffi::c_int = NESTED_INT * (LITERAL_CHAR + true_0);
+pub const PARENS: ::core::ffi::c_int = NESTED_INT * (LITERAL_CHAR as ::core::ffi::c_int + true_0);
 pub const PTR_ARITHMETIC: *const ::core::ffi::c_char = unsafe {
     LITERAL_STR
         .as_ptr()
@@ -65,8 +65,8 @@ pub const CONVERSION_CAST: ::core::ffi::c_double = LITERAL_INT as ::core::ffi::c
 pub unsafe extern "C" fn local_muts() {
     let mut literal_int: ::core::ffi::c_int = LITERAL_INT;
     let mut literal_bool: bool = LITERAL_BOOL != 0;
-    let mut literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
-    let mut literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
+    let mut literal_float: ::core::ffi::c_float = LITERAL_FLOAT;
+    let mut literal_char: ::core::ffi::c_char = LITERAL_CHAR;
     let mut literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
     let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let mut literal_array: [::core::ffi::c_int; 3] = [
@@ -77,8 +77,8 @@ pub unsafe extern "C" fn local_muts() {
     let mut literal_struct: S = LITERAL_STRUCT;
     let mut nested_int: ::core::ffi::c_int = NESTED_INT;
     let mut nested_bool: bool = NESTED_BOOL != 0;
-    let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
-    let mut nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
+    let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT;
+    let mut nested_char: ::core::ffi::c_char = NESTED_CHAR;
     let mut nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
     let mut nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
     let mut nested_array: [::core::ffi::c_int; 3] = [
@@ -90,7 +90,8 @@ pub unsafe extern "C" fn local_muts() {
     let mut negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let mut int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mut mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
-        + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+        + NESTED_FLOAT as ::core::ffi::c_double
+            * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
         - true_0 as ::core::ffi::c_double)
         as ::core::ffi::c_float;
     let mut parens: ::core::ffi::c_int = PARENS;
@@ -99,7 +100,7 @@ pub unsafe extern "C" fn local_muts() {
     let mut narrowing_cast: ::core::ffi::c_char = LITERAL_INT as ::core::ffi::c_char;
     let mut conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
     let mut indexing: ::core::ffi::c_char =
-        NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+        NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
     let mut str_concatenation_ptr: *const ::core::ffi::c_char =
         b"hello hello world\0".as_ptr() as *const ::core::ffi::c_char;
     let mut str_concatenation: [::core::ffi::c_char; 18] =
@@ -108,7 +109,7 @@ pub unsafe extern "C" fn local_muts() {
         (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let mut ref_indexing: *const ::core::ffi::c_char = NESTED_STR
         .as_ptr()
-        .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
+        .offset(LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;
     let mut ref_struct: *const S = &mut LITERAL_STRUCT as *mut S;
     let mut ternary: ::core::ffi::c_int = if LITERAL_BOOL != 0 {
@@ -121,9 +122,10 @@ pub unsafe extern "C" fn local_muts() {
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
         let mut indexing_0: ::core::ffi::c_char =
-            NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+            NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
         let mut mixed: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
-            + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+            + NESTED_FLOAT as ::core::ffi::c_double
+                * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
             - true_0 as ::core::ffi::c_double)
             as ::core::ffi::c_float;
         let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
@@ -138,8 +140,8 @@ pub unsafe extern "C" fn local_muts() {
 pub unsafe extern "C" fn local_consts() {
     let literal_int: ::core::ffi::c_int = LITERAL_INT;
     let literal_bool: bool = LITERAL_BOOL != 0;
-    let literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
-    let literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
+    let literal_float: ::core::ffi::c_float = LITERAL_FLOAT;
+    let literal_char: ::core::ffi::c_char = LITERAL_CHAR;
     let literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
     let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let literal_array: [::core::ffi::c_int; 3] = [
@@ -150,8 +152,8 @@ pub unsafe extern "C" fn local_consts() {
     let literal_struct: S = LITERAL_STRUCT;
     let nested_int: ::core::ffi::c_int = NESTED_INT;
     let nested_bool: bool = NESTED_BOOL != 0;
-    let nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
-    let nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
+    let nested_float: ::core::ffi::c_float = NESTED_FLOAT;
+    let nested_char: ::core::ffi::c_char = NESTED_CHAR;
     let nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
     let nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
     let nested_array: [::core::ffi::c_int; 3] = [
@@ -163,7 +165,8 @@ pub unsafe extern "C" fn local_consts() {
     let negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
-        + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+        + NESTED_FLOAT as ::core::ffi::c_double
+            * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
         - true_0 as ::core::ffi::c_double)
         as ::core::ffi::c_float;
     let parens: ::core::ffi::c_int = PARENS;
@@ -171,7 +174,8 @@ pub unsafe extern "C" fn local_consts() {
     let widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
     let narrowing_cast: ::core::ffi::c_char = LITERAL_INT as ::core::ffi::c_char;
     let conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
-    let indexing: ::core::ffi::c_char = NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+    let indexing: ::core::ffi::c_char =
+        NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
     let str_concatenation_ptr: *const ::core::ffi::c_char =
         b"hello hello world\0".as_ptr() as *const ::core::ffi::c_char;
     let str_concatenation: [::core::ffi::c_char; 18] =
@@ -179,7 +183,7 @@ pub unsafe extern "C" fn local_consts() {
     let builtin: ::core::ffi::c_int = (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let ref_indexing: *const ::core::ffi::c_char = NESTED_STR
         .as_ptr()
-        .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
+        .offset(LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;
     let ref_struct: *const S = &mut LITERAL_STRUCT as *mut S;
     let ternary: ::core::ffi::c_int = if LITERAL_BOOL != 0 {
@@ -192,9 +196,10 @@ pub unsafe extern "C" fn local_consts() {
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
         let mut indexing_0: ::core::ffi::c_char =
-            NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+            NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
         let mut mixed: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
-            + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+            + NESTED_FLOAT as ::core::ffi::c_double
+                * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
             - true_0 as ::core::ffi::c_double)
             as ::core::ffi::c_float;
         let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
@@ -207,10 +212,8 @@ pub unsafe extern "C" fn local_consts() {
 }
 static mut global_static_const_literal_int: ::core::ffi::c_int = LITERAL_INT;
 static mut global_static_const_literal_bool: bool = LITERAL_BOOL != 0;
-static mut global_static_const_literal_float: ::core::ffi::c_float =
-    LITERAL_FLOAT as ::core::ffi::c_float;
-static mut global_static_const_literal_char: ::core::ffi::c_char =
-    LITERAL_CHAR as ::core::ffi::c_char;
+static mut global_static_const_literal_float: ::core::ffi::c_float = LITERAL_FLOAT;
+static mut global_static_const_literal_char: ::core::ffi::c_char = LITERAL_CHAR;
 static mut global_static_const_literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
 static mut global_static_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
 static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = [
@@ -221,10 +224,8 @@ static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = [
 static mut global_static_const_literal_struct: S = LITERAL_STRUCT;
 static mut global_static_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 static mut global_static_const_nested_bool: bool = NESTED_BOOL != 0;
-static mut global_static_const_nested_float: ::core::ffi::c_float =
-    NESTED_FLOAT as ::core::ffi::c_float;
-static mut global_static_const_nested_char: ::core::ffi::c_char =
-    NESTED_CHAR as ::core::ffi::c_char;
+static mut global_static_const_nested_float: ::core::ffi::c_float = NESTED_FLOAT;
+static mut global_static_const_nested_char: ::core::ffi::c_char = NESTED_CHAR;
 static mut global_static_const_nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
 static mut global_static_const_nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
 static mut global_static_const_nested_array: [::core::ffi::c_int; 3] = [
@@ -237,7 +238,9 @@ static mut global_static_const_negative_int: ::core::ffi::c_int = -LITERAL_INT;
 static mut global_static_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
 static mut global_static_const_mixed_arithmetic: ::core::ffi::c_float =
-    (LITERAL_INT as ::core::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+    (LITERAL_INT as ::core::ffi::c_double
+        + NESTED_FLOAT as ::core::ffi::c_double
+            * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
         - true_0 as ::core::ffi::c_double) as ::core::ffi::c_float;
 static mut global_static_const_parens: ::core::ffi::c_int = PARENS;
 static mut global_static_const_ptr_arithmetic: *const ::core::ffi::c_char =
@@ -266,10 +269,9 @@ pub static mut global_const_literal_int: ::core::ffi::c_int = LITERAL_INT;
 #[no_mangle]
 pub static mut global_const_literal_bool: bool = LITERAL_BOOL != 0;
 #[no_mangle]
-pub static mut global_const_literal_float: ::core::ffi::c_float =
-    LITERAL_FLOAT as ::core::ffi::c_float;
+pub static mut global_const_literal_float: ::core::ffi::c_float = LITERAL_FLOAT;
 #[no_mangle]
-pub static mut global_const_literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
+pub static mut global_const_literal_char: ::core::ffi::c_char = LITERAL_CHAR;
 #[no_mangle]
 pub static mut global_const_literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
 #[no_mangle]
@@ -287,10 +289,9 @@ pub static mut global_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 #[no_mangle]
 pub static mut global_const_nested_bool: bool = NESTED_BOOL != 0;
 #[no_mangle]
-pub static mut global_const_nested_float: ::core::ffi::c_float =
-    NESTED_FLOAT as ::core::ffi::c_float;
+pub static mut global_const_nested_float: ::core::ffi::c_float = NESTED_FLOAT;
 #[no_mangle]
-pub static mut global_const_nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
+pub static mut global_const_nested_char: ::core::ffi::c_char = NESTED_CHAR;
 #[no_mangle]
 pub static mut global_const_nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
 #[no_mangle]
@@ -310,7 +311,9 @@ pub static mut global_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
 #[no_mangle]
 pub static mut global_const_mixed_arithmetic: ::core::ffi::c_float =
-    (LITERAL_INT as ::core::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+    (LITERAL_INT as ::core::ffi::c_double
+        + NESTED_FLOAT as ::core::ffi::c_double
+            * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
         - true_0 as ::core::ffi::c_double) as ::core::ffi::c_float;
 #[no_mangle]
 pub static mut global_const_parens: ::core::ffi::c_int = PARENS;
@@ -428,7 +431,7 @@ pub unsafe extern "C" fn use_local_value() -> ::core::ffi::c_int {
 }
 #[no_mangle]
 pub unsafe extern "C" fn use_portable_type(mut len: uintptr_t) -> bool {
-    return len <= (UINTPTR_MAX as uintptr_t).wrapping_div(2 as ::core::ffi::c_int as uintptr_t);
+    return len <= UINTPTR_MAX.wrapping_div(2 as ::core::ffi::c_int as uintptr_t);
 }
 #[no_mangle]
 pub unsafe extern "C" fn ntlm_v2_blob_len(mut ntlm: *mut ntlmdata) -> ::core::ffi::c_uint {
@@ -446,10 +449,11 @@ pub unsafe extern "C" fn late_init_var() -> ::core::ffi::c_int {
 }
 unsafe extern "C" fn c2rust_run_static_initializers() {
     global_static_const_ptr_arithmetic = PTR_ARITHMETIC;
-    global_static_const_indexing = NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+    global_static_const_indexing =
+        NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
     global_static_const_ref_indexing = NESTED_STR
         .as_ptr()
-        .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
+        .offset(LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;
     global_static_const_ternary = if LITERAL_BOOL != 0 {
         1 as ::core::ffi::c_int
@@ -458,10 +462,11 @@ unsafe extern "C" fn c2rust_run_static_initializers() {
     };
     global_static_const_member = LITERAL_STRUCT.i;
     global_const_ptr_arithmetic = PTR_ARITHMETIC;
-    global_const_indexing = NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+    global_const_indexing =
+        NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
     global_const_ref_indexing = NESTED_STR
         .as_ptr()
-        .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
+        .offset(LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;
     global_const_ternary = if LITERAL_BOOL != 0 {
         1 as ::core::ffi::c_int

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.clang15.snap
@@ -36,11 +36,11 @@ pub struct ntlmdata {
     pub target_info_len: ::core::ffi::c_uint,
 }
 pub const true_0: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
-pub const UINTPTR_MAX: ::core::ffi::c_ulong = 18446744073709551615 as ::core::ffi::c_ulong;
+pub const UINTPTR_MAX: uintptr_t = 18446744073709551615 as uintptr_t;
 pub const LITERAL_INT: ::core::ffi::c_int = 0xffff as ::core::ffi::c_int;
 pub const LITERAL_BOOL: ::core::ffi::c_int = true_0;
-pub const LITERAL_FLOAT: ::core::ffi::c_double = 3.14f64;
-pub const LITERAL_CHAR: ::core::ffi::c_int = 'x' as ::core::ffi::c_int;
+pub const LITERAL_FLOAT: ::core::ffi::c_float = 3.14f32;
+pub const LITERAL_CHAR: ::core::ffi::c_char = 'x' as ::core::ffi::c_char;
 pub const LITERAL_STR: [::core::ffi::c_char; 6] =
     unsafe { ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0") };
 pub const LITERAL_STRUCT: S = S {
@@ -48,11 +48,11 @@ pub const LITERAL_STRUCT: S = S {
 };
 pub const NESTED_INT: ::core::ffi::c_int = LITERAL_INT;
 pub const NESTED_BOOL: ::core::ffi::c_int = LITERAL_BOOL;
-pub const NESTED_FLOAT: ::core::ffi::c_double = LITERAL_FLOAT;
-pub const NESTED_CHAR: ::core::ffi::c_int = LITERAL_CHAR;
+pub const NESTED_FLOAT: ::core::ffi::c_float = LITERAL_FLOAT;
+pub const NESTED_CHAR: ::core::ffi::c_char = LITERAL_CHAR;
 pub const NESTED_STR: [::core::ffi::c_char; 6] = LITERAL_STR;
 pub const NESTED_STRUCT: S = LITERAL_STRUCT;
-pub const PARENS: ::core::ffi::c_int = NESTED_INT * (LITERAL_CHAR + true_0);
+pub const PARENS: ::core::ffi::c_int = NESTED_INT * (LITERAL_CHAR as ::core::ffi::c_int + true_0);
 pub const PTR_ARITHMETIC: *const ::core::ffi::c_char = unsafe {
     LITERAL_STR
         .as_ptr()
@@ -65,8 +65,8 @@ pub const CONVERSION_CAST: ::core::ffi::c_double = LITERAL_INT as ::core::ffi::c
 pub unsafe extern "C" fn local_muts() {
     let mut literal_int: ::core::ffi::c_int = LITERAL_INT;
     let mut literal_bool: bool = LITERAL_BOOL != 0;
-    let mut literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
-    let mut literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
+    let mut literal_float: ::core::ffi::c_float = LITERAL_FLOAT;
+    let mut literal_char: ::core::ffi::c_char = LITERAL_CHAR;
     let mut literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
     let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let mut literal_array: [::core::ffi::c_int; 3] = [
@@ -77,8 +77,8 @@ pub unsafe extern "C" fn local_muts() {
     let mut literal_struct: S = LITERAL_STRUCT;
     let mut nested_int: ::core::ffi::c_int = NESTED_INT;
     let mut nested_bool: bool = NESTED_BOOL != 0;
-    let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
-    let mut nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
+    let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT;
+    let mut nested_char: ::core::ffi::c_char = NESTED_CHAR;
     let mut nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
     let mut nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
     let mut nested_array: [::core::ffi::c_int; 3] = [
@@ -90,7 +90,8 @@ pub unsafe extern "C" fn local_muts() {
     let mut negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let mut int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mut mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
-        + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+        + NESTED_FLOAT as ::core::ffi::c_double
+            * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
         - true_0 as ::core::ffi::c_double)
         as ::core::ffi::c_float;
     let mut parens: ::core::ffi::c_int = PARENS;
@@ -99,7 +100,7 @@ pub unsafe extern "C" fn local_muts() {
     let mut narrowing_cast: ::core::ffi::c_char = LITERAL_INT as ::core::ffi::c_char;
     let mut conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
     let mut indexing: ::core::ffi::c_char =
-        NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+        NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
     let mut str_concatenation_ptr: *const ::core::ffi::c_char =
         b"hello hello world\0".as_ptr() as *const ::core::ffi::c_char;
     let mut str_concatenation: [::core::ffi::c_char; 18] =
@@ -108,7 +109,7 @@ pub unsafe extern "C" fn local_muts() {
         (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let mut ref_indexing: *const ::core::ffi::c_char = NESTED_STR
         .as_ptr()
-        .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
+        .offset(LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;
     let mut ref_struct: *const S = &mut LITERAL_STRUCT as *mut S;
     let mut ternary: ::core::ffi::c_int = if LITERAL_BOOL != 0 {
@@ -121,9 +122,10 @@ pub unsafe extern "C" fn local_muts() {
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
         let mut indexing_0: ::core::ffi::c_char =
-            NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+            NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
         let mut mixed: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
-            + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+            + NESTED_FLOAT as ::core::ffi::c_double
+                * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
             - true_0 as ::core::ffi::c_double)
             as ::core::ffi::c_float;
         let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
@@ -138,8 +140,8 @@ pub unsafe extern "C" fn local_muts() {
 pub unsafe extern "C" fn local_consts() {
     let literal_int: ::core::ffi::c_int = LITERAL_INT;
     let literal_bool: bool = LITERAL_BOOL != 0;
-    let literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
-    let literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
+    let literal_float: ::core::ffi::c_float = LITERAL_FLOAT;
+    let literal_char: ::core::ffi::c_char = LITERAL_CHAR;
     let literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
     let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let literal_array: [::core::ffi::c_int; 3] = [
@@ -150,8 +152,8 @@ pub unsafe extern "C" fn local_consts() {
     let literal_struct: S = LITERAL_STRUCT;
     let nested_int: ::core::ffi::c_int = NESTED_INT;
     let nested_bool: bool = NESTED_BOOL != 0;
-    let nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
-    let nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
+    let nested_float: ::core::ffi::c_float = NESTED_FLOAT;
+    let nested_char: ::core::ffi::c_char = NESTED_CHAR;
     let nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
     let nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
     let nested_array: [::core::ffi::c_int; 3] = [
@@ -163,7 +165,8 @@ pub unsafe extern "C" fn local_consts() {
     let negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
-        + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+        + NESTED_FLOAT as ::core::ffi::c_double
+            * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
         - true_0 as ::core::ffi::c_double)
         as ::core::ffi::c_float;
     let parens: ::core::ffi::c_int = PARENS;
@@ -171,7 +174,8 @@ pub unsafe extern "C" fn local_consts() {
     let widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
     let narrowing_cast: ::core::ffi::c_char = LITERAL_INT as ::core::ffi::c_char;
     let conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
-    let indexing: ::core::ffi::c_char = NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+    let indexing: ::core::ffi::c_char =
+        NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
     let str_concatenation_ptr: *const ::core::ffi::c_char =
         b"hello hello world\0".as_ptr() as *const ::core::ffi::c_char;
     let str_concatenation: [::core::ffi::c_char; 18] =
@@ -179,7 +183,7 @@ pub unsafe extern "C" fn local_consts() {
     let builtin: ::core::ffi::c_int = (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let ref_indexing: *const ::core::ffi::c_char = NESTED_STR
         .as_ptr()
-        .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
+        .offset(LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;
     let ref_struct: *const S = &mut LITERAL_STRUCT as *mut S;
     let ternary: ::core::ffi::c_int = if LITERAL_BOOL != 0 {
@@ -192,9 +196,10 @@ pub unsafe extern "C" fn local_consts() {
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
         let mut indexing_0: ::core::ffi::c_char =
-            NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+            NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
         let mut mixed: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
-            + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+            + NESTED_FLOAT as ::core::ffi::c_double
+                * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
             - true_0 as ::core::ffi::c_double)
             as ::core::ffi::c_float;
         let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
@@ -207,10 +212,8 @@ pub unsafe extern "C" fn local_consts() {
 }
 static mut global_static_const_literal_int: ::core::ffi::c_int = LITERAL_INT;
 static mut global_static_const_literal_bool: bool = LITERAL_BOOL != 0;
-static mut global_static_const_literal_float: ::core::ffi::c_float =
-    LITERAL_FLOAT as ::core::ffi::c_float;
-static mut global_static_const_literal_char: ::core::ffi::c_char =
-    LITERAL_CHAR as ::core::ffi::c_char;
+static mut global_static_const_literal_float: ::core::ffi::c_float = LITERAL_FLOAT;
+static mut global_static_const_literal_char: ::core::ffi::c_char = LITERAL_CHAR;
 static mut global_static_const_literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
 static mut global_static_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
 static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = [
@@ -221,10 +224,8 @@ static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = [
 static mut global_static_const_literal_struct: S = LITERAL_STRUCT;
 static mut global_static_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 static mut global_static_const_nested_bool: bool = NESTED_BOOL != 0;
-static mut global_static_const_nested_float: ::core::ffi::c_float =
-    NESTED_FLOAT as ::core::ffi::c_float;
-static mut global_static_const_nested_char: ::core::ffi::c_char =
-    NESTED_CHAR as ::core::ffi::c_char;
+static mut global_static_const_nested_float: ::core::ffi::c_float = NESTED_FLOAT;
+static mut global_static_const_nested_char: ::core::ffi::c_char = NESTED_CHAR;
 static mut global_static_const_nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
 static mut global_static_const_nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
 static mut global_static_const_nested_array: [::core::ffi::c_int; 3] = [
@@ -237,7 +238,9 @@ static mut global_static_const_negative_int: ::core::ffi::c_int = -LITERAL_INT;
 static mut global_static_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
 static mut global_static_const_mixed_arithmetic: ::core::ffi::c_float =
-    (LITERAL_INT as ::core::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+    (LITERAL_INT as ::core::ffi::c_double
+        + NESTED_FLOAT as ::core::ffi::c_double
+            * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
         - true_0 as ::core::ffi::c_double) as ::core::ffi::c_float;
 static mut global_static_const_parens: ::core::ffi::c_int = PARENS;
 static mut global_static_const_ptr_arithmetic: *const ::core::ffi::c_char =
@@ -266,10 +269,9 @@ pub static mut global_const_literal_int: ::core::ffi::c_int = LITERAL_INT;
 #[unsafe(no_mangle)]
 pub static mut global_const_literal_bool: bool = LITERAL_BOOL != 0;
 #[unsafe(no_mangle)]
-pub static mut global_const_literal_float: ::core::ffi::c_float =
-    LITERAL_FLOAT as ::core::ffi::c_float;
+pub static mut global_const_literal_float: ::core::ffi::c_float = LITERAL_FLOAT;
 #[unsafe(no_mangle)]
-pub static mut global_const_literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
+pub static mut global_const_literal_char: ::core::ffi::c_char = LITERAL_CHAR;
 #[unsafe(no_mangle)]
 pub static mut global_const_literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
 #[unsafe(no_mangle)]
@@ -287,10 +289,9 @@ pub static mut global_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 #[unsafe(no_mangle)]
 pub static mut global_const_nested_bool: bool = NESTED_BOOL != 0;
 #[unsafe(no_mangle)]
-pub static mut global_const_nested_float: ::core::ffi::c_float =
-    NESTED_FLOAT as ::core::ffi::c_float;
+pub static mut global_const_nested_float: ::core::ffi::c_float = NESTED_FLOAT;
 #[unsafe(no_mangle)]
-pub static mut global_const_nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
+pub static mut global_const_nested_char: ::core::ffi::c_char = NESTED_CHAR;
 #[unsafe(no_mangle)]
 pub static mut global_const_nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
 #[unsafe(no_mangle)]
@@ -310,7 +311,9 @@ pub static mut global_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
 #[unsafe(no_mangle)]
 pub static mut global_const_mixed_arithmetic: ::core::ffi::c_float =
-    (LITERAL_INT as ::core::ffi::c_double + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
+    (LITERAL_INT as ::core::ffi::c_double
+        + NESTED_FLOAT as ::core::ffi::c_double
+            * LITERAL_CHAR as ::core::ffi::c_int as ::core::ffi::c_double
         - true_0 as ::core::ffi::c_double) as ::core::ffi::c_float;
 #[unsafe(no_mangle)]
 pub static mut global_const_parens: ::core::ffi::c_int = PARENS;
@@ -428,7 +431,7 @@ pub unsafe extern "C" fn use_local_value() -> ::core::ffi::c_int {
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn use_portable_type(mut len: uintptr_t) -> bool {
-    return len <= (UINTPTR_MAX as uintptr_t).wrapping_div(2 as ::core::ffi::c_int as uintptr_t);
+    return len <= UINTPTR_MAX.wrapping_div(2 as ::core::ffi::c_int as uintptr_t);
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ntlm_v2_blob_len(mut ntlm: *mut ntlmdata) -> ::core::ffi::c_uint {
@@ -446,10 +449,11 @@ pub unsafe extern "C" fn late_init_var() -> ::core::ffi::c_int {
 }
 unsafe extern "C" fn c2rust_run_static_initializers() {
     global_static_const_ptr_arithmetic = PTR_ARITHMETIC;
-    global_static_const_indexing = NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+    global_static_const_indexing =
+        NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
     global_static_const_ref_indexing = NESTED_STR
         .as_ptr()
-        .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
+        .offset(LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;
     global_static_const_ternary = if LITERAL_BOOL != 0 {
         1 as ::core::ffi::c_int
@@ -458,10 +462,11 @@ unsafe extern "C" fn c2rust_run_static_initializers() {
     };
     global_static_const_member = LITERAL_STRUCT.i;
     global_const_ptr_arithmetic = PTR_ARITHMETIC;
-    global_const_indexing = NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_int as usize];
+    global_const_indexing =
+        NESTED_STR[LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as usize];
     global_const_ref_indexing = NESTED_STR
         .as_ptr()
-        .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
+        .offset(LITERAL_FLOAT as ::core::ffi::c_double as ::core::ffi::c_int as isize)
         as *const ::core::ffi::c_char;
     global_const_ternary = if LITERAL_BOOL != 0 {
         1 as ::core::ffi::c_int


### PR DESCRIPTION
- Depends on #1757
- Depends on #1756
- Fixes #1321

Before proceeding to remove `override_ty`, I added a temporary assert to compare the value passed to `convert_expr` with the value being generated by the new method. The assert eventually passed in the full CI suite, which likely means they match perfectly.

There was a comment left here concerning this issue:
https://github.com/immunant/c2rust/blob/4887dcef9a5dcaf0842269d2b82d00bd12c0d171/c2rust-transpile/src/translator/mod.rs#L4198

I don't think the cast can be removed, though. In the snapshot test, the `LITERAL_FLOAT` and `NESTED_FLOAT` macros switched type from `double` to `float`, which removed some casts to `float`, but caused new casts to `double` to be added elsewhere.