### PR TITLE
transpile: Fix snapshot tests

### DIFF
--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -461,6 +461,7 @@ fn test_call_only_once() {
 fn test_f128() {
     transpile("f128.c")
         .expect_unresolved_import("f128")
+        .expect_unresolved_import("num_traits")
         .os_specific(true)
         .run();
 }


### PR DESCRIPTION
#1727 still had errors when it was merged.