### PR TITLE
transpile: Refactor `WithStmts` and add new helper methods

### DIFF
--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -163,14 +163,14 @@ impl<'c> Translation<'c> {
         }
 
         match name {
-            "__atomic_load" | "__atomic_load_n" | "__c11_atomic_load" => ptr.and_then(|ptr| {
+            "__atomic_load" | "__atomic_load_n" | "__c11_atomic_load" => ptr.and_then_try(|ptr| {
                 let order = static_order(order);
 
                 let atomic_load = self.atomic_intrinsic_expr("load", &[order]);
                 let call = mk().call_expr(atomic_load, vec![ptr]);
                 if name == "__atomic_load" {
                     let ret = val1.expect("__atomic_load should have a ret argument");
-                    ret.and_then(|ret| {
+                    ret.and_then_try(|ret| {
                         let assignment = mk().assign_expr(
                             mk().unary_expr(UnOp::Deref(Default::default()), ret),
                             call,
@@ -193,8 +193,8 @@ impl<'c> Translation<'c> {
             "__atomic_store" | "__atomic_store_n" | "__c11_atomic_store" => {
                 let order = static_order(order);
                 let val = val1.expect("__atomic_store must have a val argument");
-                ptr.and_then(|ptr| {
-                    val.and_then(|val| {
+                ptr.and_then_try(|ptr| {
+                    val.and_then_try(|val| {
                         let atomic_store = self.atomic_intrinsic_expr("store", &[order]);
                         let val = if name == "__atomic_store" {
                             mk().unary_expr(UnOp::Deref(Default::default()), val)
@@ -214,8 +214,8 @@ impl<'c> Translation<'c> {
             // NOTE: there is no corresponding __atomic_init builtin in clang
             "__c11_atomic_init" => {
                 let val = val1.expect("__atomic_init must have a val argument");
-                ptr.and_then(|ptr| {
-                    val.and_then(|val| {
+                ptr.and_then_try(|ptr| {
+                    val.and_then_try(|val| {
                         let assignment = mk().assign_expr(
                             mk().unary_expr(UnOp::Deref(Default::default()), ptr),
                             val,
@@ -232,8 +232,8 @@ impl<'c> Translation<'c> {
             "__atomic_exchange" | "__atomic_exchange_n" | "__c11_atomic_exchange" => {
                 let order = static_order(order);
                 let val = val1.expect("__atomic_store must have a val argument");
-                ptr.and_then(|ptr| {
-                    val.and_then(|val| {
+                ptr.and_then_try(|ptr| {
+                    val.and_then_try(|val| {
                         let fn_path = self.atomic_intrinsic_expr("xchg", &[order]);
                         let val = if name == "__atomic_exchange" {
                             mk().unary_expr(UnOp::Deref(Default::default()), val)
@@ -247,7 +247,7 @@ impl<'c> Translation<'c> {
                                 .map(|x| self.convert_expr(ctx.used(), x, None))
                                 .transpose()?
                                 .expect("__atomic_exchange must have a ret pointer argument")
-                                .and_then(|ret| {
+                                .and_then_try(|ret| {
                                     let assignment = mk().assign_expr(
                                         mk().unary_expr(UnOp::Deref(Default::default()), ret),
                                         call,
@@ -287,9 +287,9 @@ impl<'c> Translation<'c> {
                 let order_fail = static_order(order_fail);
                 let weak = static_order(weak);
 
-                ptr.and_then(|ptr| {
-                    expected.and_then(|expected| {
-                        desired.and_then(|desired| {
+                ptr.and_then_try(|ptr| {
+                    expected.and_then_try(|expected| {
+                        desired.and_then_try(|desired| {
                             use Ordering::*;
                             let (order, order_fail) = match (order, order_fail) {
                                 (_, Release | AcqRel) => None,
@@ -354,8 +354,8 @@ impl<'c> Translation<'c> {
                         .kind
                         .get_qual_type()
                         .ok_or_else(|| format_err!("bad val1 type"))?;
-                    ptr.and_then(|ptr| {
-                        val.and_then(|val| {
+                    ptr.and_then_try(|ptr| {
+                        val.and_then_try(|val| {
                             self.convert_atomic_op(ctx, atomic_op, order, ptr, val, val_type_id)
                         })
                     })

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -193,79 +193,71 @@ impl<'c> Translation<'c> {
             "__atomic_store" | "__atomic_store_n" | "__c11_atomic_store" => {
                 let order = static_order(order);
                 let val = val1.expect("__atomic_store must have a val argument");
-                ptr.and_then_try(|ptr| {
-                    val.and_then_try(|val| {
-                        let atomic_store = self.atomic_intrinsic_expr("store", &[order]);
-                        let val = if name == "__atomic_store" {
-                            mk().unary_expr(UnOp::Deref(Default::default()), val)
-                        } else {
-                            val
-                        };
-                        let call = mk().call_expr(atomic_store, vec![ptr, val]);
-                        self.convert_side_effects_expr(
-                            ctx,
-                            WithStmts::new_val(call),
-                            "Builtin is not supposed to be used",
-                        )
-                    })
+                ptr.zip(val).and_then_try(|(ptr, val)| {
+                    let atomic_store = self.atomic_intrinsic_expr("store", &[order]);
+                    let val = if name == "__atomic_store" {
+                        mk().unary_expr(UnOp::Deref(Default::default()), val)
+                    } else {
+                        val
+                    };
+                    let call = mk().call_expr(atomic_store, vec![ptr, val]);
+                    self.convert_side_effects_expr(
+                        ctx,
+                        WithStmts::new_val(call),
+                        "Builtin is not supposed to be used",
+                    )
                 })
             }
 
             // NOTE: there is no corresponding __atomic_init builtin in clang
             "__c11_atomic_init" => {
                 let val = val1.expect("__atomic_init must have a val argument");
-                ptr.and_then_try(|ptr| {
-                    val.and_then_try(|val| {
-                        let assignment = mk().assign_expr(
-                            mk().unary_expr(UnOp::Deref(Default::default()), ptr),
-                            val,
-                        );
-                        self.convert_side_effects_expr(
-                            ctx,
-                            WithStmts::new_val(assignment),
-                            "Builtin is not supposed to be used",
-                        )
-                    })
+                ptr.zip(val).and_then_try(|(ptr, val)| {
+                    let assignment = mk()
+                        .assign_expr(mk().unary_expr(UnOp::Deref(Default::default()), ptr), val);
+                    self.convert_side_effects_expr(
+                        ctx,
+                        WithStmts::new_val(assignment),
+                        "Builtin is not supposed to be used",
+                    )
                 })
             }
 
             "__atomic_exchange" | "__atomic_exchange_n" | "__c11_atomic_exchange" => {
                 let order = static_order(order);
                 let val = val1.expect("__atomic_store must have a val argument");
-                ptr.and_then_try(|ptr| {
-                    val.and_then_try(|val| {
-                        let fn_path = self.atomic_intrinsic_expr("xchg", &[order]);
-                        let val = if name == "__atomic_exchange" {
-                            mk().unary_expr(UnOp::Deref(Default::default()), val)
-                        } else {
-                            val
-                        };
-                        let call = mk().call_expr(fn_path, vec![ptr, val]);
-                        if name == "__atomic_exchange" {
-                            // LLVM stores the ret pointer in the order_fail slot
-                            order_fail_id
-                                .map(|x| self.convert_expr(ctx.used(), x, None))
-                                .transpose()?
-                                .expect("__atomic_exchange must have a ret pointer argument")
-                                .and_then_try(|ret| {
-                                    let assignment = mk().assign_expr(
-                                        mk().unary_expr(UnOp::Deref(Default::default()), ret),
-                                        call,
-                                    );
-                                    self.convert_side_effects_expr(
-                                        ctx,
-                                        WithStmts::new_val(assignment),
-                                        "Builtin is not supposed to be used",
-                                    )
-                                })
-                        } else {
-                            self.convert_side_effects_expr(
-                                ctx,
-                                WithStmts::new_val(call),
-                                "Builtin is not supposed to be used",
-                            )
-                        }
-                    })
+                ptr.zip(val).and_then_try(|(ptr, val)| {
+                    let fn_path = self.atomic_intrinsic_expr("xchg", &[order]);
+                    let val = if name == "__atomic_exchange" {
+                        mk().unary_expr(UnOp::Deref(Default::default()), val)
+                    } else {
+                        val
+                    };
+                    let call = mk().call_expr(fn_path, vec![ptr, val]);
+                    if name == "__atomic_exchange" {
+                        // LLVM stores the ret pointer in the order_fail slot
+                        order_fail_id
+                            .map(|x| self.convert_expr(ctx.used(), x, None))
+                            .transpose()?
+                            .expect("__atomic_exchange must have a ret pointer argument")
+                            .and_then_try(|ret| {
+                                let assignment = mk().assign_expr(
+                                    mk().unary_expr(UnOp::Deref(Default::default()), ret),
+                                    call,
+                                );
+                                self.convert_side_effects_expr(
+                                    ctx,
+                                    WithStmts::new_val(assignment),
+                                    "Builtin is not supposed to be used",
+                                )
+                            })
+                    } else {
+                        self.convert_side_effects_expr(
+                            ctx,
+                            WithStmts::new_val(call),
+                            "Builtin is not supposed to be used",
+                        )
+                    }
                 })
             }
 
@@ -287,62 +279,57 @@ impl<'c> Translation<'c> {
                 let order_fail = static_order(order_fail);
                 let weak = static_order(weak);
 
-                ptr.and_then_try(|ptr| {
-                    expected.and_then_try(|expected| {
-                        desired.and_then_try(|desired| {
-                            use Ordering::*;
-                            let (order, order_fail) = match (order, order_fail) {
-                                (_, Release | AcqRel) => None,
-                                (SeqCst, SeqCst | Acquire | Relaxed)
-                                | (AcqRel, Acquire | Relaxed)
-                                | (Release, Relaxed)
-                                | (Acquire | Relaxed, Acquire | Relaxed) => {
-                                    Some((order, order_fail))
-                                }
-                                (SeqCst | AcqRel | Release | Acquire | Relaxed, _) => None,
+                ptr.zip(expected)
+                    .zip(desired)
+                    .and_then_try(|((ptr, expected), desired)| {
+                        use Ordering::*;
+                        let (order, order_fail) = match (order, order_fail) {
+                            (_, Release | AcqRel) => None,
+                            (SeqCst, SeqCst | Acquire | Relaxed)
+                            | (AcqRel, Acquire | Relaxed)
+                            | (Release, Relaxed)
+                            | (Acquire | Relaxed, Acquire | Relaxed) => Some((order, order_fail)),
+                            (SeqCst | AcqRel | Release | Acquire | Relaxed, _) => None,
 
-                                (_, _) => unreachable!("Did we not handle a case above??"),
-                            }
-                            .ok_or_else(|| {
-                                format_translation_err!(
-                                    self.ast_context
-                                        .display_loc(&self.ast_context[order_fail_id.unwrap()].loc),
-                                    "Invalid failure memory ordering",
-                                )
-                            })?;
-
-                            let expected =
-                                mk().unary_expr(UnOp::Deref(Default::default()), expected);
-                            let desired = match name {
-                                "__atomic_compare_exchange_n"
-                                | "__c11_atomic_compare_exchange_strong"
-                                | "__c11_atomic_compare_exchange_weak" => desired,
-                                _ => mk().unary_expr(UnOp::Deref(Default::default()), desired),
-                            };
-
-                            let atomic_cxchg =
-                                self.atomic_intrinsic_cxchg_expr(weak, order, order_fail);
-                            let call =
-                                mk().call_expr(atomic_cxchg, vec![ptr, expected.clone(), desired]);
-                            let res_name = self.renamer.borrow_mut().fresh();
-                            let res_let = mk().local_stmt(Box::new(mk().local(
-                                mk().ident_pat(&res_name),
-                                None,
-                                Some(call),
-                            )));
-                            let assignment = mk().semi_stmt(mk().assign_expr(
-                                expected,
-                                mk().anon_field_expr(mk().ident_expr(&res_name), 0),
-                            ));
-                            let return_value = mk().anon_field_expr(mk().ident_expr(&res_name), 1);
-                            self.convert_side_effects_expr(
-                                ctx,
-                                WithStmts::new(vec![res_let, assignment], return_value),
-                                "Builtin is not supposed to be used",
+                            (_, _) => unreachable!("Did we not handle a case above??"),
+                        }
+                        .ok_or_else(|| {
+                            format_translation_err!(
+                                self.ast_context
+                                    .display_loc(&self.ast_context[order_fail_id.unwrap()].loc),
+                                "Invalid failure memory ordering",
                             )
-                        })
+                        })?;
+
+                        let expected = mk().unary_expr(UnOp::Deref(Default::default()), expected);
+                        let desired = match name {
+                            "__atomic_compare_exchange_n"
+                            | "__c11_atomic_compare_exchange_strong"
+                            | "__c11_atomic_compare_exchange_weak" => desired,
+                            _ => mk().unary_expr(UnOp::Deref(Default::default()), desired),
+                        };
+
+                        let atomic_cxchg =
+                            self.atomic_intrinsic_cxchg_expr(weak, order, order_fail);
+                        let call =
+                            mk().call_expr(atomic_cxchg, vec![ptr, expected.clone(), desired]);
+                        let res_name = self.renamer.borrow_mut().fresh();
+                        let res_let = mk().local_stmt(Box::new(mk().local(
+                            mk().ident_pat(&res_name),
+                            None,
+                            Some(call),
+                        )));
+                        let assignment = mk().semi_stmt(mk().assign_expr(
+                            expected,
+                            mk().anon_field_expr(mk().ident_expr(&res_name), 0),
+                        ));
+                        let return_value = mk().anon_field_expr(mk().ident_expr(&res_name), 1);
+                        self.convert_side_effects_expr(
+                            ctx,
+                            WithStmts::new(vec![res_let, assignment], return_value),
+                            "Builtin is not supposed to be used",
+                        )
                     })
-                })
             }
 
             _ => {
@@ -354,10 +341,8 @@ impl<'c> Translation<'c> {
                         .kind
                         .get_qual_type()
                         .ok_or_else(|| format_err!("bad val1 type"))?;
-                    ptr.and_then_try(|ptr| {
-                        val.and_then_try(|val| {
-                            self.convert_atomic_op(ctx, atomic_op, order, ptr, val, val_type_id)
-                        })
+                    ptr.zip(val).and_then_try(|(ptr, val)| {
+                        self.convert_atomic_op(ctx, atomic_op, order, ptr, val, val_type_id)
                     })
                 } else {
                     unimplemented!("atomic not implemented: {}", name)

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -216,9 +216,9 @@ impl<'c> Translation<'c> {
                 let n_stmts = self.convert_expr(ctx.used(), args[1], None)?;
                 let write_bytes = mk().abs_path_expr(vec!["core", "ptr", "write_bytes"]);
                 let zero = mk().lit_expr(mk().int_lit(0, "u8"));
-                ptr_stmts.and_then_try(|ptr| {
-                    Ok(n_stmts.map(|n| mk().call_expr(write_bytes, vec![ptr, zero, n])))
-                })
+                Ok(ptr_stmts.and_then(|ptr| {
+                    n_stmts.map(|n| mk().call_expr(write_bytes, vec![ptr, zero, n]))
+                }))
             }
 
             // If the target does not support data prefetch, the address expression is evaluated if
@@ -304,8 +304,8 @@ impl<'c> Translation<'c> {
                 // `(if (type & 2) == 0 { -1isize } else { 0isize }) as libc::size_t`
                 let ptr_arg = self.convert_expr(ctx.unused(), args[0], None)?;
                 let type_arg = self.convert_expr(ctx.used(), args[1], None)?;
-                ptr_arg.and_then_try(|_| {
-                    Ok(type_arg.map(|type_arg| {
+                Ok(ptr_arg.and_then(|_| {
+                    type_arg.map(|type_arg| {
                         let type_and_2 = mk().binary_expr(
                             BinOp::BitAnd(Default::default()),
                             type_arg,
@@ -325,8 +325,8 @@ impl<'c> Translation<'c> {
                         self.use_crate(ExternCrate::Libc);
                         let size_t = mk().abs_path_ty(vec!["libc", "size_t"]);
                         mk().cast_expr(if_expr, size_t)
-                    }))
-                })
+                    })
+                }))
             }
 
             "__builtin_va_start" => {
@@ -381,7 +381,7 @@ impl<'c> Translation<'c> {
 
             "__builtin_alloca" => {
                 let count = self.convert_expr(ctx.used(), args[0], None)?;
-                count.and_then_try(|count| {
+                Ok(count.and_then(|count| {
                     // Get `alloca` allocation storage.
                     let mut fn_ctx = self.function_context.borrow_mut();
                     let alloca_allocations_name =
@@ -410,8 +410,8 @@ impl<'c> Translation<'c> {
                     let pointee_ty = mk().abs_path_ty(vec!["core", "ffi", "c_void"]);
                     let expr = mk().cast_expr(expr, mk().mutbl().ptr_ty(pointee_ty));
 
-                    Ok(WithStmts::new(vec![push_stmt], expr))
-                })
+                    WithStmts::new(vec![push_stmt], expr)
+                }))
             }
 
             "__builtin_ia32_pause" => {

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -33,16 +33,14 @@ impl<'c> Translation<'c> {
         // Emit `arg0.{method_name}(arg1)`
         let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
         let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
-        arg0.and_then_try(|arg0| {
-            arg1.and_then_try(|arg1| {
-                let arg1 = mk().cast_expr(arg1, mk().path_ty(vec!["u32"]));
-                let method_call_expr = mk().method_call_expr(arg0, rotate_method_name, vec![arg1]);
-                self.convert_side_effects_expr(
-                    ctx,
-                    WithStmts::new_val(method_call_expr),
-                    "Builtin is not supposed to be used",
-                )
-            })
+        arg0.zip(arg1).and_then_try(|(arg0, arg1)| {
+            let arg1 = mk().cast_expr(arg1, mk().path_ty(vec!["u32"]));
+            let method_call_expr = mk().method_call_expr(arg0, rotate_method_name, vec![arg1]);
+            self.convert_side_effects_expr(
+                ctx,
+                WithStmts::new_val(method_call_expr),
+                "Builtin is not supposed to be used",
+            )
         })
     }
 
@@ -462,23 +460,21 @@ impl<'c> Translation<'c> {
                 let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
                 let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
                 let arg2 = self.convert_expr(ctx.used(), args[2], None)?;
-                arg0.and_then_try(|arg0| {
-                    arg1.and_then_try(|arg1| {
-                        arg2.and_then_try(|arg2| {
-                            let returns_val = builtin_name.starts_with("__sync_val");
-                            self.convert_atomic_cxchg(
-                                ctx,
-                                false,
-                                SeqCst,
-                                SeqCst,
-                                arg0,
-                                arg1,
-                                arg2,
-                                returns_val,
-                            )
-                        })
+                arg0.zip(arg1)
+                    .zip(arg2)
+                    .and_then_try(|((arg0, arg1), arg2)| {
+                        let returns_val = builtin_name.starts_with("__sync_val");
+                        self.convert_atomic_cxchg(
+                            ctx,
+                            false,
+                            SeqCst,
+                            SeqCst,
+                            arg0,
+                            arg1,
+                            arg2,
+                            returns_val,
+                        )
                     })
-                })
             }
 
             "__sync_synchronize" => {
@@ -500,15 +496,13 @@ impl<'c> Translation<'c> {
                 let atomic_func = self.atomic_intrinsic_expr("xchg", &[Acquire]);
                 let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
                 let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
-                arg0.and_then_try(|arg0| {
-                    arg1.and_then_try(|arg1| {
-                        let call_expr = mk().call_expr(atomic_func, vec![arg0, arg1]);
-                        self.convert_side_effects_expr(
-                            ctx,
-                            WithStmts::new_val(call_expr),
-                            "Builtin is not supposed to be used",
-                        )
-                    })
+                arg0.zip(arg1).and_then_try(|(arg0, arg1)| {
+                    let call_expr = mk().call_expr(atomic_func, vec![arg0, arg1]);
+                    self.convert_side_effects_expr(
+                        ctx,
+                        WithStmts::new_val(call_expr),
+                        "Builtin is not supposed to be used",
+                    )
                 })
             }
 
@@ -562,10 +556,8 @@ impl<'c> Translation<'c> {
                         .kind
                         .get_qual_type()
                         .ok_or_else(|| format_err!("bad arg1 type"))?;
-                    arg0.and_then_try(|arg0| {
-                        arg1.and_then_try(|arg1| {
-                            self.convert_atomic_op(ctx, atomic_op, SeqCst, arg0, arg1, arg1_type_id)
-                        })
+                    arg0.zip(arg1).and_then_try(|(arg0, arg1)| {
+                        self.convert_atomic_op(ctx, atomic_op, SeqCst, arg0, arg1, arg1_type_id)
                     })
                 } else if let Some(fn_name) = simd_fn_from_builtin_fn(builtin_name) {
                     self.convert_simd_builtin(ctx, fn_name, args)

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -33,8 +33,8 @@ impl<'c> Translation<'c> {
         // Emit `arg0.{method_name}(arg1)`
         let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
         let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
-        arg0.and_then(|arg0| {
-            arg1.and_then(|arg1| {
+        arg0.and_then_try(|arg0| {
+            arg1.and_then_try(|arg1| {
                 let arg1 = mk().cast_expr(arg1, mk().path_ty(vec!["u32"]));
                 let method_call_expr = mk().method_call_expr(arg0, rotate_method_name, vec![arg1]);
                 self.convert_side_effects_expr(
@@ -216,7 +216,7 @@ impl<'c> Translation<'c> {
                 let n_stmts = self.convert_expr(ctx.used(), args[1], None)?;
                 let write_bytes = mk().abs_path_expr(vec!["core", "ptr", "write_bytes"]);
                 let zero = mk().lit_expr(mk().int_lit(0, "u8"));
-                ptr_stmts.and_then(|ptr| {
+                ptr_stmts.and_then_try(|ptr| {
                     Ok(n_stmts.map(|n| mk().call_expr(write_bytes, vec![ptr, zero, n])))
                 })
             }
@@ -304,7 +304,7 @@ impl<'c> Translation<'c> {
                 // `(if (type & 2) == 0 { -1isize } else { 0isize }) as libc::size_t`
                 let ptr_arg = self.convert_expr(ctx.unused(), args[0], None)?;
                 let type_arg = self.convert_expr(ctx.used(), args[1], None)?;
-                ptr_arg.and_then(|_| {
+                ptr_arg.and_then_try(|_| {
                     Ok(type_arg.map(|type_arg| {
                         let type_and_2 = mk().binary_expr(
                             BinOp::BitAnd(Default::default()),
@@ -381,7 +381,7 @@ impl<'c> Translation<'c> {
 
             "__builtin_alloca" => {
                 let count = self.convert_expr(ctx.used(), args[0], None)?;
-                count.and_then(|count| {
+                count.and_then_try(|count| {
                     // Get `alloca` allocation storage.
                     let mut fn_ctx = self.function_context.borrow_mut();
                     let alloca_allocations_name =
@@ -462,9 +462,9 @@ impl<'c> Translation<'c> {
                 let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
                 let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
                 let arg2 = self.convert_expr(ctx.used(), args[2], None)?;
-                arg0.and_then(|arg0| {
-                    arg1.and_then(|arg1| {
-                        arg2.and_then(|arg2| {
+                arg0.and_then_try(|arg0| {
+                    arg1.and_then_try(|arg1| {
+                        arg2.and_then_try(|arg2| {
                             let returns_val = builtin_name.starts_with("__sync_val");
                             self.convert_atomic_cxchg(
                                 ctx,
@@ -500,8 +500,8 @@ impl<'c> Translation<'c> {
                 let atomic_func = self.atomic_intrinsic_expr("xchg", &[Acquire]);
                 let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
                 let arg1 = self.convert_expr(ctx.used(), args[1], None)?;
-                arg0.and_then(|arg0| {
-                    arg1.and_then(|arg1| {
+                arg0.and_then_try(|arg0| {
+                    arg1.and_then_try(|arg1| {
                         let call_expr = mk().call_expr(atomic_func, vec![arg0, arg1]);
                         self.convert_side_effects_expr(
                             ctx,
@@ -520,7 +520,7 @@ impl<'c> Translation<'c> {
                 // Emit `atomic_store_release(arg0, 0)`
                 let atomic_func = self.atomic_intrinsic_expr("store", &[Release]);
                 let arg0 = self.convert_expr(ctx.used(), args[0], None)?;
-                arg0.and_then(|arg0| {
+                arg0.and_then_try(|arg0| {
                     let zero = mk().lit_expr(mk().int_lit(0, ""));
                     let call_expr = mk().call_expr(atomic_func, vec![arg0, zero]);
                     self.convert_side_effects_expr(
@@ -562,8 +562,8 @@ impl<'c> Translation<'c> {
                         .kind
                         .get_qual_type()
                         .ok_or_else(|| format_err!("bad arg1 type"))?;
-                    arg0.and_then(|arg0| {
-                        arg1.and_then(|arg1| {
+                    arg0.and_then_try(|arg0| {
+                        arg1.and_then_try(|arg1| {
                             self.convert_atomic_op(ctx, atomic_op, SeqCst, arg0, arg1, arg1_type_id)
                         })
                     })
@@ -609,7 +609,7 @@ impl<'c> Translation<'c> {
         args: &[CExprId],
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let args = self.convert_exprs(ctx.used(), args, None)?;
-        args.and_then(|args| {
+        args.and_then_try(|args| {
             let [a, b, c]: [_; 3] = args
                 .try_into()
                 .map_err(|_| "`convert_overflow_arith` must have exactly 3 arguments")?;
@@ -649,7 +649,7 @@ impl<'c> Translation<'c> {
         self.use_crate(ExternCrate::Libc);
         let mem = mk().abs_path_expr(vec!["libc", name]);
         let args = self.convert_exprs(ctx.used(), args, None)?;
-        args.and_then(|args| {
+        args.and_then_try(|args| {
             if args.len() != arg_types.len() {
                 // This should not generally happen, as the C frontend checks these first
                 Err(err_msg(format!(

--- a/c2rust-transpile/src/translator/functions.rs
+++ b/c2rust-transpile/src/translator/functions.rs
@@ -447,7 +447,7 @@ impl<'c> Translation<'c> {
             }
         };
 
-        let call = func.and_then(|func| {
+        let call = func.and_then_try(|func| {
             // We want to decay refs only when function is variadic
             ctx.decay_ref = DecayRef::from(is_variadic);
 

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -180,7 +180,7 @@ impl<'c> Translation<'c> {
         // If we are translating a static variable,
         // then the fresh variable should also be static.
         if ctx.is_static {
-            val.wrap_unsafe().and_then(|val| {
+            val.wrap_unsafe().and_then_try(|val| {
                 let item = mk().mutbl().static_item(&fresh_name, fresh_ty, val);
                 let fresh_stmt = mk().item_stmt(item);
                 let mut val = WithStmts::new(vec![fresh_stmt], mk().ident_expr(fresh_name));
@@ -196,7 +196,7 @@ impl<'c> Translation<'c> {
                 Ok(val)
             })
         } else {
-            val.and_then(|val| {
+            val.and_then_try(|val| {
                 let mutbl = if qty.qualifiers.is_const {
                     Mutability::Immutable
                 } else {
@@ -230,7 +230,7 @@ impl<'c> Translation<'c> {
                 // Convert all of the provided initializer values
 
                 let to_array_element = |id: CExprId| -> TranslationResult<_> {
-                    self.convert_expr(ctx.used(), id, None)?.result_map(|x| {
+                    self.convert_expr(ctx.used(), id, None)?.try_map(|x| {
                         // Array literals require all of their elements to be
                         // the correct type; they will not use implicit casts to
                         // change mut to const. This becomes a problem when an

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -180,7 +180,7 @@ impl<'c> Translation<'c> {
         // If we are translating a static variable,
         // then the fresh variable should also be static.
         if ctx.is_static {
-            val.wrap_unsafe().and_then_try(|val| {
+            Ok(val.wrap_unsafe().and_then(|val| {
                 let item = mk().mutbl().static_item(&fresh_name, fresh_ty, val);
                 let fresh_stmt = mk().item_stmt(item);
                 let mut val = WithStmts::new(vec![fresh_stmt], mk().ident_expr(fresh_name));
@@ -193,10 +193,10 @@ impl<'c> Translation<'c> {
                     val.set_unsafe();
                 }
 
-                Ok(val)
-            })
+                val
+            }))
         } else {
-            val.and_then_try(|val| {
+            Ok(val.and_then(|val| {
                 let mutbl = if qty.qualifiers.is_const {
                     Mutability::Immutable
                 } else {
@@ -208,11 +208,8 @@ impl<'c> Translation<'c> {
                     Some(val),
                 );
                 let fresh_stmt = mk().local_stmt(Box::new(local));
-                Ok(WithStmts::new(
-                    vec![fresh_stmt],
-                    mk().ident_expr(fresh_name),
-                ))
-            })
+                WithStmts::new(vec![fresh_stmt], mk().ident_expr(fresh_name))
+            }))
         }
     }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2299,7 +2299,7 @@ impl<'c> Translation<'c> {
                     .get_type()
                     .ok_or_else(|| format_err!("bad pointer type for condition"))?;
 
-                val.result_map(|val| self.convert_pointer_is_null(ctx, ptr_type, val, is_null))
+                val.try_map(|val| self.convert_pointer_is_null(ctx, ptr_type, val, is_null))
             };
 
         match self.ast_context[cond_id].kind {
@@ -2347,7 +2347,7 @@ impl<'c> Translation<'c> {
                 // a ptr (rhs) (even though the reverse works!). We could also be smarter here and just
                 // specify Yes for that particular case, given enough analysis.
                 let val = self.convert_expr(ctx.used().decay_ref(), cond_id, None)?;
-                val.result_map(|e| self.match_bool(ctx, target, ty_id, e))
+                val.try_map(|e| self.match_bool(ctx, target, ty_id, e))
             }
         }
     }
@@ -2829,26 +2829,26 @@ impl<'c> Translation<'c> {
                     type_id = elt;
 
                     // Convert this expression
-                    let expr = self
-                        .convert_expr(ctx.used(), expr_id, None)?
-                        .and_then(|expr| {
-                            let name = self
-                                .renamer
-                                .borrow_mut()
-                                .insert(CDeclId(expr_id.0), "vla")
-                                .unwrap(); // try using declref name?
-                                           // TODO: store the name corresponding to expr_id
+                    let expr =
+                        self.convert_expr(ctx.used(), expr_id, None)?
+                            .and_then_try(|expr| {
+                                let name = self
+                                    .renamer
+                                    .borrow_mut()
+                                    .insert(CDeclId(expr_id.0), "vla")
+                                    .unwrap(); // try using declref name?
+                                               // TODO: store the name corresponding to expr_id
 
-                            let local = mk().local(
-                                mk().ident_pat(name),
-                                None,
-                                Some(mk().cast_expr(expr, mk().path_ty(vec!["usize"]))),
-                            );
+                                let local = mk().local(
+                                    mk().ident_pat(name),
+                                    None,
+                                    Some(mk().cast_expr(expr, mk().path_ty(vec!["usize"]))),
+                                );
 
-                            let res: TranslationResult<WithStmts<()>> =
-                                Ok(WithStmts::new(vec![mk().local_stmt(Box::new(local))], ()));
-                            res
-                        })?;
+                                let res: TranslationResult<WithStmts<()>> =
+                                    Ok(WithStmts::new(vec![mk().local_stmt(Box::new(local))], ()));
+                                res
+                            })?;
 
                     stmts.extend(expr.into_stmts());
                 }
@@ -2871,7 +2871,7 @@ impl<'c> Translation<'c> {
             let len = len.expect("Sizeof a VLA type with count expression omitted");
 
             let elts = self.compute_size_of_type(ctx, elts, override_ty)?;
-            return elts.and_then(|lhs| {
+            return elts.and_then_try(|lhs| {
                 let len = self.convert_expr(ctx.used().not_static(), len, override_ty)?;
                 Ok(len.map(|len| {
                     let rhs = cast_int(len, "usize", true);
@@ -3381,7 +3381,7 @@ impl<'c> Translation<'c> {
                     let then = mk().block(lhs.into_stmts());
                     let else_ = mk().block_expr(mk().block(rhs.into_stmts()));
 
-                    let mut res = cond.and_then(|c| -> TranslationResult<_> {
+                    let mut res = cond.and_then_try(|c| -> TranslationResult<_> {
                         Ok(WithStmts::new(
                             vec![mk().semi_stmt(mk().ifte_expr(c, then, Some(else_)))],
                             self.panic_or_err("Conditional expression is not supposed to be used"),
@@ -3411,7 +3411,7 @@ impl<'c> Translation<'c> {
                     let rhs = self.convert_expr(ctx, rhs, None)?;
                     lhs.merge_unsafe(rhs.is_unsafe());
 
-                    lhs.and_then(|val| {
+                    lhs.and_then_try(|val| {
                         Ok(WithStmts::new(
                             vec![mk().semi_stmt(mk().ifte_expr(
                                 val,
@@ -3424,7 +3424,7 @@ impl<'c> Translation<'c> {
                         ))
                     })
                 } else {
-                    self.name_reference_write_read(ctx, lhs)?.result_map(
+                    self.name_reference_write_read(ctx, lhs)?.try_map(
                         |NamedReference {
                              rvalue: lhs_val, ..
                          }| {
@@ -3542,7 +3542,7 @@ impl<'c> Translation<'c> {
         if ctx.is_unused() {
             // Recall that if `used` is false, the `stmts` field of the output must contain
             // all side-effects (and a function call can always have side-effects)
-            expr.and_then(|expr| {
+            expr.and_then_try(|expr| {
                 Ok(WithStmts::new(
                     vec![mk().semi_stmt(expr)],
                     self.panic_or_err(panic_msg),
@@ -3728,7 +3728,7 @@ impl<'c> Translation<'c> {
                     self.f128_cast_to(val, target_ty_kind)
                 } else if let &CTypeKind::Enum(enum_decl_id) = target_ty_kind {
                     // Casts targeting `enum` types...
-                    val.result_map(|val| {
+                    val.try_map(|val| {
                         self.convert_cast_to_enum(ctx, target_cty.ctype, enum_decl_id, expr, val)
                     })
                 } else if target_ty_kind.is_floating_type() && source_ty_kind.is_bool() {
@@ -3736,7 +3736,7 @@ impl<'c> Translation<'c> {
                         mk().cast_expr(mk().cast_expr(val, mk().path_ty(vec!["u8"])), target_ty)
                     }))
                 } else if let &CTypeKind::Enum(..) = source_ty_kind {
-                    val.result_map(|val| self.convert_cast_from_enum(target_cty.ctype, val))
+                    val.try_map(|val| self.convert_cast_from_enum(target_cty.ctype, val))
                 } else {
                     Ok(val.map(|val| mk().cast_expr(val, target_ty)))
                 }
@@ -3746,7 +3746,7 @@ impl<'c> Translation<'c> {
                 let mut val = if source_cty.qualifiers.is_volatile {
                     // If the expression is volatile and used as something that isn't an LValue,
                     // this constitutes a volatile read.
-                    val.result_map(|val| self.volatile_read(val, target_cty))?
+                    val.try_map(|val| self.volatile_read(val, target_cty))?
                 } else {
                     val
                 };
@@ -3780,7 +3780,7 @@ impl<'c> Translation<'c> {
             CastKind::IntegralToBoolean
             | CastKind::FloatingToBoolean
             | CastKind::PointerToBoolean => {
-                val.result_map(|e| self.match_bool(ctx, true, source_cty.ctype, e))
+                val.try_map(|e| self.match_bool(ctx, true, source_cty.ctype, e))
             }
 
             CastKind::FloatingRealToComplex

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2829,26 +2829,24 @@ impl<'c> Translation<'c> {
                     type_id = elt;
 
                     // Convert this expression
-                    let expr =
-                        self.convert_expr(ctx.used(), expr_id, None)?
-                            .and_then_try(|expr| {
-                                let name = self
-                                    .renamer
-                                    .borrow_mut()
-                                    .insert(CDeclId(expr_id.0), "vla")
-                                    .unwrap(); // try using declref name?
-                                               // TODO: store the name corresponding to expr_id
+                    let expr = self
+                        .convert_expr(ctx.used(), expr_id, None)?
+                        .and_then(|expr| {
+                            let name = self
+                                .renamer
+                                .borrow_mut()
+                                .insert(CDeclId(expr_id.0), "vla")
+                                .unwrap(); // try using declref name?
+                                           // TODO: store the name corresponding to expr_id
 
-                                let local = mk().local(
-                                    mk().ident_pat(name),
-                                    None,
-                                    Some(mk().cast_expr(expr, mk().path_ty(vec!["usize"]))),
-                                );
+                            let local = mk().local(
+                                mk().ident_pat(name),
+                                None,
+                                Some(mk().cast_expr(expr, mk().path_ty(vec!["usize"]))),
+                            );
 
-                                let res: TranslationResult<WithStmts<()>> =
-                                    Ok(WithStmts::new(vec![mk().local_stmt(Box::new(local))], ()));
-                                res
-                            })?;
+                            WithStmts::new(vec![mk().local_stmt(Box::new(local))], ())
+                        });
 
                     stmts.extend(expr.into_stmts());
                 }
@@ -3381,12 +3379,12 @@ impl<'c> Translation<'c> {
                     let then = mk().block(lhs.into_stmts());
                     let else_ = mk().block_expr(mk().block(rhs.into_stmts()));
 
-                    let mut res = cond.and_then_try(|c| -> TranslationResult<_> {
-                        Ok(WithStmts::new(
+                    let mut res = cond.and_then(|c| {
+                        WithStmts::new(
                             vec![mk().semi_stmt(mk().ifte_expr(c, then, Some(else_)))],
                             self.panic_or_err("Conditional expression is not supposed to be used"),
-                        ))
-                    })?;
+                        )
+                    });
                     res.merge_unsafe(is_unsafe);
                     Ok(res)
                 } else {
@@ -3411,8 +3409,8 @@ impl<'c> Translation<'c> {
                     let rhs = self.convert_expr(ctx, rhs, None)?;
                     lhs.merge_unsafe(rhs.is_unsafe());
 
-                    lhs.and_then_try(|val| {
-                        Ok(WithStmts::new(
+                    Ok(lhs.and_then(|val| {
+                        WithStmts::new(
                             vec![mk().semi_stmt(mk().ifte_expr(
                                 val,
                                 mk().block(rhs.into_stmts()),
@@ -3421,8 +3419,8 @@ impl<'c> Translation<'c> {
                             self.panic_or_err(
                                 "Binary conditional expression is not supposed to be used",
                             ),
-                        ))
-                    })
+                        )
+                    }))
                 } else {
                     self.name_reference_write_read(ctx, lhs)?.try_map(
                         |NamedReference {
@@ -3542,12 +3540,9 @@ impl<'c> Translation<'c> {
         if ctx.is_unused() {
             // Recall that if `used` is false, the `stmts` field of the output must contain
             // all side-effects (and a function call can always have side-effects)
-            expr.and_then_try(|expr| {
-                Ok(WithStmts::new(
-                    vec![mk().semi_stmt(expr)],
-                    self.panic_or_err(panic_msg),
-                ))
-            })
+            Ok(expr.and_then(|expr| {
+                WithStmts::new(vec![mk().semi_stmt(expr)], self.panic_or_err(panic_msg))
+            }))
         } else {
             Ok(expr)
         }

--- a/c2rust-transpile/src/translator/named_references.rs
+++ b/c2rust-transpile/src/translator/named_references.rs
@@ -108,7 +108,7 @@ impl<'c> Translation<'c> {
             .ok_or_else(|| format_err!("bad reference type"))?;
         let read = |write| self.read(reference_ty, write);
         let reference = self.convert_expr(ctx.used(), reference, Some(reference_ty))?;
-        reference.and_then(|reference| {
+        reference.and_then_try(|reference| {
             if !uses_read && is_lvalue(&reference) {
                 Ok(WithStmts::new_val(NamedReference {
                     lvalue: reference,

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -32,17 +32,18 @@ impl<'c> Translation<'c> {
             And | Or => {
                 let lhs = self.convert_condition(ctx, true, lhs)?;
                 let rhs = self.convert_condition(ctx, true, rhs)?;
-                lhs.map(|x| bool_to_int(mk().binary_expr(BinOp::from(op), x, rhs.to_expr())))
-                    .and_then_try(|out| {
+                Ok(lhs
+                    .map(|x| bool_to_int(mk().binary_expr(BinOp::from(op), x, rhs.to_expr())))
+                    .and_then(|out| {
                         if ctx.is_unused() {
-                            Ok(WithStmts::new(
+                            WithStmts::new(
                                 vec![mk().semi_stmt(out)],
                                 self.panic_or_err("Binary expression is not supposed to be used"),
-                            ))
+                            )
                         } else {
-                            Ok(WithStmts::new_val(out))
+                            WithStmts::new_val(out)
                         }
-                    })
+                    }))
             }
 
             // No sequence-point cases
@@ -517,9 +518,9 @@ impl<'c> Translation<'c> {
                         }
                     };
 
-                    assign_stmt.and_then_try(|assign_stmt| {
-                        Ok(WithStmts::new(vec![mk().semi_stmt(assign_stmt)], read))
-                    })
+                    Ok(assign_stmt.and_then(|assign_stmt| {
+                        WithStmts::new(vec![mk().semi_stmt(assign_stmt)], read)
+                    }))
                 },
             )
         })

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -171,21 +171,20 @@ impl<'c> Translation<'c> {
                         }
                     }
 
-                    self.convert_expr(ctx, lhs, Some(lhs_type_id))?
-                        .and_then_try(|lhs_val| {
-                            self.convert_expr(rhs_ctx, rhs, Some(rhs_type_id))?
-                                .and_then_try(|rhs_val| {
-                                    self.convert_binary_operator(
-                                        op,
-                                        ty,
-                                        expr_type_id.ctype,
-                                        lhs_type_id,
-                                        rhs_type_id,
-                                        lhs_val,
-                                        rhs_val,
-                                    )
-                                })
-                        })
+                    let lhs_val = self.convert_expr(ctx, lhs, Some(lhs_type_id))?;
+                    let rhs_val = self.convert_expr(rhs_ctx, rhs, Some(rhs_type_id))?;
+
+                    lhs_val.zip(rhs_val).and_then_try(|(lhs_val, rhs_val)| {
+                        self.convert_binary_operator(
+                            op,
+                            ty,
+                            expr_type_id.ctype,
+                            lhs_type_id,
+                            rhs_type_id,
+                            lhs_val,
+                            rhs_val,
+                        )
+                    })
                 }
             }
         }
@@ -412,117 +411,115 @@ impl<'c> Translation<'c> {
             })
         };
 
-        rhs_translation.and_then_try(|rhs| {
-            lhs_translation.and_then_try(
-                |NamedReference {
-                     lvalue: write,
-                     rvalue: read,
-                 }| {
-                    // Assignment expression itself
-                    use CBinOp::*;
-                    let assign_stmt = match op {
-                        // Regular (possibly volatile) assignment
-                        Assign if !is_volatile => WithStmts::new_val(mk().assign_expr(write, rhs)),
-                        Assign => WithStmts::new_unsafe_val(self.volatile_write(
-                            write,
-                            initial_lhs_type_id,
+        rhs_translation.zip(lhs_translation).and_then_try(|(rhs, lhs)| {
+            let NamedReference {
+                lvalue: write,
+                rvalue: read,
+            } = lhs;
+
+            // Assignment expression itself
+            use CBinOp::*;
+            let assign_stmt = match op {
+                // Regular (possibly volatile) assignment
+                Assign if !is_volatile => WithStmts::new_val(mk().assign_expr(write, rhs)),
+                Assign => WithStmts::new_unsafe_val(self.volatile_write(
+                    write,
+                    initial_lhs_type_id,
+                    rhs,
+                )?),
+
+                // Anything volatile needs to be desugared into explicit reads and writes
+                op if is_volatile || is_unsigned_arith => {
+                    // Cast the lhs to the compute lhs type, do the compute, and then
+                    // cast the compute result to the final lhs type.
+
+                    let op = op
+                        .underlying_assignment()
+                        .expect("Cannot convert non-assignment operator");
+
+                    let lhs = self.convert_cast(
+                        ctx,
+                        initial_lhs_type_id,
+                        expr_or_comp_type_id,
+                        WithStmts::new_val(read.clone()),
+                        None,
+                        None,
+                        None,
+                    )?;
+
+                    let ty = self.convert_type(result_type_id.ctype)?;
+                    let val = lhs.and_then_try(|lhs|
+                        self.convert_binary_operator(
+                            op,
+                            ty,
+                            result_type_id.ctype,
+                            expr_or_comp_type_id,
+                            rhs_type_id,
+                            lhs,
                             rhs,
-                        )?),
+                        )
+                    )?;
 
-                        // Anything volatile needs to be desugared into explicit reads and writes
-                        op if is_volatile || is_unsigned_arith => {
-                            // Cast the lhs to the compute lhs type, do the compute, and then
-                            // cast the compute result to the final lhs type.
+                    let val = self.convert_cast(
+                        ctx,
+                        result_type_id,
+                        expr_type_id,
+                        val,
+                        None,
+                        None,
+                        None,
+                    )?;
 
-                            let op = op
-                                .underlying_assignment()
-                                .expect("Cannot convert non-assignment operator");
-
-                            let lhs = self.convert_cast(
-                                ctx,
-                                initial_lhs_type_id,
-                                expr_or_comp_type_id,
-                                WithStmts::new_val(read.clone()),
-                                None,
-                                None,
-                                None,
-                            )?;
-
-                            let ty = self.convert_type(result_type_id.ctype)?;
-                            let val = lhs.and_then_try(|lhs|
-                                self.convert_binary_operator(
-                                    op,
-                                    ty,
-                                    result_type_id.ctype,
-                                    expr_or_comp_type_id,
-                                    rhs_type_id,
-                                    lhs,
-                                    rhs,
-                                )
-                            )?;
-
-                            let val = self.convert_cast(
-                                ctx,
-                                result_type_id,
-                                expr_type_id,
-                                val,
-                                None,
-                                None,
-                                None,
-                            )?;
-
-                            #[allow(clippy::let_and_return /* , reason = "block is large, so variable name helps" */)]
-                            let write = if is_volatile {
-                                val.and_then_try(|val| {
-                                    TranslationResult::Ok(WithStmts::new_unsafe_val(
-                                        self.volatile_write(write, initial_lhs_type_id, val)?,
-                                    ))
-                                })?
-                            } else {
-                                val.map(|val| mk().assign_expr(write, val))
-                            };
-                            write
-                        }
-
-                        // Everything else
-                        AssignAdd | AssignSubtract if pointer_lhs.is_some() => {
-                            let ptr = self.convert_pointer_offset(
-                                write.clone(),
-                                rhs,
-                                pointer_lhs.unwrap().ctype,
-                                op == AssignSubtract,
-                                false,
-                            );
-                            ptr.map(|ptr| mk().assign_expr(write, ptr))
-                        }
-
-                        _ => {
-                            let bin_op = op
-                                .underlying_assignment()
-                                .expect("Cannot convert non-assignment operator");
-                            let bin_op_kind = BinOp::from(op);
-
-                            self.convert_assignment_operator_aux(
-                                ctx,
-                                bin_op_kind,
-                                bin_op,
-                                read.clone(),
-                                write,
-                                rhs,
-                                initial_lhs_type_id,
-                                compute_lhs_type_id.unwrap(),
-                                compute_res_type_id.unwrap(),
-                                expr_type_id,
-                                rhs_type_id,
-                            )?
-                        }
+                    #[allow(clippy::let_and_return /* , reason = "block is large, so variable name helps" */)]
+                    let write = if is_volatile {
+                        val.and_then_try(|val| {
+                            TranslationResult::Ok(WithStmts::new_unsafe_val(
+                                self.volatile_write(write, initial_lhs_type_id, val)?,
+                            ))
+                        })?
+                    } else {
+                        val.map(|val| mk().assign_expr(write, val))
                     };
+                    write
+                }
 
-                    Ok(assign_stmt.and_then(|assign_stmt| {
-                        WithStmts::new(vec![mk().semi_stmt(assign_stmt)], read)
-                    }))
-                },
-            )
+                // Everything else
+                AssignAdd | AssignSubtract if pointer_lhs.is_some() => {
+                    let ptr = self.convert_pointer_offset(
+                        write.clone(),
+                        rhs,
+                        pointer_lhs.unwrap().ctype,
+                        op == AssignSubtract,
+                        false,
+                    );
+                    ptr.map(|ptr| mk().assign_expr(write, ptr))
+                }
+
+                _ => {
+                    let bin_op = op
+                        .underlying_assignment()
+                        .expect("Cannot convert non-assignment operator");
+                    let bin_op_kind = BinOp::from(op);
+
+                    self.convert_assignment_operator_aux(
+                        ctx,
+                        bin_op_kind,
+                        bin_op,
+                        read.clone(),
+                        write,
+                        rhs,
+                        initial_lhs_type_id,
+                        compute_lhs_type_id.unwrap(),
+                        compute_res_type_id.unwrap(),
+                        expr_type_id,
+                        rhs_type_id,
+                    )?
+                }
+            };
+
+            Ok(assign_stmt.and_then(|assign_stmt| {
+                WithStmts::new(vec![mk().semi_stmt(assign_stmt)], read)
+            }))
         })
     }
 

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -26,14 +26,14 @@ impl<'c> Translation<'c> {
             Comma => {
                 // The value of the LHS of a comma expression is always discarded
                 self.convert_expr(ctx.unused(), lhs, None)?
-                    .and_then(|_| self.convert_expr(ctx, rhs, Some(expr_type_id)))
+                    .and_then_try(|_| self.convert_expr(ctx, rhs, Some(expr_type_id)))
             }
 
             And | Or => {
                 let lhs = self.convert_condition(ctx, true, lhs)?;
                 let rhs = self.convert_condition(ctx, true, rhs)?;
                 lhs.map(|x| bool_to_int(mk().binary_expr(BinOp::from(op), x, rhs.to_expr())))
-                    .and_then(|out| {
+                    .and_then_try(|out| {
                         if ctx.is_unused() {
                             Ok(WithStmts::new(
                                 vec![mk().semi_stmt(out)],
@@ -124,7 +124,7 @@ impl<'c> Translation<'c> {
                 if ctx.is_unused() {
                     Ok(self
                         .convert_expr(ctx, lhs, Some(lhs_type_id))?
-                        .and_then(|_| self.convert_expr(ctx, rhs, Some(rhs_type_id)))?
+                        .and_then_try(|_| self.convert_expr(ctx, rhs, Some(rhs_type_id)))?
                         .map(|_| self.panic_or_err("Binary expression is not supposed to be used")))
                 } else {
                     let rhs_ctx = ctx;
@@ -147,7 +147,7 @@ impl<'c> Translation<'c> {
 
                         if self.ast_context.is_null_expr(lhs) {
                             let val = self.convert_expr(rhs_ctx, rhs, Some(rhs_type_id))?;
-                            let val = val.result_map(|rhs_rs| {
+                            let val = val.try_map(|rhs_rs| {
                                 self.convert_pointer_is_null(
                                     ctx,
                                     rhs_type_id.ctype,
@@ -158,7 +158,7 @@ impl<'c> Translation<'c> {
                             return Ok(val.map(bool_to_int));
                         } else if self.ast_context.is_null_expr(rhs) {
                             let val = self.convert_expr(ctx, lhs, Some(lhs_type_id))?;
-                            let val = val.result_map(|lhs_rs| {
+                            let val = val.try_map(|lhs_rs| {
                                 self.convert_pointer_is_null(
                                     ctx,
                                     lhs_type_id.ctype,
@@ -171,9 +171,9 @@ impl<'c> Translation<'c> {
                     }
 
                     self.convert_expr(ctx, lhs, Some(lhs_type_id))?
-                        .and_then(|lhs_val| {
+                        .and_then_try(|lhs_val| {
                             self.convert_expr(rhs_ctx, rhs, Some(rhs_type_id))?
-                                .and_then(|rhs_val| {
+                                .and_then_try(|rhs_val| {
                                     self.convert_binary_operator(
                                         op,
                                         ty,
@@ -224,7 +224,7 @@ impl<'c> Translation<'c> {
             )?;
 
             let ty = self.convert_type(compute_res_type_id.ctype)?;
-            let val = lhs.and_then(|lhs| {
+            let val = lhs.and_then_try(|lhs| {
                 self.convert_binary_operator(
                     bin_op,
                     ty,
@@ -411,8 +411,8 @@ impl<'c> Translation<'c> {
             })
         };
 
-        rhs_translation.and_then(|rhs| {
-            lhs_translation.and_then(
+        rhs_translation.and_then_try(|rhs| {
+            lhs_translation.and_then_try(
                 |NamedReference {
                      lvalue: write,
                      rvalue: read,
@@ -448,7 +448,7 @@ impl<'c> Translation<'c> {
                             )?;
 
                             let ty = self.convert_type(result_type_id.ctype)?;
-                            let val = lhs.and_then(|lhs|
+                            let val = lhs.and_then_try(|lhs|
                                 self.convert_binary_operator(
                                     op,
                                     ty,
@@ -472,7 +472,7 @@ impl<'c> Translation<'c> {
 
                             #[allow(clippy::let_and_return /* , reason = "block is large, so variable name helps" */)]
                             let write = if is_volatile {
-                                val.and_then(|val| {
+                                val.and_then_try(|val| {
                                     TranslationResult::Ok(WithStmts::new_unsafe_val(
                                         self.volatile_write(write, initial_lhs_type_id, val)?,
                                     ))
@@ -517,7 +517,7 @@ impl<'c> Translation<'c> {
                         }
                     };
 
-                    assign_stmt.and_then(|assign_stmt| {
+                    assign_stmt.and_then_try(|assign_stmt| {
                         Ok(WithStmts::new(vec![mk().semi_stmt(assign_stmt)], read))
                     })
                 },
@@ -709,7 +709,7 @@ impl<'c> Translation<'c> {
             .get_qual_type()
             .ok_or_else(|| format_err!("bad post inc type"))?;
 
-        self.name_reference_write_read(ctx, arg)?.and_then(
+        self.name_reference_write_read(ctx, arg)?.and_then_try(
             |NamedReference {
                  lvalue: write,
                  rvalue: read,

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -205,7 +205,7 @@ impl<'c> Translation<'c> {
         }
 
         self.convert_expr(ctx.used(), arg, None)?
-            .result_map(|val: Box<Expr>| {
+            .try_map(|val: Box<Expr>| {
                 if let CTypeKind::Function(..) =
                     self.ast_context.resolve_type(cqual_type.ctype).kind
                 {
@@ -259,7 +259,7 @@ impl<'c> Translation<'c> {
         }
 
         let rhs = self.convert_expr(ctx.used(), rhs, None)?;
-        rhs.and_then(|rhs| {
+        rhs.and_then_try(|rhs| {
             let simple_index_array = if ctx.needs_address() {
                 // We can't necessarily index into an array if we're using
                 // that element to compute an address.
@@ -308,7 +308,7 @@ impl<'c> Translation<'c> {
                 };
 
                 let lhs = self.convert_expr(ctx.used(), arr, None)?;
-                lhs.and_then(|lhs| {
+                lhs.and_then_try(|lhs| {
                     // stmts.extend(lhs.stmts_mut());
                     // is_unsafe = is_unsafe || lhs.is_unsafe();
 
@@ -324,7 +324,7 @@ impl<'c> Translation<'c> {
             } else {
                 // LHS must be ref decayed for the offset method call's self param
                 let lhs = self.convert_expr(ctx.used().decay_ref(), lhs, None)?;
-                lhs.and_then(|lhs| {
+                lhs.and_then_try(|lhs| {
                     // stmts.extend(lhs.stmts_mut());
                     // is_unsafe = is_unsafe || lhs.is_unsafe();
 
@@ -451,7 +451,7 @@ impl<'c> Translation<'c> {
             self.import_type(source_cty);
             self.import_type(target_cty);
 
-            val.and_then(|val| {
+            val.and_then_try(|val| {
                 Ok(WithStmts::new_unsafe_val(transmute_expr(
                     source_ty, target_ty, val,
                 )))
@@ -482,7 +482,7 @@ impl<'c> Translation<'c> {
             }
 
             self.use_crate(ExternCrate::Libc);
-            val.and_then(|mut val| {
+            val.and_then_try(|mut val| {
                 // First cast the integer to pointer size
                 let intptr_t = mk().abs_path_ty(vec!["libc", "intptr_t"]);
                 val = mk().cast_expr(val, intptr_t.clone());
@@ -499,7 +499,7 @@ impl<'c> Translation<'c> {
                 mk().cast_expr(val, target_ty)
             }))
         } else if let &CTypeKind::Enum(..) = source_ty_kind {
-            val.result_map(|val| self.convert_cast_from_enum(target_cty, val))
+            val.try_map(|val| self.convert_cast_from_enum(target_cty, val))
         } else {
             Ok(val.map(|val| mk().cast_expr(val, target_ty)))
         }
@@ -525,15 +525,13 @@ impl<'c> Translation<'c> {
         let target_ty_kind = &self.ast_context.resolve_type(target_cty).kind;
 
         if self.ast_context.is_function_pointer(source_cty) {
-            val.and_then(|val| {
+            val.and_then_try(|val| {
                 Ok(WithStmts::new_unsafe_val(transmute_expr(
                     source_ty, target_ty, val,
                 )))
             })
         } else if let &CTypeKind::Enum(enum_decl_id) = target_ty_kind {
-            val.result_map(|val| {
-                self.convert_cast_to_enum(ctx, target_cty, enum_decl_id, expr, val)
-            })
+            val.try_map(|val| self.convert_cast_to_enum(ctx, target_cty, enum_decl_id, expr, val))
         } else {
             Ok(val.map(|val| mk().cast_expr(val, target_ty)))
         }

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -308,19 +308,17 @@ impl<'c> Translation<'c> {
                 };
 
                 let lhs = self.convert_expr(ctx.used(), arr, None)?;
-                lhs.and_then_try(|lhs| {
+                Ok(lhs.and_then(|lhs| {
                     // stmts.extend(lhs.stmts_mut());
                     // is_unsafe = is_unsafe || lhs.is_unsafe();
 
                     // Don't dereference the offset if we're still within the variable portion
                     if let Some(elt_type_id) = var_elt_type_id {
-                        Ok(self.convert_pointer_offset(lhs, rhs, elt_type_id, false, deref))
+                        self.convert_pointer_offset(lhs, rhs, elt_type_id, false, deref)
                     } else {
-                        Ok(WithStmts::new_val(
-                            mk().index_expr(lhs, cast_int(rhs, "usize", false)),
-                        ))
+                        WithStmts::new_val(mk().index_expr(lhs, cast_int(rhs, "usize", false)))
                     }
-                })
+                }))
             } else {
                 // LHS must be ref decayed for the offset method call's self param
                 let lhs = self.convert_expr(ctx.used().decay_ref(), lhs, None)?;
@@ -451,11 +449,9 @@ impl<'c> Translation<'c> {
             self.import_type(source_cty);
             self.import_type(target_cty);
 
-            val.and_then_try(|val| {
-                Ok(WithStmts::new_unsafe_val(transmute_expr(
-                    source_ty, target_ty, val,
-                )))
-            })
+            Ok(val.and_then(|val| {
+                WithStmts::new_unsafe_val(transmute_expr(source_ty, target_ty, val))
+            }))
         } else {
             // Normal case
             let target_ty = self.convert_type(target_cty)?;
@@ -482,15 +478,13 @@ impl<'c> Translation<'c> {
             }
 
             self.use_crate(ExternCrate::Libc);
-            val.and_then_try(|mut val| {
+            Ok(val.and_then(|mut val| {
                 // First cast the integer to pointer size
                 let intptr_t = mk().abs_path_ty(vec!["libc", "intptr_t"]);
                 val = mk().cast_expr(val, intptr_t.clone());
 
-                Ok(WithStmts::new_unsafe_val(transmute_expr(
-                    intptr_t, target_ty, val,
-                )))
-            })
+                WithStmts::new_unsafe_val(transmute_expr(intptr_t, target_ty, val))
+            }))
         } else if source_ty_kind.is_bool() {
             self.use_crate(ExternCrate::Libc);
             Ok(val.map(|mut val| {
@@ -525,11 +519,9 @@ impl<'c> Translation<'c> {
         let target_ty_kind = &self.ast_context.resolve_type(target_cty).kind;
 
         if self.ast_context.is_function_pointer(source_cty) {
-            val.and_then_try(|val| {
-                Ok(WithStmts::new_unsafe_val(transmute_expr(
-                    source_ty, target_ty, val,
-                )))
-            })
+            Ok(val.and_then(|val| {
+                WithStmts::new_unsafe_val(transmute_expr(source_ty, target_ty, val))
+            }))
         } else if let &CTypeKind::Enum(enum_decl_id) = target_ty_kind {
             val.try_map(|val| self.convert_cast_to_enum(ctx, target_cty, enum_decl_id, expr, val))
         } else {

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -223,7 +223,7 @@ impl<'c> Translation<'c> {
         );
 
         let param_translation = self.convert_exprs(ctx.used(), &processed_args, None)?;
-        param_translation.and_then(|call_params| {
+        param_translation.and_then_try(|call_params| {
             let call = mk().call_expr(mk().ident_expr(fn_name), call_params);
 
             if ctx.is_used() {
@@ -294,7 +294,7 @@ impl<'c> Translation<'c> {
         len: usize,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let param_translation = self.convert_exprs(ctx, ids, None)?;
-        param_translation.and_then(|mut params| {
+        param_translation.and_then_try(|mut params| {
             // When used in a const context, we cannot call the standard functions since they
             // are not const and so we are forced to transmute
             let call = if ctx.is_const {
@@ -385,7 +385,7 @@ impl<'c> Translation<'c> {
             &[first_expr_id, second_expr_id, mask_expr_id],
             None,
         )?;
-        param_translation.and_then(|params| {
+        param_translation.and_then_try(|params| {
             let [first, second, third]: [_; 3] = params
                 .try_into()
                 .map_err(|_| "`convert_shuffle_vector` must have exactly 3 parameters")?;

--- a/c2rust-transpile/src/translator/simd.rs
+++ b/c2rust-transpile/src/translator/simd.rs
@@ -223,18 +223,18 @@ impl<'c> Translation<'c> {
         );
 
         let param_translation = self.convert_exprs(ctx.used(), &processed_args, None)?;
-        param_translation.and_then_try(|call_params| {
+        Ok(param_translation.and_then(|call_params| {
             let call = mk().call_expr(mk().ident_expr(fn_name), call_params);
 
             if ctx.is_used() {
-                Ok(WithStmts::new_val(call))
+                WithStmts::new_val(call)
             } else {
-                Ok(WithStmts::new(
+                WithStmts::new(
                     vec![mk().semi_stmt(call)],
                     self.panic_or_err("No value for unused shuffle vector return"),
-                ))
+                )
             }
-        })
+        }))
     }
 
     /// Generate a zero value to be used for initialization of a given vector type. The type

--- a/c2rust-transpile/src/translator/structs_unions.rs
+++ b/c2rust-transpile/src/translator/structs_unions.rs
@@ -518,7 +518,7 @@ impl<'a> Translation<'a> {
         let mut val = fields.map(|fields| mk().struct_expr(name.as_str(), fields));
 
         if !bitfield_inits.is_empty() {
-            val = val.and_then_try(|val| -> TranslationResult<_> {
+            val = val.and_then(|val| {
                 let local_pat = mk().mutbl().ident_pat("init");
                 let local_variable = Box::new(mk().local(local_pat, None, Some(val)));
 
@@ -543,11 +543,11 @@ impl<'a> Translation<'a> {
                 let val = mk().block_expr(mk().block(stmts));
 
                 if is_unsafe {
-                    Ok(WithStmts::new_unsafe_val(val))
+                    WithStmts::new_unsafe_val(val)
                 } else {
-                    Ok(WithStmts::new_val(val))
+                    WithStmts::new_val(val)
                 }
-            })?;
+            });
         }
 
         // If the structure is split into an outer/inner,

--- a/c2rust-transpile/src/translator/structs_unions.rs
+++ b/c2rust-transpile/src/translator/structs_unions.rs
@@ -518,7 +518,7 @@ impl<'a> Translation<'a> {
         let mut val = fields.map(|fields| mk().struct_expr(name.as_str(), fields));
 
         if !bitfield_inits.is_empty() {
-            val = val.and_then(|val| -> TranslationResult<_> {
+            val = val.and_then_try(|val| -> TranslationResult<_> {
                 let local_pat = mk().mutbl().ident_pat("init");
                 let local_variable = Box::new(mk().local(local_pat, None, Some(val)));
 
@@ -715,7 +715,7 @@ impl<'a> Translation<'a> {
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let ctx = ctx.set_bitfield_write(true);
         let named_reference = self.name_reference_write_read(ctx, lhs)?;
-        named_reference.and_then(
+        named_reference.and_then_try(
             |NamedReference {
                  lvalue: lhs_expr, ..
              }| {

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -230,7 +230,7 @@ impl<'c> Translation<'c> {
                     .ptr_ty(mk().abs_path_ty(vec!["core", "ffi", "c_void"]));
             }
 
-            val.and_then_try(|val| {
+            Ok(val.and_then(|val| {
                 let path = mk().path_segment_with_args(
                     mk().ident("arg"),
                     mk().angle_bracketed_args(vec![arg_ty]),
@@ -241,10 +241,10 @@ impl<'c> Translation<'c> {
                 }
 
                 if ctx.is_unused() {
-                    Ok(WithStmts::new(
+                    WithStmts::new(
                         vec![mk().semi_stmt(val)],
                         self.panic_or_err("convert_vaarg unused"),
-                    ))
+                    )
                 } else {
                     let val = if have_fn_ptr {
                         // transmute result of call to `arg` when expecting a function pointer
@@ -253,9 +253,9 @@ impl<'c> Translation<'c> {
                         val
                     };
 
-                    Ok(WithStmts::new_val(val))
+                    WithStmts::new_val(val)
                 }
-            })
+            }))
         } else {
             Err(format_err!("Variable argument list translation is not enabled.").into())
         }

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -230,7 +230,7 @@ impl<'c> Translation<'c> {
                     .ptr_ty(mk().abs_path_ty(vec!["core", "ffi", "c_void"]));
             }
 
-            val.and_then(|val| {
+            val.and_then_try(|val| {
                 let path = mk().path_segment_with_args(
                     mk().ident("arg"),
                     mk().angle_bracketed_args(vec![arg_ty]),

--- a/c2rust-transpile/src/with_stmts.rs
+++ b/c2rust-transpile/src/with_stmts.rs
@@ -35,6 +35,20 @@ impl<T> WithStmts<T> {
         }
     }
 
+    pub fn and_then<U, F>(self, f: F) -> WithStmts<U>
+    where
+        F: FnOnce(T) -> WithStmts<U>,
+    {
+        let mut next = f(self.val);
+        let mut stmts = self.stmts;
+        stmts.append(&mut next.stmts);
+        WithStmts {
+            val: next.val,
+            stmts,
+            is_unsafe: self.is_unsafe || next.is_unsafe,
+        }
+    }
+
     pub fn and_then_try<U, E, F>(self, f: F) -> Result<WithStmts<U>, E>
     where
         F: FnOnce(T) -> Result<WithStmts<U>, E>,

--- a/c2rust-transpile/src/with_stmts.rs
+++ b/c2rust-transpile/src/with_stmts.rs
@@ -85,6 +85,16 @@ impl<T> WithStmts<T> {
         })
     }
 
+    pub fn zip<U>(self, mut next: WithStmts<U>) -> WithStmts<(T, U)> {
+        let mut stmts = self.stmts;
+        stmts.append(&mut next.stmts);
+        WithStmts {
+            val: (self.val, next.val),
+            stmts,
+            is_unsafe: self.is_unsafe || next.is_unsafe,
+        }
+    }
+
     pub fn set_unsafe(&mut self) {
         self.is_unsafe = true;
     }

--- a/c2rust-transpile/src/with_stmts.rs
+++ b/c2rust-transpile/src/with_stmts.rs
@@ -18,6 +18,7 @@ impl<T> WithStmts<T> {
             is_unsafe: false,
         }
     }
+
     pub fn new_val(val: T) -> Self {
         WithStmts {
             stmts: vec![],
@@ -25,6 +26,7 @@ impl<T> WithStmts<T> {
             is_unsafe: false,
         }
     }
+
     pub fn new_unsafe_val(val: T) -> Self {
         WithStmts {
             stmts: vec![],
@@ -32,6 +34,7 @@ impl<T> WithStmts<T> {
             is_unsafe: true,
         }
     }
+
     pub fn and_then<U, E, F>(self, f: F) -> Result<WithStmts<U>, E>
     where
         F: FnOnce(T) -> Result<WithStmts<U>, E>,
@@ -45,6 +48,7 @@ impl<T> WithStmts<T> {
             is_unsafe: self.is_unsafe || next.is_unsafe,
         })
     }
+
     pub fn map<U, F>(self, f: F) -> WithStmts<U>
     where
         F: FnOnce(T) -> U,
@@ -55,6 +59,7 @@ impl<T> WithStmts<T> {
             is_unsafe: self.is_unsafe,
         }
     }
+
     pub fn result_map<U, E, F>(self, f: F) -> Result<WithStmts<U>, E>
     where
         F: FnOnce(T) -> Result<U, E>,
@@ -77,9 +82,11 @@ impl<T> WithStmts<T> {
     pub fn into_stmts(self) -> Vec<Stmt> {
         self.stmts
     }
+
     pub fn into_value(self) -> T {
         self.val
     }
+
     pub fn discard_unsafe(self) -> (Vec<Stmt>, T) {
         (self.stmts, self.val)
     }
@@ -87,6 +94,7 @@ impl<T> WithStmts<T> {
     pub fn stmts(&self) -> &[Stmt] {
         &self.stmts
     }
+
     pub fn stmts_mut(&mut self) -> &mut Vec<Stmt> {
         &mut self.stmts
     }

--- a/c2rust-transpile/src/with_stmts.rs
+++ b/c2rust-transpile/src/with_stmts.rs
@@ -35,7 +35,7 @@ impl<T> WithStmts<T> {
         }
     }
 
-    pub fn and_then<U, E, F>(self, f: F) -> Result<WithStmts<U>, E>
+    pub fn and_then_try<U, E, F>(self, f: F) -> Result<WithStmts<U>, E>
     where
         F: FnOnce(T) -> Result<WithStmts<U>, E>,
     {
@@ -60,7 +60,7 @@ impl<T> WithStmts<T> {
         }
     }
 
-    pub fn result_map<U, E, F>(self, f: F) -> Result<WithStmts<U>, E>
+    pub fn try_map<U, E, F>(self, f: F) -> Result<WithStmts<U>, E>
     where
         F: FnOnce(T) -> Result<U, E>,
     {


### PR DESCRIPTION
`WithStmts` has methods to map to `Expr`, `Result<Expr>`, and `Result<WithStmts>`, but a method to map to `WithStmts` alone was missing. I found myself wanting such a method quite a few times. So this adds one. In order to make the naming more consistent, methods that return `Result` now include `try` in the name, fitting how things are named in the Rust standard library. That then frees up the name `and_then` to be used for the missing method.

`WithStmts::zip` helps keep code cleaner, as it reduces the amount of nested closures that are otherwise needed.