### PR TITLE
transpile: Use `null_mut` in statics/const contexts too

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4257,7 +4257,7 @@ impl<'c> Translation<'c> {
 
             CastKind::NullToPointer => {
                 assert!(val.stmts().is_empty());
-                Ok(WithStmts::new_val(self.null_ptr(ctx, target_cty.ctype)?))
+                Ok(WithStmts::new_val(self.null_ptr(target_cty.ctype)?))
             }
 
             CastKind::ToUnion => self.convert_cast_to_union(val, opt_field_id),
@@ -4369,7 +4369,7 @@ impl<'c> Translation<'c> {
                 )),
             }
         } else if let &CTypeKind::Pointer(_) = resolved_ty {
-            self.null_ptr(ctx, resolved_ty_id).map(WithStmts::new_val)
+            self.null_ptr(resolved_ty_id).map(WithStmts::new_val)
         } else if let &CTypeKind::ConstantArray(elt, sz) = resolved_ty {
             let sz = mk().lit_expr(mk().int_unsuffixed_lit(sz as u128));
             Ok(self

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -392,7 +392,7 @@ impl<'c> Translation<'c> {
 
     /// Construct an expression for a NULL at any type, including forward declarations,
     /// function pointers, and normal pointers.
-    pub fn null_ptr(&self, ctx: ExprContext, type_id: CTypeId) -> TranslationResult<Box<Expr>> {
+    pub fn null_ptr(&self, type_id: CTypeId) -> TranslationResult<Box<Expr>> {
         if self.ast_context.is_function_pointer(type_id) {
             return Ok(mk().path_expr(vec!["None"]));
         }
@@ -402,18 +402,14 @@ impl<'c> Translation<'c> {
             .get_pointee_qual_type(type_id)
             .ok_or_else(|| TranslationError::generic("null_ptr requires a pointer"))?;
 
-        let func = if pointer_qty.qualifiers.is_const
-            // mutable references/pointers are not allowed in const context
-            // TODO: Rust 1.83: Allowed, so this can be removed.
-            || ctx.is_const
-        {
+        let func = if pointer_qty.qualifiers.is_const {
             "null"
         } else {
             "null_mut"
         };
         let pointee_ty = self.convert_pointee_type(pointer_qty.ctype)?;
         let type_args = mk().angle_bracketed_args(vec![pointee_ty.clone()]);
-        let mut val = mk().call_expr(
+        let val = mk().call_expr(
             mk().abs_path_expr(vec![
                 mk().path_segment("core"),
                 mk().path_segment("ptr"),
@@ -421,11 +417,6 @@ impl<'c> Translation<'c> {
             ]),
             vec![],
         );
-
-        // TODO: Rust 1.83: Remove.
-        if ctx.is_const && !pointer_qty.qualifiers.is_const {
-            val = mk().cast_expr(val, mk().mutbl().ptr_ty(pointee_ty));
-        }
 
         Ok(val)
     }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2021.snap
@@ -23,7 +23,7 @@ pub struct Foo_s {
 pub type Foo_t = Foo_s;
 #[no_mangle]
 pub static mut scope: *mut Scope = &Scope {
-    next: ::core::ptr::null::<Scope>() as *mut Scope,
+    next: ::core::ptr::null_mut::<Scope>(),
 } as *const Scope as *mut Scope;
 #[no_mangle]
 pub unsafe extern "C" fn foo() {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@empty_init.c.2024.snap
@@ -24,7 +24,7 @@ pub struct Foo_s {
 pub type Foo_t = Foo_s;
 #[unsafe(no_mangle)]
 pub static mut scope: *mut Scope = &Scope {
-    next: ::core::ptr::null::<Scope>() as *mut Scope,
+    next: ::core::ptr::null_mut::<Scope>(),
 } as *const Scope as *mut Scope;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn foo() {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
@@ -359,7 +359,7 @@ pub unsafe extern "C" fn reference_define() -> ::core::ffi::c_int {
 }
 #[no_mangle]
 pub static mut fns: fn_ptrs = fn_ptrs {
-    v: ::core::ptr::null::<::core::ffi::c_void>() as *mut ::core::ffi::c_void,
+    v: ::core::ptr::null_mut::<::core::ffi::c_void>(),
     fn1: None,
     fn2: None,
 };

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
@@ -359,7 +359,7 @@ pub unsafe extern "C" fn reference_define() -> ::core::ffi::c_int {
 }
 #[unsafe(no_mangle)]
 pub static mut fns: fn_ptrs = fn_ptrs {
-    v: ::core::ptr::null::<::core::ffi::c_void>() as *mut ::core::ffi::c_void,
+    v: ::core::ptr::null_mut::<::core::ffi::c_void>(),
     fn1: None,
     fn2: None,
 };

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2021.snap
@@ -19,7 +19,7 @@ pub struct S {
 }
 #[no_mangle]
 pub static mut volatile_global_struct: S = S {
-    p: ::core::ptr::null::<::core::ffi::c_int>() as *mut ::core::ffi::c_int,
+    p: ::core::ptr::null_mut::<::core::ffi::c_int>(),
 };
 #[no_mangle]
 pub unsafe extern "C" fn test_volatile() {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@volatile.c.2024.snap
@@ -19,7 +19,7 @@ pub struct S {
 }
 #[unsafe(no_mangle)]
 pub static mut volatile_global_struct: S = S {
-    p: ::core::ptr::null::<::core::ffi::c_int>() as *mut ::core::ffi::c_int,
+    p: ::core::ptr::null_mut::<::core::ffi::c_int>(),
 };
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn test_volatile() {


### PR DESCRIPTION
Apparently this just compiles, so the code that made an exception for this case was not (no longer?) needed.