### PR TITLE
refactor: Fix a bug in `reorganize_definitions` for uses of foreign types

### DIFF
--- a/c2rust-refactor/src/transform/reorganize_definitions.rs
+++ b/c2rust-refactor/src/transform/reorganize_definitions.rs
@@ -1585,15 +1585,9 @@ impl<'a, 'tcx> HeaderDeclarations<'a, 'tcx> {
                         if let ItemKind::Use(..) = item.kind {
                             // If the import refers to an existing foreign item, do
                             // not replace it.
-                            let path = self.cx.resolve_use_id(item.id);
-                            if let Some(did) = path.res.opt_def_id() {
-                                if let Some(Node::ForeignItem(_)) =
-                                    self.cx.hir_map().get_if_local(did)
-                                {
-                                    return ContainsDecl::Definition(existing_decl);
-                                }
+                            if is_use_of_foreign(&item, &self.cx) {
+                                return ContainsDecl::Definition(existing_decl);
                             }
-
                             return ContainsDecl::Equivalent(existing_decl);
                         }
                         if foreign_equiv(&existing_foreign, &item) {
@@ -1629,15 +1623,9 @@ impl<'a, 'tcx> HeaderDeclarations<'a, 'tcx> {
                             return ContainsDecl::Equivalent(existing_decl);
                         } else if let ItemKind::Use(_) = existing_item.kind {
                             // A use takes precedence over a foreign declaration
-                            // unless the use refers to the foreign declaration are
-                            // attempting to insert.
-                            let path = self.cx.resolve_use_id(existing_item.id);
-                            if let Some(did) = path.res.opt_def_id() {
-                                if let Some(Node::ForeignItem(_)) =
-                                    self.cx.hir_map().get_if_local(did)
-                                {
-                                    return ContainsDecl::Definition(existing_decl);
-                                }
+                            // unless the use also refers to a foreign.
+                            if is_use_of_foreign(&existing_item, &self.cx) {
+                                return ContainsDecl::Definition(existing_decl);
                             }
                             return ContainsDecl::Equivalent(existing_decl);
                         }
@@ -1716,6 +1704,19 @@ fn foreign_equiv(foreign: &ForeignItem, item: &Item) -> bool {
 
         _ => false,
     }
+}
+
+/// Check if the [`Item`] is a [`Use`] of another [`ForeignItem`].
+fn is_use_of_foreign(item: &Item, cx: &RefactorCtxt) -> bool {
+    if !matches!(item.kind, ItemKind::Use(..)) {
+        return false;
+    }
+
+    let path = cx.resolve_use_id(item.id);
+    let Some(did) = path.res.opt_def_id() else {
+        return false;
+    };
+    matches!(cx.hir_map().get_if_local(did), Some(Node::ForeignItem(_)))
 }
 
 /// Check if the `Item` has the `#[header_src = "/some/path"]` attribute

--- a/c2rust-refactor/src/transform/reorganize_definitions.rs
+++ b/c2rust-refactor/src/transform/reorganize_definitions.rs
@@ -1562,8 +1562,12 @@ impl<'a, 'tcx> HeaderDeclarations<'a, 'tcx> {
             for existing_decl in existing_decls {
                 match &existing_decl.kind {
                     DeclKind::Item(existing_item) => match (&existing_item.kind, &item.kind) {
-                        // Replace a use with a real definition
+                        // Replace a use with a real definition, but a use of
+                        // an internal definition takes precedence over a foreign one.
                         (ItemKind::Use(..), _) => {
+                            if is_use_of_foreign(&item, &self.cx) {
+                                return ContainsDecl::Definition(existing_decl);
+                            }
                             return ContainsDecl::Use(existing_decl);
                         }
 

--- a/c2rust-refactor/tests/snapshots.rs
+++ b/c2rust-refactor/tests/snapshots.rs
@@ -425,7 +425,6 @@ fn test_reorganize_definitions() {
 fn test_reorganize_foreign_types() {
     refactor("reorganize_definitions")
         .named("reorganize_foreign_types.rs")
-        .new_expect_compile_error(true)
         .test();
 }
 

--- a/c2rust-refactor/tests/snapshots.rs
+++ b/c2rust-refactor/tests/snapshots.rs
@@ -422,6 +422,14 @@ fn test_reorganize_definitions() {
 }
 
 #[test]
+fn test_reorganize_foreign_types() {
+    refactor("reorganize_definitions")
+        .named("reorganize_foreign_types.rs")
+        .new_expect_compile_error(true)
+        .test();
+}
+
+#[test]
 fn test_sink_lets() {
     refactor("sink_lets").test();
 }

--- a/c2rust-refactor/tests/snapshots/reorganize_foreign_types.rs
+++ b/c2rust-refactor/tests/snapshots/reorganize_foreign_types.rs
@@ -1,0 +1,40 @@
+#![feature(extern_types)]
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+
+pub mod foreign1 {
+    pub struct Foo(i32);
+    #[c2rust::header_src = "foo.h:1"]
+    pub mod foo_h {
+        pub use super::Foo;
+    }
+    #[c2rust::header_src = "baz.h:1"]
+    pub mod baz_h {
+        // reorganize_definitions should preserve this import
+        pub use super::foo_h::Foo;
+        #[c2rust::src_loc = "2:1"]
+        pub type FooPtr = *mut Foo;
+    }
+}
+
+pub mod foreign2 {
+    #[c2rust::header_src = "foo.h:1"]
+    pub mod foo_h {
+        extern "C" {
+            #[c2rust::src_loc = "1:1"]
+            pub type Foo;
+        }
+        #[c2rust::src_loc = "2:1"]
+        pub type FooPtr = *mut Foo;
+    }
+    #[c2rust::header_src = "baz.h:1"]
+    pub mod baz_h {
+        pub use super::foo_h::Foo;
+        #[c2rust::src_loc = "2:1"]
+        pub type FooPtr = *mut Foo;
+    }
+}
+
+fn main() {
+    println!("hello!");
+}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_definitions_opaque_type.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_definitions_opaque_type.rs.snap
@@ -1,0 +1,24 @@
+---
+source: c2rust-refactor/tests/snapshots.rs
+expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- tests/snapshots/reorganize_definitions_opaque_type.rs --edition 2021
+---
+#![feature(extern_types)]
+#![feature(rustc_private)]
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+
+pub mod foo_h {
+    pub type Foo = *mut crate::FooStruct;
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FooStruct {
+    pub x: i32,
+}
+
+pub unsafe fn takes_foo(_foo: crate::foo_h::Foo) {}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_types.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_types.rs.snap
@@ -1,0 +1,21 @@
+---
+source: c2rust-refactor/tests/snapshots.rs
+expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- tests/snapshots/reorganize_foreign_types.rs --edition 2021
+---
+#![feature(extern_types)]
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+
+pub mod baz_h {
+
+    pub type FooPtr = *mut Foo;
+}
+pub mod foreign1 {
+    pub struct Foo(i32);
+}
+
+pub mod foreign2 {}
+
+fn main() {
+    println!("hello!");
+}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_types.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_types.rs.snap
@@ -7,6 +7,7 @@ expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- t
 #![register_tool(c2rust)]
 
 pub mod baz_h {
+    pub use crate::foreign1::Foo;
 
     pub type FooPtr = *mut Foo;
 }


### PR DESCRIPTION
* Fixes #1733.