### PR TITLE
transpile: Handle `InitList` correctly for all scalar types

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -2752,6 +2752,10 @@ impl CTypeKind {
         )
     }
 
+    pub fn is_scalar(&self) -> bool {
+        self.is_integral_type() || self.is_floating_type() || self.is_enum() || self.is_pointer()
+    }
+
     pub fn as_underlying_decl(&self) -> Option<CDeclId> {
         use CTypeKind::*;
         match *self {

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -257,8 +257,11 @@ impl<'c> Translation<'c> {
                 self.vector_list_initializer(ctx, ids, ctype, len)
             }
             ref kind if kind.is_scalar() => {
-                let id = ids.first().unwrap();
-                self.convert_expr(ctx.used(), *id, None)
+                if let Some(&first) = ids.first() {
+                    self.convert_expr(ctx.used(), first, None)
+                } else {
+                    self.implicit_default_expr(ctx.used(), ty.ctype)
+                }
             }
             ref t => Err(format_err!("Init list not implemented for {:?}", t).into()),
         }

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -253,18 +253,10 @@ impl<'c> Translation<'c> {
             CTypeKind::Union(union_id) => {
                 self.convert_union_literal(ctx, union_id, ids.as_ref(), ty, opt_union_field_id)
             }
-            CTypeKind::Pointer(_) => {
-                let id = ids.first().unwrap();
-                self.convert_expr(ctx.used(), *id, None)
-            }
-            CTypeKind::Enum(_) => {
-                let id = ids.first().unwrap();
-                self.convert_expr(ctx.used(), *id, None)
-            }
             CTypeKind::Vector(CQualTypeId { ctype, .. }, len) => {
                 self.vector_list_initializer(ctx, ids, ctype, len)
             }
-            ref kind if kind.is_integral_type() => {
+            ref kind if kind.is_scalar() => {
                 let id = ids.first().unwrap();
                 self.convert_expr(ctx.used(), *id, None)
             }

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -406,6 +406,13 @@ fn test_rotate() {
 }
 
 #[test]
+fn test_scalar_init() {
+    transpile("scalar_init.c")
+        .expect_unresolved_import("f128")
+        .run();
+}
+
+#[test]
 fn test_static_assert() {
     transpile("static_assert.c").run();
 }

--- a/c2rust-transpile/tests/snapshots/scalar_init.c
+++ b/c2rust-transpile/tests/snapshots/scalar_init.c
@@ -1,0 +1,19 @@
+#include <stdbool.h>
+
+enum E {
+    A,
+};
+
+void scalar_init() {
+    bool b = { true };
+    char c = { 'c' };
+    int i = { 42 };
+    long l = { 42l };
+    float f = { 42.0f };
+    double d = { 42.0 };
+    long double ld = { 42.0l };
+    // Doesn't work on MacOS, so avoid it for now so this test doesn't become OS-specific.
+    // __float128 q = { 42.0q };
+    enum E e = { A };
+    int *p = { &i };
+}

--- a/c2rust-transpile/tests/snapshots/scalar_init.c
+++ b/c2rust-transpile/tests/snapshots/scalar_init.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include <stdlib.h>
 
 enum E {
     A,
@@ -16,4 +17,29 @@ void scalar_init() {
     // __float128 q = { 42.0q };
     enum E e = { A };
     int *p = { &i };
+
+// Empty initializer lists for scalars was only added in C23 and clang 17.
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L) || (defined(__clang__) && (__clang_major__ >= 17))
+    bool eb = {};
+    char ec = {};
+    int ei = {};
+    long el = {};
+    float ef = {};
+    double ed = {};
+    long double eld = {};
+    // __float128 eq = {};
+    // enums don't allow empty init lists in C
+    int *ep = {};
+#else
+    bool eb;
+    char ec;
+    int ei;
+    long el;
+    float ef;
+    double ed;
+    long double eld;
+    // __float128 eq;
+    // enums don't allow empty init lists in C
+    int *ep;
+#endif
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
@@ -25,4 +25,12 @@ pub unsafe extern "C" fn scalar_init() {
     let mut ld: ::f128::f128 = ::f128::f128::new(42.0);
     let mut e: E = A;
     let mut p: *mut ::core::ffi::c_int = &raw mut i;
+    let mut eb: bool = false;
+    let mut ec: ::core::ffi::c_char = 0;
+    let mut ei: ::core::ffi::c_int = 0;
+    let mut el: ::core::ffi::c_long = 0;
+    let mut ef: ::core::ffi::c_float = 0.;
+    let mut ed: ::core::ffi::c_double = 0.;
+    let mut eld: ::f128::f128 = ::f128::f128::ZERO;
+    let mut ep: *mut ::core::ffi::c_int = ::core::ptr::null_mut::<::core::ffi::c_int>();
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
@@ -1,0 +1,28 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/scalar_init.2021.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![feature(raw_ref_op)]
+pub type E = ::core::ffi::c_uint;
+pub const A: E = 0;
+pub const true_0: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
+#[no_mangle]
+pub unsafe extern "C" fn scalar_init() {
+    let mut b: bool = true_0 != 0;
+    let mut c: ::core::ffi::c_char = 'c' as i32 as ::core::ffi::c_char;
+    let mut i: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut l: ::core::ffi::c_long = 42 as ::core::ffi::c_long;
+    let mut f: ::core::ffi::c_float = 42.0f32;
+    let mut d: ::core::ffi::c_double = 42.0f64;
+    let mut ld: ::f128::f128 = ::f128::f128::new(42.0);
+    let mut e: E = A;
+    let mut p: *mut ::core::ffi::c_int = &raw mut i;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
@@ -25,4 +25,12 @@ pub unsafe extern "C" fn scalar_init() {
     let mut ld: ::f128::f128 = ::f128::f128::new(42.0);
     let mut e: E = A;
     let mut p: *mut ::core::ffi::c_int = &raw mut i;
+    let mut eb: bool = false;
+    let mut ec: ::core::ffi::c_char = 0;
+    let mut ei: ::core::ffi::c_int = 0;
+    let mut el: ::core::ffi::c_long = 0;
+    let mut ef: ::core::ffi::c_float = 0.;
+    let mut ed: ::core::ffi::c_double = 0.;
+    let mut eld: ::f128::f128 = ::f128::f128::ZERO;
+    let mut ep: *mut ::core::ffi::c_int = ::core::ptr::null_mut::<::core::ffi::c_int>();
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
@@ -1,0 +1,28 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/scalar_init.2024.rs
+---
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unsafe_op_in_unsafe_fn,
+    unused_assignments,
+    unused_mut
+)]
+pub type E = ::core::ffi::c_uint;
+pub const A: E = 0;
+pub const true_0: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn scalar_init() {
+    let mut b: bool = true_0 != 0;
+    let mut c: ::core::ffi::c_char = 'c' as i32 as ::core::ffi::c_char;
+    let mut i: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut l: ::core::ffi::c_long = 42 as ::core::ffi::c_long;
+    let mut f: ::core::ffi::c_float = 42.0f32;
+    let mut d: ::core::ffi::c_double = 42.0f64;
+    let mut ld: ::f128::f128 = ::f128::f128::new(42.0);
+    let mut e: E = A;
+    let mut p: *mut ::core::ffi::c_int = &raw mut i;
+}


### PR DESCRIPTION
* Reopened #1697.

- Fixes #1691.