### PR TITLE
transpile: Use raw borrows in assembly translations

### DIFF
--- a/c2rust-rust-tools/src/lib.rs
+++ b/c2rust-rust-tools/src/lib.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 use log::warn;
+use std::collections::HashSet;
 use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -7,6 +8,7 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 use std::process::Command;
+use std::str;
 use std::str::FromStr;
 
 use crate::RustEdition::Edition2021;
@@ -148,6 +150,7 @@ pub struct Rustc<'a> {
     edition: RustEdition,
     crate_name: Option<&'a str>,
     expect_error: bool,
+    imported_crates: &'a [&'a str],
 }
 
 pub fn rustc(rs_path: &Path) -> Rustc {
@@ -156,6 +159,7 @@ pub fn rustc(rs_path: &Path) -> Rustc {
         edition: Default::default(),
         crate_name: None,
         expect_error: false,
+        imported_crates: Default::default(),
     }
 }
 
@@ -178,20 +182,39 @@ impl<'a> Rustc<'a> {
         }
     }
 
+    pub fn expect_unresolved_imports(self, imported_crates: &'a [&'a str]) -> Self {
+        Self {
+            imported_crates,
+            ..self
+        }
+    }
+
     pub fn run(self) {
         let Self {
             rs_path,
             edition,
             crate_name,
             expect_error,
+            imported_crates,
         } = self;
         let crate_name =
             crate_name.unwrap_or_else(|| rs_path.file_stem().unwrap().to_str().unwrap());
-        run_rustc(rs_path, edition, crate_name, expect_error);
+        run_rustc(rs_path, edition, crate_name, expect_error, &imported_crates);
     }
 }
 
