### PR TITLE
transpile: Use wrapping functions for atomic unsigned arithmetic

### DIFF
--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -350,8 +350,14 @@ impl<'c> Translation<'c> {
                     let order = static_order(order);
                     let val =
                         val1.expect("__atomic arithmetic operations must have a val argument");
+                    let val_type_id = self.ast_context[val1_id.unwrap()]
+                        .kind
+                        .get_qual_type()
+                        .ok_or_else(|| format_err!("bad val1 type"))?;
                     ptr.and_then(|ptr| {
-                        val.and_then(|val| self.convert_atomic_op(ctx, atomic_op, order, ptr, val))
+                        val.and_then(|val| {
+                            self.convert_atomic_op(ctx, atomic_op, order, ptr, val, val_type_id)
+                        })
                     })
                 } else {
                     unimplemented!("atomic not implemented: {}", name)
@@ -390,6 +396,7 @@ impl<'c> Translation<'c> {
         order: Ordering,
         dst: Box<Expr>,
         src: Box<Expr>,
+        src_type_id: CQualTypeId,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         // Emit `atomic_func(a0, a1) (op a1)?`
         let atomic_func =
@@ -424,13 +431,24 @@ impl<'c> Translation<'c> {
                 atomic_func,
                 vec![mk().ident_expr(&arg0_name), mk().ident_expr(&arg1_name)],
             );
-            let val = mk().binary_expr(atomic_op.rust_bin_op(), call, mk().ident_expr(arg1_name));
-            let val = if atomic_op.is_nand() {
-                // For nand, return `!(atomic_nand(arg0, arg1) & arg1)`
-                mk().unary_expr(UnOp::Not(Default::default()), val)
+
+            let src_type_kind = &self.ast_context.resolve_type(src_type_id.ctype).kind;
+            let arg1 = mk().ident_expr(arg1_name);
+
+            let mut val = if let Some(wrapping_arith_fn) = atomic_op
+                .rust_wrapping_arith_fn()
+                .filter(|_| src_type_kind.is_unsigned_integral_type())
+            {
+                mk().method_call_expr(call, wrapping_arith_fn, vec![arg1])
             } else {
-                val
+                mk().binary_expr(atomic_op.rust_bin_op(), call, arg1)
             };
+
+            if atomic_op.is_nand() {
+                // For nand, return `!(atomic_nand(arg0, arg1) & arg1)`
+                val = mk().unary_expr(UnOp::Not(Default::default()), val);
+            }
+
             self.convert_side_effects_expr(
                 ctx,
                 WithStmts::new(vec![arg0_let, arg1_let], val),
@@ -594,5 +612,13 @@ impl CAtomicBinOp {
             // See uses of `Self::is_nand`.
             Self::FetchNand | Self::NandFetch => BinOp::BitAnd(Default::default()),
         }
+    }
+
+    pub fn rust_wrapping_arith_fn(self) -> Option<&'static str> {
+        Some(match self {
+            Self::FetchAdd | Self::AddFetch => "wrapping_add",
+            Self::FetchSub | Self::SubFetch => "wrapping_sub",
+            _ => return None,
+        })
     }
 }

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -345,51 +345,18 @@ impl<'c> Translation<'c> {
                 })
             }
 
