### PR TITLE
transpile: Translate some literals in conditionals as `bool` directly

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2634,6 +2634,16 @@ impl<'c> Translation<'c> {
                 null_pointer_case(ptr, !target)
             }
 
+            CExprKind::Literal(_, ref literal @ CLiteral::Integer(0 | 1, _))
+                if !self.expr_is_expanded_macro(ctx, cond_id, None) =>
+            {
+                // If there is a literal `0` or `1` here, translate them directly rather than
+                // with a comparison. But not if they're inside a macro; we want to keep that.
+                // TODO: What about the `false` and `true` macros in stdbool.h?
+                let val = mk().lit_expr(mk().bool_lit(target == literal.get_bool()));
+                Ok(WithStmts::new_val(val))
+            }
+
             CExprKind::Unary(_, c_ast::UnOp::Not, subexpr_id, _) => {
                 self.convert_condition(ctx, !target, subexpr_id)
             }

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -308,6 +308,14 @@ fn test_atomics() {
 }
 
 #[test]
+fn test_bool() {
+    transpile("bool.c")
+        .expect_compile_error_edition_2021(true)
+        .expect_compile_error_edition_2024(true)
+        .run();
+}
+
+#[test]
 fn test_compound_literals() {
     transpile("compound_literals.c").run();
 }

