### PR TITLE
transpile: Treat `LValueToRValue` casts as potential volatile reads

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3032,20 +3032,15 @@ impl<'c> Translation<'c> {
         lhs_type: CQualTypeId,
         write: bool,
     ) -> TranslationResult<Box<Expr>> {
-        let mutbl = if write {
-            Mutability::Mutable
-        } else {
-            Mutability::Immutable
-        };
         let addr_lhs = match *lhs {
             Expr::Unary(ExprUnary {
                 op: UnOp::Deref(_),
                 expr: e,
                 ..
             }) => {
-                if write == lhs_type.qualifiers.is_const {
+                if write && lhs_type.qualifiers.is_const {
                     let lhs_type = self.convert_type(lhs_type.ctype)?;
-                    let ty = mk().set_mutbl(mutbl).ptr_ty(lhs_type);
+                    let ty = mk().set_mutbl(Mutability::Mutable).ptr_ty(lhs_type);
 
                     mk().cast_expr(e, ty)
                 } else {
@@ -3053,6 +3048,12 @@ impl<'c> Translation<'c> {
                 }
             }
             _ => {
+                let mutbl = if write {
+                    Mutability::Mutable
+                } else {
+                    Mutability::Immutable
+                };
+
                 self.use_feature("raw_ref_op");
                 mk().set_mutbl(mutbl).raw_borrow_expr(lhs)
             }

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3456,12 +3456,6 @@ impl<'c> Translation<'c> {
 
                 let mut val = mk().path_expr(vec![rustname]);
 
-                // If the variable is volatile and used as something that isn't an LValue, this
-                // constitutes a volatile read.
-                if lrvalue.is_rvalue() && qual_ty.qualifiers.is_volatile {
-                    val = self.volatile_read(val, qual_ty)?;
-                }
-
                 // If the variable is actually an `EnumConstant`, we need to add a cast to the
                 // expected integral type.
                 if let &CDeclKind::EnumConstant { .. } = decl {
@@ -3518,7 +3512,7 @@ impl<'c> Translation<'c> {
 
                 // if the context wants a different type, add a cast
                 if let Some(expected_ty) = override_ty {
-                    if expected_ty != qual_ty {
+                    if lrvalue.is_rvalue() && expected_ty != qual_ty {
                         val = mk().cast_expr(val, self.convert_type(expected_ty.ctype)?);
                     }
                 }
@@ -3659,16 +3653,8 @@ impl<'c> Translation<'c> {
                             return self.convert_expr(ctx, expr, override_ty);
                         }
                     }
-                    // LValueToRValue casts don't actually change the type, so it still makes sense
-                    // to translate their inner expression with the expected type from outside the
-                    // cast.
-                    if kind == CastKind::LValueToRValue
-                        && Some(source_ty.ctype) != override_ty.map(|x| x.ctype)
-                    {
-                        self.convert_expr(ctx, expr, override_ty)?
-                    } else {
-                        self.convert_expr(ctx, expr, None)?
-                    }
+
+                    self.convert_expr(ctx, expr, None)?
                 };
                 // Shuffle Vector "function" builtins will add a cast to the output of the
                 // builtin call which is unnecessary for translation purposes
@@ -3689,8 +3675,8 @@ impl<'c> Translation<'c> {
                 )
             }
 
-            Unary(type_id, op, arg, lrvalue) => {
-                self.convert_unary_operator(ctx, op, override_ty.unwrap_or(type_id), arg, lrvalue)
+            Unary(type_id, op, arg, _lrvalue) => {
+                self.convert_unary_operator(ctx, op, override_ty.unwrap_or(type_id), arg)
             }
 
             Conditional(ty, cond, lhs, rhs) => {
@@ -3781,8 +3767,8 @@ impl<'c> Translation<'c> {
                 )
                 .map_err(|e| e.add_loc(self.ast_context.display_loc(src_loc))),
 
-            ArraySubscript(_, lhs, rhs, _) => self
-                .convert_array_subscript(ctx, lhs, rhs, override_ty, true)
+            ArraySubscript(_, lhs, rhs, lrvalue) => self
+                .convert_array_subscript(ctx, lhs, rhs, lrvalue, override_ty, true)
                 .map_err(|e| e.add_loc(self.ast_context.display_loc(src_loc))),
 
             Call(call_expr_ty, func, ref args) => {
@@ -3893,8 +3879,8 @@ impl<'c> Translation<'c> {
                 )
             }
 
-            Member(qual_ty, expr, decl, kind, _) => {
-                self.convert_member_expr(ctx, qual_ty, expr, decl, kind, override_ty)
+            Member(qual_ty, expr, decl, kind, lrvalue) => {
+                self.convert_member_expr(ctx, qual_ty, expr, decl, kind, lrvalue, override_ty)
             }
 
             Paren(_, val) => self.convert_expr(ctx, val, override_ty),
@@ -4153,10 +4139,6 @@ impl<'c> Translation<'c> {
         let source_ty_kind = &self.ast_context.resolve_type(source_cty.ctype).kind;
         let target_ty_kind = &self.ast_context.resolve_type(target_cty.ctype).kind;
 
-        if source_ty_kind == target_ty_kind {
-            return Ok(val);
-        }
-
         let kind = kind.unwrap_or_else(|| {
             CastKind::from_types(source_ty_kind, target_ty_kind).unwrap_or_else(|| {
                 warn!(
@@ -4167,6 +4149,10 @@ impl<'c> Translation<'c> {
                 CastKind::BitCast
             })
         });
+
+        if source_ty_kind == target_ty_kind && kind != CastKind::LValueToRValue {
+            return Ok(val);
+        }
 
         match kind {
             CastKind::BitCast | CastKind::NoOp => {
@@ -4241,7 +4227,25 @@ impl<'c> Translation<'c> {
                 }
             }
 
-            CastKind::LValueToRValue | CastKind::ToVoid | CastKind::ConstCast => Ok(val),
+            CastKind::LValueToRValue => {
+                let mut val = if source_cty.qualifiers.is_volatile {
+                    // If the expression is volatile and used as something that isn't an LValue,
+                    // this constitutes a volatile read.
+                    val.result_map(|val| self.volatile_read(val, target_cty))?
+                } else {
+                    val
+                };
+
+                // if the context wants a different type, add a cast
+                if target_cty.ctype != source_cty.ctype {
+                    let ty = self.convert_type(target_cty.ctype)?;
+                    val = val.map(|val| mk().cast_expr(val, ty));
+                }
+
+                Ok(val)
+            }
+
+            CastKind::ToVoid | CastKind::ConstCast => Ok(val),
 
             CastKind::FunctionToPointerDecay | CastKind::BuiltinFnToFnPtr => {
                 Ok(val.map(|x| mk().call_expr(mk().ident_expr("Some"), vec![x])))

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -850,7 +850,6 @@ impl<'c> Translation<'c> {
         name: CUnOp,
         cqual_type: CQualTypeId,
         arg: CExprId,
-        lrvalue: LRValue,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let mut unary = match name {
             CUnOp::AddressOf => self.convert_address_of(ctx, cqual_type, arg),
@@ -858,7 +857,7 @@ impl<'c> Translation<'c> {
             CUnOp::PreDecrement => self.convert_pre_increment(ctx, cqual_type, false, arg),
             CUnOp::PostIncrement => self.convert_post_increment(ctx, cqual_type, true, arg),
             CUnOp::PostDecrement => self.convert_post_increment(ctx, cqual_type, false, arg),
-            CUnOp::Deref => self.convert_deref(ctx, cqual_type, arg, lrvalue),
+            CUnOp::Deref => self.convert_deref(ctx, cqual_type, arg),
             CUnOp::Plus => self.convert_expr(ctx.used(), arg, Some(cqual_type)), // promotion is explicit in the clang AST
 
             CUnOp::Negate => self.convert_negate_operator(ctx, cqual_type, arg),

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -36,9 +36,10 @@ impl<'c> Translation<'c> {
                     ctx.used().set_needs_address(true),
                     lhs,
                     rhs,
+                    LRValue::RValue, // if we bypass the deref, we stay an RValue
                     Some(cqual_type),
-                    false,
-                )
+                    false, // don't deref, keep as pointer
+                );
             }
             // An AddrOf DeclRef/Member is safe to not decay
             // if the translator isn't already giving a hard yes to decaying (ie, BitCasts).
@@ -203,7 +204,6 @@ impl<'c> Translation<'c> {
         ctx: ExprContext,
         cqual_type: CQualTypeId,
         arg: CExprId,
-        lrvalue: LRValue,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let arg_expr_kind = &self.ast_context.index(arg).kind;
 
@@ -220,14 +220,7 @@ impl<'c> Translation<'c> {
                 } else if let Some(_vla) = self.compute_size_of_expr(cqual_type.ctype) {
                     Ok(val)
                 } else {
-                    let mut val = mk().unary_expr(UnOp::Deref(Default::default()), val);
-
-                    // If the type on the other side of the pointer we are dereferencing is volatile and
-                    // this whole expression is not an LValue, we should make this a volatile read
-                    if lrvalue.is_rvalue() && cqual_type.qualifiers.is_volatile {
-                        val = self.volatile_read(val, cqual_type)?
-                    }
-                    Ok(val)
+                    Ok(mk().unary_expr(UnOp::Deref(Default::default()), val))
                 }
             })
     }
@@ -237,6 +230,7 @@ impl<'c> Translation<'c> {
         ctx: ExprContext,
         lhs: CExprId,
         rhs: CExprId,
+        lrvalue: LRValue,
         override_ty: Option<CQualTypeId>,
         deref: bool,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
@@ -359,7 +353,7 @@ impl<'c> Translation<'c> {
                         self.convert_pointer_offset(lhs, rhs, pointee_type_id.ctype, false, deref);
                     // if the context wants a different type, add a cast
                     if let Some(expected_ty) = override_ty {
-                        if expected_ty != pointee_type_id {
+                        if lrvalue.is_rvalue() && expected_ty != pointee_type_id {
                             let ty = self.convert_type(expected_ty.ctype)?;
                             val = val.map(|val| mk().cast_expr(val, ty));
                         }

--- a/c2rust-transpile/src/translator/structs_unions.rs
+++ b/c2rust-transpile/src/translator/structs_unions.rs
@@ -16,6 +16,7 @@ use crate::translator::{ConvertedDecl, ExprContext, Translation, PADDING_SUFFIX}
 use crate::with_stmts::WithStmts;
 use crate::ExternCrate;
 use c2rust_ast_builder::mk;
+use c2rust_ast_exporter::clang_ast::LRValue;
 use c2rust_ast_printer::pprust;
 use proc_macro2::Span;
 use syn::{
@@ -1019,6 +1020,7 @@ impl<'a> Translation<'a> {
         expr: CExprId,
         decl: CDeclId,
         kind: MemberKind,
+        lrvalue: LRValue,
         override_ty: Option<CQualTypeId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         if ctx.is_unused() {
@@ -1079,7 +1081,7 @@ impl<'a> Translation<'a> {
 
         // if the context wants a different type, add a cast
         if let Some(expected_ty) = override_ty {
-            if expected_ty != qual_ty {
+            if lrvalue.is_rvalue() && expected_ty != qual_ty {
                 let ty = self.convert_type(expected_ty.ctype)?;
                 val = val.map(|v| mk().cast_expr(v, ty));
             }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn test_volatile() {
             ::core::ptr::read_volatile::<::core::ffi::c_int>(&raw const vi);
         ::core::ptr::write_volatile(&raw mut vi, i);
         let mut pvi: *mut ::core::ffi::c_int = &raw mut vi;
-        i = ::core::ptr::read_volatile::<::core::ffi::c_int>(pvi as *const ::core::ffi::c_int);
+        i = ::core::ptr::read_volatile::<::core::ffi::c_int>(pvi);
         ::core::ptr::write_volatile(pvi, i);
         ::core::ptr::write_volatile(
             &raw mut volatile_global_struct.p,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
@@ -25,10 +25,11 @@ pub static mut volatile_global_struct: S = S {
 pub unsafe extern "C" fn test_volatile() {
     unsafe {
         let mut vi: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-        let mut i: ::core::ffi::c_int = vi;
+        let mut i: ::core::ffi::c_int =
+            ::core::ptr::read_volatile::<::core::ffi::c_int>(&raw const vi);
         ::core::ptr::write_volatile(&raw mut vi, i);
         let mut pvi: *mut ::core::ffi::c_int = &raw mut vi;
-        i = *pvi;
+        i = ::core::ptr::read_volatile::<::core::ffi::c_int>(pvi as *const ::core::ffi::c_int);
         ::core::ptr::write_volatile(pvi, i);
         ::core::ptr::write_volatile(
             &raw mut volatile_global_struct.p,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
@@ -24,6 +24,12 @@ pub static mut volatile_global_struct: S = S {
 #[no_mangle]
 pub unsafe extern "C" fn test_volatile() {
     unsafe {
+        let mut vi: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+        let mut i: ::core::ffi::c_int = vi;
+        ::core::ptr::write_volatile(&raw mut vi, i);
+        let mut pvi: *mut ::core::ffi::c_int = &raw mut vi;
+        i = *pvi;
+        ::core::ptr::write_volatile(pvi, i);
         ::core::ptr::write_volatile(
             &raw mut volatile_global_struct.p,
             ::core::ptr::read_volatile::<*mut ::core::ffi::c_int>(

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn test_volatile() {
             ::core::ptr::read_volatile::<::core::ffi::c_int>(&raw const vi);
         ::core::ptr::write_volatile(&raw mut vi, i);
         let mut pvi: *mut ::core::ffi::c_int = &raw mut vi;
-        i = ::core::ptr::read_volatile::<::core::ffi::c_int>(pvi as *const ::core::ffi::c_int);
+        i = ::core::ptr::read_volatile::<::core::ffi::c_int>(pvi);
         ::core::ptr::write_volatile(pvi, i);
         ::core::ptr::write_volatile(
             &raw mut volatile_global_struct.p,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
@@ -23,6 +23,12 @@ pub static mut volatile_global_struct: S = S {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn test_volatile() {
     unsafe {
+        let mut vi: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+        let mut i: ::core::ffi::c_int = vi;
+        ::core::ptr::write_volatile(&raw mut vi, i);
+        let mut pvi: *mut ::core::ffi::c_int = &raw mut vi;
+        i = *pvi;
+        ::core::ptr::write_volatile(pvi, i);
         ::core::ptr::write_volatile(
             &raw mut volatile_global_struct.p,
             ::core::ptr::read_volatile::<*mut ::core::ffi::c_int>(

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
@@ -24,10 +24,11 @@ pub static mut volatile_global_struct: S = S {
 pub unsafe extern "C" fn test_volatile() {
     unsafe {
         let mut vi: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-        let mut i: ::core::ffi::c_int = vi;
+        let mut i: ::core::ffi::c_int =
+            ::core::ptr::read_volatile::<::core::ffi::c_int>(&raw const vi);
         ::core::ptr::write_volatile(&raw mut vi, i);
         let mut pvi: *mut ::core::ffi::c_int = &raw mut vi;
-        i = *pvi;
+        i = ::core::ptr::read_volatile::<::core::ffi::c_int>(pvi as *const ::core::ffi::c_int);
         ::core::ptr::write_volatile(pvi, i);
         ::core::ptr::write_volatile(
             &raw mut volatile_global_struct.p,

--- a/c2rust-transpile/tests/snapshots/volatile.c
+++ b/c2rust-transpile/tests/snapshots/volatile.c
@@ -1,6 +1,14 @@
 struct S { int * volatile p; } volatile_global_struct;
 
 void test_volatile(void) {
+    volatile int vi = 0;
+    int i = vi;
+    vi = i;
+
+    volatile int *pvi = &vi;
+    i = *pvi;
+    *pvi = i;
+
     // https://github.com/immunant/c2rust/issues/1237
     --(volatile_global_struct.p);
 }


### PR DESCRIPTION
- Depends on #1717.
- Fixes #292.

Previously, volatile reads were handled in `convert_expr` for variable `DeclRef` directly. But that isn't the right place, since all variable `DeclRef` are lvalues and you can't tell at that point whether it's being read or written. Likewise for dereference expressions, which are still lvalues as a whole.

So I've moved it to where `LValueToRValue` casts are handled, which seems to be more correct. Now `volatile_read` is indeed generated.