### PR TITLE
Disable related_decls in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
       matrix:
         crate:
           - merge_rust
+          # - related_decls
           - rust_util
           - split_ffi_entry_points
           - split_rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,6 @@ jobs:
       matrix:
         crate:
           - merge_rust
-          - related_decls
           - rust_util
           - split_ffi_entry_points
           - split_rust


### PR DESCRIPTION
Currently related_decls is failing in CI because of changes in the latest Rust toolchain. There's a PR for a fix in the CRISP repo (https://github.com/GaloisInc/Tractor-Crisp/pull/106), but in the meantime this is broken locally for us. I think if the development of the tool is mainly happening in the CRISP repo and we're just vendoring a copy here then we don't need to be testing this in CI (similar to how we wouldn't test a crates.io crate in our CI).

I've left the other tools enabled for now, but if the others are similarly being developed in the CRISP repo then we might want to remove those from our CI as well.