### PR TITLE
transpile: Add `f128` snapshot test

### DIFF
--- a/c2rust-transpile/tests/snapshots/f128.c
+++ b/c2rust-transpile/tests/snapshots/f128.c
@@ -1,0 +1,37 @@
+#include <stdbool.h>
+#include <math.h>
+
+void long_double_test(void) {
+    long double one = 1.0l;
+    long double zero;
+    long double add = one + zero;
+    long double huge = __builtin_huge_vall();
+
+    int i = one;
+    float f = one;
+    long double cast_from_int = i;
+    long double cast_from_float = f;
+
+    bool is_inf = isinf(huge);
+    if (one) {
+        int dummy;
+    }
+}
+
+void float128_test(void) {
+    __float128 one = 1.0q;
+    __float128 zero;
+    __float128 add = one + zero;
+    __float128 huge = __builtin_huge_vall();
+
+    int i = one;
+    float f = one;
+    __float128 cast_from_int = i;
+    __float128 cast_from_float = f;
+    long double ld_from_float128 = one;
+
+    bool is_inf = isinf(huge);
+    if (one) {
+        int dummy;
+    }
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.2021.snap
@@ -1,0 +1,57 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/f128.2021.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]
+use ::num_traits::Float;
+#[no_mangle]
+pub unsafe extern "C" fn long_double_test() {
+    unsafe {
+        let mut one: ::f128::f128 = ::f128::f128::new(1.0);
+        let mut zero: ::f128::f128 = ::f128::f128::ZERO;
+        let mut add: ::f128::f128 = one + zero;
+        let mut huge: ::f128::f128 = ::f128::f128::INFINITY;
+        let mut i: ::core::ffi::c_int = one.to_i32().unwrap();
+        let mut f: ::core::ffi::c_float = one.to_f32().unwrap();
+        let mut cast_from_int: ::f128::f128 = ::f128::f128::new(i);
+        let mut cast_from_float: ::f128::f128 = ::f128::f128::new(f);
+        let mut is_inf: bool = if huge.is_infinite() {
+            if huge.is_sign_positive() { 1 } else { -1 }
+        } else {
+            0
+        } != 0;
+        if one != ::f128::f128::ZERO {
+            let mut dummy: ::core::ffi::c_int = 0;
+        }
+    }
+}
+#[no_mangle]
+pub unsafe extern "C" fn float128_test() {
+    unsafe {
+        let mut one: ::f128::f128 = ::f128::f128::new(1.0);
+        let mut zero: ::f128::f128 = ::f128::f128::ZERO;
+        let mut add: ::f128::f128 = one + zero;
+        let mut huge: ::f128::f128 = ::f128::f128::INFINITY;
+        let mut i: ::core::ffi::c_int = one.to_i32().unwrap();
+        let mut f: ::core::ffi::c_float = one.to_f32().unwrap();
+        let mut cast_from_int: ::f128::f128 = ::f128::f128::new(i);
+        let mut cast_from_float: ::f128::f128 = ::f128::f128::new(f);
+        let mut ld_from_float128: ::f128::f128 = one;
+        let mut is_inf: bool = if huge.is_infinite() {
+            if huge.is_sign_positive() { 1 } else { -1 }
+        } else {
+            0
+        } != 0;
+        if one != ::f128::f128::ZERO {
+            let mut dummy: ::core::ffi::c_int = 0;
+        }
+    }
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@f128.2024.snap
@@ -1,0 +1,57 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/f128.2024.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]
+use ::num_traits::Float;
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn long_double_test() {
+    unsafe {
+        let mut one: ::f128::f128 = ::f128::f128::new(1.0);
+        let mut zero: ::f128::f128 = ::f128::f128::ZERO;
+        let mut add: ::f128::f128 = one + zero;
+        let mut huge: ::f128::f128 = ::f128::f128::INFINITY;
+        let mut i: ::core::ffi::c_int = one.to_i32().unwrap();
+        let mut f: ::core::ffi::c_float = one.to_f32().unwrap();
+        let mut cast_from_int: ::f128::f128 = ::f128::f128::new(i);
+        let mut cast_from_float: ::f128::f128 = ::f128::f128::new(f);
+        let mut is_inf: bool = if huge.is_infinite() {
+            if huge.is_sign_positive() { 1 } else { -1 }
+        } else {
+            0
+        } != 0;
+        if one != ::f128::f128::ZERO {
+            let mut dummy: ::core::ffi::c_int = 0;
+        }
+    }
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn float128_test() {
+    unsafe {
+        let mut one: ::f128::f128 = ::f128::f128::new(1.0);
+        let mut zero: ::f128::f128 = ::f128::f128::ZERO;
+        let mut add: ::f128::f128 = one + zero;
+        let mut huge: ::f128::f128 = ::f128::f128::INFINITY;
+        let mut i: ::core::ffi::c_int = one.to_i32().unwrap();
+        let mut f: ::core::ffi::c_float = one.to_f32().unwrap();
+        let mut cast_from_int: ::f128::f128 = ::f128::f128::new(i);
+        let mut cast_from_float: ::f128::f128 = ::f128::f128::new(f);
+        let mut ld_from_float128: ::f128::f128 = one;
+        let mut is_inf: bool = if huge.is_infinite() {
+            if huge.is_sign_positive() { 1 } else { -1 }
+        } else {
+            0
+        } != 0;
+        if one != ::f128::f128::ZERO {
+            let mut dummy: ::core::ffi::c_int = 0;
+        }
+    }
+}


### PR DESCRIPTION
- Depends on #1696.
- Depends on #1695.
- Depends on #1688.
- Depends on #1687.

Rather than adding snapshot tests separately in each of these PRs, this adds a single one that covers them all.