### PR TITLE
transpile: Handle `InitList` correctly for all scalar types

### DIFF
--- a/c2rust-rust-tools/src/lib.rs
+++ b/c2rust-rust-tools/src/lib.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 use log::warn;
+use std::collections::HashSet;
 use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -7,6 +8,7 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 use std::process::Command;
+use std::str;
 use std::str::FromStr;
 
 use crate::RustEdition::Edition2021;
@@ -148,6 +150,7 @@ pub struct Rustc<'a> {
     edition: RustEdition,
     crate_name: Option<&'a str>,
     expect_error: bool,
+    imported_crates: &'a [&'a str],
 }
 
 pub fn rustc(rs_path: &Path) -> Rustc {
@@ -156,6 +159,7 @@ pub fn rustc(rs_path: &Path) -> Rustc {
         edition: Default::default(),
         crate_name: None,
         expect_error: false,
+        imported_crates: Default::default(),
     }
 }
 
@@ -178,20 +182,39 @@ impl<'a> Rustc<'a> {
         }
     }
 
+    pub fn expect_unresolved_imports(self, imported_crates: &'a [&'a str]) -> Self {
+        Self {
+            imported_crates,
+            ..self
+        }
+    }
+
     pub fn run(self) {
         let Self {
             rs_path,
             edition,
             crate_name,
             expect_error,
+            imported_crates,
         } = self;
         let crate_name =
             crate_name.unwrap_or_else(|| rs_path.file_stem().unwrap().to_str().unwrap());
-        run_rustc(rs_path, edition, crate_name, expect_error);
+        run_rustc(rs_path, edition, crate_name, expect_error, &imported_crates);
     }
 }
 
