### PR TITLE
transpile: Prefix `c_ast::{BinOp, UnOp, UnTypeOp}` with `C` to disambiguate better

### DIFF
--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -1366,30 +1366,30 @@ impl ConversionContext {
                         .expect("Expected operator")
                         .as_str()
                     {
-                        "&" => UnOp::AddressOf,
-                        "*" => UnOp::Deref,
-                        "+" => UnOp::Plus,
-                        "-" => UnOp::Negate,
-                        "~" => UnOp::Complement,
-                        "!" => UnOp::Not,
+                        "&" => CUnOp::AddressOf,
+                        "*" => CUnOp::Deref,
+                        "+" => CUnOp::Plus,
+                        "-" => CUnOp::Negate,
+                        "~" => CUnOp::Complement,
+                        "!" => CUnOp::Not,
                         "++" => {
                             if prefix {
-                                UnOp::PreIncrement
+                                CUnOp::PreIncrement
                             } else {
-                                UnOp::PostIncrement
+                                CUnOp::PostIncrement
                             }
                         }
                         "--" => {
                             if prefix {
-                                UnOp::PreDecrement
+                                CUnOp::PreDecrement
                             } else {
-                                UnOp::PostDecrement
+                                CUnOp::PostDecrement
                             }
                         }
-                        "__real" => UnOp::Real,
-                        "__imag" => UnOp::Imag,
-                        "__extension__" => UnOp::Extension,
-                        "co_await" => UnOp::Coawait,
+                        "__real" => CUnOp::Real,
+                        "__imag" => CUnOp::Imag,
+                        "__extension__" => CUnOp::Extension,
+                        "co_await" => CUnOp::Coawait,
                         o => panic!("Unexpected operator: {}", o),
                     };
 
@@ -1495,36 +1495,36 @@ impl ConversionContext {
                         .expect("Expected operator")
                         .as_str()
                     {
-                        "*" => BinOp::Multiply,
-                        "/" => BinOp::Divide,
-                        "%" => BinOp::Modulus,
-                        "+" => BinOp::Add,
-                        "-" => BinOp::Subtract,
-                        "<<" => BinOp::ShiftLeft,
-                        ">>" => BinOp::ShiftRight,
-                        "<" => BinOp::Less,
-                        ">" => BinOp::Greater,
-                        "<=" => BinOp::LessEqual,
-                        ">=" => BinOp::GreaterEqual,
-                        "==" => BinOp::EqualEqual,
-                        "!=" => BinOp::NotEqual,
-                        "&" => BinOp::BitAnd,
-                        "^" => BinOp::BitXor,
-                        "|" => BinOp::BitOr,
-                        "&&" => BinOp::And,
-                        "||" => BinOp::Or,
-                        "+=" => BinOp::AssignAdd,
-                        "-=" => BinOp::AssignSubtract,
-                        "*=" => BinOp::AssignMultiply,
-                        "/=" => BinOp::AssignDivide,
-                        "%=" => BinOp::AssignModulus,
-                        "^=" => BinOp::AssignBitXor,
-                        "<<=" => BinOp::AssignShiftLeft,
-                        ">>=" => BinOp::AssignShiftRight,
-                        "|=" => BinOp::AssignBitOr,
-                        "&=" => BinOp::AssignBitAnd,
-                        "=" => BinOp::Assign,
-                        "," => BinOp::Comma,
+                        "*" => CBinOp::Multiply,
+                        "/" => CBinOp::Divide,
+                        "%" => CBinOp::Modulus,
+                        "+" => CBinOp::Add,
+                        "-" => CBinOp::Subtract,
+                        "<<" => CBinOp::ShiftLeft,
+                        ">>" => CBinOp::ShiftRight,
+                        "<" => CBinOp::Less,
+                        ">" => CBinOp::Greater,
+                        "<=" => CBinOp::LessEqual,
+                        ">=" => CBinOp::GreaterEqual,
+                        "==" => CBinOp::EqualEqual,
+                        "!=" => CBinOp::NotEqual,
+                        "&" => CBinOp::BitAnd,
+                        "^" => CBinOp::BitXor,
+                        "|" => CBinOp::BitOr,
+                        "&&" => CBinOp::And,
+                        "||" => CBinOp::Or,
+                        "+=" => CBinOp::AssignAdd,
+                        "-=" => CBinOp::AssignSubtract,
+                        "*=" => CBinOp::AssignMultiply,
+                        "/=" => CBinOp::AssignDivide,
+                        "%=" => CBinOp::AssignModulus,
+                        "^=" => CBinOp::AssignBitXor,
+                        "<<=" => CBinOp::AssignShiftLeft,
+                        ">>=" => CBinOp::AssignShiftRight,
+                        "|=" => CBinOp::AssignBitOr,
+                        "&=" => CBinOp::AssignBitAnd,
+                        "=" => CBinOp::Assign,
+                        "," => CBinOp::Comma,
                         _ => unimplemented!(),
                     };
 
@@ -1629,9 +1629,9 @@ impl ConversionContext {
                     let kind_name =
                         from_value::<String>(node.extras[0].clone()).expect("expected kind");
                     let kind = match kind_name.as_str() {
-                        "sizeof" => UnTypeOp::SizeOf,
-                        "alignof" => UnTypeOp::AlignOf,
-                        "preferredalignof" => UnTypeOp::PreferredAlignOf,
+                        "sizeof" => CUnTypeOp::SizeOf,
+                        "alignof" => CUnTypeOp::AlignOf,
+                        "preferredalignof" => CUnTypeOp::PreferredAlignOf,
                         str => panic!("Unsupported operation: {}", str),
                     };
 

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -646,7 +646,7 @@ impl TypedAstContext {
 
     /// Returns the expression inside an `__extension__` operator.
     pub fn resolve_extension(&self, expr_id: CExprId) -> CExprId {
-        if let CExprKind::Unary(_, UnOp::Extension, subexpr, _) = self.index(expr_id).kind {
+        if let CExprKind::Unary(_, CUnOp::Extension, subexpr, _) = self.index(expr_id).kind {
             subexpr
         } else {
             expr_id
@@ -816,11 +816,11 @@ impl TypedAstContext {
             ShuffleVector(..) |
             ConvertVector(..) |
             Call(..) |
-            Unary(_, UnOp::PreIncrement, _, _) |
-            Unary(_, UnOp::PostIncrement, _, _) |
-            Unary(_, UnOp::PreDecrement, _, _) |
-            Unary(_, UnOp::PostDecrement, _, _) |
-            Binary(_, BinOp::Assign, _, _, _, _) |
+            Unary(_, CUnOp::PreIncrement, _, _) |
+            Unary(_, CUnOp::PostIncrement, _, _) |
+            Unary(_, CUnOp::PreDecrement, _, _) |
+            Unary(_, CUnOp::PostDecrement, _, _) |
+            Binary(_, CBinOp::Assign, _, _, _, _) |
             InitList { .. } |
             ImplicitValueInit { .. } |
             Predefined(..) |
@@ -896,8 +896,8 @@ impl TypedAstContext {
             UnaryType(_, _, expr, _) => expr.map_or(true, is_const),
             // Not sure what a `OffsetOfKind::Variable` means.
             OffsetOf(_, _) => true,
-            // `ptr::offset` (ptr `BinOp::Add`) was `const` stabilized in `1.61.0`.
-            // `ptr::offset_from` (ptr `BinOp::Subtract`) was `const` stabilized in `1.65.0`.
+            // `ptr::offset` (ptr `CBinOp::Add`) was `const` stabilized in `1.61.0`.
+            // `ptr::offset_from` (ptr `CBinOp::Subtract`) was `const` stabilized in `1.65.0`.
             // TODO `f128` is not yet handled, as we should eventually
             // switch to the (currently unstable) `f128` primitive type (#1262).
             Binary(_, _, lhs, rhs, _, _) => is_const(lhs) && is_const(rhs),
@@ -1183,7 +1183,7 @@ impl TypedAstContext {
                             } else {
                                 Some(rhs_type_id)
                             }
-                        } else if op == BinOp::ShiftLeft || op == BinOp::ShiftRight {
+                        } else if op == CBinOp::ShiftLeft || op == CBinOp::ShiftRight {
                             Some(lhs_type_id)
                         } else {
                             return;
@@ -1195,11 +1195,11 @@ impl TypedAstContext {
                     ),
                     CExprKind::Paren(_ty, e) => self.ast_context.c_exprs[&e].kind.get_qual_type(),
                     CExprKind::UnaryType(_, op, _, _) => {
-                        // All of these `UnTypeOp`s should return `size_t`.
+                        // All of these `CUnTypeOp`s should return `size_t`.
                         let kind = match op {
-                            UnTypeOp::SizeOf => CTypeKind::Size,
-                            UnTypeOp::AlignOf => CTypeKind::Size,
-                            UnTypeOp::PreferredAlignOf => CTypeKind::Size,
+                            CUnTypeOp::SizeOf => CTypeKind::Size,
+                            CUnTypeOp::AlignOf => CTypeKind::Size,
+                            CUnTypeOp::PreferredAlignOf => CTypeKind::Size,
                         };
                         let ty = self
                             .ast_context
@@ -1582,10 +1582,10 @@ pub enum CExprKind {
     Literal(CQualTypeId, CLiteral),
 
     /// Unary operator.
-    Unary(CQualTypeId, UnOp, CExprId, LRValue),
+    Unary(CQualTypeId, CUnOp, CExprId, LRValue),
 
     /// Unary type operator.
-    UnaryType(CQualTypeId, UnTypeOp, Option<CExprId>, CQualTypeId),
+    UnaryType(CQualTypeId, CUnTypeOp, Option<CExprId>, CQualTypeId),
 
     /// `offsetof` expression.
     OffsetOf(CQualTypeId, OffsetOfKind),
@@ -1593,7 +1593,7 @@ pub enum CExprKind {
     /// Binary operator.
     Binary(
         CQualTypeId,
-        BinOp,
+        CBinOp,
         CExprId,
         CExprId,
         Option<CQualTypeId>,
@@ -1851,7 +1851,7 @@ impl CastKind {
 
 /// Represents a unary operator in C (6.5.3 Unary operators) and GNU C extensions
 #[derive(Debug, Clone, Copy)]
-pub enum UnOp {
+pub enum CUnOp {
     AddressOf,     // &x
     Deref,         // *x
     Plus,          // +x
@@ -1868,9 +1868,9 @@ pub enum UnOp {
     Coawait,       // [C++ Coroutines] co_await x
 }
 
-impl UnOp {
+impl CUnOp {
     pub fn as_str(&self) -> &'static str {
-        use UnOp::*;
+        use CUnOp::*;
         match self {
             AddressOf => "&",
             Deref => "*",
@@ -1895,7 +1895,7 @@ impl UnOp {
         ast_context: &TypedAstContext,
         arg_type: CQualTypeId,
     ) -> Option<CQualTypeId> {
-        use UnOp::*;
+        use CUnOp::*;
         let resolved_ty = ast_context.resolve_type(arg_type.ctype);
         Some(match self {
             // We could construct CTypeKind::Pointer here, but it is not guaranteed to have a
@@ -1926,7 +1926,7 @@ impl UnOp {
     }
 }
 
-impl Display for UnOp {
+impl Display for CUnOp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.as_str())
     }
@@ -1934,15 +1934,15 @@ impl Display for UnOp {
 
 /// Represents a unary type operator in C
 #[derive(Debug, Clone, Copy)]
-pub enum UnTypeOp {
+pub enum CUnTypeOp {
     SizeOf,
     AlignOf,
     PreferredAlignOf,
 }
 
-impl UnTypeOp {
+impl CUnTypeOp {
     pub fn as_str(&self) -> &'static str {
-        use UnTypeOp::*;
+        use CUnTypeOp::*;
         match self {
             SizeOf => "sizeof",
             AlignOf => "alignof",
@@ -1951,22 +1951,22 @@ impl UnTypeOp {
     }
 }
 
-impl Display for UnTypeOp {
+impl Display for CUnTypeOp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.as_str())
     }
 }
 
-impl UnOp {
+impl CUnOp {
     /// Check is the operator is rendered before or after is operand.
     pub fn is_prefix(&self) -> bool {
-        !matches!(*self, UnOp::PostIncrement | UnOp::PostDecrement)
+        !matches!(*self, CUnOp::PostIncrement | CUnOp::PostDecrement)
     }
 }
 
 /// Represents a binary operator in C (6.5.5 Multiplicative operators - 6.5.14 Logical OR operator)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BinOp {
+pub enum CBinOp {
     Multiply,     // *
     Divide,       // /
     Modulus,      // %
@@ -2001,9 +2001,9 @@ pub enum BinOp {
     Comma,  // ,
 }
 
-impl BinOp {
+impl CBinOp {
     pub fn as_str(&self) -> &'static str {
-        use BinOp::*;
+        use CBinOp::*;
         match self {
             Multiply => "*",
             Divide => "/",
@@ -2043,7 +2043,7 @@ impl BinOp {
     /// Does the rust equivalent of this operator have type (T, T) -> U?
     #[rustfmt::skip]
     pub fn input_types_same(&self) -> bool {
-        use BinOp::*;
+        use CBinOp::*;
         self.all_types_same() || matches!(self,
             Less | Greater | LessEqual | GreaterEqual | EqualEqual | NotEqual
             | And | Or
@@ -2056,7 +2056,7 @@ impl BinOp {
     /// Does the rust equivalent of this operator have type (T, T) -> T?
     /// This ignores cases where one argument is a pointer and we translate to `.offset()`.
     pub fn all_types_same(&self) -> bool {
-        use BinOp::*;
+        use CBinOp::*;
         matches!(
             self,
             Multiply | Divide | Modulus | Add | Subtract | BitAnd | BitXor | BitOr
@@ -2064,19 +2064,19 @@ impl BinOp {
     }
 }
 
-impl Display for BinOp {
+impl Display for CBinOp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.as_str())
     }
 }
 
-impl BinOp {
+impl CBinOp {
     /// Maps compound assignment operators to operator underlying them, and returns `None` for all
     /// other operators.
     ///
     /// For example, `AssignAdd` maps to `Some(Add)` but `Add` maps to `None`.
-    pub fn underlying_assignment(&self) -> Option<BinOp> {
-        use BinOp::*;
+    pub fn underlying_assignment(&self) -> Option<CBinOp> {
+        use CBinOp::*;
         Some(match *self {
             AssignAdd => Add,
             AssignSubtract => Subtract,

--- a/c2rust-transpile/src/c_ast/print.rs
+++ b/c2rust-transpile/src/c_ast/print.rs
@@ -287,11 +287,11 @@ impl<W: Write> Printer<W> {
         Ok(())
     }
 
-    pub fn print_unop(&mut self, op: &UnOp, _context: &TypedAstContext) -> Result<()> {
+    pub fn print_unop(&mut self, op: &CUnOp, _context: &TypedAstContext) -> Result<()> {
         self.writer.write_all(op.as_str().as_bytes())
     }
 
-    pub fn print_binop(&mut self, op: &BinOp, _context: &TypedAstContext) -> Result<()> {
+    pub fn print_binop(&mut self, op: &CBinOp, _context: &TypedAstContext) -> Result<()> {
         self.writer.write_all(op.as_str().as_bytes())
     }
 

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -1783,7 +1783,7 @@ impl CfgBuilder {
                 // This case typically happens in macros from system headers.
                 // We simply inline the common statement at this point rather
                 // than to try and create new control-flow blocks.
-                let blk_or_wip = if let CExprKind::Unary(_, UnOp::Extension, sube, _) =
+                let blk_or_wip = if let CExprKind::Unary(_, CUnOp::Extension, sube, _) =
                     translator.ast_context[expr].kind
                 {
                     if let CExprKind::Statements(_, stmtid) = translator.ast_context[sube].kind {

--- a/c2rust-transpile/src/translator/enums.rs
+++ b/c2rust-transpile/src/translator/enums.rs
@@ -2,8 +2,8 @@ use c2rust_ast_builder::mk;
 use proc_macro2::Span;
 use syn::Expr;
 
+use crate::c_ast::CUnOp;
 use crate::{
-    c_ast,
     diagnostics::TranslationResult,
     translator::{signed_int_expr, ConvertedDecl, ExprContext, Translation},
     with_stmts::WithStmts,
@@ -110,7 +110,7 @@ impl<'c> Translation<'c> {
                     return Ok(self.enum_for_i64(enum_type_id, i as i64));
                 }
 
-                CExprKind::Unary(_, c_ast::UnOp::Negate, subexpr_id, _) => {
+                CExprKind::Unary(_, CUnOp::Negate, subexpr_id, _) => {
                     if let &CExprKind::Literal(_, CLiteral::Integer(i, _)) =
                         &self.ast_context[subexpr_id].kind
                     {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -17,14 +17,13 @@ use log::{error, trace, warn};
 use proc_macro2::{Punct, Spacing::*, Span, TokenStream, TokenTree};
 use syn::spanned::Spanned as _;
 use syn::{
-    AttrStyle, BareVariadic, Block, Expr, ExprBinary, ExprBlock, ExprBreak, ExprCast, ExprField,
-    ExprIndex, ExprParen, ExprReturn, ExprUnary, FnArg, ForeignItem, ForeignItemFn,
+    AttrStyle, BareVariadic, BinOp, Block, Expr, ExprBinary, ExprBlock, ExprBreak, ExprCast,
+    ExprField, ExprIndex, ExprParen, ExprReturn, ExprUnary, FnArg, ForeignItem, ForeignItemFn,
     ForeignItemMacro, ForeignItemStatic, ForeignItemType, Ident, Item, ItemConst, ItemEnum,
     ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod, ItemStatic, ItemStruct,
     ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Lit, MacroDelimiter, PathSegment,
-    ReturnType, Stmt, Type, TypeTuple, UseTree, Visibility,
+    ReturnType, Stmt, Type, TypeTuple, UnOp, UseTree, Visibility,
 };
-use syn::{BinOp, UnOp}; // To override `c_ast::{BinOp,UnOp}` from glob import.
 
 use crate::diagnostics::TranslationResult;
 use crate::rust_ast::comment_store::CommentStore;
@@ -1707,9 +1706,9 @@ impl<'c> Translation<'c> {
         expr_id: Option<CExprId>,
         qtype: CQualTypeId,
     ) -> bool {
-        use crate::c_ast::BinOp::{Add, Divide, Modulus, Multiply, Subtract};
+        use crate::c_ast::CBinOp::{Add, Divide, Modulus, Multiply, Subtract};
+        use crate::c_ast::CUnOp::{AddressOf, Negate};
         use crate::c_ast::CastKind::{IntegralToPointer, PointerToIntegral};
-        use crate::c_ast::UnOp::{AddressOf, Negate};
 
         let expr_id = match expr_id {
             Some(expr_id) => expr_id,
@@ -2607,25 +2606,25 @@ impl<'c> Translation<'c> {
             };
 
         match self.ast_context[cond_id].kind {
-            CExprKind::Binary(_, c_ast::BinOp::EqualEqual, null_expr, ptr, _, _)
+            CExprKind::Binary(_, CBinOp::EqualEqual, null_expr, ptr, _, _)
                 if self.ast_context.is_null_expr(null_expr) =>
             {
                 null_pointer_case(ptr, target)
             }
 
-            CExprKind::Binary(_, c_ast::BinOp::EqualEqual, ptr, null_expr, _, _)
+            CExprKind::Binary(_, CBinOp::EqualEqual, ptr, null_expr, _, _)
                 if self.ast_context.is_null_expr(null_expr) =>
             {
                 null_pointer_case(ptr, target)
             }
 
-            CExprKind::Binary(_, c_ast::BinOp::NotEqual, null_expr, ptr, _, _)
+            CExprKind::Binary(_, CBinOp::NotEqual, null_expr, ptr, _, _)
                 if self.ast_context.is_null_expr(null_expr) =>
             {
                 null_pointer_case(ptr, !target)
             }
 
-            CExprKind::Binary(_, c_ast::BinOp::NotEqual, ptr, null_expr, _, _)
+            CExprKind::Binary(_, CBinOp::NotEqual, ptr, null_expr, _, _)
                 if self.ast_context.is_null_expr(null_expr) =>
             {
                 null_pointer_case(ptr, !target)
@@ -2641,7 +2640,7 @@ impl<'c> Translation<'c> {
                 Ok(WithStmts::new_val(val))
             }
 
-            CExprKind::Unary(_, c_ast::UnOp::Not, subexpr_id, _) => {
+            CExprKind::Unary(_, CUnOp::Not, subexpr_id, _) => {
                 self.convert_condition(ctx, !target, subexpr_id)
             }
 
@@ -2944,8 +2943,7 @@ impl<'c> Translation<'c> {
                         }
 
                         // ref decayed ptrs generally need a type annotation
-                        if let Some(CExprKind::Unary(_, c_ast::UnOp::AddressOf, _, _)) =
-                            initializer_kind
+                        if let Some(CExprKind::Unary(_, CUnOp::AddressOf, _, _)) = initializer_kind
                         {
                             return true;
                         }
@@ -3377,7 +3375,7 @@ impl<'c> Translation<'c> {
 
             UnaryType(_ty, kind, opt_expr, arg_ty) => {
                 let result = match kind {
-                    UnTypeOp::SizeOf => match opt_expr {
+                    CUnTypeOp::SizeOf => match opt_expr {
                         None => self.compute_size_of_type(ctx, arg_ty.ctype, override_ty)?,
                         Some(_) => {
                             let inner = self.variable_array_base_type(arg_ty.ctype);
@@ -3393,10 +3391,10 @@ impl<'c> Translation<'c> {
                             }
                         }
                     },
-                    UnTypeOp::AlignOf => {
+                    CUnTypeOp::AlignOf => {
                         self.compute_align_of_type(arg_ty.ctype, false, src_loc)?
                     }
-                    UnTypeOp::PreferredAlignOf => {
+                    CUnTypeOp::PreferredAlignOf => {
                         self.compute_align_of_type(arg_ty.ctype, true, src_loc)?
                     }
                 };

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -2,29 +2,29 @@
 
 use super::*;
 
-impl From<c_ast::BinOp> for BinOp {
-    fn from(op: c_ast::BinOp) -> Self {
+impl From<CBinOp> for BinOp {
+    fn from(op: CBinOp) -> Self {
         match op {
-            c_ast::BinOp::Multiply => BinOp::Mul(Default::default()),
-            c_ast::BinOp::Divide => BinOp::Div(Default::default()),
-            c_ast::BinOp::Modulus => BinOp::Rem(Default::default()),
-            c_ast::BinOp::Add => BinOp::Add(Default::default()),
-            c_ast::BinOp::Subtract => BinOp::Sub(Default::default()),
-            c_ast::BinOp::ShiftLeft => BinOp::Shl(Default::default()),
-            c_ast::BinOp::ShiftRight => BinOp::Shr(Default::default()),
-            c_ast::BinOp::Less => BinOp::Lt(Default::default()),
-            c_ast::BinOp::Greater => BinOp::Gt(Default::default()),
-            c_ast::BinOp::LessEqual => BinOp::Le(Default::default()),
-            c_ast::BinOp::GreaterEqual => BinOp::Ge(Default::default()),
-            c_ast::BinOp::EqualEqual => BinOp::Eq(Default::default()),
-            c_ast::BinOp::NotEqual => BinOp::Ne(Default::default()),
-            c_ast::BinOp::BitAnd => BinOp::BitAnd(Default::default()),
-            c_ast::BinOp::BitXor => BinOp::BitXor(Default::default()),
-            c_ast::BinOp::BitOr => BinOp::BitOr(Default::default()),
-            c_ast::BinOp::And => BinOp::And(Default::default()),
-            c_ast::BinOp::Or => BinOp::Or(Default::default()),
+            CBinOp::Multiply => BinOp::Mul(Default::default()),
+            CBinOp::Divide => BinOp::Div(Default::default()),
+            CBinOp::Modulus => BinOp::Rem(Default::default()),
+            CBinOp::Add => BinOp::Add(Default::default()),
+            CBinOp::Subtract => BinOp::Sub(Default::default()),
+            CBinOp::ShiftLeft => BinOp::Shl(Default::default()),
+            CBinOp::ShiftRight => BinOp::Shr(Default::default()),
+            CBinOp::Less => BinOp::Lt(Default::default()),
+            CBinOp::Greater => BinOp::Gt(Default::default()),
+            CBinOp::LessEqual => BinOp::Le(Default::default()),
+            CBinOp::GreaterEqual => BinOp::Ge(Default::default()),
+            CBinOp::EqualEqual => BinOp::Eq(Default::default()),
+            CBinOp::NotEqual => BinOp::Ne(Default::default()),
+            CBinOp::BitAnd => BinOp::BitAnd(Default::default()),
+            CBinOp::BitXor => BinOp::BitXor(Default::default()),
+            CBinOp::BitOr => BinOp::BitOr(Default::default()),
+            CBinOp::And => BinOp::And(Default::default()),
+            CBinOp::Or => BinOp::Or(Default::default()),
 
-            _ => panic!("C BinOp {:?} is not a valid Rust BinOp", op),
+            _ => panic!("CBinOp {:?} is not a valid Rust BinOp", op),
         }
     }
 }
@@ -34,7 +34,7 @@ impl<'c> Translation<'c> {
         &self,
         mut ctx: ExprContext,
         expr_type_id: CQualTypeId,
-        op: c_ast::BinOp,
+        op: CBinOp,
         lhs: CExprId,
         rhs: CExprId,
         opt_lhs_type_id: Option<CQualTypeId>,
@@ -48,7 +48,7 @@ impl<'c> Translation<'c> {
 
         let lhs_loc = &self.ast_context[lhs].loc;
         let rhs_loc = &self.ast_context[rhs].loc;
-        use c_ast::BinOp::*;
+        use CBinOp::*;
         match op {
             Comma => {
                 // The value of the LHS of a comma expression is always discarded
@@ -90,7 +90,7 @@ impl<'c> Translation<'c> {
                 // and so we need to decay references to pointers to do so. See
                 // https://github.com/rust-lang/rust/issues/53772. This might be removable
                 // once the above issue is resolved.
-                if op == c_ast::BinOp::EqualEqual || op == c_ast::BinOp::NotEqual {
+                if op == CBinOp::EqualEqual || op == CBinOp::NotEqual {
                     ctx = ctx.decay_ref();
                 }
 
@@ -159,7 +159,7 @@ impl<'c> Translation<'c> {
                     // When we use methods on pointers (ie wrapping_offset_from or offset)
                     // we must ensure we have an explicit raw ptr for the self param, as
                     // self references do not decay
-                    if op == c_ast::BinOp::Subtract || op == c_ast::BinOp::Add {
+                    if op == CBinOp::Subtract || op == CBinOp::Add {
                         let ty_kind = &self.ast_context.resolve_type(lhs_type_id.ctype).kind;
 
                         if let CTypeKind::Pointer(_) = ty_kind {
@@ -194,7 +194,7 @@ impl<'c> Translation<'c> {
         &self,
         ctx: ExprContext,
         bin_op_kind: BinOp,
-        bin_op: c_ast::BinOp,
+        bin_op: CBinOp,
         read: Box<Expr>,
         write: Box<Expr>,
         rhs: Box<Expr>,
@@ -265,14 +265,14 @@ impl<'c> Translation<'c> {
     fn convert_assignment_operator(
         &self,
         ctx: ExprContext,
-        op: c_ast::BinOp,
+        op: CBinOp,
         expr_type_id: CQualTypeId,
         lhs: CExprId,
         rhs: CExprId,
         compute_lhs_type_id: Option<CQualTypeId>,
         compute_res_type_id: Option<CQualTypeId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        if op == c_ast::BinOp::Assign {
+        if op == CBinOp::Assign {
             assert!(compute_lhs_type_id.is_none());
             assert!(compute_res_type_id.is_none());
         } else {
@@ -301,7 +301,7 @@ impl<'c> Translation<'c> {
             let neither_ptr =
                 !lhs_resolved_ty.kind.is_pointer() && !rhs_resolved_ty.kind.is_pointer();
 
-            use c_ast::BinOp::*;
+            use CBinOp::*;
             match op.underlying_assignment() {
                 Some(Add) => neither_ptr,
                 Some(Subtract) => neither_ptr,
@@ -344,7 +344,7 @@ impl<'c> Translation<'c> {
     fn convert_assignment_operator_with_rhs(
         &self,
         ctx: ExprContext,
-        op: c_ast::BinOp,
+        op: CBinOp,
         expr_type_id: CQualTypeId,
         lhs: CExprId,
         rhs_type_id: CQualTypeId,
@@ -352,7 +352,7 @@ impl<'c> Translation<'c> {
         compute_lhs_type_id: Option<CQualTypeId>,
         compute_res_type_id: Option<CQualTypeId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        if op == c_ast::BinOp::Assign {
+        if op == CBinOp::Assign {
             assert!(compute_lhs_type_id.is_none());
             assert!(compute_res_type_id.is_none());
         } else {
@@ -403,11 +403,11 @@ impl<'c> Translation<'c> {
         };
 
         let is_unsigned_arith = match op {
-            c_ast::BinOp::AssignAdd
-            | c_ast::BinOp::AssignSubtract
-            | c_ast::BinOp::AssignMultiply
-            | c_ast::BinOp::AssignDivide
-            | c_ast::BinOp::AssignModulus => compute_resolved_ty.kind.is_unsigned_integral_type(),
+            CBinOp::AssignAdd
+            | CBinOp::AssignSubtract
+            | CBinOp::AssignMultiply
+            | CBinOp::AssignDivide
+            | CBinOp::AssignModulus => compute_resolved_ty.kind.is_unsigned_integral_type(),
             _ => false,
         };
 
@@ -432,7 +432,7 @@ impl<'c> Translation<'c> {
                      rvalue: read,
                  }| {
                     // Assignment expression itself
-                    use c_ast::BinOp::*;
+                    use CBinOp::*;
                     let assign_stmt = match op {
                         // Regular (possibly volatile) assignment
                         Assign if !is_volatile => WithStmts::new_val(mk().assign_expr(write, rhs)),
@@ -567,7 +567,7 @@ impl<'c> Translation<'c> {
     fn convert_binary_operator(
         &self,
         ctx: ExprContext,
-        op: c_ast::BinOp,
+        op: CBinOp,
         ty: Box<Type>,
         ctype: CTypeId,
         lhs_type: CQualTypeId,
@@ -583,38 +583,36 @@ impl<'c> Translation<'c> {
             .is_unsigned_integral_type();
 
         Ok(WithStmts::new_val(match op {
-            c_ast::BinOp::Add => return self.convert_addition(lhs_type, rhs_type, lhs, rhs),
-            c_ast::BinOp::Subtract => {
-                return self.convert_subtraction(ty, lhs_type, rhs_type, lhs, rhs)
-            }
+            CBinOp::Add => return self.convert_addition(lhs_type, rhs_type, lhs, rhs),
+            CBinOp::Subtract => return self.convert_subtraction(ty, lhs_type, rhs_type, lhs, rhs),
 
-            c_ast::BinOp::Multiply if is_unsigned_integral_type => {
+            CBinOp::Multiply if is_unsigned_integral_type => {
                 mk().method_call_expr(lhs, "wrapping_mul", vec![rhs])
             }
-            c_ast::BinOp::Multiply => mk().binary_expr(BinOp::Mul(Default::default()), lhs, rhs),
+            CBinOp::Multiply => mk().binary_expr(BinOp::Mul(Default::default()), lhs, rhs),
 
-            c_ast::BinOp::Divide if is_unsigned_integral_type => {
+            CBinOp::Divide if is_unsigned_integral_type => {
                 mk().method_call_expr(lhs, "wrapping_div", vec![rhs])
             }
-            c_ast::BinOp::Divide => mk().binary_expr(BinOp::Div(Default::default()), lhs, rhs),
+            CBinOp::Divide => mk().binary_expr(BinOp::Div(Default::default()), lhs, rhs),
 
-            c_ast::BinOp::Modulus if is_unsigned_integral_type => {
+            CBinOp::Modulus if is_unsigned_integral_type => {
                 mk().method_call_expr(lhs, "wrapping_rem", vec![rhs])
             }
-            c_ast::BinOp::Modulus => mk().binary_expr(BinOp::Rem(Default::default()), lhs, rhs),
+            CBinOp::Modulus => mk().binary_expr(BinOp::Rem(Default::default()), lhs, rhs),
 
-            c_ast::BinOp::BitXor => mk().binary_expr(BinOp::BitXor(Default::default()), lhs, rhs),
+            CBinOp::BitXor => mk().binary_expr(BinOp::BitXor(Default::default()), lhs, rhs),
 
-            c_ast::BinOp::ShiftRight => mk().binary_expr(BinOp::Shr(Default::default()), lhs, rhs),
-            c_ast::BinOp::ShiftLeft => mk().binary_expr(BinOp::Shl(Default::default()), lhs, rhs),
+            CBinOp::ShiftRight => mk().binary_expr(BinOp::Shr(Default::default()), lhs, rhs),
+            CBinOp::ShiftLeft => mk().binary_expr(BinOp::Shl(Default::default()), lhs, rhs),
 
-            c_ast::BinOp::EqualEqual | c_ast::BinOp::NotEqual => {
+            CBinOp::EqualEqual | CBinOp::NotEqual => {
                 // Using `.is_none()` and `.is_some()` for null comparison means
                 // we don't have to rely on `trait PartialEq` as much
                 // and it is also more idiomatic.
                 let (is_null, bin_op) = match op {
-                    c_ast::BinOp::EqualEqual => (true, BinOp::Eq(Default::default())),
-                    c_ast::BinOp::NotEqual => (false, BinOp::Ne(Default::default())),
+                    CBinOp::EqualEqual => (true, BinOp::Eq(Default::default())),
+                    CBinOp::NotEqual => (false, BinOp::Ne(Default::default())),
                     _ => unreachable!(),
                 };
                 let expr = match lhs_rhs_ids {
@@ -629,21 +627,19 @@ impl<'c> Translation<'c> {
 
                 bool_to_int(expr)
             }
-            c_ast::BinOp::Less => {
-                bool_to_int(mk().binary_expr(BinOp::Lt(Default::default()), lhs, rhs))
-            }
-            c_ast::BinOp::Greater => {
+            CBinOp::Less => bool_to_int(mk().binary_expr(BinOp::Lt(Default::default()), lhs, rhs)),
+            CBinOp::Greater => {
                 bool_to_int(mk().binary_expr(BinOp::Gt(Default::default()), lhs, rhs))
             }
-            c_ast::BinOp::GreaterEqual => {
+            CBinOp::GreaterEqual => {
                 bool_to_int(mk().binary_expr(BinOp::Ge(Default::default()), lhs, rhs))
             }
-            c_ast::BinOp::LessEqual => {
+            CBinOp::LessEqual => {
                 bool_to_int(mk().binary_expr(BinOp::Le(Default::default()), lhs, rhs))
             }
 
-            c_ast::BinOp::BitAnd => mk().binary_expr(BinOp::BitAnd(Default::default()), lhs, rhs),
-            c_ast::BinOp::BitOr => mk().binary_expr(BinOp::BitOr(Default::default()), lhs, rhs),
+            CBinOp::BitAnd => mk().binary_expr(BinOp::BitAnd(Default::default()), lhs, rhs),
+            CBinOp::BitOr => mk().binary_expr(BinOp::BitOr(Default::default()), lhs, rhs),
 
             op => unimplemented!("Translation of binary operator {:?}", op),
         }))
@@ -723,9 +719,9 @@ impl<'c> Translation<'c> {
         arg: CExprId,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let op = if up {
-            c_ast::BinOp::AssignAdd
+            CBinOp::AssignAdd
         } else {
-            c_ast::BinOp::AssignSubtract
+            CBinOp::AssignSubtract
         };
 
         let arg_type = self.ast_context[arg]
@@ -872,34 +868,34 @@ impl<'c> Translation<'c> {
     pub fn convert_unary_operator(
         &self,
         ctx: ExprContext,
-        name: c_ast::UnOp,
+        name: CUnOp,
         cqual_type: CQualTypeId,
         arg: CExprId,
         lrvalue: LRValue,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let mut unary = match name {
-            c_ast::UnOp::AddressOf => self.convert_address_of(ctx, cqual_type, arg),
-            c_ast::UnOp::PreIncrement => self.convert_pre_increment(ctx, cqual_type, true, arg),
-            c_ast::UnOp::PreDecrement => self.convert_pre_increment(ctx, cqual_type, false, arg),
-            c_ast::UnOp::PostIncrement => self.convert_post_increment(ctx, cqual_type, true, arg),
-            c_ast::UnOp::PostDecrement => self.convert_post_increment(ctx, cqual_type, false, arg),
-            c_ast::UnOp::Deref => self.convert_deref(ctx, cqual_type, arg, lrvalue),
-            c_ast::UnOp::Plus => self.convert_expr(ctx.used(), arg, Some(cqual_type)), // promotion is explicit in the clang AST
+            CUnOp::AddressOf => self.convert_address_of(ctx, cqual_type, arg),
+            CUnOp::PreIncrement => self.convert_pre_increment(ctx, cqual_type, true, arg),
+            CUnOp::PreDecrement => self.convert_pre_increment(ctx, cqual_type, false, arg),
+            CUnOp::PostIncrement => self.convert_post_increment(ctx, cqual_type, true, arg),
+            CUnOp::PostDecrement => self.convert_post_increment(ctx, cqual_type, false, arg),
+            CUnOp::Deref => self.convert_deref(ctx, cqual_type, arg, lrvalue),
+            CUnOp::Plus => self.convert_expr(ctx.used(), arg, Some(cqual_type)), // promotion is explicit in the clang AST
 
-            c_ast::UnOp::Negate => self.convert_negate_operator(ctx, cqual_type, arg),
-            c_ast::UnOp::Complement => Ok(self
+            CUnOp::Negate => self.convert_negate_operator(ctx, cqual_type, arg),
+            CUnOp::Complement => Ok(self
                 .convert_expr(ctx.used(), arg, Some(cqual_type))?
                 .map(|a| mk().unary_expr(UnOp::Not(Default::default()), a))),
 
-            c_ast::UnOp::Not => {
+            CUnOp::Not => {
                 let val = self.convert_condition(ctx, false, arg)?;
                 Ok(val.map(|x| mk().cast_expr(x, mk().abs_path_ty(vec!["core", "ffi", "c_int"]))))
             }
-            c_ast::UnOp::Extension => {
+            CUnOp::Extension => {
                 let arg = self.convert_expr(ctx, arg, Some(cqual_type))?;
                 Ok(arg)
             }
-            c_ast::UnOp::Real | c_ast::UnOp::Imag | c_ast::UnOp::Coawait => {
+            CUnOp::Real | CUnOp::Imag | CUnOp::Coawait => {
                 panic!("Unsupported extension operator")
             }
         }?;
@@ -911,11 +907,11 @@ impl<'c> Translation<'c> {
         // it's a no-op around the inner expression.
         if !matches!(
             name,
-            c_ast::UnOp::PreDecrement
-                | c_ast::UnOp::PreIncrement
-                | c_ast::UnOp::PostDecrement
-                | c_ast::UnOp::PostIncrement
-                | c_ast::UnOp::Extension
+            CUnOp::PreDecrement
+                | CUnOp::PreIncrement
+                | CUnOp::PostDecrement
+                | CUnOp::PostIncrement
+                | CUnOp::Extension
         ) {
             unary = self.convert_side_effects_expr(
                 ctx,

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -5,8 +5,8 @@ use c2rust_ast_exporter::clang_ast::LRValue;
 use failure::{err_msg, format_err};
 use syn::{BinOp, Expr, Type, UnOp};
 
+use crate::c_ast::CUnOp;
 use crate::{
-    c_ast,
     diagnostics::{TranslationError, TranslationErrorKind, TranslationResult},
     format_translation_err,
     translator::{
@@ -27,7 +27,7 @@ impl<'c> Translation<'c> {
 
         match arg_kind {
             // C99 6.5.3.2 para 4
-            CExprKind::Unary(_, c_ast::UnOp::Deref, target, _) => {
+            CExprKind::Unary(_, CUnOp::Deref, target, _) => {
                 return self.convert_expr(ctx, *target, None)
             }
             // Array subscript functions as a deref too.
@@ -207,7 +207,7 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let arg_expr_kind = &self.ast_context.index(arg).kind;
 
-        if let &CExprKind::Unary(_, c_ast::UnOp::AddressOf, arg, _) = arg_expr_kind {
+        if let &CExprKind::Unary(_, CUnOp::AddressOf, arg, _) = arg_expr_kind {
             return self.convert_expr(ctx.used(), arg, None);
         }
 

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -3,11 +3,11 @@
 
 use super::*;
 
-use crate::c_ast::BinOp::{Add, BitAnd, ShiftRight};
 use crate::c_ast::CExprKind::{Binary, Call, Conditional, ExplicitCast, ImplicitCast, Literal};
 use crate::c_ast::CLiteral::Integer;
 use crate::c_ast::CTypeKind::{Char, Double, Float, Int, LongLong, Short};
 use crate::c_ast::CastKind::{BitCast, IntegralCast};
+use crate::CBinOp::{Add, BitAnd, ShiftRight};
 
 /// As of rustc 1.29, rust is known to be missing some SIMD functions.
 /// See <https://github.com/rust-lang-nursery/stdsimd/issues/579>

--- a/c2rust-transpile/src/translator/structs_unions.rs
+++ b/c2rust-transpile/src/translator/structs_unions.rs
@@ -6,10 +6,9 @@ use std::ops::Index;
 
 use super::named_references::NamedReference;
 use super::TranslationError;
-use crate::c_ast;
 use crate::c_ast::{
-    BinOp, CDeclId, CDeclKind, CExprId, CExprKind, CFieldId, CQualTypeId, CRecordId, CTypeId,
-    MemberKind,
+    CBinOp, CDeclId, CDeclKind, CExprId, CExprKind, CFieldId, CQualTypeId, CRecordId, CTypeId,
+    CUnOp, MemberKind,
 };
 use crate::diagnostics::TranslationResult;
 use crate::translator::variadic::mk_va_list_ty;
@@ -20,8 +19,8 @@ use c2rust_ast_builder::mk;
 use c2rust_ast_printer::pprust;
 use proc_macro2::Span;
 use syn::{
-    self, BinOp as RBinOp, Expr, ExprAssign, ExprBinary, ExprBlock, ExprCast, ExprMethodCall,
-    ExprUnary, Field, Stmt, Type, UnOp,
+    self, BinOp, Expr, ExprAssign, ExprBinary, ExprBlock, ExprCast, ExprMethodCall, ExprUnary,
+    Field, Stmt, Type, UnOp,
 };
 
 use itertools::EitherOrBoth::{Both, Right};
@@ -151,7 +150,7 @@ impl<'a> Translation<'a> {
             let outer_size = self.mk_size_of_ty_expr(outer_ty)?.to_expr();
             let inner_size = self.mk_size_of_ty_expr(inner_ty)?.to_expr();
             let padding_value =
-                mk().binary_expr(RBinOp::Sub(Default::default()), outer_size, inner_size);
+                mk().binary_expr(BinOp::Sub(Default::default()), outer_size, inner_size);
             let padding_const = mk()
                 .span(span)
                 .call_attr("allow", vec!["dead_code", "non_upper_case_globals"])
@@ -712,7 +711,7 @@ impl<'a> Translation<'a> {
     pub fn convert_bitfield_assignment_op_with_rhs(
         &self,
         ctx: ExprContext,
-        op: BinOp,
+        op: CBinOp,
         lhs: CExprId,
         rhs_expr: Box<Expr>,
         field_id: CDeclId,
@@ -733,41 +732,37 @@ impl<'a> Translation<'a> {
                 // Allow the value of this assignment to be used as the RHS of other assignments
                 let val = lhs_expr_read.clone();
                 let param_expr = match op {
-                    BinOp::AssignAdd => {
-                        mk().binary_expr(RBinOp::Add(Default::default()), lhs_expr_read, rhs_expr)
+                    CBinOp::AssignAdd => {
+                        mk().binary_expr(BinOp::Add(Default::default()), lhs_expr_read, rhs_expr)
                     }
-                    BinOp::AssignSubtract => {
-                        mk().binary_expr(RBinOp::Sub(Default::default()), lhs_expr_read, rhs_expr)
+                    CBinOp::AssignSubtract => {
+                        mk().binary_expr(BinOp::Sub(Default::default()), lhs_expr_read, rhs_expr)
                     }
-                    BinOp::AssignMultiply => {
-                        mk().binary_expr(RBinOp::Mul(Default::default()), lhs_expr_read, rhs_expr)
+                    CBinOp::AssignMultiply => {
+                        mk().binary_expr(BinOp::Mul(Default::default()), lhs_expr_read, rhs_expr)
                     }
-                    BinOp::AssignDivide => {
-                        mk().binary_expr(RBinOp::Div(Default::default()), lhs_expr_read, rhs_expr)
+                    CBinOp::AssignDivide => {
+                        mk().binary_expr(BinOp::Div(Default::default()), lhs_expr_read, rhs_expr)
                     }
-                    BinOp::AssignModulus => {
-                        mk().binary_expr(RBinOp::Rem(Default::default()), lhs_expr_read, rhs_expr)
+                    CBinOp::AssignModulus => {
+                        mk().binary_expr(BinOp::Rem(Default::default()), lhs_expr_read, rhs_expr)
                     }
-                    BinOp::AssignBitXor => mk().binary_expr(
-                        RBinOp::BitXor(Default::default()),
-                        lhs_expr_read,
-                        rhs_expr,
-                    ),
-                    BinOp::AssignShiftLeft => {
-                        mk().binary_expr(RBinOp::Shl(Default::default()), lhs_expr_read, rhs_expr)
+                    CBinOp::AssignBitXor => {
+                        mk().binary_expr(BinOp::BitXor(Default::default()), lhs_expr_read, rhs_expr)
                     }
-                    BinOp::AssignShiftRight => {
-                        mk().binary_expr(RBinOp::Shr(Default::default()), lhs_expr_read, rhs_expr)
+                    CBinOp::AssignShiftLeft => {
+                        mk().binary_expr(BinOp::Shl(Default::default()), lhs_expr_read, rhs_expr)
                     }
-                    BinOp::AssignBitOr => {
-                        mk().binary_expr(RBinOp::BitOr(Default::default()), lhs_expr_read, rhs_expr)
+                    CBinOp::AssignShiftRight => {
+                        mk().binary_expr(BinOp::Shr(Default::default()), lhs_expr_read, rhs_expr)
                     }
-                    BinOp::AssignBitAnd => mk().binary_expr(
-                        RBinOp::BitAnd(Default::default()),
-                        lhs_expr_read,
-                        rhs_expr,
-                    ),
-                    BinOp::Assign => rhs_expr,
+                    CBinOp::AssignBitOr => {
+                        mk().binary_expr(BinOp::BitOr(Default::default()), lhs_expr_read, rhs_expr)
+                    }
+                    CBinOp::AssignBitAnd => {
+                        mk().binary_expr(BinOp::BitAnd(Default::default()), lhs_expr_read, rhs_expr)
+                    }
+                    CBinOp::Assign => rhs_expr,
                     _ => panic!("Cannot convert non-assignment operator"),
                 };
 
@@ -1033,7 +1028,7 @@ impl<'a> Translation<'a> {
         let mut val = match kind {
             MemberKind::Dot => self.convert_expr(ctx, expr, None)?,
             MemberKind::Arrow => {
-                if let CExprKind::Unary(_, c_ast::UnOp::AddressOf, subexpr_id, _) =
+                if let CExprKind::Unary(_, CUnOp::AddressOf, subexpr_id, _) =
                     self.ast_context[expr].kind
                 {
                     // Special-case the `(&x)->field` pattern


### PR DESCRIPTION
There's both a Rust and a C `BinOp`, and they keep causing name clashes. Since the naming scheme elsewhere already prefixes C types with `C` (`CExpr`, `CLiteral` etc), this makes these follow that scheme so there's less hassle in the future.