-fn run_rustc(rs_path: &Path, edition: RustEdition, crate_name: &str, expect_error: bool) {
+fn run_rustc(
+    rs_path: &Path,
+    edition: RustEdition,
+    crate_name: &str,
+    expect_error: bool,
+    imported_crates: &[&str],
+) {
+    let rs = fs_err::read_to_string(rs_path).unwrap();
+    for imported_crate in imported_crates {
+        assert!(rs.contains(&format!("::{imported_crate}")));
+    }
+
     // There's no good way to not create an output with `rustc`,
     // so just create an `.rlib` and then delete it immediately.
     let rlib_path = rs_path.with_file_name(format!("lib{crate_name}.rlib"));
@@ -215,6 +238,49 @@ fn run_rustc(rs_path: &Path, edition: RustEdition, crate_name: &str, expect_erro
     }
     io::stdout().write_all(&output.stdout).unwrap();
     io::stderr().write_all(&output.stderr).unwrap();
+
+    // Using rustc itself to build snapshots that reference crates (like libc) is difficult because we don't know
+    // the appropriate --extern libc=/path/to/liblibc-XXXXXXXXXXXXXXXX.rlib to pass.
+    // Skip for now, as we've already compared the literal text,
+    // and we're checking the error messages here.
+    let stderr = str::from_utf8(&output.stderr).unwrap();
+    let error_lines = stderr
+        .split('\n')
+        // .split(|&b| b == b'\n')
+        .filter(|line| line.starts_with("error[E"))
+        .collect::<HashSet<_>>();
+    dbg!(&error_lines);
+    for imported_crate in imported_crates {
+        // For `::{imported_crate}::*`.
+        let absolute_path = match edition {
+            Edition2021 => format!("error[E0433]: failed to resolve: could not find `{imported_crate}` in the list of imported crates"),
+            Edition2024 => format!("error[E0433]: cannot find `{imported_crate}` in the crate root"),
+        };
+        // For `use ::{imported_crate}*`.
+        let absolute_use_path = format!("error[E0432]: unresolved import `{imported_crate}`");
+        // For `{imported_crate}::*`.
+        let relative_path = match edition {
+            Edition2021 => format!("error[E0433]: failed to resolve: use of undeclared crate or module `{imported_crate}`"),
+            Edition2024 => format!("error[E0433]: cannot find module or crate `{imported_crate}` in this scope"),
+        };
+
+        let absolute_path = absolute_path.as_str();
+        let absolute_use_path = absolute_use_path.as_str();
+        let relative_path = relative_path.as_str();
+        dbg!(absolute_path);
+        dbg!(absolute_use_path);
+        dbg!(relative_path);
+
+        assert!(
+            error_lines.contains(absolute_path)
+                || error_lines.contains(absolute_use_path)
+                || error_lines.contains(relative_path)
+        );
+    }
+    if !imported_crates.is_empty() {
+        return;
+    }
+
     if expect_error {
         assert!(
             !status.success(),

--- a/c2rust-rust-tools/src/lib.rs
+++ b/c2rust-rust-tools/src/lib.rs
@@ -3,6 +3,8 @@ use log::warn;
 use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::io;
+use std::io::Write;
 use std::path::Path;
 use std::process::Command;
 use std::str::FromStr;
@@ -206,10 +208,13 @@ fn run_rustc(rs_path: &Path, edition: RustEdition, crate_name: &str, expect_erro
         "-o",
     ]);
     cmd.args([&rlib_path, rs_path]);
-    let status = cmd.status().unwrap();
+    let output = cmd.output().unwrap();
+    let status = output.status;
     if status.success() {
         fs_err::remove_file(&rlib_path).unwrap();
     }
+    io::stdout().write_all(&output.stdout).unwrap();
+    io::stderr().write_all(&output.stderr).unwrap();
     if expect_error {
         assert!(
             !status.success(),

--- a/c2rust-rust-tools/src/lib.rs
+++ b/c2rust-rust-tools/src/lib.rs
@@ -244,7 +244,7 @@ fn run_rustc(
     // Skip for now, as we've already compared the literal text,
     // and we're checking the error messages here.
     let stderr = str::from_utf8(&output.stderr).unwrap();
-    let error_lines = stderr
+    let mut error_lines = stderr
         .split('\n')
         // .split(|&b| b == b'\n')
         .filter(|line| line.starts_with("error[E"))
@@ -271,13 +271,16 @@ fn run_rustc(
         dbg!(absolute_use_path);
         dbg!(relative_path);
 
-        assert!(
-            error_lines.contains(absolute_path)
-                || error_lines.contains(absolute_use_path)
-                || error_lines.contains(relative_path)
-        );
+        // Pre-compute to avoid `||` short-circuiting.
+        let absolute_path = error_lines.remove(absolute_path);
+        let absolute_use_path = error_lines.remove(absolute_use_path);
+        let relative_path = error_lines.remove(relative_path);
+
+        assert!(absolute_path || absolute_use_path || relative_path);
     }
     if !imported_crates.is_empty() {
+        dbg!(&error_lines);
+        assert!(error_lines.is_empty());
         return;
     }
 

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -883,7 +883,8 @@ impl<'c> Translation<'c> {
                     // c2rust-ast-exporter added it (there's no gcc equivalent);
                     // in this case, we need to do what clang does and pass in
                     // the operand by-address instead of by-value
-                    out_expr = mk().mutbl().borrow_expr(out_expr);
+                    self.use_feature("raw_ref_op");
+                    out_expr = mk().mutbl().raw_borrow_expr(out_expr);
                 }
 
                 if let Some(_tied_operand) = tied_operands.get(&(output_idx, true)) {
@@ -895,12 +896,13 @@ impl<'c> Translation<'c> {
                     // type conversions into the `c2rust-asm-casts` crate,
                     // so we call into that one from here.
 
-                    // Convert `x` into `let freshN = &mut x; *x`
+                    // Convert `x` into `let freshN = &raw mut x; *x`
+                    self.use_feature("raw_ref_op");
                     let output_name = self.renamer.borrow_mut().fresh();
                     let output_local = mk().local(
                         mk().ident_pat(&output_name),
                         None,
-                        Some(mk().mutbl().borrow_expr(out_expr)),
+                        Some(mk().mutbl().raw_borrow_expr(out_expr)),
                     );
                     stmts.push(mk().local_stmt(Box::new(output_local)));
 
@@ -924,7 +926,8 @@ impl<'c> Translation<'c> {
                 let mut in_expr = in_expr.into_value();
 
                 if operand.mem_only {
-                    in_expr = mk().borrow_expr(in_expr);
+                    self.use_feature("raw_ref_op");
+                    in_expr = mk().raw_borrow_expr(in_expr);
                 }
                 if let Some(tied_operand) = tied_operands.get(&(input_idx, false)) {
                     self.use_crate(ExternCrate::C2RustAsmCasts);

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -101,6 +101,7 @@ fn transpile_snapshot(
     c_path: &Path,
     edition: RustEdition,
     expect_compile_error: bool,
+    imported_crates: &[&str],
 ) {
     let cfg = config(edition);
     compile_and_transpile_file(c_path, cfg);
@@ -133,21 +134,11 @@ fn transpile_snapshot(
 
     insta::assert_snapshot!(snapshot_name, &rs, &debug_expr);
 
-    // Using rustc itself to build snapshots that reference libc is difficult because we don't know
-    // the appropriate --extern libc=/path/to/liblibc-XXXXXXXXXXXXXXXX.rlib to pass. Skip for now,
-    // as we've already compared the literal text.
-    if rs.contains("libc::") {
-        eprintln!(
-            "warning: skipping compiling {} with rustc since it depends on libc",
-            rs_path.display()
-        );
-        return;
-    }
-
     rustc(&rs_path)
         .edition(edition)
         .crate_name(crate_name)
         .expect_error(expect_compile_error)
+        .expect_unresolved_imports(imported_crates)
         .run();
 }
 
@@ -158,6 +149,7 @@ struct TranspileTest<'a> {
     os_specific: bool,
     expect_compile_error_edition_2021: bool,
     expect_compile_error_edition_2024: bool,
+    imported_crates: Vec<&'a str>,
 }
 
 fn transpile(c_file_name: &str) -> TranspileTest {
@@ -167,6 +159,7 @@ fn transpile(c_file_name: &str) -> TranspileTest {
         os_specific: false,
         expect_compile_error_edition_2021: false,
         expect_compile_error_edition_2024: false,
+        imported_crates: Default::default(),
     }
 }
 
@@ -211,6 +204,11 @@ impl<'a> TranspileTest<'a> {
             .expect_compile_error_edition_2024(expect_error)
     }
 
+    pub fn expect_unresolved_import(mut self, imported_crate: &'a str) -> Self {
+        self.imported_crates.push(imported_crate);
+        self
+    }
+
     pub fn run(self) {
         let Self {
             c_file_name,
@@ -218,6 +216,7 @@ impl<'a> TranspileTest<'a> {
             os_specific,
             expect_compile_error_edition_2021,
             expect_compile_error_edition_2024,
+            imported_crates,
         } = self;
 
         let specific_dir_prefix = [arch_specific.then_some("arch"), os_specific.then_some("os")]
@@ -268,12 +267,14 @@ impl<'a> TranspileTest<'a> {
             &c_path,
             Edition2021,
             expect_compile_error_edition_2021,
+            &imported_crates,
         );
         transpile_snapshot(
             &platform,
             &c_path,
             Edition2024,
             expect_compile_error_edition_2024,
+            &imported_crates,
         );
     }
 }
@@ -451,7 +452,10 @@ fn test_rotate_os_specific() {
 
 #[test]
 fn test_sigign() {
-    transpile("sigign.c").os_specific(true).run();
+    transpile("sigign.c")
+        .os_specific(true)
+        .expect_unresolved_import("libc")
+        .run();
 }
 
 #[test]
@@ -461,12 +465,18 @@ fn test_typedefidx() {
 
 #[test]
 fn test_types() {
-    transpile("types.c").os_specific(true).run();
+    transpile("types.c")
+        .os_specific(true)
+        .expect_unresolved_import("libc")
+        .run();
 }
 
 #[test]
 fn test_wide_strings() {
-    transpile("wide_strings.c").os_specific(true).run();
+    transpile("wide_strings.c")
+        .os_specific(true)
+        .expect_unresolved_import("libc")
+        .run();
 }
 
 // arch-os-specific

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -414,6 +414,17 @@ fn test_str_init() {
 // arch-specific
 
 #[test]
+fn test_asm() {
+    #[cfg(target_arch = "x86_64")]
+    transpile("asm.c")
+        .arch_specific(true)
+        .expect_unresolved_import("c2rust_asm_casts")
+        .run();
+    #[cfg(not(target_arch = "x86_64"))]
+    transpile("asm.c").arch_specific(true).run();
+}
+
+#[test]
 fn test_spin() {
     transpile("spin.c").arch_specific(true).run();
 }

--- a/c2rust-transpile/tests/snapshots/arch-specific/asm.c
+++ b/c2rust-transpile/tests/snapshots/arch-specific/asm.c
@@ -1,0 +1,23 @@
+#ifdef __aarch64__
+
+// nothing here yet...
+
+#endif
+
+#ifdef __x86_64__
+
+// Tests https://github.com/immunant/c2rust/issues/398
+int six(void) {
+    int out = 0;
+    int six = 6;
+
+    asm (
+        "add %0, %1\n\t"
+        : "=r"(out)
+        : "r"(six), "0"(out)
+    );
+
+    return out;
+}
+
+#endif

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2021.aarch64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2021.aarch64.snap
@@ -1,0 +1,13 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/arch-specific/asm.2024.aarch64.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2021.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2021.x86_64.snap
@@ -11,7 +11,7 @@ expression: cat tests/snapshots/arch-specific/asm.2021.x86_64.rs
     unused_mut
 )]
 #![deny(unsafe_op_in_unsafe_fn)]
-#![feature(asm)]
+#![feature(asm, raw_ref_op)]
 use ::c2rust_asm_casts::AsmCastTrait;
 use ::core::arch::asm;
 #[no_mangle]
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn six() -> ::core::ffi::c_int {
     unsafe {
         let mut out: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
         let mut six_0: ::core::ffi::c_int = 6 as ::core::ffi::c_int;
-        let c2rust_fresh0 = &mut out;
+        let c2rust_fresh0 = &raw mut out;
         let c2rust_fresh1;
         let c2rust_fresh2 = out;
         asm!(

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2021.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2021.x86_64.snap
@@ -1,0 +1,34 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/arch-specific/asm.2021.x86_64.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]
+#![feature(asm)]
+use ::c2rust_asm_casts::AsmCastTrait;
+use ::core::arch::asm;
+#[no_mangle]
+pub unsafe extern "C" fn six() -> ::core::ffi::c_int {
+    unsafe {
+        let mut out: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+        let mut six_0: ::core::ffi::c_int = 6 as ::core::ffi::c_int;
+        let c2rust_fresh0 = &mut out;
+        let c2rust_fresh1;
+        let c2rust_fresh2 = out;
+        asm!(
+            "add {0}, {1}\n", "\t\n", inlateout(reg)
+            c2rust_asm_casts::AsmCast::cast_in(c2rust_fresh0, c2rust_fresh2) =>
+            c2rust_fresh1, inlateout(reg) six_0 => _, options(preserves_flags, pure,
+            readonly, att_syntax)
+        );
+        c2rust_asm_casts::AsmCast::cast_out(c2rust_fresh0, c2rust_fresh2, c2rust_fresh1);
+        return out;
+    }
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2024.aarch64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2024.aarch64.snap
@@ -1,0 +1,13 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/arch-specific/asm.2024.aarch64.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2024.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2024.x86_64.snap
@@ -1,0 +1,33 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/arch-specific/asm.2024.x86_64.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![deny(unsafe_op_in_unsafe_fn)]
+use ::c2rust_asm_casts::AsmCastTrait;
+use ::core::arch::asm;
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn six() -> ::core::ffi::c_int {
+    unsafe {
+        let mut out: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+        let mut six_0: ::core::ffi::c_int = 6 as ::core::ffi::c_int;
+        let c2rust_fresh0 = &mut out;
+        let c2rust_fresh1;
+        let c2rust_fresh2 = out;
+        asm!(
+            "add {0}, {1}\n", "\t\n", inlateout(reg)
+            c2rust_asm_casts::AsmCast::cast_in(c2rust_fresh0, c2rust_fresh2) =>
+            c2rust_fresh1, inlateout(reg) six_0 => _, options(preserves_flags, pure,
+            readonly, att_syntax)
+        );
+        c2rust_asm_casts::AsmCast::cast_out(c2rust_fresh0, c2rust_fresh2, c2rust_fresh1);
+        return out;
+    }
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2024.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@asm.c.2024.x86_64.snap
@@ -18,7 +18,7 @@ pub unsafe extern "C" fn six() -> ::core::ffi::c_int {
     unsafe {
         let mut out: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
         let mut six_0: ::core::ffi::c_int = 6 as ::core::ffi::c_int;
-        let c2rust_fresh0 = &mut out;
+        let c2rust_fresh0 = &raw mut out;
         let c2rust_fresh1;
         let c2rust_fresh2 = out;
         asm!(

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2021.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2021.x86_64.snap
@@ -64,11 +64,11 @@ pub unsafe extern "C" fn VM_CallCompiled(
             "movq ({2}), %rax\n", "movq ({0}), %r8\n", "movq ({1}), %r9\n",
             "push %r15\n", "push %r14\n", "push %r13\n", "push %r12\n", "callq *%rax\n",
             "pop %r12\n", "pop %r13\n", "pop %r14\n", "pop %r15\n", "\n",
-            "mov {restmp0:x}, %bx\n", in (reg) & (* vm).instructionPointers, in (reg) &
-            (* vm).dataBase, in (reg) & entryPoint, restmp0 = inlateout(reg) opStackOfs,
-            inlateout("di") opStack, inlateout("si") programStack, out("rax") _,
-            out("rcx") _, out("rdx") _, out("r8") _, out("r9") _, out("r10") _,
-            out("r11") _, options(att_syntax)
+            "mov {restmp0:x}, %bx\n", in (reg) & raw const (* vm).instructionPointers, in
+            (reg) & raw const (* vm).dataBase, in (reg) & raw const entryPoint, restmp0 =
+            inlateout(reg) opStackOfs, inlateout("di") opStack, inlateout("si")
+            programStack, out("rax") _, out("rcx") _, out("rdx") _, out("r8") _,
+            out("r9") _, out("r10") _, out("r11") _, options(att_syntax)
         );
         if opStackOfs != 1 as ::core::ffi::c_int
             || *opStack as ::core::ffi::c_uint != 0xdeadbeef as ::core::ffi::c_uint

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2024.x86_64.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@vm_x86.c.2024.x86_64.snap
@@ -63,11 +63,11 @@ pub unsafe extern "C" fn VM_CallCompiled(
             "movq ({2}), %rax\n", "movq ({0}), %r8\n", "movq ({1}), %r9\n",
             "push %r15\n", "push %r14\n", "push %r13\n", "push %r12\n", "callq *%rax\n",
             "pop %r12\n", "pop %r13\n", "pop %r14\n", "pop %r15\n", "\n",
-            "mov {restmp0:x}, %bx\n", in (reg) & (* vm).instructionPointers, in (reg) &
-            (* vm).dataBase, in (reg) & entryPoint, restmp0 = inlateout(reg) opStackOfs,
-            inlateout("di") opStack, inlateout("si") programStack, out("rax") _,
-            out("rcx") _, out("rdx") _, out("r8") _, out("r9") _, out("r10") _,
-            out("r11") _, options(att_syntax)
+            "mov {restmp0:x}, %bx\n", in (reg) & raw const (* vm).instructionPointers, in
+            (reg) & raw const (* vm).dataBase, in (reg) & raw const entryPoint, restmp0 =
+            inlateout(reg) opStackOfs, inlateout("di") opStack, inlateout("si")
+            programStack, out("rax") _, out("rcx") _, out("rdx") _, out("r8") _,
+            out("r9") _, out("r10") _, out("r11") _, options(att_syntax)
         );
         if opStackOfs != 1 as ::core::ffi::c_int
             || *opStack as ::core::ffi::c_uint != 0xdeadbeef as ::core::ffi::c_uint


### PR DESCRIPTION
- Fixes #398 
- Fixes #309

Since this depends on the changes made to asm-casts in #1712, I don't know if this will work as-is or if other changes are needed. It doesn't seem like the asm-casts crate is available for snapshot tests in any case?