### PR TITLE
ast-exporter: Enable `Float128` for older versions of clang too

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -478,10 +478,9 @@ private:
             case BuiltinType::Bool: return TagBool;
             case BuiltinType::WChar_S: return TagSWChar;
             case BuiltinType::WChar_U: return TagUWChar;
-
-#if CLANG_VERSION_MAJOR >= 17
             case BuiltinType::Float128: return TagFloat128;
 
+#if CLANG_VERSION_MAJOR >= 17
             // From `clang/include/clang/Basic/AArch64ACLETypes.def`,
             // but we can't `#include` it in an external clang tool.
             case BuiltinType::SveInt8:


### PR DESCRIPTION
From what I've been able to find, `Float128` is available since Clang 3.9, which is older than the minimum required by c2rust. So the `#if` may have been misplaced there.