### PR TITLE
transpile: Use raw borrows in volatile reads and writes

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3055,12 +3055,8 @@ impl<'c> Translation<'c> {
                 }
             }
             _ => {
-                let addr_lhs = mk().set_mutbl(mutbl).borrow_expr(lhs);
-
-                let lhs_type = self.convert_type(lhs_type.ctype)?;
-                let ty = mk().set_mutbl(mutbl).ptr_ty(lhs_type);
-
-                mk().cast_expr(addr_lhs, ty)
+                self.use_feature("raw_ref_op");
+                mk().set_mutbl(mutbl).raw_borrow_expr(lhs)
             }
         };
         Ok(addr_lhs)

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -412,10 +412,7 @@ fn test_str_init() {
 
 #[test]
 fn test_volatile() {
-    transpile("volatile.c")
-        // https://github.com/immunant/c2rust/pull/1689#discussion_r3015140974
-        .expect_compile_error_edition_2024(true)
-        .run();
+    transpile("volatile.c").run();
 }
 
 // arch-specific

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
@@ -11,6 +11,7 @@ expression: cat tests/snapshots/volatile.2021.rs
     unused_mut
 )]
 #![deny(unsafe_op_in_unsafe_fn)]
+#![feature(raw_ref_op)]
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct S {
@@ -24,9 +25,9 @@ pub static mut volatile_global_struct: S = S {
 pub unsafe extern "C" fn test_volatile() {
     unsafe {
         ::core::ptr::write_volatile(
-            &mut volatile_global_struct.p as *mut *mut ::core::ffi::c_int,
+            &raw mut volatile_global_struct.p,
             ::core::ptr::read_volatile::<*mut ::core::ffi::c_int>(
-                &volatile_global_struct.p as *const *mut ::core::ffi::c_int,
+                &raw const volatile_global_struct.p,
             )
             .offset(-1),
         );

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
@@ -24,9 +24,9 @@ pub static mut volatile_global_struct: S = S {
 pub unsafe extern "C" fn test_volatile() {
     unsafe {
         ::core::ptr::write_volatile(
-            &mut volatile_global_struct.p as *mut *mut ::core::ffi::c_int,
+            &raw mut volatile_global_struct.p,
             ::core::ptr::read_volatile::<*mut ::core::ffi::c_int>(
-                &volatile_global_struct.p as *const *mut ::core::ffi::c_int,
+                &raw const volatile_global_struct.p,
             )
             .offset(-1),
         );


### PR DESCRIPTION
- Depends on #1689 for the `volatile.c` test.
- Fixes #1683.

This eliminates the last remaining use of regular borrows, other than those made on temporaries (where they are both necessary and sound).