### PR TITLE
transpile: Do not swap negation and literal if literal is in a macro

### DIFF
--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -912,9 +912,11 @@ impl<'c> Translation<'c> {
             .kind
             .is_unsigned_integral_type();
 
-        if let (&CExprKind::Literal(_, CLiteral::Integer(val, base)), false) =
-            (&self.ast_context[arg_id].kind, is_unsigned_integral_type)
-        {
+        if let (&CExprKind::Literal(_, CLiteral::Integer(val, base)), false, false) = (
+            &self.ast_context[arg_id].kind,
+            is_unsigned_integral_type,
+            self.expr_is_expanded_macro(ctx, arg_id, Some(expr_type_id)),
+        ) {
             // If we are negating a literal, generate a negated literal directly.
             // This will create an expression like `-1 as ty` without parentheses,
             // rather than `-(1 as ty)`.

--- a/c2rust-transpile/tests/snapshots/macros.c
+++ b/c2rust-transpile/tests/snapshots/macros.c
@@ -22,6 +22,7 @@ struct S {
 #define NESTED_ARRAY LITERAL_ARRAY
 #define NESTED_STRUCT LITERAL_STRUCT
 
+#define NEGATIVE_INT -LITERAL_INT
 #define INT_ARITHMETIC NESTED_INT + LITERAL_INT + 1
 #define MIXED_ARITHMETIC LITERAL_INT + NESTED_FLOAT *LITERAL_CHAR - true
 #define PARENS (NESTED_INT * (LITERAL_CHAR + true))
@@ -67,6 +68,7 @@ void local_muts() {
   int nested_array[] = NESTED_ARRAY;
   struct S nested_struct = NESTED_STRUCT;
 
+  int negative_int = NEGATIVE_INT;
   int int_arithmetic = INT_ARITHMETIC;
   float mixed_arithmetic = MIXED_ARITHMETIC;
   int parens = PARENS;
@@ -104,6 +106,7 @@ void local_consts() {
   const int nested_array[] = NESTED_ARRAY;
   const struct S nested_struct = NESTED_STRUCT;
 
+  const int negative_int = NEGATIVE_INT;
   const int int_arithmetic = INT_ARITHMETIC;
   const float mixed_arithmetic = MIXED_ARITHMETIC;
   const int parens = PARENS;
@@ -183,6 +186,7 @@ static const char global_static_const_nested_str[] = NESTED_STR;
 static const int global_static_const_nested_array[] = NESTED_ARRAY;
 static const struct S global_static_const_nested_struct = NESTED_STRUCT;
 
+static const int global_static_const_negative_int = NEGATIVE_INT;
 static const int global_static_const_int_arithmetic = INT_ARITHMETIC;
 static const float global_static_const_mixed_arithmetic = MIXED_ARITHMETIC;
 static const int global_static_const_parens = PARENS;
@@ -222,6 +226,7 @@ void global_static_consts() {
   (void)global_static_const_nested_array;
   (void)global_static_const_nested_struct;
 
+  (void)global_static_const_negative_int;
   (void)global_static_const_int_arithmetic;
   (void)global_static_const_mixed_arithmetic;
   (void)global_static_const_parens;
@@ -260,6 +265,7 @@ const char global_const_nested_str[] = NESTED_STR;
 const int global_const_nested_array[] = NESTED_ARRAY;
 const struct S global_const_nested_struct = NESTED_STRUCT;
 
+const int global_const_negative_int = NEGATIVE_INT;
 const int global_const_int_arithmetic = INT_ARITHMETIC;
 const float global_const_mixed_arithmetic = MIXED_ARITHMETIC;
 const int global_const_parens = PARENS;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
@@ -86,6 +86,7 @@ pub unsafe extern "C" fn local_muts() {
         3 as ::core::ffi::c_int,
     ];
     let mut nested_struct: S = NESTED_STRUCT;
+    let mut negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
     let mut int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mut mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
         + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
@@ -158,6 +159,7 @@ pub unsafe extern "C" fn local_consts() {
         3 as ::core::ffi::c_int,
     ];
     let nested_struct: S = NESTED_STRUCT;
+    let negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
     let int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
         + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
@@ -230,6 +232,7 @@ static mut global_static_const_nested_array: [::core::ffi::c_int; 3] = [
     3 as ::core::ffi::c_int,
 ];
 static mut global_static_const_nested_struct: S = NESTED_STRUCT;
+static mut global_static_const_negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
 static mut global_static_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
 static mut global_static_const_mixed_arithmetic: ::core::ffi::c_float =
@@ -299,6 +302,8 @@ pub static mut global_const_nested_array: [::core::ffi::c_int; 3] = [
 ];
 #[no_mangle]
 pub static mut global_const_nested_struct: S = NESTED_STRUCT;
+#[no_mangle]
+pub static mut global_const_negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
 #[no_mangle]
 pub static mut global_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn local_muts() {
         3 as ::core::ffi::c_int,
     ];
     let mut nested_struct: S = NESTED_STRUCT;
-    let mut negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
+    let mut negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let mut int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mut mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
         + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn local_consts() {
         3 as ::core::ffi::c_int,
     ];
     let nested_struct: S = NESTED_STRUCT;
-    let negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
+    let negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
         + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
@@ -232,7 +232,7 @@ static mut global_static_const_nested_array: [::core::ffi::c_int; 3] = [
     3 as ::core::ffi::c_int,
 ];
 static mut global_static_const_nested_struct: S = NESTED_STRUCT;
-static mut global_static_const_negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
+static mut global_static_const_negative_int: ::core::ffi::c_int = -LITERAL_INT;
 static mut global_static_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
 static mut global_static_const_mixed_arithmetic: ::core::ffi::c_float =
@@ -303,7 +303,7 @@ pub static mut global_const_nested_array: [::core::ffi::c_int; 3] = [
 #[no_mangle]
 pub static mut global_const_nested_struct: S = NESTED_STRUCT;
 #[no_mangle]
-pub static mut global_const_negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
+pub static mut global_const_negative_int: ::core::ffi::c_int = -LITERAL_INT;
 #[no_mangle]
 pub static mut global_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn local_muts() {
         3 as ::core::ffi::c_int,
     ];
     let mut nested_struct: S = NESTED_STRUCT;
-    let mut negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
+    let mut negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let mut int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mut mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
         + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn local_consts() {
         3 as ::core::ffi::c_int,
     ];
     let nested_struct: S = NESTED_STRUCT;
-    let negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
+    let negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
         + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
@@ -232,7 +232,7 @@ static mut global_static_const_nested_array: [::core::ffi::c_int; 3] = [
     3 as ::core::ffi::c_int,
 ];
 static mut global_static_const_nested_struct: S = NESTED_STRUCT;
-static mut global_static_const_negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
+static mut global_static_const_negative_int: ::core::ffi::c_int = -LITERAL_INT;
 static mut global_static_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
 static mut global_static_const_mixed_arithmetic: ::core::ffi::c_float =
@@ -303,7 +303,7 @@ pub static mut global_const_nested_array: [::core::ffi::c_int; 3] = [
 #[unsafe(no_mangle)]
 pub static mut global_const_nested_struct: S = NESTED_STRUCT;
 #[unsafe(no_mangle)]
-pub static mut global_const_negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
+pub static mut global_const_negative_int: ::core::ffi::c_int = -LITERAL_INT;
 #[unsafe(no_mangle)]
 pub static mut global_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
@@ -86,6 +86,7 @@ pub unsafe extern "C" fn local_muts() {
         3 as ::core::ffi::c_int,
     ];
     let mut nested_struct: S = NESTED_STRUCT;
+    let mut negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
     let mut int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mut mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
         + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
@@ -158,6 +159,7 @@ pub unsafe extern "C" fn local_consts() {
         3 as ::core::ffi::c_int,
     ];
     let nested_struct: S = NESTED_STRUCT;
+    let negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
     let int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
     let mixed_arithmetic: ::core::ffi::c_float = (LITERAL_INT as ::core::ffi::c_double
         + NESTED_FLOAT * LITERAL_CHAR as ::core::ffi::c_double
@@ -230,6 +232,7 @@ static mut global_static_const_nested_array: [::core::ffi::c_int; 3] = [
     3 as ::core::ffi::c_int,
 ];
 static mut global_static_const_nested_struct: S = NESTED_STRUCT;
+static mut global_static_const_negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
 static mut global_static_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
 static mut global_static_const_mixed_arithmetic: ::core::ffi::c_float =
@@ -299,6 +302,8 @@ pub static mut global_const_nested_array: [::core::ffi::c_int; 3] = [
 ];
 #[unsafe(no_mangle)]
 pub static mut global_const_nested_struct: S = NESTED_STRUCT;
+#[unsafe(no_mangle)]
+pub static mut global_const_negative_int: ::core::ffi::c_int = -0xffff as ::core::ffi::c_int;
 #[unsafe(no_mangle)]
 pub static mut global_const_int_arithmetic: ::core::ffi::c_int =
     NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;


### PR DESCRIPTION
A small addition to #1686 so that the swapping does not happen if the literal occurs inside a macro. Because otherwise that bypasses macro expansion, which is not desirable.