### PR TITLE
transpile: Split off `can_propagate_cast` function, elide some more casts

### DIFF
--- a/c2rust-transpile/src/translator/enums.rs
+++ b/c2rust-transpile/src/translator/enums.rs
@@ -6,7 +6,7 @@ use crate::{
     diagnostics::TranslationResult,
     translator::{signed_int_expr, ConvertedDecl, ExprContext, Translation},
     with_stmts::WithStmts,
-    CDeclKind, CEnumConstantId, CEnumId, CExprId, CExprKind, CQualTypeId, CTypeKind, ConstIntExpr,
+    CDeclKind, CEnumConstantId, CEnumId, CQualTypeId, CTypeId, CTypeKind, ConstIntExpr,
 };
 
 impl<'c> Translation<'c> {
@@ -76,6 +76,10 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let val = self.enum_constant_expr(enum_constant_id);
 
+        if self.enum_constant_matches_type(expr_type_id.ctype, enum_constant_id) {
+            return Ok(WithStmts::new_val(val));
+        }
+
         // Add a cast to the expected integral type.
         let enum_id = self.ast_context.parents[&enum_constant_id];
         self.convert_cast_from_enum(ctx, enum_id, expr_type_id, val)
@@ -108,32 +112,8 @@ impl<'c> Translation<'c> {
         ctx: ExprContext,
         mut source_cty: CQualTypeId,
         enum_id: CEnumId,
-        expr: Option<CExprId>,
         mut val: Box<Expr>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        if let Some(expr) = expr {
-            match self.ast_context.index_unwrap_parens(expr).kind {
-                // This is the case of finding a variable which is an `EnumConstant` of the same
-                // enum we are casting to. Here, we can just remove the extraneous cast instead of
-                // generating a new one.
-                CExprKind::DeclRef(_, enum_constant_id, _)
-                    if self.is_variant_of_enum(enum_id, enum_constant_id) =>
-                {
-                    // `enum`s shouldn't need portable `override_ty`s.
-                    let expr_is_macro = self.expr_is_expanded_macro(ctx, expr, None);
-
-                    // If this DeclRef expanded to a const macro, we actually need to insert a cast,
-                    // because the translation of a const macro skips implicit casts in its context.
-                    if !expr_is_macro {
-                        val = self.enum_constant_expr(enum_constant_id);
-                        return Ok(WithStmts::new_val(val));
-                    }
-                }
-
-                _ => {}
-            }
-        }
-
         // We could be casting from enum to enum...
         if let CTypeKind::Enum(source_enum_id) =
             self.ast_context.resolve_type(source_cty.ctype).kind
@@ -208,13 +188,16 @@ impl<'c> Translation<'c> {
         mk().call_expr(mk().ident_expr(enum_name), vec![value])
     }
 
-    fn is_variant_of_enum(&self, enum_id: CEnumId, enum_constant_id: CEnumConstantId) -> bool {
-        let variants = match self.ast_context[enum_id].kind {
-            CDeclKind::Enum { ref variants, .. } => variants,
-            _ => panic!("{:?} does not point to an `enum` declaration", enum_id),
+    pub(crate) fn enum_constant_matches_type(
+        &self,
+        type_id: CTypeId,
+        enum_constant_id: CEnumConstantId,
+    ) -> bool {
+        let CTypeKind::Enum(type_enum_id) = self.ast_context.resolve_type(type_id).kind else {
+            return false;
         };
-
-        variants.contains(&enum_constant_id)
+        let constant_enum_id = self.ast_context.parents[&enum_constant_id];
+        type_enum_id == constant_enum_id
     }
 
     pub(crate) fn enum_integral_type(&self, enum_id: CEnumId) -> CQualTypeId {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3932,6 +3932,18 @@ impl<'c> Translation<'c> {
         }
 
         let expr_kind = &self.ast_context.index_unwrap_parens(expr_id).kind;
+
+        if let &CExprKind::DeclRef(_, decl_id, _) = expr_kind {
+            if let CDeclKind::EnumConstant { .. } = self.ast_context[decl_id].kind {
+                // In C, `EnumConstant`s have some integral type, _not_ the enum type.
+                // However, if we then immediately have a cast to convert this variable back into
+                // the enum type, we would like to produce Rust with _no_ casts.
+                if self.enum_constant_matches_type(target_type_id.ctype, decl_id) {
+                    return true;
+                }
+            }
+        }
+
         let mut literal_expr_kind = expr_kind;
         let mut is_negated = false;
 
@@ -3998,7 +4010,7 @@ impl<'c> Translation<'c> {
             }
 
             CastKind::PointerToIntegral => {
-                self.convert_pointer_to_integral_cast(ctx, source_cty, target_cty, val, expr)
+                self.convert_pointer_to_integral_cast(ctx, source_cty, target_cty, val)
             }
 
             CastKind::IntegralCast
@@ -4034,9 +4046,7 @@ impl<'c> Translation<'c> {
                 {
                     self.f128_cast_to(val, target_ty_kind)
                 } else if let &CTypeKind::Enum(enum_id) = target_ty_kind {
-                    val.and_then_try(|val| {
-                        self.convert_cast_to_enum(ctx, source_cty, enum_id, expr, val)
-                    })
+                    val.and_then_try(|val| self.convert_cast_to_enum(ctx, source_cty, enum_id, val))
                 } else if target_ty_kind.is_floating_type() && source_ty_kind.is_bool() {
                     Ok(val.map(|val| {
                         mk().cast_expr(mk().cast_expr(val, mk().path_ty(vec!["u8"])), target_ty)

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3848,28 +3848,15 @@ impl<'c> Translation<'c> {
             return self.convert_condition(ctx, true, expr);
         }
 
-        let expr_kind = &self.ast_context.index_unwrap_parens(expr).kind;
         let target_ty = override_ty.unwrap_or(ty);
 
         // In general, if we are casting the result of an expression, then the inner
         // expression should be translated to whatever type it normally would.
-        // But for literals, if we don't absolutely have to cast, we would rather the
-        // literal is translated according to the type we're expecting, and then we can
-        // skip the cast entirely.
-        if !is_explicit {
-            let mut literal_expr_kind = expr_kind;
-            let mut is_negated = false;
-
-            if let &CExprKind::Unary(_, CUnOp::Negate, subexpr_id, _) = literal_expr_kind {
-                literal_expr_kind = &self.ast_context.index_unwrap_parens(subexpr_id).kind;
-                is_negated = true;
-            }
-
-            if let CExprKind::Literal(_, lit) = literal_expr_kind {
-                if self.literal_matches_ty(lit, target_ty, is_negated) {
-                    return self.convert_expr(ctx, expr, Some(target_ty));
-                }
-            }
+        // But for some expression types, if we don't absolutely have to cast,
+        // we would rather the expression is translated according to the type we're
+        // expecting, and then we can skip the cast entirely.
+        if self.can_propagate_cast(expr, target_ty, is_explicit) {
+            return self.convert_expr(ctx, expr, Some(target_ty));
         }
 
         match kind {
@@ -3931,6 +3918,36 @@ impl<'c> Translation<'c> {
             Some(kind),
             opt_field_id,
         )
+    }
+
+    fn can_propagate_cast(
+        &self,
+        expr_id: CExprId,
+        target_type_id: CQualTypeId,
+        is_explicit: bool,
+    ) -> bool {
+        // Always preserve explicit casts.
+        if is_explicit {
+            return false;
+        }
+
+        let expr_kind = &self.ast_context.index_unwrap_parens(expr_id).kind;
+        let mut literal_expr_kind = expr_kind;
+        let mut is_negated = false;
+
+        if let &CExprKind::Unary(_, CUnOp::Negate, subexpr_id, _) = literal_expr_kind {
+            literal_expr_kind = &self.ast_context.index_unwrap_parens(subexpr_id).kind;
+            is_negated = true;
+        }
+
+        if let CExprKind::Literal(_, lit) = literal_expr_kind {
+            // Does the inner literal fit in the type we're casting to?
+            if self.literal_matches_ty(lit, target_type_id, is_negated) {
+                return true;
+            }
+        }
+
+        false
     }
 
     pub fn make_cast(

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3941,6 +3941,18 @@ impl<'c> Translation<'c> {
                 if self.enum_constant_matches_type(target_type_id.ctype, decl_id) {
                     return true;
                 }
+
+                let source_enum_id = self.ast_context.parents[&decl_id];
+                let source_integral_type_id = self.enum_integral_type(source_enum_id);
+                let target_type_resolved_id = self
+                    .ast_context
+                    .resolve_type_id_no_typedef(target_type_id.ctype);
+
+                // Likewise, if we are casting to the inner integral type of the enum, then
+                // translate the enum constant directly as that.
+                if target_type_resolved_id == source_integral_type_id.ctype {
+                    return true;
+                }
             }
         }
 

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -611,7 +611,6 @@ impl<'c> Translation<'c> {
         source_cty: CQualTypeId,
         target_cty: CQualTypeId,
         val: WithStmts<Box<Expr>>,
-        expr: Option<CExprId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         if ctx.is_const {
             return Err(format_translation_err!(
@@ -654,7 +653,6 @@ impl<'c> Translation<'c> {
                         ctx,
                         CQualTypeId::new(size_type_id),
                         enum_decl_id,
-                        expr,
                         val,
                     )
                 })

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
@@ -52,8 +52,7 @@ pub unsafe extern "C" fn test_enums() {
     foo = Foo(c2rust_fresh1.0 as ::core::ffi::c_uint);
     let mut e: Foo = Foo1;
     let mut enum_enum: ::core::ffi::c_int = (e.0 == foo.0) as ::core::ffi::c_int;
-    let mut enum_constant: ::core::ffi::c_int =
-        (e.0 == Foo0.0 as ::core::ffi::c_int as ::core::ffi::c_uint) as ::core::ffi::c_int;
+    let mut enum_constant: ::core::ffi::c_int = (e.0 == Foo0.0) as ::core::ffi::c_int;
     let mut wrong_enum_enum: ::core::ffi::c_int =
         (e.0 == bar.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
     let mut wrong_enum_constant: ::core::ffi::c_int =

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
@@ -53,8 +53,7 @@ pub unsafe extern "C" fn test_enums() {
     foo = Foo(c2rust_fresh1.0 as ::core::ffi::c_uint);
     let mut e: Foo = Foo1;
     let mut enum_enum: ::core::ffi::c_int = (e.0 == foo.0) as ::core::ffi::c_int;
-    let mut enum_constant: ::core::ffi::c_int =
-        (e.0 == Foo0.0 as ::core::ffi::c_int as ::core::ffi::c_uint) as ::core::ffi::c_int;
+    let mut enum_constant: ::core::ffi::c_int = (e.0 == Foo0.0) as ::core::ffi::c_int;
     let mut wrong_enum_enum: ::core::ffi::c_int =
         (e.0 == bar.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
     let mut wrong_enum_constant: ::core::ffi::c_int =


### PR DESCRIPTION
- Depends on #1620
- Fixes #128