--- a/c2rust-transpile/tests/snapshots/bool.c
+++ b/c2rust-transpile/tests/snapshots/bool.c
@@ -1,0 +1,33 @@
+#include <stdbool.h>
+
+#define MACRO_INT0 0
+#define MACRO_IDENT0 false
+
+#define MACRO_INT1 1
+#define MACRO_IDENT1 true
+
+void test_bool() {
+    bool int0 = 0;    
+    bool ident0 = false;
+    bool macro_int0 = MACRO_INT0;
+    bool macro_ident0 = MACRO_IDENT0;
+
+    bool int1 = 1;
+    bool ident1 = true;
+    bool macro_int1 = MACRO_INT1;
+    bool macro_ident1 = MACRO_IDENT1;
+
+    0 ? 2 : 3;
+    false ? 2 : 3;
+    MACRO_INT0 ? 2 : 3;
+    MACRO_IDENT0 ? 2 : 3;
+
+    1 ? 2 : 3;
+    true ? 2 : 3;
+    MACRO_INT1 ? 2 : 3;
+    MACRO_IDENT1 ? 2 : 3;
+
+    // Doesn't compile currently.
+    // See https://github.com/immunant/c2rust/issues/340.
+    int0 |= int1;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2021.snap
@@ -20,15 +20,15 @@ pub const MACRO_IDENT1: ::core::ffi::c_int = true_0;
 #[no_mangle]
 pub unsafe extern "C" fn test_bool() {
     unsafe {
-        let mut int0: bool = 0 as ::core::ffi::c_int != 0;
+        let mut int0: bool = false;
         let mut ident0: bool = false_0 != 0;
         let mut macro_int0: bool = MACRO_INT0 != 0;
         let mut macro_ident0: bool = MACRO_IDENT0 != 0;
-        let mut int1: bool = 1 as ::core::ffi::c_int != 0;
+        let mut int1: bool = true;
         let mut ident1: bool = true_0 != 0;
         let mut macro_int1: bool = MACRO_INT1 != 0;
         let mut macro_ident1: bool = MACRO_IDENT1 != 0;
-        if 0 as ::core::ffi::c_int != 0 {
+        if false {
         } else {
         };
         if false_0 != 0 {
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn test_bool() {
         if MACRO_IDENT0 != 0 {
         } else {
         };
-        if 1 as ::core::ffi::c_int != 0 {
+        if true {
         } else {
         };
         if true_0 != 0 {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2021.snap
@@ -1,0 +1,57 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/bool.2021.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]
+pub const true_0: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
+pub const false_0: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+pub const MACRO_INT0: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+pub const MACRO_IDENT0: ::core::ffi::c_int = false_0;
+pub const MACRO_INT1: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
+pub const MACRO_IDENT1: ::core::ffi::c_int = true_0;
+#[no_mangle]
+pub unsafe extern "C" fn test_bool() {
+    unsafe {
+        let mut int0: bool = 0 as ::core::ffi::c_int != 0;
+        let mut ident0: bool = false_0 != 0;
+        let mut macro_int0: bool = MACRO_INT0 != 0;
+        let mut macro_ident0: bool = MACRO_IDENT0 != 0;
+        let mut int1: bool = 1 as ::core::ffi::c_int != 0;
+        let mut ident1: bool = true_0 != 0;
+        let mut macro_int1: bool = MACRO_INT1 != 0;
+        let mut macro_ident1: bool = MACRO_IDENT1 != 0;
+        if 0 as ::core::ffi::c_int != 0 {
+        } else {
+        };
+        if false_0 != 0 {
+        } else {
+        };
+        if MACRO_INT0 != 0 {
+        } else {
+        };
+        if MACRO_IDENT0 != 0 {
+        } else {
+        };
+        if 1 as ::core::ffi::c_int != 0 {
+        } else {
+        };
+        if true_0 != 0 {
+        } else {
+        };
+        if MACRO_INT1 != 0 {
+        } else {
+        };
+        if MACRO_IDENT1 != 0 {
+        } else {
+        };
+        int0 = (int0 as ::core::ffi::c_int | int1 as ::core::ffi::c_int) as bool;
+    }
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2024.snap
@@ -20,15 +20,15 @@ pub const MACRO_IDENT1: ::core::ffi::c_int = true_0;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn test_bool() {
     unsafe {
-        let mut int0: bool = 0 as ::core::ffi::c_int != 0;
+        let mut int0: bool = false;
         let mut ident0: bool = false_0 != 0;
         let mut macro_int0: bool = MACRO_INT0 != 0;
         let mut macro_ident0: bool = MACRO_IDENT0 != 0;
-        let mut int1: bool = 1 as ::core::ffi::c_int != 0;
+        let mut int1: bool = true;
         let mut ident1: bool = true_0 != 0;
         let mut macro_int1: bool = MACRO_INT1 != 0;
         let mut macro_ident1: bool = MACRO_IDENT1 != 0;
-        if 0 as ::core::ffi::c_int != 0 {
+        if false {
         } else {
         };
         if false_0 != 0 {
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn test_bool() {
         if MACRO_IDENT0 != 0 {
         } else {
         };
-        if 1 as ::core::ffi::c_int != 0 {
+        if true {
         } else {
         };
         if true_0 != 0 {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2024.snap
@@ -1,0 +1,57 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/bool.2024.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]
+pub const true_0: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
+pub const false_0: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+pub const MACRO_INT0: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+pub const MACRO_IDENT0: ::core::ffi::c_int = false_0;
+pub const MACRO_INT1: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
+pub const MACRO_IDENT1: ::core::ffi::c_int = true_0;
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn test_bool() {
+    unsafe {
+        let mut int0: bool = 0 as ::core::ffi::c_int != 0;
+        let mut ident0: bool = false_0 != 0;
+        let mut macro_int0: bool = MACRO_INT0 != 0;
+        let mut macro_ident0: bool = MACRO_IDENT0 != 0;
+        let mut int1: bool = 1 as ::core::ffi::c_int != 0;
+        let mut ident1: bool = true_0 != 0;
+        let mut macro_int1: bool = MACRO_INT1 != 0;
+        let mut macro_ident1: bool = MACRO_IDENT1 != 0;
+        if 0 as ::core::ffi::c_int != 0 {
+        } else {
+        };
+        if false_0 != 0 {
+        } else {
+        };
+        if MACRO_INT0 != 0 {
+        } else {
+        };
+        if MACRO_IDENT0 != 0 {
+        } else {
+        };
+        if 1 as ::core::ffi::c_int != 0 {
+        } else {
+        };
+        if true_0 != 0 {
+        } else {
+        };
+        if MACRO_INT1 != 0 {
+        } else {
+        };
+        if MACRO_IDENT1 != 0 {
+        } else {
+        };
+        int0 = (int0 as ::core::ffi::c_int | int1 as ::core::ffi::c_int) as bool;
+    }
+}


### PR DESCRIPTION
- Depends on #1647.
- Fixes #190.

Makes things look a little nicer. I've tried to be conservative here and only consider literal `0` and `1` this way. No other literals, and no macros either.

Unfortunately that includes the `false` and `true` macros found in the `stdbool.h` header. There would need to be some way to detect those and treat them differently from other macros. See also #288.