### PR TITLE
transpile: Use `convert_cast` in `operators.rs`

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4149,7 +4149,7 @@ impl<'c> Translation<'c> {
         }
     }
 
-    fn convert_cast(
+    pub fn convert_cast(
         &self,
         ctx: ExprContext,
         source_cty: CQualTypeId,

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -206,6 +206,7 @@ impl<'c> Translation<'c> {
         read: Box<Expr>,
         write: Box<Expr>,
         rhs: Box<Expr>,
+        initial_lhs_type_id: CQualTypeId,
         compute_lhs_type_id: CQualTypeId,
         compute_res_type_id: CQualTypeId,
         lhs_type_id: CQualTypeId,
@@ -220,46 +221,33 @@ impl<'c> Translation<'c> {
                 rhs,
             )))
         } else {
-            let compute_lhs_resolved_ty = &self.ast_context.resolve_type(compute_lhs_type_id.ctype);
-            let lhs_type = self.convert_type(compute_lhs_type_id.ctype)?;
-
-            // We can't simply as-cast into a non primitive like f128
-            let lhs = if compute_lhs_resolved_ty.kind == CTypeKind::LongDouble {
-                self.use_crate(ExternCrate::F128);
-
-                let fn_path = mk().abs_path_expr(vec!["f128", "f128", "from"]);
-                let args = vec![read];
-
-                mk().call_expr(fn_path, args)
-            } else {
-                mk().cast_expr(read, lhs_type)
-            };
-            let ty = self.convert_type(compute_res_type_id.ctype)?;
-            let mut val = self.convert_binary_operator(
+            let lhs = self.convert_cast(
                 ctx,
-                bin_op,
-                ty,
-                compute_res_type_id.ctype,
+                initial_lhs_type_id,
                 compute_lhs_type_id,
-                rhs_type_id,
-                lhs,
-                rhs,
+                WithStmts::new_val(read.clone()),
+                None,
+                None,
                 None,
             )?;
 
-            let resolve_lhs_kind = &self.ast_context.resolve_type(lhs_type_id.ctype).kind;
+            let ty = self.convert_type(compute_res_type_id.ctype)?;
+            let val = lhs.and_then(|lhs| {
+                self.convert_binary_operator(
+                    ctx,
+                    bin_op,
+                    ty,
+                    compute_res_type_id.ctype,
+                    compute_lhs_type_id,
+                    rhs_type_id,
+                    lhs,
+                    rhs,
+                    None,
+                )
+            })?;
 
-            val = if let &CTypeKind::Enum(enum_id) = resolve_lhs_kind {
-                val.result_map(|val| {
-                    self.convert_cast_to_enum(ctx, lhs_type_id.ctype, enum_id, None, val)
-                })?
-            } else if compute_lhs_resolved_ty.kind == CTypeKind::LongDouble {
-                // We can't as-cast from a non primitive like f128 back to the result_type
-                self.f128_cast_to(val, resolve_lhs_kind)?
-            } else {
-                let result_type = self.convert_type(lhs_type_id.ctype)?;
-                val.map(|val| mk().cast_expr(val, result_type))
-            };
+            let val =
+                self.convert_cast(ctx, compute_res_type_id, lhs_type_id, val, None, None, None)?;
 
             Ok(val.map(|val| mk().assign_expr(write.clone(), val)))
         }
@@ -452,29 +440,26 @@ impl<'c> Translation<'c> {
 
                         // Anything volatile needs to be desugared into explicit reads and writes
                         op if is_volatile || is_unsigned_arith => {
+                            // Cast the lhs to the compute lhs type, do the compute, and then
+                            // cast the compute result to the final lhs type.
+
                             let op = op
                                 .underlying_assignment()
                                 .expect("Cannot convert non-assignment operator");
 
-                            let val = if expr_or_comp_type_id.ctype == initial_lhs_type_id.ctype {
+                            let lhs = self.convert_cast(
+                                ctx,
+                                initial_lhs_type_id,
+                                expr_or_comp_type_id,
+                                WithStmts::new_val(read.clone()),
+                                None,
+                                None,
+                                None,
+                            )?;
+
+                            let ty = self.convert_type(result_type_id.ctype)?;
+                            let val = lhs.and_then(|lhs|
                                 self.convert_binary_operator(
-                                    ctx,
-                                    op,
-                                    ty,
-                                    expr_type_id.ctype,
-                                    initial_lhs_type_id,
-                                    rhs_type_id,
-                                    read.clone(),
-                                    rhs,
-                                    None,
-                                )?
-                            } else {
-                                let lhs_type =
-                                    self.convert_type(compute_lhs_type_id.unwrap().ctype)?;
-                                let write_type = self.convert_type(expr_type_id.ctype)?;
-                                let lhs = mk().cast_expr(read.clone(), lhs_type);
-                                let ty = self.convert_type(result_type_id.ctype)?;
-                                let mut val = self.convert_binary_operator(
                                     ctx,
                                     op,
                                     ty,
@@ -484,25 +469,18 @@ impl<'c> Translation<'c> {
                                     lhs,
                                     rhs,
                                     None,
-                                )?;
+                                )
+                            )?;
 
-                                let expr_resolved_ty_kind = &self.ast_context.resolve_type(expr_type_id.ctype).kind;
-
-                                val = if let &CTypeKind::Enum(enum_id) = expr_resolved_ty_kind {
-                                    val.result_map(|val| self.convert_cast_to_enum(
-                                        ctx,
-                                        expr_type_id.ctype,
-                                        enum_id,
-                                        None,
-                                        val,
-                                    ))?
-                                } else {
-                                    let expr_type = self.convert_type(expr_type_id.ctype)?;
-                                    val.map(|val| mk().cast_expr(val, expr_type))
-                                };
-
-                                val.map(|val| mk().cast_expr(val, write_type))
-                            };
+                            let val = self.convert_cast(
+                                ctx,
+                                result_type_id,
+                                expr_type_id,
+                                val,
+                                None,
+                                None,
+                                None,
+                            )?;
 
                             #[allow(clippy::let_and_return /* , reason = "block is large, so variable name helps" */)]
                             let write = if is_volatile {
@@ -554,6 +532,7 @@ impl<'c> Translation<'c> {
                                 read.clone(),
                                 write,
                                 rhs,
+                                initial_lhs_type_id,
                                 compute_lhs_type_id.unwrap(),
                                 compute_res_type_id.unwrap(),
                                 expr_type_id,

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -309,10 +309,7 @@ fn test_atomics() {
 
 #[test]
 fn test_bool() {
-    transpile("bool.c")
-        .expect_compile_error_edition_2021(true)
-        .expect_compile_error_edition_2024(true)
-        .run();
+    transpile("bool.c").run();
 }
 
 #[test]

--- a/c2rust-transpile/tests/snapshots/bool.c
+++ b/c2rust-transpile/tests/snapshots/bool.c
@@ -27,7 +27,6 @@ void test_bool() {
     MACRO_INT1 ? 2 : 3;
     MACRO_IDENT1 ? 2 : 3;
 
-    // Doesn't compile currently.
-    // See https://github.com/immunant/c2rust/issues/340.
+    // Tests https://github.com/immunant/c2rust/issues/340
     int0 |= int1;
 }

--- a/c2rust-transpile/tests/snapshots/exprs.c
+++ b/c2rust-transpile/tests/snapshots/exprs.c
@@ -34,6 +34,16 @@ void unary_with_side_effect(){
     arr[side_effect()]--;
 }
 
+void unsigned_compound_desugaring(void) {
+    enum E { EA };
+
+    int i = 0;
+    unsigned int u = 0;
+    enum E e = EA;
+    e += u;
+    i += u;
+}
+
 void compound_literal(){
     /// https://github.com/immunant/c2rust/issues/1234
     int i = (enum {A, B, C}){1};

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2021.snap
@@ -52,6 +52,6 @@ pub unsafe extern "C" fn test_bool() {
         if MACRO_IDENT1 != 0 {
         } else {
         };
-        int0 = (int0 as ::core::ffi::c_int | int1 as ::core::ffi::c_int) as bool;
+        int0 = int0 as ::core::ffi::c_int | int1 as ::core::ffi::c_int != 0;
     }
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@bool.c.2024.snap
@@ -52,6 +52,6 @@ pub unsafe extern "C" fn test_bool() {
         if MACRO_IDENT1 != 0 {
         } else {
         };
-        int0 = (int0 as ::core::ffi::c_int | int1 as ::core::ffi::c_int) as bool;
+        int0 = int0 as ::core::ffi::c_int | int1 as ::core::ffi::c_int != 0;
     }
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.snap
@@ -67,8 +67,8 @@ pub unsafe extern "C" fn unsigned_compound_desugaring() {
         let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
         let mut u: ::core::ffi::c_uint = 0 as ::core::ffi::c_uint;
         let mut e: E = EA;
-        e = (e as ::core::ffi::c_uint).wrapping_add(u) as E as E;
-        i = (i as ::core::ffi::c_uint).wrapping_add(u) as ::core::ffi::c_int as ::core::ffi::c_int;
+        e = (e as ::core::ffi::c_uint).wrapping_add(u) as E;
+        i = (i as ::core::ffi::c_uint).wrapping_add(u) as ::core::ffi::c_int;
     }
 }
 #[no_mangle]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.snap
@@ -15,6 +15,8 @@ expression: cat tests/snapshots/exprs.2021.rs
 extern "C" {
     fn puts(str: *const ::core::ffi::c_char) -> ::core::ffi::c_int;
 }
+pub type E = ::core::ffi::c_uint;
+pub const EA: E = 0;
 pub type C2Rust_Unnamed = ::core::ffi::c_uint;
 pub const C: C2Rust_Unnamed = 2;
 pub const B: C2Rust_Unnamed = 1;
@@ -57,6 +59,16 @@ pub unsafe extern "C" fn unary_with_side_effect() {
         arr[side_effect() as usize] = arr[side_effect() as usize].offset(-1);
         arr[side_effect() as usize] = arr[side_effect() as usize].offset(1);
         arr[side_effect() as usize] = arr[side_effect() as usize].offset(-1);
+    }
+}
+#[no_mangle]
+pub unsafe extern "C" fn unsigned_compound_desugaring() {
+    unsafe {
+        let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+        let mut u: ::core::ffi::c_uint = 0 as ::core::ffi::c_uint;
+        let mut e: E = EA;
+        e = (e as ::core::ffi::c_uint).wrapping_add(u) as E as E;
+        i = (i as ::core::ffi::c_uint).wrapping_add(u) as ::core::ffi::c_int as ::core::ffi::c_int;
     }
 }
 #[no_mangle]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.snap
@@ -66,8 +66,8 @@ pub unsafe extern "C" fn unsigned_compound_desugaring() {
         let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
         let mut u: ::core::ffi::c_uint = 0 as ::core::ffi::c_uint;
         let mut e: E = EA;
-        e = (e as ::core::ffi::c_uint).wrapping_add(u) as E as E;
-        i = (i as ::core::ffi::c_uint).wrapping_add(u) as ::core::ffi::c_int as ::core::ffi::c_int;
+        e = (e as ::core::ffi::c_uint).wrapping_add(u) as E;
+        i = (i as ::core::ffi::c_uint).wrapping_add(u) as ::core::ffi::c_int;
     }
 }
 #[unsafe(no_mangle)]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.snap
@@ -14,6 +14,8 @@ expression: cat tests/snapshots/exprs.2024.rs
 unsafe extern "C" {
     unsafe fn puts(str: *const ::core::ffi::c_char) -> ::core::ffi::c_int;
 }
+pub type E = ::core::ffi::c_uint;
+pub const EA: E = 0;
 pub type C2Rust_Unnamed = ::core::ffi::c_uint;
 pub const C: C2Rust_Unnamed = 2;
 pub const B: C2Rust_Unnamed = 1;
@@ -56,6 +58,16 @@ pub unsafe extern "C" fn unary_with_side_effect() {
         arr[side_effect() as usize] = arr[side_effect() as usize].offset(-1);
         arr[side_effect() as usize] = arr[side_effect() as usize].offset(1);
         arr[side_effect() as usize] = arr[side_effect() as usize].offset(-1);
+    }
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn unsigned_compound_desugaring() {
+    unsafe {
+        let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+        let mut u: ::core::ffi::c_uint = 0 as ::core::ffi::c_uint;
+        let mut e: E = EA;
+        e = (e as ::core::ffi::c_uint).wrapping_add(u) as E as E;
+        i = (i as ::core::ffi::c_uint).wrapping_add(u) as ::core::ffi::c_int as ::core::ffi::c_int;
     }
 }
 #[unsafe(no_mangle)]


### PR DESCRIPTION
- Fixes #1701
- Fixes #340

The various edge cases in these bits of code were essentially duplicating what `convert_cast` was doing, but worse and easier to miss. So this just reuses the more robust logic that `convert_cast` already has for this.