-            "__atomic_add_fetch"
-            | "__atomic_sub_fetch"
-            | "__atomic_and_fetch"
-            | "__atomic_xor_fetch"
-            | "__atomic_or_fetch"
-            | "__atomic_nand_fetch"
-            | "__atomic_fetch_add"
-            | "__atomic_fetch_sub"
-            | "__atomic_fetch_and"
-            | "__atomic_fetch_xor"
-            | "__atomic_fetch_or"
-            | "__atomic_fetch_nand"
-            | "__c11_atomic_fetch_add"
-            | "__c11_atomic_fetch_sub"
-            | "__c11_atomic_fetch_and"
-            | "__c11_atomic_fetch_xor"
-            | "__c11_atomic_fetch_or"
-            | "__c11_atomic_fetch_nand" => {
-                let intrinsic_name = if name.contains("_add") {
-                    "xadd"
-                } else if name.contains("_sub") {
-                    "xsub"
-                } else if name.contains("_or") {
-                    "or"
-                } else if name.contains("_xor") {
-                    "xor"
-                } else if name.contains("_nand") {
-                    "nand"
-                } else {
-                    "and"
-                };
-
-                let order = static_order(order);
-
-                let fetch_first =
-                    name.starts_with("__atomic_fetch") || name.starts_with("__c11_atomic_fetch");
-                let val = val1.expect("__atomic arithmetic operations must have a val argument");
-                ptr.and_then(|ptr| {
-                    val.and_then(|val| {
-                        self.convert_atomic_op(ctx, intrinsic_name, order, ptr, val, fetch_first)
+            _ => {
+                if let Some(atomic_op) = CAtomicBinOp::from_atomic_fn(name) {
+                    let order = static_order(order);
+                    let val =
+                        val1.expect("__atomic arithmetic operations must have a val argument");
+                    ptr.and_then(|ptr| {
+                        val.and_then(|val| self.convert_atomic_op(ctx, atomic_op, order, ptr, val))
                     })
-                })
+                } else {
+                    unimplemented!("atomic not implemented: {}", name)
+                }
             }
-
-            _ => unimplemented!("atomic not implemented: {}", name),
         }
     }
 
@@ -419,16 +386,16 @@ impl<'c> Translation<'c> {
     pub(crate) fn convert_atomic_op(
         &self,
         ctx: ExprContext,
-        base_name: &str,
+        atomic_op: CAtomicBinOp,
         order: Ordering,
         dst: Box<Expr>,
         src: Box<Expr>,
-        fetch_first: bool,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         // Emit `atomic_func(a0, a1) (op a1)?`
-        let atomic_func = self.atomic_intrinsic_expr(base_name, &[order]);
+        let atomic_func =
+            self.atomic_intrinsic_expr(atomic_op.rust_intrinsic_base_name(), &[order]);
 
-        if fetch_first {
+        if atomic_op.fetches_first() {
             let call_expr = mk().call_expr(atomic_func, vec![dst, src]);
             self.convert_side_effects_expr(
                 ctx,
@@ -436,16 +403,6 @@ impl<'c> Translation<'c> {
                 "Builtin is not supposed to be used",
             )
         } else {
-            let (binary_op, is_nand) = match base_name {
-                "xadd" => (BinOp::Add(Default::default()), false),
-                "xsub" => (BinOp::Sub(Default::default()), false),
-                "or" => (BinOp::BitOr(Default::default()), false),
-                "xor" => (BinOp::BitXor(Default::default()), false),
-                "nand" => (BinOp::BitAnd(Default::default()), true),
-                "and" => (BinOp::BitAnd(Default::default()), false),
-                _ => panic!("Unexpected atomic intrinsic base name: {base_name}"),
-            };
-
             // Since the value of `arg1` is used twice, we need to copy
             // it into a local temporary so we don't duplicate any side-effects
             // To preserve ordering of side-effects, we also do this for arg0
@@ -467,8 +424,8 @@ impl<'c> Translation<'c> {
                 atomic_func,
                 vec![mk().ident_expr(&arg0_name), mk().ident_expr(&arg1_name)],
             );
-            let val = mk().binary_expr(binary_op, call, mk().ident_expr(arg1_name));
-            let val = if is_nand {
+            let val = mk().binary_expr(atomic_op.rust_bin_op(), call, mk().ident_expr(arg1_name));
+            let val = if atomic_op.is_nand() {
                 // For nand, return `!(atomic_nand(arg0, arg1) & arg1)`
                 mk().unary_expr(UnOp::Not(Default::default()), val)
             } else {
@@ -479,6 +436,163 @@ impl<'c> Translation<'c> {
                 WithStmts::new(vec![arg0_let, arg1_let], val),
                 "Builtin is not supposed to be used",
             )
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CAtomicBinOp {
+    FetchAdd,
+    FetchSub,
+    FetchOr,
+    FetchAnd,
+    FetchXor,
+    FetchNand,
+
+    AddFetch,
+    SubFetch,
+    OrFetch,
+    AndFetch,
+    XorFetch,
+    NandFetch,
+}
+
+impl CAtomicBinOp {
+    pub fn from_atomic_fn(name: &str) -> Option<Self> {
+        Some(match name {
+            "__atomic_fetch_add" | "__c11_atomic_fetch_add" => Self::FetchAdd,
+            "__atomic_fetch_sub" | "__c11_atomic_fetch_sub" => Self::FetchSub,
+            "__atomic_fetch_or" | "__c11_atomic_fetch_or" => Self::FetchOr,
+            "__atomic_fetch_and" | "__c11_atomic_fetch_and" => Self::FetchAnd,
+            "__atomic_fetch_xor" | "__c11_atomic_fetch_xor" => Self::FetchXor,
+            "__atomic_fetch_nand" | "__c11_atomic_fetch_nand" => Self::FetchNand,
+
+            "__atomic_add_fetch" => Self::AddFetch,
+            "__atomic_sub_fetch" => Self::SubFetch,
+            "__atomic_or_fetch" => Self::OrFetch,
+            "__atomic_and_fetch" => Self::AndFetch,
+            "__atomic_xor_fetch" => Self::XorFetch,
+            "__atomic_nand_fetch" => Self::NandFetch,
+
+            _ => return None,
+        })
+    }
+
+    pub fn from_sync_builtin_fn(name: &str) -> Option<Self> {
+        Some(match name {
+            "__sync_add_and_fetch_1"
+            | "__sync_add_and_fetch_2"
+            | "__sync_add_and_fetch_4"
+            | "__sync_add_and_fetch_8"
+            | "__sync_add_and_fetch_16" => Self::AddFetch,
+
+            "__sync_sub_and_fetch_1"
+            | "__sync_sub_and_fetch_2"
+            | "__sync_sub_and_fetch_4"
+            | "__sync_sub_and_fetch_8"
+            | "__sync_sub_and_fetch_16" => Self::SubFetch,
+
+            "__sync_or_and_fetch_1"
+            | "__sync_or_and_fetch_2"
+            | "__sync_or_and_fetch_4"
+            | "__sync_or_and_fetch_8"
+            | "__sync_or_and_fetch_16" => Self::OrFetch,
+
+            "__sync_and_and_fetch_1"
+            | "__sync_and_and_fetch_2"
+            | "__sync_and_and_fetch_4"
+            | "__sync_and_and_fetch_8"
+            | "__sync_and_and_fetch_16" => Self::AndFetch,
+
+            "__sync_xor_and_fetch_1"
+            | "__sync_xor_and_fetch_2"
+            | "__sync_xor_and_fetch_4"
+            | "__sync_xor_and_fetch_8"
+            | "__sync_xor_and_fetch_16" => Self::XorFetch,
+
+            "__sync_nand_and_fetch_1"
+            | "__sync_nand_and_fetch_2"
+            | "__sync_nand_and_fetch_4"
+            | "__sync_nand_and_fetch_8"
+            | "__sync_nand_and_fetch_16" => Self::NandFetch,
+
+            "__sync_fetch_and_add_1"
+            | "__sync_fetch_and_add_2"
+            | "__sync_fetch_and_add_4"
+            | "__sync_fetch_and_add_8"
+            | "__sync_fetch_and_add_16" => Self::FetchAdd,
+
+            "__sync_fetch_and_sub_1"
+            | "__sync_fetch_and_sub_2"
+            | "__sync_fetch_and_sub_4"
+            | "__sync_fetch_and_sub_8"
+            | "__sync_fetch_and_sub_16" => Self::FetchSub,
+
+            "__sync_fetch_and_or_1"
+            | "__sync_fetch_and_or_2"
+            | "__sync_fetch_and_or_4"
+            | "__sync_fetch_and_or_8"
+            | "__sync_fetch_and_or_16" => Self::FetchOr,
+
+            "__sync_fetch_and_and_1"
+            | "__sync_fetch_and_and_2"
+            | "__sync_fetch_and_and_4"
+            | "__sync_fetch_and_and_8"
+            | "__sync_fetch_and_and_16" => Self::FetchAnd,
+
+            "__sync_fetch_and_xor_1"
+            | "__sync_fetch_and_xor_2"
+            | "__sync_fetch_and_xor_4"
+            | "__sync_fetch_and_xor_8"
+            | "__sync_fetch_and_xor_16" => Self::FetchXor,
+
+            "__sync_fetch_and_nand_1"
+            | "__sync_fetch_and_nand_2"
+            | "__sync_fetch_and_nand_4"
+            | "__sync_fetch_and_nand_8"
+            | "__sync_fetch_and_nand_16" => Self::FetchNand,
+
+            _ => return None,
+        })
+    }
+
+    pub fn fetches_first(self) -> bool {
+        matches!(
+            self,
+            Self::FetchAdd
+                | Self::FetchSub
+                | Self::FetchOr
+                | Self::FetchAnd
+                | Self::FetchXor
+                | Self::FetchNand
+        )
+    }
+
+    pub fn is_nand(self) -> bool {
+        matches!(self, Self::FetchNand | Self::NandFetch)
+    }
+
+    pub fn rust_intrinsic_base_name(self) -> &'static str {
+        match self {
+            Self::FetchAdd | Self::AddFetch => "xadd",
+            Self::FetchSub | Self::SubFetch => "xsub",
+            Self::FetchOr | Self::OrFetch => "or",
+            Self::FetchAnd | Self::AndFetch => "and",
+            Self::FetchXor | Self::XorFetch => "xor",
+            Self::FetchNand | Self::NandFetch => "nand",
+        }
+    }
+
+    pub fn rust_bin_op(self) -> BinOp {
+        match self {
+            Self::FetchAdd | Self::AddFetch => BinOp::Add(Default::default()),
+            Self::FetchSub | Self::SubFetch => BinOp::Sub(Default::default()),
+            Self::FetchOr | Self::OrFetch => BinOp::BitOr(Default::default()),
+            Self::FetchAnd | Self::AndFetch => BinOp::BitAnd(Default::default()),
+            Self::FetchXor | Self::XorFetch => BinOp::BitXor(Default::default()),
+            // Gets translated to `!(atomic_nand(arg0, arg1) & arg1)`.
+            // See uses of `Self::is_nand`.
+            Self::FetchNand | Self::NandFetch => BinOp::BitAnd(Default::default()),
         }
     }
 }

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -644,9 +644,13 @@ impl<'c> Translation<'c> {
                 if let Some(atomic_op) = CAtomicBinOp::from_sync_builtin_fn(builtin_name) {
                     let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
                     let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
+                    let arg1_type_id = self.ast_context[args[1]]
+                        .kind
+                        .get_qual_type()
+                        .ok_or_else(|| format_err!("bad arg1 type"))?;
                     arg0.and_then(|arg0| {
                         arg1.and_then(|arg1| {
-                            self.convert_atomic_op(ctx, atomic_op, SeqCst, arg0, arg1)
+                            self.convert_atomic_op(ctx, atomic_op, SeqCst, arg0, arg1, arg1_type_id)
                         })
                     })
                 } else {

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -4,6 +4,7 @@
 use super::*;
 
 use crate::format_translation_err;
+use crate::translator::atomics::CAtomicBinOp;
 use c2rust_rust_tools::RustEdition::Edition2024;
 use std::sync::atomic::Ordering::Acquire;
 use std::sync::atomic::Ordering::Release;
@@ -565,90 +566,6 @@ impl<'c> Translation<'c> {
                     })
                 })
             }
-            "__sync_fetch_and_add_1"
-            | "__sync_fetch_and_add_2"
-            | "__sync_fetch_and_add_4"
-            | "__sync_fetch_and_add_8"
-            | "__sync_fetch_and_add_16"
-            | "__sync_fetch_and_sub_1"
-            | "__sync_fetch_and_sub_2"
-            | "__sync_fetch_and_sub_4"
-            | "__sync_fetch_and_sub_8"
-            | "__sync_fetch_and_sub_16"
-            | "__sync_fetch_and_or_1"
-            | "__sync_fetch_and_or_2"
-            | "__sync_fetch_and_or_4"
-            | "__sync_fetch_and_or_8"
-            | "__sync_fetch_and_or_16"
-            | "__sync_fetch_and_and_1"
-            | "__sync_fetch_and_and_2"
-            | "__sync_fetch_and_and_4"
-            | "__sync_fetch_and_and_8"
-            | "__sync_fetch_and_and_16"
-            | "__sync_fetch_and_xor_1"
-            | "__sync_fetch_and_xor_2"
-            | "__sync_fetch_and_xor_4"
-            | "__sync_fetch_and_xor_8"
-            | "__sync_fetch_and_xor_16"
-            | "__sync_fetch_and_nand_1"
-            | "__sync_fetch_and_nand_2"
-            | "__sync_fetch_and_nand_4"
-            | "__sync_fetch_and_nand_8"
-            | "__sync_fetch_and_nand_16"
-            | "__sync_add_and_fetch_1"
-            | "__sync_add_and_fetch_2"
-            | "__sync_add_and_fetch_4"
-            | "__sync_add_and_fetch_8"
-            | "__sync_add_and_fetch_16"
-            | "__sync_sub_and_fetch_1"
-            | "__sync_sub_and_fetch_2"
-            | "__sync_sub_and_fetch_4"
-            | "__sync_sub_and_fetch_8"
-            | "__sync_sub_and_fetch_16"
-            | "__sync_or_and_fetch_1"
-            | "__sync_or_and_fetch_2"
-            | "__sync_or_and_fetch_4"
-            | "__sync_or_and_fetch_8"
-            | "__sync_or_and_fetch_16"
-            | "__sync_and_and_fetch_1"
-            | "__sync_and_and_fetch_2"
-            | "__sync_and_and_fetch_4"
-            | "__sync_and_and_fetch_8"
-            | "__sync_and_and_fetch_16"
-            | "__sync_xor_and_fetch_1"
-            | "__sync_xor_and_fetch_2"
-            | "__sync_xor_and_fetch_4"
-            | "__sync_xor_and_fetch_8"
-            | "__sync_xor_and_fetch_16"
-            | "__sync_nand_and_fetch_1"
-            | "__sync_nand_and_fetch_2"
-            | "__sync_nand_and_fetch_4"
-            | "__sync_nand_and_fetch_8"
-            | "__sync_nand_and_fetch_16" => {
-                let base_name = if builtin_name.contains("_add_") {
-                    "xadd"
-                } else if builtin_name.contains("_sub_") {
-                    "xsub"
-                } else if builtin_name.contains("_or_") {
-                    "or"
-                } else if builtin_name.contains("_xor_") {
-                    "xor"
-                } else if builtin_name.contains("_nand_") {
-                    "nand"
-                } else {
-                    // We can't explicitly check for "_and_" since they all contain it
-                    "and"
-                };
-
-                let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
-                let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
-                let fetch_first = builtin_name.starts_with("__sync_fetch");
-                arg0.and_then(|arg0| {
-                    arg1.and_then(|arg1| {
-                        self.convert_atomic_op(ctx, base_name, SeqCst, arg0, arg1, fetch_first)
-                    })
-                })
-            }
 
             "__sync_synchronize" => {
                 let atomic_func = self.atomic_intrinsic_expr("fence", &[SeqCst]);
@@ -723,11 +640,23 @@ impl<'c> Translation<'c> {
             | "__builtin_rotateright32"
             | "__builtin_rotateright64" => self.convert_builtin_rotate(ctx, args, "rotate_right"),
 
-            _ => Err(format_translation_err!(
-                self.ast_context.display_loc(src_loc),
-                "Unimplemented builtin {}",
-                builtin_name
-            )),
+            _ => {
+                if let Some(atomic_op) = CAtomicBinOp::from_sync_builtin_fn(builtin_name) {
+                    let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
+                    let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
+                    arg0.and_then(|arg0| {
+                        arg1.and_then(|arg1| {
+                            self.convert_atomic_op(ctx, atomic_op, SeqCst, arg0, arg1)
+                        })
+                    })
+                } else {
+                    Err(format_translation_err!(
+                        self.ast_context.display_loc(src_loc),
+                        "Unimplemented builtin {}",
+                        builtin_name
+                    ))
+                }
+            }
         }
     }
 

--- a/c2rust-transpile/tests/snapshots/atomics.c
+++ b/c2rust-transpile/tests/snapshots/atomics.c
@@ -20,3 +20,23 @@ _Atomic(int) c11_atomics(_Atomic(int) x) {
 
     return x;
 }
+
+int fetch_after_atomics_signed(int x) {
+    __atomic_add_fetch(&x, 2, __ATOMIC_SEQ_CST);
+    __atomic_sub_fetch(&x, 1, __ATOMIC_SEQ_CST);
+    __atomic_and_fetch(&x, 0xF, __ATOMIC_SEQ_CST);
+    __atomic_or_fetch(&x, 0x10, __ATOMIC_SEQ_CST);
+    __atomic_nand_fetch(&x, 0xFF, __ATOMIC_SEQ_CST);
+
+    return x;
+}
+
+unsigned int fetch_after_atomics_unsigned(unsigned int x) {
+    __atomic_add_fetch(&x, 2, __ATOMIC_SEQ_CST);
+    __atomic_sub_fetch(&x, 1, __ATOMIC_SEQ_CST);
+    __atomic_and_fetch(&x, 0xF, __ATOMIC_SEQ_CST);
+    __atomic_or_fetch(&x, 0x10, __ATOMIC_SEQ_CST);
+    __atomic_nand_fetch(&x, 0xFF, __ATOMIC_SEQ_CST);
+
+    return x;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2021.snap
@@ -42,4 +42,50 @@ pub unsafe extern "C" fn c11_atomics(mut x: ::core::ffi::c_int) -> ::core::ffi::
         return x;
     }
 }
+#[no_mangle]
+pub unsafe extern "C" fn fetch_after_atomics_signed(
+    mut x: ::core::ffi::c_int,
+) -> ::core::ffi::c_int {
+    unsafe {
+        let c2rust_fresh2 = &raw mut x;
+        let c2rust_fresh3 = 2 as ::core::ffi::c_int;
+        ::core::intrinsics::atomic_xadd_seqcst(c2rust_fresh2, c2rust_fresh3) + c2rust_fresh3;
+        let c2rust_fresh4 = &raw mut x;
+        let c2rust_fresh5 = 1 as ::core::ffi::c_int;
+        ::core::intrinsics::atomic_xsub_seqcst(c2rust_fresh4, c2rust_fresh5) - c2rust_fresh5;
+        let c2rust_fresh6 = &raw mut x;
+        let c2rust_fresh7 = 0xf as ::core::ffi::c_int;
+        ::core::intrinsics::atomic_and_seqcst(c2rust_fresh6, c2rust_fresh7) & c2rust_fresh7;
+        let c2rust_fresh8 = &raw mut x;
+        let c2rust_fresh9 = 0x10 as ::core::ffi::c_int;
+        ::core::intrinsics::atomic_or_seqcst(c2rust_fresh8, c2rust_fresh9) | c2rust_fresh9;
+        let c2rust_fresh10 = &raw mut x;
+        let c2rust_fresh11 = 0xff as ::core::ffi::c_int;
+        !(::core::intrinsics::atomic_nand_seqcst(c2rust_fresh10, c2rust_fresh11) & c2rust_fresh11);
+        return x;
+    }
+}
+#[no_mangle]
+pub unsafe extern "C" fn fetch_after_atomics_unsigned(
+    mut x: ::core::ffi::c_uint,
+) -> ::core::ffi::c_uint {
+    unsafe {
+        let c2rust_fresh12 = &raw mut x;
+        let c2rust_fresh13 = 2 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        ::core::intrinsics::atomic_xadd_seqcst(c2rust_fresh12, c2rust_fresh13) + c2rust_fresh13;
+        let c2rust_fresh14 = &raw mut x;
+        let c2rust_fresh15 = 1 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        ::core::intrinsics::atomic_xsub_seqcst(c2rust_fresh14, c2rust_fresh15) - c2rust_fresh15;
+        let c2rust_fresh16 = &raw mut x;
+        let c2rust_fresh17 = 0xf as ::core::ffi::c_int as ::core::ffi::c_uint;
+        ::core::intrinsics::atomic_and_seqcst(c2rust_fresh16, c2rust_fresh17) & c2rust_fresh17;
+        let c2rust_fresh18 = &raw mut x;
+        let c2rust_fresh19 = 0x10 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        ::core::intrinsics::atomic_or_seqcst(c2rust_fresh18, c2rust_fresh19) | c2rust_fresh19;
+        let c2rust_fresh20 = &raw mut x;
+        let c2rust_fresh21 = 0xff as ::core::ffi::c_int as ::core::ffi::c_uint;
+        !(::core::intrinsics::atomic_nand_seqcst(c2rust_fresh20, c2rust_fresh21) & c2rust_fresh21);
+        return x;
+    }
+}
 pub const __ATOMIC_SEQ_CST: ::core::ffi::c_int = 5 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2021.snap
@@ -72,10 +72,12 @@ pub unsafe extern "C" fn fetch_after_atomics_unsigned(
     unsafe {
         let c2rust_fresh12 = &raw mut x;
         let c2rust_fresh13 = 2 as ::core::ffi::c_int as ::core::ffi::c_uint;
-        ::core::intrinsics::atomic_xadd_seqcst(c2rust_fresh12, c2rust_fresh13) + c2rust_fresh13;
+        ::core::intrinsics::atomic_xadd_seqcst(c2rust_fresh12, c2rust_fresh13)
+            .wrapping_add(c2rust_fresh13);
         let c2rust_fresh14 = &raw mut x;
         let c2rust_fresh15 = 1 as ::core::ffi::c_int as ::core::ffi::c_uint;
-        ::core::intrinsics::atomic_xsub_seqcst(c2rust_fresh14, c2rust_fresh15) - c2rust_fresh15;
+        ::core::intrinsics::atomic_xsub_seqcst(c2rust_fresh14, c2rust_fresh15)
+            .wrapping_sub(c2rust_fresh15);
         let c2rust_fresh16 = &raw mut x;
         let c2rust_fresh17 = 0xf as ::core::ffi::c_int as ::core::ffi::c_uint;
         ::core::intrinsics::atomic_and_seqcst(c2rust_fresh16, c2rust_fresh17) & c2rust_fresh17;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2024.snap
@@ -116,13 +116,15 @@ pub unsafe extern "C" fn fetch_after_atomics_unsigned(
         ::core::intrinsics::atomic_xadd::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
             c2rust_fresh12,
             c2rust_fresh13,
-        ) + c2rust_fresh13;
+        )
+        .wrapping_add(c2rust_fresh13);
         let c2rust_fresh14 = &raw mut x;
         let c2rust_fresh15 = 1 as ::core::ffi::c_int as ::core::ffi::c_uint;
         ::core::intrinsics::atomic_xsub::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
             c2rust_fresh14,
             c2rust_fresh15,
-        ) - c2rust_fresh15;
+        )
+        .wrapping_sub(c2rust_fresh15);
         let c2rust_fresh16 = &raw mut x;
         let c2rust_fresh17 = 0xf as ::core::ffi::c_int as ::core::ffi::c_uint;
         ::core::intrinsics::atomic_and::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2024.snap
@@ -68,4 +68,80 @@ pub unsafe extern "C" fn c11_atomics(mut x: ::core::ffi::c_int) -> ::core::ffi::
         return x;
     }
 }
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fetch_after_atomics_signed(
+    mut x: ::core::ffi::c_int,
+) -> ::core::ffi::c_int {
+    unsafe {
+        let c2rust_fresh2 = &raw mut x;
+        let c2rust_fresh3 = 2 as ::core::ffi::c_int;
+        ::core::intrinsics::atomic_xadd::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
+            c2rust_fresh2,
+            c2rust_fresh3,
+        ) + c2rust_fresh3;
+        let c2rust_fresh4 = &raw mut x;
+        let c2rust_fresh5 = 1 as ::core::ffi::c_int;
+        ::core::intrinsics::atomic_xsub::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
+            c2rust_fresh4,
+            c2rust_fresh5,
+        ) - c2rust_fresh5;
+        let c2rust_fresh6 = &raw mut x;
+        let c2rust_fresh7 = 0xf as ::core::ffi::c_int;
+        ::core::intrinsics::atomic_and::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
+            c2rust_fresh6,
+            c2rust_fresh7,
+        ) & c2rust_fresh7;
+        let c2rust_fresh8 = &raw mut x;
+        let c2rust_fresh9 = 0x10 as ::core::ffi::c_int;
+        ::core::intrinsics::atomic_or::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
+            c2rust_fresh8,
+            c2rust_fresh9,
+        ) | c2rust_fresh9;
+        let c2rust_fresh10 = &raw mut x;
+        let c2rust_fresh11 = 0xff as ::core::ffi::c_int;
+        !(::core::intrinsics::atomic_nand::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
+            c2rust_fresh10,
+            c2rust_fresh11,
+        ) & c2rust_fresh11);
+        return x;
+    }
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fetch_after_atomics_unsigned(
+    mut x: ::core::ffi::c_uint,
+) -> ::core::ffi::c_uint {
+    unsafe {
+        let c2rust_fresh12 = &raw mut x;
+        let c2rust_fresh13 = 2 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        ::core::intrinsics::atomic_xadd::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
+            c2rust_fresh12,
+            c2rust_fresh13,
+        ) + c2rust_fresh13;
+        let c2rust_fresh14 = &raw mut x;
+        let c2rust_fresh15 = 1 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        ::core::intrinsics::atomic_xsub::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
+            c2rust_fresh14,
+            c2rust_fresh15,
+        ) - c2rust_fresh15;
+        let c2rust_fresh16 = &raw mut x;
+        let c2rust_fresh17 = 0xf as ::core::ffi::c_int as ::core::ffi::c_uint;
+        ::core::intrinsics::atomic_and::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
+            c2rust_fresh16,
+            c2rust_fresh17,
+        ) & c2rust_fresh17;
+        let c2rust_fresh18 = &raw mut x;
+        let c2rust_fresh19 = 0x10 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        ::core::intrinsics::atomic_or::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
+            c2rust_fresh18,
+            c2rust_fresh19,
+        ) | c2rust_fresh19;
+        let c2rust_fresh20 = &raw mut x;
+        let c2rust_fresh21 = 0xff as ::core::ffi::c_int as ::core::ffi::c_uint;
+        !(::core::intrinsics::atomic_nand::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
+            c2rust_fresh20,
+            c2rust_fresh21,
+        ) & c2rust_fresh21);
+        return x;
+    }
+}
 pub const __ATOMIC_SEQ_CST: ::core::ffi::c_int = 5 as ::core::ffi::c_int;


### PR DESCRIPTION
- Fixes #1708