-fn run_rustc(rs_path: &Path, edition: RustEdition, crate_name: &str, expect_error: bool) {
+fn run_rustc(
+    rs_path: &Path,
+    edition: RustEdition,
+    crate_name: &str,
+    expect_error: bool,
+    imported_crates: &[&str],
+) {
+    let rs = fs_err::read_to_string(rs_path).unwrap();
+    for imported_crate in imported_crates {
+        assert!(rs.contains(&format!("::{imported_crate}")));
+    }
+
     // There's no good way to not create an output with `rustc`,
     // so just create an `.rlib` and then delete it immediately.
     let rlib_path = rs_path.with_file_name(format!("lib{crate_name}.rlib"));
@@ -215,6 +238,49 @@ fn run_rustc(rs_path: &Path, edition: RustEdition, crate_name: &str, expect_erro
     }
     io::stdout().write_all(&output.stdout).unwrap();
     io::stderr().write_all(&output.stderr).unwrap();
+
+    // Using rustc itself to build snapshots that reference crates (like libc) is difficult because we don't know
+    // the appropriate --extern libc=/path/to/liblibc-XXXXXXXXXXXXXXXX.rlib to pass.
+    // Skip for now, as we've already compared the literal text,
+    // and we're checking the error messages here.
+    let stderr = str::from_utf8(&output.stderr).unwrap();
+    let error_lines = stderr
+        .split('\n')
+        // .split(|&b| b == b'\n')
+        .filter(|line| line.starts_with("error[E"))
+        .collect::<HashSet<_>>();
+    dbg!(&error_lines);
+    for imported_crate in imported_crates {
+        // For `::{imported_crate}::*`.
+        let absolute_path = match edition {
+            Edition2021 => format!("error[E0433]: failed to resolve: could not find `{imported_crate}` in the list of imported crates"),
+            Edition2024 => format!("error[E0433]: cannot find `{imported_crate}` in the crate root"),
+        };
+        // For `use ::{imported_crate}*`.
+        let absolute_use_path = format!("error[E0432]: unresolved import `{imported_crate}`");
+        // For `{imported_crate}::*`.
+        let relative_path = match edition {
+            Edition2021 => format!("error[E0433]: failed to resolve: use of undeclared crate or module `{imported_crate}`"),
+            Edition2024 => format!("error[E0433]: cannot find module or crate `{imported_crate}` in this scope"),
+        };
+
+        let absolute_path = absolute_path.as_str();
+        let absolute_use_path = absolute_use_path.as_str();
+        let relative_path = relative_path.as_str();
+        dbg!(absolute_path);
+        dbg!(absolute_use_path);
+        dbg!(relative_path);
+
+        assert!(
+            error_lines.contains(absolute_path)
+                || error_lines.contains(absolute_use_path)
+                || error_lines.contains(relative_path)
+        );
+    }
+    if !imported_crates.is_empty() {
+        return;
+    }
+
     if expect_error {
         assert!(
             !status.success(),

--- a/c2rust-rust-tools/src/lib.rs
+++ b/c2rust-rust-tools/src/lib.rs
@@ -3,6 +3,8 @@ use log::warn;
 use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::io;
+use std::io::Write;
 use std::path::Path;
 use std::process::Command;
 use std::str::FromStr;
@@ -206,10 +208,13 @@ fn run_rustc(rs_path: &Path, edition: RustEdition, crate_name: &str, expect_erro
         "-o",
     ]);
     cmd.args([&rlib_path, rs_path]);
-    let status = cmd.status().unwrap();
+    let output = cmd.output().unwrap();
+    let status = output.status;
     if status.success() {
         fs_err::remove_file(&rlib_path).unwrap();
     }
+    io::stdout().write_all(&output.stdout).unwrap();
+    io::stderr().write_all(&output.stderr).unwrap();
     if expect_error {
         assert!(
             !status.success(),

--- a/c2rust-rust-tools/src/lib.rs
+++ b/c2rust-rust-tools/src/lib.rs
@@ -244,7 +244,7 @@ fn run_rustc(
     // Skip for now, as we've already compared the literal text,
     // and we're checking the error messages here.
     let stderr = str::from_utf8(&output.stderr).unwrap();
-    let error_lines = stderr
+    let mut error_lines = stderr
         .split('\n')
         // .split(|&b| b == b'\n')
         .filter(|line| line.starts_with("error[E"))
@@ -271,13 +271,16 @@ fn run_rustc(
         dbg!(absolute_use_path);
         dbg!(relative_path);
 
-        assert!(
-            error_lines.contains(absolute_path)
-                || error_lines.contains(absolute_use_path)
-                || error_lines.contains(relative_path)
-        );
+        // Pre-compute to avoid `||` short-circuiting.
+        let absolute_path = error_lines.remove(absolute_path);
+        let absolute_use_path = error_lines.remove(absolute_use_path);
+        let relative_path = error_lines.remove(relative_path);
+
+        assert!(absolute_path || absolute_use_path || relative_path);
     }
     if !imported_crates.is_empty() {
+        dbg!(&error_lines);
+        assert!(error_lines.is_empty());
         return;
     }
 

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -2739,6 +2739,10 @@ impl CTypeKind {
         )
     }
 
+    pub fn is_scalar(&self) -> bool {
+        self.is_integral_type() || self.is_floating_type() || self.is_enum() || self.is_pointer()
+    }
+
     pub fn as_underlying_decl(&self) -> Option<CDeclId> {
         use CTypeKind::*;
         match *self {

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -257,8 +257,11 @@ impl<'c> Translation<'c> {
                 self.vector_list_initializer(ctx, ids, ctype, len)
             }
             ref kind if kind.is_scalar() => {
-                let id = ids.first().unwrap();
-                self.convert_expr(ctx.used(), *id, None)
+                if let Some(&first) = ids.first() {
+                    self.convert_expr(ctx.used(), first, None)
+                } else {
+                    self.implicit_default_expr(ctx.used(), ty.ctype)
+                }
             }
             ref t => Err(format_err!("Init list not implemented for {:?}", t).into()),
         }

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -253,18 +253,10 @@ impl<'c> Translation<'c> {
             CTypeKind::Union(union_id) => {
                 self.convert_union_literal(ctx, union_id, ids.as_ref(), ty, opt_union_field_id)
             }
-            CTypeKind::Pointer(_) => {
-                let id = ids.first().unwrap();
-                self.convert_expr(ctx.used(), *id, None)
-            }
-            CTypeKind::Enum(_) => {
-                let id = ids.first().unwrap();
-                self.convert_expr(ctx.used(), *id, None)
-            }
             CTypeKind::Vector(CQualTypeId { ctype, .. }, len) => {
                 self.vector_list_initializer(ctx, ids, ctype, len)
             }
-            ref kind if kind.is_integral_type() => {
+            ref kind if kind.is_scalar() => {
                 let id = ids.first().unwrap();
                 self.convert_expr(ctx.used(), *id, None)
             }

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -101,6 +101,7 @@ fn transpile_snapshot(
     c_path: &Path,
     edition: RustEdition,
     expect_compile_error: bool,
+    imported_crates: &[&str],
 ) {
     let cfg = config(edition);
     compile_and_transpile_file(c_path, cfg);
@@ -133,21 +134,11 @@ fn transpile_snapshot(
 
     insta::assert_snapshot!(snapshot_name, &rs, &debug_expr);
 
-    // Using rustc itself to build snapshots that reference libc is difficult because we don't know
-    // the appropriate --extern libc=/path/to/liblibc-XXXXXXXXXXXXXXXX.rlib to pass. Skip for now,
-    // as we've already compared the literal text.
-    if rs.contains("libc::") {
-        eprintln!(
-            "warning: skipping compiling {} with rustc since it depends on libc",
-            rs_path.display()
-        );
-        return;
-    }
-
     rustc(&rs_path)
         .edition(edition)
         .crate_name(crate_name)
         .expect_error(expect_compile_error)
+        .expect_unresolved_imports(imported_crates)
         .run();
 }
 
@@ -158,6 +149,7 @@ struct TranspileTest<'a> {
     os_specific: bool,
     expect_compile_error_edition_2021: bool,
     expect_compile_error_edition_2024: bool,
+    imported_crates: Vec<&'a str>,
 }
 
 fn transpile(c_file_name: &str) -> TranspileTest {
@@ -167,6 +159,7 @@ fn transpile(c_file_name: &str) -> TranspileTest {
         os_specific: false,
         expect_compile_error_edition_2021: false,
         expect_compile_error_edition_2024: false,
+        imported_crates: Default::default(),
     }
 }
 
@@ -211,6 +204,11 @@ impl<'a> TranspileTest<'a> {
             .expect_compile_error_edition_2024(expect_error)
     }
 
+    pub fn expect_unresolved_import(mut self, imported_crate: &'a str) -> Self {
+        self.imported_crates.push(imported_crate);
+        self
+    }
+
     pub fn run(self) {
         let Self {
             c_file_name,
@@ -218,6 +216,7 @@ impl<'a> TranspileTest<'a> {
             os_specific,
             expect_compile_error_edition_2021,
             expect_compile_error_edition_2024,
+            imported_crates,
         } = self;
 
         let specific_dir_prefix = [arch_specific.then_some("arch"), os_specific.then_some("os")]
@@ -268,12 +267,14 @@ impl<'a> TranspileTest<'a> {
             &c_path,
             Edition2021,
             expect_compile_error_edition_2021,
+            &imported_crates,
         );
         transpile_snapshot(
             &platform,
             &c_path,
             Edition2024,
             expect_compile_error_edition_2024,
+            &imported_crates,
         );
     }
 }
@@ -451,7 +452,10 @@ fn test_rotate_os_specific() {
 
 #[test]
 fn test_sigign() {
-    transpile("sigign.c").os_specific(true).run();
+    transpile("sigign.c")
+        .os_specific(true)
+        .expect_unresolved_import("libc")
+        .run();
 }
 
 #[test]
@@ -461,12 +465,18 @@ fn test_typedefidx() {
 
 #[test]
 fn test_types() {
-    transpile("types.c").os_specific(true).run();
+    transpile("types.c")
+        .os_specific(true)
+        .expect_unresolved_import("libc")
+        .run();
 }
 
 #[test]
 fn test_wide_strings() {
-    transpile("wide_strings.c").os_specific(true).run();
+    transpile("wide_strings.c")
+        .os_specific(true)
+        .expect_unresolved_import("libc")
+        .run();
 }
 
 // arch-os-specific

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -402,6 +402,13 @@ fn test_rotate() {
 }
 
 #[test]
+fn test_scalar_init() {
+    transpile("scalar_init.c")
+        .expect_unresolved_import("f128")
+        .run();
+}
+
+#[test]
 fn test_static_assert() {
     transpile("static_assert.c").run();
 }

--- a/c2rust-transpile/tests/snapshots/scalar_init.c
+++ b/c2rust-transpile/tests/snapshots/scalar_init.c
@@ -1,0 +1,19 @@
+#include <stdbool.h>
+
+enum E {
+    A,
+};
+
+void scalar_init() {
+    bool b = { true };
+    char c = { 'c' };
+    int i = { 42 };
+    long l = { 42l };
+    float f = { 42.0f };
+    double d = { 42.0 };
+    long double ld = { 42.0l };
+    // Doesn't work on MacOS, so avoid it for now so this test doesn't become OS-specific.
+    // __float128 q = { 42.0q };
+    enum E e = { A };
+    int *p = { &i };
+}

--- a/c2rust-transpile/tests/snapshots/scalar_init.c
+++ b/c2rust-transpile/tests/snapshots/scalar_init.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include <stdlib.h>
 
 enum E {
     A,
@@ -16,4 +17,29 @@ void scalar_init() {
     // __float128 q = { 42.0q };
     enum E e = { A };
     int *p = { &i };
+
+// Empty initializer lists for scalars was only added in C23 and clang 17.
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L) || (defined(__clang__) && (__clang_major__ >= 17))
+    bool eb = {};
+    char ec = {};
+    int ei = {};
+    long el = {};
+    float ef = {};
+    double ed = {};
+    long double eld = {};
+    // __float128 eq = {};
+    // enums don't allow empty init lists in C
+    int *ep = {};
+#else
+    bool eb;
+    char ec;
+    int ei;
+    long el;
+    float ef;
+    double ed;
+    long double eld;
+    // __float128 eq;
+    // enums don't allow empty init lists in C
+    int *ep;
+#endif
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
@@ -1,0 +1,31 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/scalar_init.2021.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]
+#![feature(raw_ref_op)]
+pub type E = ::core::ffi::c_uint;
+pub const A: E = 0;
+pub const true_0: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
+#[no_mangle]
+pub unsafe extern "C" fn scalar_init() {
+    unsafe {
+        let mut b: bool = true_0 != 0;
+        let mut c: ::core::ffi::c_char = 'c' as i32 as ::core::ffi::c_char;
+        let mut i: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+        let mut l: ::core::ffi::c_long = 42 as ::core::ffi::c_long;
+        let mut f: ::core::ffi::c_float = 42.0f32;
+        let mut d: ::core::ffi::c_double = 42.0f64;
+        let mut ld: ::f128::f128 = ::f128::f128::new(42.0);
+        let mut e: E = A;
+        let mut p: *mut ::core::ffi::c_int = &raw mut i;
+    }
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
@@ -27,5 +27,13 @@ pub unsafe extern "C" fn scalar_init() {
         let mut ld: ::f128::f128 = ::f128::f128::new(42.0);
         let mut e: E = A;
         let mut p: *mut ::core::ffi::c_int = &raw mut i;
+        let mut eb: bool = false;
+        let mut ec: ::core::ffi::c_char = 0;
+        let mut ei: ::core::ffi::c_int = 0;
+        let mut el: ::core::ffi::c_long = 0;
+        let mut ef: ::core::ffi::c_float = 0.;
+        let mut ed: ::core::ffi::c_double = 0.;
+        let mut eld: ::f128::f128 = ::f128::f128::ZERO;
+        let mut ep: *mut ::core::ffi::c_int = ::core::ptr::null_mut::<::core::ffi::c_int>();
     }
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
@@ -26,5 +26,13 @@ pub unsafe extern "C" fn scalar_init() {
         let mut ld: ::f128::f128 = ::f128::f128::new(42.0);
         let mut e: E = A;
         let mut p: *mut ::core::ffi::c_int = &raw mut i;
+        let mut eb: bool = false;
+        let mut ec: ::core::ffi::c_char = 0;
+        let mut ei: ::core::ffi::c_int = 0;
+        let mut el: ::core::ffi::c_long = 0;
+        let mut ef: ::core::ffi::c_float = 0.;
+        let mut ed: ::core::ffi::c_double = 0.;
+        let mut eld: ::f128::f128 = ::f128::f128::ZERO;
+        let mut ep: *mut ::core::ffi::c_int = ::core::ptr::null_mut::<::core::ffi::c_int>();
     }
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
@@ -1,0 +1,30 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/scalar_init.2024.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]
+pub type E = ::core::ffi::c_uint;
+pub const A: E = 0;
+pub const true_0: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn scalar_init() {
+    unsafe {
+        let mut b: bool = true_0 != 0;
+        let mut c: ::core::ffi::c_char = 'c' as i32 as ::core::ffi::c_char;
+        let mut i: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+        let mut l: ::core::ffi::c_long = 42 as ::core::ffi::c_long;
+        let mut f: ::core::ffi::c_float = 42.0f32;
+        let mut d: ::core::ffi::c_double = 42.0f64;
+        let mut ld: ::f128::f128 = ::f128::f128::new(42.0);
+        let mut e: E = A;
+        let mut p: *mut ::core::ffi::c_int = &raw mut i;
+    }
+}


### PR DESCRIPTION
- Fixes #1691.