### PR TITLE
transpile: Minor improvements of cast handling

### DIFF
--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -32,11 +32,12 @@ impl<'c> Translation<'c> {
     }
 
     /// Return whether the literal can be directly translated as this type.
-    pub fn literal_matches_ty(&self, lit: &CLiteral, ty: CQualTypeId) -> bool {
+    pub fn literal_matches_ty(&self, lit: &CLiteral, ty: CQualTypeId, is_negated: bool) -> bool {
         let ty_kind = &self.ast_context.resolve_type(ty.ctype).kind;
         match *lit {
             CLiteral::Integer(value, _) if ty_kind.is_integral_type() && !ty_kind.is_bool() => {
                 ty_kind.guaranteed_integer_in_range(value)
+                    && (!is_negated || ty_kind.is_signed_integral_type())
             }
             // `convert_literal` always casts these to i32.
             CLiteral::Character(_value) => matches!(ty_kind, CTypeKind::Int32),

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3628,11 +3628,9 @@ impl<'c> Translation<'c> {
                 // But for literals, if we don't absolutely have to cast, we would rather the
                 // literal is translated according to the type we're expecting, and then we can
                 // skip the cast entirely.
-                if let (Some(ty), CExprKind::Literal(_ty, lit)) =
-                    (override_ty, &self.ast_context[expr].kind)
-                {
-                    if !is_explicit && self.literal_matches_ty(lit, ty) {
-                        return self.convert_expr(ctx, expr, override_ty);
+                if let CExprKind::Literal(_ty, lit) = &self.ast_context[expr].kind {
+                    if !is_explicit && self.literal_matches_ty(lit, target_ty) {
+                        return self.convert_expr(ctx, expr, Some(target_ty));
                     }
                 }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3605,6 +3605,11 @@ impl<'c> Translation<'c> {
                 // A reference must be decayed if a bitcast is required. Const casts in
                 // LLVM 8 are now NoOp casts, so we need to include it as well.
                 match kind {
+                    CastKind::IntegralToBoolean
+                    | CastKind::FloatingToBoolean
+                    | CastKind::PointerToBoolean => {
+                        return self.convert_condition(ctx, true, expr);
+                    }
                     CastKind::BitCast | CastKind::PointerToIntegral | CastKind::NoOp => {
                         ctx.decay_ref = DecayRef::Yes
                     }
@@ -4264,11 +4269,7 @@ impl<'c> Translation<'c> {
             CastKind::IntegralToBoolean
             | CastKind::FloatingToBoolean
             | CastKind::PointerToBoolean => {
-                if let Some(expr) = expr {
-                    self.convert_condition(ctx, true, expr)
-                } else {
-                    val.result_map(|e| self.match_bool(ctx, true, source_cty.ctype, e))
-                }
+                val.result_map(|e| self.match_bool(ctx, true, source_cty.ctype, e))
             }
 
             CastKind::FloatingRealToComplex

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3616,61 +3616,60 @@ impl<'c> Translation<'c> {
                     _ => {}
                 }
 
-                let mut source_ty = self.ast_context[expr]
-                    .kind
-                    .get_qual_type()
-                    .ok_or_else(|| format_err!("bad source type"))?;
+                let target_ty = override_ty.unwrap_or(ty);
 
-                let val = if is_explicit {
-                    // If we're casting a function, look for its declared ty to use as a more
-                    // precise source type. The AST node's type will not preserve typedef arg types
-                    // but the function's declaration will.
-                    if let Some(func_decl) = self.ast_context.fn_declref_decl(expr) {
-                        let kind_with_declared_args =
-                            self.ast_context.fn_decl_ty_with_declared_args(func_decl);
-                        let func_ty = self
-                            .ast_context
-                            .type_for_kind(&kind_with_declared_args)
-                            .unwrap_or_else(|| {
-                                panic!("no type for kind {kind_with_declared_args:?}")
-                            });
-                        let func_ptr_ty = self
-                            .ast_context
-                            .type_for_kind(&CTypeKind::Pointer(CQualTypeId::new(func_ty)))
-                            .unwrap_or_else(|| {
-                                panic!("no type for kind {kind_with_declared_args:?}")
-                            });
-
-                        source_ty = CQualTypeId::new(func_ptr_ty);
+                // In general, if we are casting the result of an expression, then the inner
+                // expression should be translated to whatever type it normally would.
+                // But for literals, if we don't absolutely have to cast, we would rather the
+                // literal is translated according to the type we're expecting, and then we can
+                // skip the cast entirely.
+                if let (Some(ty), CExprKind::Literal(_ty, lit)) =
+                    (override_ty, &self.ast_context[expr].kind)
+                {
+                    if !is_explicit && self.literal_matches_ty(lit, ty) {
+                        return self.convert_expr(ctx, expr, override_ty);
                     }
+                }
 
+                let mut val = self.convert_expr(ctx, expr, None)?;
+
+                if is_explicit {
                     let stmts = self.compute_variable_array_sizes(ctx, ty.ctype)?;
-                    let mut val = self.convert_expr(ctx, expr, None)?;
                     val.prepend_stmts(stmts);
-                    val
-                } else {
-                    // In general, if we are casting the result of an expression, then the inner
-                    // expression should be translated to whatever type it normally would.
-                    // But for literals, if we don't absolutely have to cast, we would rather the
-                    // literal is translated according to the type we're expecting, and then we can
-                    // skip the cast entirely.
-                    if let (Some(ty), CExprKind::Literal(_ty, lit)) =
-                        (override_ty, &self.ast_context[expr].kind)
-                    {
-                        if self.literal_matches_ty(lit, ty) {
-                            return self.convert_expr(ctx, expr, override_ty);
-                        }
-                    }
+                }
 
-                    self.convert_expr(ctx, expr, None)?
-                };
                 // Shuffle Vector "function" builtins will add a cast to the output of the
                 // builtin call which is unnecessary for translation purposes
                 if self.casting_simd_builtin_call(expr, is_explicit, kind) {
                     return Ok(val);
                 }
 
-                let target_ty = override_ty.unwrap_or(ty);
+                let source_ty = if let Some(func_decl) = self
+                    .ast_context
+                    .fn_declref_decl(expr)
+                    .filter(|_| is_explicit)
+                {
+                    // If we're casting a function, look for its declared ty to use as a more
+                    // precise source type. The AST node's type will not preserve typedef arg types
+                    // but the function's declaration will.
+                    let kind_with_declared_args =
+                        self.ast_context.fn_decl_ty_with_declared_args(func_decl);
+                    let func_ty = self
+                        .ast_context
+                        .type_for_kind(&kind_with_declared_args)
+                        .unwrap_or_else(|| panic!("no type for kind {kind_with_declared_args:?}"));
+                    let func_ptr_ty = self
+                        .ast_context
+                        .type_for_kind(&CTypeKind::Pointer(CQualTypeId::new(func_ty)))
+                        .unwrap_or_else(|| panic!("no type for kind {kind_with_declared_args:?}"));
+
+                    CQualTypeId::new(func_ptr_ty)
+                } else {
+                    self.ast_context[expr]
+                        .kind
+                        .get_qual_type()
+                        .ok_or_else(|| format_err!("bad source type"))?
+                };
 
                 self.convert_cast(
                     ctx,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3621,6 +3621,7 @@ impl<'c> Translation<'c> {
                     _ => {}
                 }
 
+                let expr_kind = &self.ast_context[expr].kind;
                 let target_ty = override_ty.unwrap_or(ty);
 
                 // In general, if we are casting the result of an expression, then the inner
@@ -3628,9 +3629,19 @@ impl<'c> Translation<'c> {
                 // But for literals, if we don't absolutely have to cast, we would rather the
                 // literal is translated according to the type we're expecting, and then we can
                 // skip the cast entirely.
-                if let CExprKind::Literal(_ty, lit) = &self.ast_context[expr].kind {
-                    if !is_explicit && self.literal_matches_ty(lit, target_ty) {
-                        return self.convert_expr(ctx, expr, Some(target_ty));
+                if !is_explicit {
+                    let mut literal_expr_kind = expr_kind;
+                    let mut is_negated = false;
+
+                    if let &CExprKind::Unary(_, CUnOp::Negate, subexpr_id, _) = literal_expr_kind {
+                        literal_expr_kind = &self.ast_context[subexpr_id].kind;
+                        is_negated = true;
+                    }
+
+                    if let CExprKind::Literal(_, lit) = literal_expr_kind {
+                        if self.literal_matches_ty(lit, target_ty, is_negated) {
+                            return self.convert_expr(ctx, expr, Some(target_ty));
+                        }
                     }
                 }
 

--- a/c2rust-transpile/tests/snapshots/exprs.c
+++ b/c2rust-transpile/tests/snapshots/exprs.c
@@ -44,6 +44,15 @@ void unsigned_compound_desugaring(void) {
     i += u;
 }
 
+typedef int int_t;
+
+void cast_literals(void) {
+    int i = 1L;
+    int_t it = 1L;
+    int i_neg = -1L;
+    int_t it_neg = -1L;
+}
+
 void compound_literal(){
     /// https://github.com/immunant/c2rust/issues/1234
     int i = (enum {A, B, C}){1};

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.snap
@@ -71,8 +71,7 @@ pub unsafe extern "C" fn entry() {
         'e' as i32 as ::core::ffi::c_char,
         'f' as i32 as ::core::ffi::c_char,
     ];
-    let mut char_with_ints: [::core::ffi::c_char; 2] =
-        [1 as ::core::ffi::c_int as ::core::ffi::c_char, 0];
+    let mut char_with_ints: [::core::ffi::c_char; 2] = [1 as ::core::ffi::c_char, 0];
     let mut char_with_init: [::core::ffi::c_char; 5] =
         ::core::mem::transmute::<[u8; 5], [::core::ffi::c_char; 5]>(*b"abcd\0");
     let mut char_too_long: [::core::ffi::c_char; 3] =

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.snap
@@ -71,8 +71,7 @@ pub unsafe extern "C" fn entry() {
         'e' as i32 as ::core::ffi::c_char,
         'f' as i32 as ::core::ffi::c_char,
     ];
-    let mut char_with_ints: [::core::ffi::c_char; 2] =
-        [1 as ::core::ffi::c_int as ::core::ffi::c_char, 0];
+    let mut char_with_ints: [::core::ffi::c_char; 2] = [1 as ::core::ffi::c_char, 0];
     let mut char_with_init: [::core::ffi::c_char; 5] =
         ::core::mem::transmute::<[u8; 5], [::core::ffi::c_char; 5]>(*b"abcd\0");
     let mut char_too_long: [::core::ffi::c_char; 3] =

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2021.snap
@@ -63,21 +63,21 @@ pub unsafe extern "C" fn fetch_after_atomics_unsigned(
     mut x: ::core::ffi::c_uint,
 ) -> ::core::ffi::c_uint {
     let c2rust_fresh12 = &raw mut x;
-    let c2rust_fresh13 = 2 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let c2rust_fresh13 = 2 as ::core::ffi::c_uint;
     ::core::intrinsics::atomic_xadd_seqcst(c2rust_fresh12, c2rust_fresh13)
         .wrapping_add(c2rust_fresh13);
     let c2rust_fresh14 = &raw mut x;
-    let c2rust_fresh15 = 1 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let c2rust_fresh15 = 1 as ::core::ffi::c_uint;
     ::core::intrinsics::atomic_xsub_seqcst(c2rust_fresh14, c2rust_fresh15)
         .wrapping_sub(c2rust_fresh15);
     let c2rust_fresh16 = &raw mut x;
-    let c2rust_fresh17 = 0xf as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let c2rust_fresh17 = 0xf as ::core::ffi::c_uint;
     ::core::intrinsics::atomic_and_seqcst(c2rust_fresh16, c2rust_fresh17) & c2rust_fresh17;
     let c2rust_fresh18 = &raw mut x;
-    let c2rust_fresh19 = 0x10 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let c2rust_fresh19 = 0x10 as ::core::ffi::c_uint;
     ::core::intrinsics::atomic_or_seqcst(c2rust_fresh18, c2rust_fresh19) | c2rust_fresh19;
     let c2rust_fresh20 = &raw mut x;
-    let c2rust_fresh21 = 0xff as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let c2rust_fresh21 = 0xff as ::core::ffi::c_uint;
     !(::core::intrinsics::atomic_nand_seqcst(c2rust_fresh20, c2rust_fresh21) & c2rust_fresh21);
     return x;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2024.snap
@@ -108,33 +108,33 @@ pub unsafe extern "C" fn fetch_after_atomics_unsigned(
     mut x: ::core::ffi::c_uint,
 ) -> ::core::ffi::c_uint {
     let c2rust_fresh12 = &raw mut x;
-    let c2rust_fresh13 = 2 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let c2rust_fresh13 = 2 as ::core::ffi::c_uint;
     ::core::intrinsics::atomic_xadd::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
         c2rust_fresh12,
         c2rust_fresh13,
     )
     .wrapping_add(c2rust_fresh13);
     let c2rust_fresh14 = &raw mut x;
-    let c2rust_fresh15 = 1 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let c2rust_fresh15 = 1 as ::core::ffi::c_uint;
     ::core::intrinsics::atomic_xsub::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
         c2rust_fresh14,
         c2rust_fresh15,
     )
     .wrapping_sub(c2rust_fresh15);
     let c2rust_fresh16 = &raw mut x;
-    let c2rust_fresh17 = 0xf as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let c2rust_fresh17 = 0xf as ::core::ffi::c_uint;
     ::core::intrinsics::atomic_and::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
         c2rust_fresh16,
         c2rust_fresh17,
     ) & c2rust_fresh17;
     let c2rust_fresh18 = &raw mut x;
-    let c2rust_fresh19 = 0x10 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let c2rust_fresh19 = 0x10 as ::core::ffi::c_uint;
     ::core::intrinsics::atomic_or::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
         c2rust_fresh18,
         c2rust_fresh19,
     ) | c2rust_fresh19;
     let c2rust_fresh20 = &raw mut x;
-    let c2rust_fresh21 = 0xff as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let c2rust_fresh21 = 0xff as ::core::ffi::c_uint;
     !(::core::intrinsics::atomic_nand::<_, _, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
         c2rust_fresh20,
         c2rust_fresh21,

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.snap
@@ -67,8 +67,8 @@ pub unsafe extern "C" fn unsigned_compound_desugaring() {
 pub unsafe extern "C" fn cast_literals() {
     let mut i: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
     let mut it: int_t = 1 as int_t;
-    let mut i_neg: ::core::ffi::c_int = -1 as ::core::ffi::c_long as ::core::ffi::c_int;
-    let mut it_neg: int_t = -1 as ::core::ffi::c_long as int_t;
+    let mut i_neg: ::core::ffi::c_int = -1 as ::core::ffi::c_int;
+    let mut it_neg: int_t = -1 as int_t;
 }
 #[no_mangle]
 pub unsafe extern "C" fn compound_literal() {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.snap
@@ -17,6 +17,7 @@ extern "C" {
 }
 pub type E = ::core::ffi::c_uint;
 pub const EA: E = 0;
+pub type int_t = ::core::ffi::c_int;
 pub type C2Rust_Unnamed = ::core::ffi::c_uint;
 pub const C: C2Rust_Unnamed = 2;
 pub const B: C2Rust_Unnamed = 1;
@@ -61,6 +62,13 @@ pub unsafe extern "C" fn unsigned_compound_desugaring() {
     let mut e: E = EA;
     e = (e as ::core::ffi::c_uint).wrapping_add(u) as E;
     i = (i as ::core::ffi::c_uint).wrapping_add(u) as ::core::ffi::c_int;
+}
+#[no_mangle]
+pub unsafe extern "C" fn cast_literals() {
+    let mut i: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
+    let mut it: int_t = 1 as int_t;
+    let mut i_neg: ::core::ffi::c_int = -1 as ::core::ffi::c_long as ::core::ffi::c_int;
+    let mut it_neg: int_t = -1 as ::core::ffi::c_long as int_t;
 }
 #[no_mangle]
 pub unsafe extern "C" fn compound_literal() {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.snap
@@ -67,8 +67,8 @@ pub unsafe extern "C" fn unsigned_compound_desugaring() {
 pub unsafe extern "C" fn cast_literals() {
     let mut i: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
     let mut it: int_t = 1 as int_t;
-    let mut i_neg: ::core::ffi::c_int = -1 as ::core::ffi::c_long as ::core::ffi::c_int;
-    let mut it_neg: int_t = -1 as ::core::ffi::c_long as int_t;
+    let mut i_neg: ::core::ffi::c_int = -1 as ::core::ffi::c_int;
+    let mut it_neg: int_t = -1 as int_t;
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn compound_literal() {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.snap
@@ -17,6 +17,7 @@ unsafe extern "C" {
 }
 pub type E = ::core::ffi::c_uint;
 pub const EA: E = 0;
+pub type int_t = ::core::ffi::c_int;
 pub type C2Rust_Unnamed = ::core::ffi::c_uint;
 pub const C: C2Rust_Unnamed = 2;
 pub const B: C2Rust_Unnamed = 1;
@@ -61,6 +62,13 @@ pub unsafe extern "C" fn unsigned_compound_desugaring() {
     let mut e: E = EA;
     e = (e as ::core::ffi::c_uint).wrapping_add(u) as E;
     i = (i as ::core::ffi::c_uint).wrapping_add(u) as ::core::ffi::c_int;
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cast_literals() {
+    let mut i: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
+    let mut it: int_t = 1 as int_t;
+    let mut i_neg: ::core::ffi::c_int = -1 as ::core::ffi::c_long as ::core::ffi::c_int;
+    let mut it_neg: int_t = -1 as ::core::ffi::c_long as int_t;
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn compound_literal() {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.linux.snap
@@ -14,15 +14,13 @@ expression: cat tests/snapshots/os-specific/rotate.2021.linux.rs
 pub unsafe extern "C" fn rotate_left_64(
     mut x: ::core::ffi::c_ulonglong,
 ) -> ::core::ffi::c_ulonglong {
-    return (x as ::core::ffi::c_ulong)
-        .rotate_left(4 as ::core::ffi::c_int as ::core::ffi::c_ulong as u32)
+    return (x as ::core::ffi::c_ulong).rotate_left(4 as ::core::ffi::c_ulong as u32)
         as ::core::ffi::c_ulonglong;
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_64(
     mut x: ::core::ffi::c_ulonglong,
 ) -> ::core::ffi::c_ulonglong {
-    return (x as ::core::ffi::c_ulong)
-        .rotate_right(4 as ::core::ffi::c_int as ::core::ffi::c_ulong as u32)
+    return (x as ::core::ffi::c_ulong).rotate_right(4 as ::core::ffi::c_ulong as u32)
         as ::core::ffi::c_ulonglong;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.macos.snap
@@ -14,11 +14,11 @@ expression: cat tests/snapshots/os-specific/rotate.2021.macos.rs
 pub unsafe extern "C" fn rotate_left_64(
     mut x: ::core::ffi::c_ulonglong,
 ) -> ::core::ffi::c_ulonglong {
-    return x.rotate_left(4 as ::core::ffi::c_int as ::core::ffi::c_ulonglong as u32);
+    return x.rotate_left(4 as ::core::ffi::c_ulonglong as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_64(
     mut x: ::core::ffi::c_ulonglong,
 ) -> ::core::ffi::c_ulonglong {
-    return x.rotate_right(4 as ::core::ffi::c_int as ::core::ffi::c_ulonglong as u32);
+    return x.rotate_right(4 as ::core::ffi::c_ulonglong as u32);
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2021.snap
@@ -12,25 +12,25 @@ expression: cat tests/snapshots/rotate.2021.rs
 )]
 #[no_mangle]
 pub unsafe extern "C" fn rotate_left_8(mut x: ::core::ffi::c_uchar) -> ::core::ffi::c_uchar {
-    return x.rotate_left(1 as ::core::ffi::c_int as ::core::ffi::c_uchar as u32);
+    return x.rotate_left(1 as ::core::ffi::c_uchar as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_left_16(mut x: ::core::ffi::c_ushort) -> ::core::ffi::c_ushort {
-    return x.rotate_left(2 as ::core::ffi::c_int as ::core::ffi::c_ushort as u32);
+    return x.rotate_left(2 as ::core::ffi::c_ushort as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_left_32(mut x: ::core::ffi::c_uint) -> ::core::ffi::c_uint {
-    return x.rotate_left(3 as ::core::ffi::c_int as ::core::ffi::c_uint as u32);
+    return x.rotate_left(3 as ::core::ffi::c_uint as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_8(mut x: ::core::ffi::c_uchar) -> ::core::ffi::c_uchar {
-    return x.rotate_right(1 as ::core::ffi::c_int as ::core::ffi::c_uchar as u32);
+    return x.rotate_right(1 as ::core::ffi::c_uchar as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_16(mut x: ::core::ffi::c_ushort) -> ::core::ffi::c_ushort {
-    return x.rotate_right(2 as ::core::ffi::c_int as ::core::ffi::c_ushort as u32);
+    return x.rotate_right(2 as ::core::ffi::c_ushort as u32);
 }
 #[no_mangle]
 pub unsafe extern "C" fn rotate_right_32(mut x: ::core::ffi::c_uint) -> ::core::ffi::c_uint {
-    return x.rotate_right(3 as ::core::ffi::c_int as ::core::ffi::c_uint as u32);
+    return x.rotate_right(3 as ::core::ffi::c_uint as u32);
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.linux.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.linux.snap
@@ -15,15 +15,13 @@ expression: cat tests/snapshots/os-specific/rotate.2024.linux.rs
 pub unsafe extern "C" fn rotate_left_64(
     mut x: ::core::ffi::c_ulonglong,
 ) -> ::core::ffi::c_ulonglong {
-    return (x as ::core::ffi::c_ulong)
-        .rotate_left(4 as ::core::ffi::c_int as ::core::ffi::c_ulong as u32)
+    return (x as ::core::ffi::c_ulong).rotate_left(4 as ::core::ffi::c_ulong as u32)
         as ::core::ffi::c_ulonglong;
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rotate_right_64(
     mut x: ::core::ffi::c_ulonglong,
 ) -> ::core::ffi::c_ulonglong {
-    return (x as ::core::ffi::c_ulong)
-        .rotate_right(4 as ::core::ffi::c_int as ::core::ffi::c_ulong as u32)
+    return (x as ::core::ffi::c_ulong).rotate_right(4 as ::core::ffi::c_ulong as u32)
         as ::core::ffi::c_ulonglong;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.macos.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.macos.snap
@@ -15,11 +15,11 @@ expression: cat tests/snapshots/os-specific/rotate.2024.macos.rs
 pub unsafe extern "C" fn rotate_left_64(
     mut x: ::core::ffi::c_ulonglong,
 ) -> ::core::ffi::c_ulonglong {
-    return x.rotate_left(4 as ::core::ffi::c_int as ::core::ffi::c_ulonglong as u32);
+    return x.rotate_left(4 as ::core::ffi::c_ulonglong as u32);
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rotate_right_64(
     mut x: ::core::ffi::c_ulonglong,
 ) -> ::core::ffi::c_ulonglong {
-    return x.rotate_right(4 as ::core::ffi::c_int as ::core::ffi::c_ulonglong as u32);
+    return x.rotate_right(4 as ::core::ffi::c_ulonglong as u32);
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@rotate.c.2024.snap
@@ -13,25 +13,25 @@ expression: cat tests/snapshots/rotate.2024.rs
 )]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rotate_left_8(mut x: ::core::ffi::c_uchar) -> ::core::ffi::c_uchar {
-    return x.rotate_left(1 as ::core::ffi::c_int as ::core::ffi::c_uchar as u32);
+    return x.rotate_left(1 as ::core::ffi::c_uchar as u32);
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rotate_left_16(mut x: ::core::ffi::c_ushort) -> ::core::ffi::c_ushort {
-    return x.rotate_left(2 as ::core::ffi::c_int as ::core::ffi::c_ushort as u32);
+    return x.rotate_left(2 as ::core::ffi::c_ushort as u32);
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rotate_left_32(mut x: ::core::ffi::c_uint) -> ::core::ffi::c_uint {
-    return x.rotate_left(3 as ::core::ffi::c_int as ::core::ffi::c_uint as u32);
+    return x.rotate_left(3 as ::core::ffi::c_uint as u32);
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rotate_right_8(mut x: ::core::ffi::c_uchar) -> ::core::ffi::c_uchar {
-    return x.rotate_right(1 as ::core::ffi::c_int as ::core::ffi::c_uchar as u32);
+    return x.rotate_right(1 as ::core::ffi::c_uchar as u32);
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rotate_right_16(mut x: ::core::ffi::c_ushort) -> ::core::ffi::c_ushort {
-    return x.rotate_right(2 as ::core::ffi::c_int as ::core::ffi::c_ushort as u32);
+    return x.rotate_right(2 as ::core::ffi::c_ushort as u32);
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rotate_right_32(mut x: ::core::ffi::c_uint) -> ::core::ffi::c_uint {
-    return x.rotate_right(3 as ::core::ffi::c_int as ::core::ffi::c_uint as u32);
+    return x.rotate_right(3 as ::core::ffi::c_uint as u32);
 }


### PR DESCRIPTION
Two unrelated changes that modify the same code, so they are bundled. Double-translating is generally bad, because translation can have side-effects on the translator, like adding a feature or importing a type.