### PR TITLE
transpile: Include enums in `CastKind::from_types`

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1803,17 +1803,17 @@ impl CastKind {
 
             (CTypeKind::Function(..), CTypeKind::Pointer(..)) => CastKind::FunctionToPointerDecay,
 
-            (_, CTypeKind::Pointer(..)) if source_ty_kind.is_integral_type() => {
+            (_, CTypeKind::Pointer(..)) if source_ty_kind.is_enum_or_integral_type() => {
                 CastKind::IntegralToPointer
             }
 
             (CTypeKind::Pointer(..), CTypeKind::Bool) => CastKind::PointerToBoolean,
 
-            (CTypeKind::Pointer(..), _) if target_ty_kind.is_integral_type() => {
+            (CTypeKind::Pointer(..), _) if target_ty_kind.is_enum_or_integral_type() => {
                 CastKind::PointerToIntegral
             }
 
-            (_, CTypeKind::Bool) if source_ty_kind.is_integral_type() => {
+            (_, CTypeKind::Bool) if source_ty_kind.is_enum_or_integral_type() => {
                 CastKind::IntegralToBoolean
             }
 
@@ -1821,11 +1821,17 @@ impl CastKind {
                 CastKind::BooleanToSignedIntegral
             }
 
-            (_, _) if source_ty_kind.is_integral_type() && target_ty_kind.is_integral_type() => {
+            (_, _)
+                if source_ty_kind.is_enum_or_integral_type()
+                    && target_ty_kind.is_enum_or_integral_type() =>
+            {
                 CastKind::IntegralCast
             }
 
-            (_, _) if source_ty_kind.is_integral_type() && target_ty_kind.is_floating_type() => {
+            (_, _)
+                if source_ty_kind.is_enum_or_integral_type()
+                    && target_ty_kind.is_floating_type() =>
+            {
                 CastKind::IntegralToFloating
             }
 
@@ -1833,7 +1839,10 @@ impl CastKind {
                 CastKind::FloatingToBoolean
             }
 
-            (_, _) if source_ty_kind.is_floating_type() && target_ty_kind.is_integral_type() => {
+            (_, _)
+                if source_ty_kind.is_floating_type()
+                    && target_ty_kind.is_enum_or_integral_type() =>
+            {
                 CastKind::FloatingToIntegral
             }
 
@@ -2682,6 +2691,10 @@ impl CTypeKind {
 
     pub fn is_enum(&self) -> bool {
         matches!(*self, Self::Enum { .. })
+    }
+
+    pub fn is_enum_or_integral_type(&self) -> bool {
+        self.is_integral_type() || self.is_enum()
     }
 
     pub fn is_integral_type(&self) -> bool {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4228,16 +4228,8 @@ impl<'c> Translation<'c> {
                     self.f128_cast_to(val, target_ty_kind)
                 } else if let &CTypeKind::Enum(enum_decl_id) = target_ty_kind {
                     // Casts targeting `enum` types...
-                    let expr =
-                        expr.ok_or_else(|| format_err!("Casts to enums require a C ExprId"))?;
                     val.result_map(|val| {
-                        self.convert_cast_to_enum(
-                            ctx,
-                            target_cty.ctype,
-                            enum_decl_id,
-                            Some(expr),
-                            val,
-                        )
+                        self.convert_cast_to_enum(ctx, target_cty.ctype, enum_decl_id, expr, val)
                     })
                 } else if target_ty_kind.is_floating_type() && source_ty_kind.is_bool() {
                     Ok(val.map(|val| {

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -547,9 +547,8 @@ impl<'c> Translation<'c> {
                 )))
             })
         } else if let &CTypeKind::Enum(enum_decl_id) = target_ty_kind {
-            let expr = expr.ok_or_else(|| format_err!("Casts to enums require a C ExprId"))?;
             val.result_map(|val| {
-                self.convert_cast_to_enum(ctx, target_cty, enum_decl_id, Some(expr), val)
+                self.convert_cast_to_enum(ctx, target_cty, enum_decl_id, expr, val)
             })
         } else {
             Ok(val.map(|val| mk().cast_expr(val, target_ty)))


### PR DESCRIPTION
This wasn't catching enum types yet, so they'd end up defaulting to `BitCast`.