### PR TITLE
transpile: Return `CastKind::NoOp` if types are the same

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1861,6 +1861,10 @@ pub enum CastKind {
 
 impl CastKind {
     pub fn from_types(source_ty_kind: &CTypeKind, target_ty_kind: &CTypeKind) -> Option<Self> {
+        if source_ty_kind == target_ty_kind {
+            return Some(CastKind::NoOp);
+        }
+
         Some(match (source_ty_kind, target_ty_kind) {
             (CTypeKind::VariableArray(..), CTypeKind::Pointer(..))
             | (CTypeKind::ConstantArray(..), CTypeKind::Pointer(..))


### PR DESCRIPTION
There were errors showing up when the two types were the same. This now returns a valid `CastKind` in that case.