### PR TITLE
ast-exporter: handle foreign/extern enums properly

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -2625,11 +2625,20 @@ class TranslateASTVisitor final
 
 void TypeEncoder::VisitEnumType(const EnumType *T) {
     auto ed = T->getDecl()->getDefinition();
+
+    // getDefinition can return NULL if there is only a forward declaration like `enum Foo;`
+    // Forward declarations of enums are not actually allowed by the C standard,
+    // but are supported by LLVM and are used in real code, see
+    // https://github.com/immunant/c2rust/pull/1743#discussion_r3120875668
+    if (!ed) {
+        ed = T->getDecl()->getCanonicalDecl();
+    }
+
     encodeType(T, TagEnumType, [T, ed](CborEncoder *local) {
         cbor_encode_uint(local, uintptr_t(ed));
     });
 
-    if (ed != nullptr) astEncoder->TraverseDecl(ed);
+    astEncoder->TraverseDecl(ed);
 }
 
 void TypeEncoder::VisitRecordType(const RecordType *T) {

--- a/tests/unit/enums/src/enum_fwd_decl.c
+++ b/tests/unit/enums/src/enum_fwd_decl.c
@@ -10,4 +10,4 @@ struct _Evas_Func
 };
 
 // dummy item imported by `test_enums.rs`
-int foo(int i) { return i;}
+struct _Evas_Func foo(struct _Evas_Func i) { return i;}


### PR DESCRIPTION
- Fixes #1740

`getDefinition` returns `NULL` if there is no definition, only a forward declaration. That would then be exported as node number 0, which would not have any valid decl associated with it. This PR adds a check for the `NULL` case and uses the canonical decl instead.