### PR TITLE
refactor: Also include constructor ids in `RenameUnnamed` and `reorganize_definitions`

### DIFF
--- a/c2rust-refactor/src/transform/items.rs
+++ b/c2rust-refactor/src/transform/items.rs
@@ -145,6 +145,15 @@ impl Transform for RenameUnnamed {
             renamer
                 .new_idents
                 .insert(cx.hir_map().node_to_hir_id(i.id), new_name);
+
+            if let ItemKind::Struct(variant_data, _) | ItemKind::Union(variant_data, _) = &i.kind {
+                if let Some(ctor_id) = variant_data.ctor_id() {
+                    renamer
+                        .new_idents
+                        .insert(cx.hir_map().node_to_hir_id(ctor_id), new_name);
+                }
+            }
+
             renamer.new_to_old.insert(new_name, i.ident);
             counter += 1;
             smallvec![i.map(|i| Item {

--- a/c2rust-refactor/src/transform/reorganize_definitions.rs
+++ b/c2rust-refactor/src/transform/reorganize_definitions.rs
@@ -12,7 +12,7 @@ use rustc_ast::*;
 use rustc_ast_pretty::pprust::{self, item_to_string, PrintState};
 use rustc_data_structures::map_in_place::MapInPlace;
 use rustc_hir::def::{DefKind, Namespace, PerNS, Res};
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, Node};
 use rustc_middle::metadata::ModChild;
 use rustc_middle::ty::{self, ParamEnv};
@@ -122,6 +122,7 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
         self.update_module_info_items(krate);
 
         self.move_items(header_decls, krate);
+        self.add_ctor_mappings();
 
         self.update_paths(krate)
     }
@@ -763,6 +764,42 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
                 .retain(|attr| !is_c2rust_attr(attr, "header_src"));
             smallvec![item]
         });
+    }
+
+    fn add_ctor_mappings(&mut self) {
+        let get_ctor = |def_id: DefId| -> Option<LocalDefId> {
+            self.cx.hir_map().get_if_local(def_id).and_then(|node| {
+                let item = match node {
+                    hir::Node::Item(item) => item,
+                    _ => return None,
+                };
+                let hir_id = match &item.kind {
+                    hir::ItemKind::Struct(variant_data, _)
+                    | hir::ItemKind::Union(variant_data, _) => variant_data.ctor_hir_id()?,
+                    _ => return None,
+                };
+                self.cx.hir_map().opt_local_def_id(hir_id)
+            })
+        };
+
+        let ctor_mapping: HashMap<DefId, Replacement> = self
+            .path_mapping
+            .iter()
+            .filter_map(|(&def_id, replacement)| {
+                Some((
+                    get_ctor(def_id)?.to_def_id(),
+                    Replacement {
+                        def: replacement
+                            .def
+                            .and_then(|def| get_ctor(def))
+                            .map(LocalDefId::to_def_id),
+                        ..replacement.clone()
+                    },
+                ))
+            })
+            .collect();
+
+        self.path_mapping.extend(ctor_mapping);
     }
 
     /// Update paths to moved items and remove redundant imports.


### PR DESCRIPTION
- Fixes #1660 

Constructors for tuple/unit structs have a separate ID from their parent item, so they need to be included or calls to those constructors are not renamed. There may be more issues like this in other parts of the refactorer, but these fixes were enough to get #1620 to pass the tests.