### PR TITLE
asm-casts: Take raw pointer for `out` argument

### DIFF
--- a/c2rust-asm-casts/src/lib.rs
+++ b/c2rust-asm-casts/src/lib.rs
@@ -14,8 +14,8 @@ pub struct AsmCast<Out, In>(PhantomData<(Out, In)>);
 pub trait AsmCastTrait<Out, In> {
     type Type;
 
-    fn cast_in(_: &mut Out, x: In) -> Self::Type;
-    fn cast_out(out: &mut Out, _: In, x: Self::Type);
+    unsafe fn cast_in(_: *mut Out, x: In) -> Self::Type;
+    unsafe fn cast_out(out: *mut Out, _: In, x: Self::Type);
 }
 
 macro_rules! impl_triple {
@@ -23,11 +23,11 @@ macro_rules! impl_triple {
 		impl<$($param),*> AsmCastTrait<$out, $in> for AsmCast<$out, $in> {
 			type Type = $inner;
 
-			fn cast_in(_: &mut $out, x: $in) -> Self::Type {
+			unsafe fn cast_in(_: *mut $out, x: $in) -> Self::Type {
 				x as Self::Type
 			}
 
-			fn cast_out(out: &mut $out, _: $in, x: Self::Type) {
+			unsafe fn cast_out(out: *mut $out, _: $in, x: Self::Type) {
 				*out = x as $out;
 			}
 		}
@@ -126,8 +126,8 @@ mod tests {
 
                     let x = 42usize as $ty1;
                     let mut y: $ty2 = 0 as $ty2;
-                    let z = AsmCast::cast_in(&mut y, x) + 1;
-                    AsmCast::cast_out(&mut y, x, z);
+                    let z = unsafe { AsmCast::cast_in(&mut y, x) } + 1;
+                    unsafe { AsmCast::cast_out(&mut y, x, z) };
                     assert_eq!(y as u64, 43);
                 })*
             }


### PR DESCRIPTION
This is needed to make the transpiler generate raw borrows for assembly, which in turn is needed to deal with #309 and #398.

This is a potentially breaking API change for the asm-casts crate, because it makes the trait methods `unsafe`.