### PR TITLE
transpile: Resolve type first in `zero_initializer`

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -743,6 +743,24 @@ impl TypedAstContext {
         self.index(resolved_typ_id)
     }
 
+    pub fn resolve_type_id_no_typedef(&self, typ: CTypeId) -> CTypeId {
+        use CTypeKind::*;
+        let ty = match self.index(typ).kind {
+            Attributed(ty, _) => ty.ctype,
+            Elaborated(ty) => ty,
+            Decayed(ty) => ty,
+            TypeOf(ty) => ty,
+            Paren(ty) => ty,
+            _ => return typ,
+        };
+        self.resolve_type_id_no_typedef(ty)
+    }
+
+    pub fn resolve_type_no_typedef(&self, typ: CTypeId) -> &CType {
+        let resolved_typ_id = self.resolve_type_id_no_typedef(typ);
+        self.index(resolved_typ_id)
+    }
+
     /// Extract decl of referenced function.
     /// Looks for ImplicitCast(FunctionToPointerDecay, DeclRef(function_decl))
     pub fn fn_declref_decl(&self, func_expr: CExprId) -> Option<&CDeclKind> {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4460,7 +4460,7 @@ impl<'c> Translation<'c> {
         log::debug!("deferring imports to save them for {name} in {func_name}");
         self.defer_imports();
 
-        let name_decl_id = match self.ast_context.index(type_id).kind {
+        let name_decl_id = match self.ast_context.resolve_type_no_typedef(type_id).kind {
             CTypeKind::Typedef(decl_id) => decl_id,
             _ => decl_id,
         };

--- a/c2rust-transpile/tests/snapshots/empty_init.c
+++ b/c2rust-transpile/tests/snapshots/empty_init.c
@@ -4,3 +4,11 @@ struct Scope {
 };
 
 Scope *scope = &(Scope){};
+
+typedef struct Foo_s {
+    int x;
+} Foo_t;
+
+void foo(void) {
+    Foo_t f;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2021.snap
@@ -15,7 +15,17 @@ expression: cat tests/snapshots/empty_init.2021.rs
 pub struct Scope {
     pub next: *mut Scope,
 }
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Foo_s {
+    pub x: ::core::ffi::c_int,
+}
+pub type Foo_t = Foo_s;
 #[no_mangle]
 pub static mut scope: *mut Scope = &Scope {
     next: ::core::ptr::null::<Scope>() as *mut Scope,
 } as *const Scope as *mut Scope;
+#[no_mangle]
+pub unsafe extern "C" fn foo() {
+    let mut f: Foo_t = Foo_s { x: 0 };
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2021.snap
@@ -27,5 +27,5 @@ pub static mut scope: *mut Scope = &Scope {
 } as *const Scope as *mut Scope;
 #[no_mangle]
 pub unsafe extern "C" fn foo() {
-    let mut f: Foo_t = Foo_s { x: 0 };
+    let mut f: Foo_t = Foo_t { x: 0 };
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2024.snap
@@ -28,5 +28,5 @@ pub static mut scope: *mut Scope = &Scope {
 } as *const Scope as *mut Scope;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn foo() {
-    let mut f: Foo_t = Foo_s { x: 0 };
+    let mut f: Foo_t = Foo_t { x: 0 };
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2024.snap
@@ -16,7 +16,17 @@ expression: cat tests/snapshots/empty_init.2024.rs
 pub struct Scope {
     pub next: *mut Scope,
 }
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct Foo_s {
+    pub x: ::core::ffi::c_int,
+}
+pub type Foo_t = Foo_s;
 #[unsafe(no_mangle)]
 pub static mut scope: *mut Scope = &Scope {
     next: ::core::ptr::null::<Scope>() as *mut Scope,
 } as *const Scope as *mut Scope;
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn foo() {
+    let mut f: Foo_t = Foo_s { x: 0 };
+}


### PR DESCRIPTION
- Fixes #1747 

This needed an extra helper function that resolves types but keeps typedefs.