### PR TITLE
transpile: Pass correct types when translating prefix inc/dec operators

### DIFF
--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -727,6 +727,12 @@ impl<'c> Translation<'c> {
         } else {
             c_ast::BinOp::AssignSubtract
         };
+
+        let arg_type = self.ast_context[arg]
+            .kind
+            .get_qual_type()
+            .ok_or_else(|| format_err!("bad arg type"))?;
+
         let one = match self.ast_context.resolve_type(ty.ctype).kind {
             // TODO: If rust gets f16 support:
             // CTypeKind::Half |
@@ -741,19 +747,27 @@ impl<'c> Translation<'c> {
             }
             _ => mk().lit_expr(mk().int_unsuffixed_lit(1)),
         };
-        let arg_type = self.ast_context[arg]
-            .kind
-            .get_qual_type()
-            .ok_or_else(|| format_err!("bad arg type"))?;
+
+        let one_type_id =
+            if let CTypeKind::Pointer(..) = self.ast_context.resolve_type(arg_type.ctype).kind {
+                CQualTypeId::new(
+                    self.ast_context
+                        .type_for_kind(&CTypeKind::Int)
+                        .ok_or_else(|| format_err!("couldn't find type for CTypeKind::Int"))?,
+                )
+            } else {
+                arg_type
+            };
+
         self.convert_assignment_operator_with_rhs(
             ctx.used(),
             op,
-            arg_type,
-            arg,
             ty,
+            arg,
+            one_type_id,
             WithStmts::new_val(one),
             Some(arg_type),
-            Some(arg_type),
+            Some(ty),
         )
     }
 

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -410,6 +410,11 @@ fn test_str_init() {
     transpile("str_init.c").run();
 }
 
+#[test]
+fn test_volatile() {
+    transpile("volatile.c").expect_compile_error(true).run();
+}
+
 // arch-specific
 
 #[test]

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -412,7 +412,10 @@ fn test_str_init() {
 
 #[test]
 fn test_volatile() {
-    transpile("volatile.c").expect_compile_error(true).run();
+    transpile("volatile.c")
+        // https://github.com/immunant/c2rust/pull/1689#discussion_r3015140974
+        .expect_compile_error_edition_2024(true)
+        .run();
 }
 
 // arch-specific

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
@@ -1,0 +1,34 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/volatile.2021.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct S {
+    pub p: *mut ::core::ffi::c_int,
+}
+#[no_mangle]
+pub static mut volatile_global_struct: S = S {
+    p: ::core::ptr::null::<::core::ffi::c_int>() as *mut ::core::ffi::c_int,
+};
+#[no_mangle]
+pub unsafe extern "C" fn test_volatile() {
+    unsafe {
+        ::core::ptr::write_volatile(
+            &mut volatile_global_struct.p as *mut *mut ::core::ffi::c_int,
+            ::core::ptr::read_volatile::<*mut ::core::ffi::c_int>(
+                &volatile_global_struct.p as *const *mut ::core::ffi::c_int,
+            )
+            .offset_from(1) as *mut ::core::ffi::c_int,
+        );
+    }
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn test_volatile() {
             ::core::ptr::read_volatile::<*mut ::core::ffi::c_int>(
                 &volatile_global_struct.p as *const *mut ::core::ffi::c_int,
             )
-            .offset_from(1) as *mut ::core::ffi::c_int,
+            .offset(-1),
         );
     }
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
@@ -1,0 +1,34 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/volatile.2024.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct S {
+    pub p: *mut ::core::ffi::c_int,
+}
+#[unsafe(no_mangle)]
+pub static mut volatile_global_struct: S = S {
+    p: ::core::ptr::null::<::core::ffi::c_int>() as *mut ::core::ffi::c_int,
+};
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn test_volatile() {
+    unsafe {
+        ::core::ptr::write_volatile(
+            &mut volatile_global_struct.p as *mut *mut ::core::ffi::c_int,
+            ::core::ptr::read_volatile::<*mut ::core::ffi::c_int>(
+                &volatile_global_struct.p as *const *mut ::core::ffi::c_int,
+            )
+            .offset_from(1) as *mut ::core::ffi::c_int,
+        );
+    }
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn test_volatile() {
             ::core::ptr::read_volatile::<*mut ::core::ffi::c_int>(
                 &volatile_global_struct.p as *const *mut ::core::ffi::c_int,
             )
-            .offset_from(1) as *mut ::core::ffi::c_int,
+            .offset(-1),
         );
     }
 }

--- a/c2rust-transpile/tests/snapshots/volatile.c
+++ b/c2rust-transpile/tests/snapshots/volatile.c
@@ -1,0 +1,6 @@
+struct S { int * volatile p; } volatile_global_struct;
+
+void test_volatile(void) {
+    // https://github.com/immunant/c2rust/issues/1237
+    --(volatile_global_struct.p);
+}


### PR DESCRIPTION
- Fixes #1237.

Firstly, the types being passed were wrong in general, as if the arguments had been switched around. But also, for pointer increment/decrement, the implied RHS is not itself a pointer. So this PR solves that by using `int` as the implied type there instead.