### PR TITLE
transpile: Add helpers/reduce repetition relating to `CBinOp`

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -11,6 +11,7 @@ use std::ops::Index;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::{iter, mem};
+use syn::BinOp;
 
 pub use self::conversion::*;
 pub use self::print::Printer;
@@ -2141,6 +2142,33 @@ impl CBinOp {
             self,
             Multiply | Divide | Modulus | Add | Subtract | BitAnd | BitXor | BitOr
         )
+    }
+}
+
+impl From<CBinOp> for BinOp {
+    fn from(op: CBinOp) -> Self {
+        match op {
+            CBinOp::Multiply => BinOp::Mul(Default::default()),
+            CBinOp::Divide => BinOp::Div(Default::default()),
+            CBinOp::Modulus => BinOp::Rem(Default::default()),
+            CBinOp::Add => BinOp::Add(Default::default()),
+            CBinOp::Subtract => BinOp::Sub(Default::default()),
+            CBinOp::ShiftLeft => BinOp::Shl(Default::default()),
+            CBinOp::ShiftRight => BinOp::Shr(Default::default()),
+            CBinOp::Less => BinOp::Lt(Default::default()),
+            CBinOp::Greater => BinOp::Gt(Default::default()),
+            CBinOp::LessEqual => BinOp::Le(Default::default()),
+            CBinOp::GreaterEqual => BinOp::Ge(Default::default()),
+            CBinOp::EqualEqual => BinOp::Eq(Default::default()),
+            CBinOp::NotEqual => BinOp::Ne(Default::default()),
+            CBinOp::BitAnd => BinOp::BitAnd(Default::default()),
+            CBinOp::BitXor => BinOp::BitXor(Default::default()),
+            CBinOp::BitOr => BinOp::BitOr(Default::default()),
+            CBinOp::And => BinOp::And(Default::default()),
+            CBinOp::Or => BinOp::Or(Default::default()),
+
+            _ => panic!("CBinOp {:?} is not a valid Rust BinOp", op),
+        }
     }
 }
 

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -2121,6 +2121,20 @@ impl CBinOp {
         }
     }
 
+    pub fn wrapping_method(&self) -> &'static str {
+        match self {
+            CBinOp::Add => "wrapping_add",
+            CBinOp::Subtract => "wrapping_sub",
+            CBinOp::Multiply => "wrapping_mul",
+            CBinOp::Divide => "wrapping_div",
+            CBinOp::Modulus => "wrapping_rem",
+            _ => panic!(
+                "CBinOp {:?} is not a valid Rust wrapping arithmetic method",
+                self
+            ),
+        }
+    }
+
     /// Does the rust equivalent of this operator have type (T, T) -> U?
     #[rustfmt::skip]
     pub fn input_types_same(&self) -> bool {

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -2167,6 +2167,17 @@ impl From<CBinOp> for BinOp {
             CBinOp::And => BinOp::And(Default::default()),
             CBinOp::Or => BinOp::Or(Default::default()),
 
+            CBinOp::AssignAdd => BinOp::AddAssign(Default::default()),
+            CBinOp::AssignSubtract => BinOp::SubAssign(Default::default()),
+            CBinOp::AssignMultiply => BinOp::MulAssign(Default::default()),
+            CBinOp::AssignDivide => BinOp::DivAssign(Default::default()),
+            CBinOp::AssignModulus => BinOp::RemAssign(Default::default()),
+            CBinOp::AssignBitXor => BinOp::BitXorAssign(Default::default()),
+            CBinOp::AssignShiftLeft => BinOp::ShlAssign(Default::default()),
+            CBinOp::AssignShiftRight => BinOp::ShrAssign(Default::default()),
+            CBinOp::AssignBitOr => BinOp::BitOrAssign(Default::default()),
+            CBinOp::AssignBitAnd => BinOp::BitAndAssign(Default::default()),
+
             _ => panic!("CBinOp {:?} is not a valid Rust BinOp", op),
         }
     }

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -2,33 +2,6 @@
 
 use super::*;
 
-impl From<CBinOp> for BinOp {
-    fn from(op: CBinOp) -> Self {
-        match op {
-            CBinOp::Multiply => BinOp::Mul(Default::default()),
-            CBinOp::Divide => BinOp::Div(Default::default()),
-            CBinOp::Modulus => BinOp::Rem(Default::default()),
-            CBinOp::Add => BinOp::Add(Default::default()),
-            CBinOp::Subtract => BinOp::Sub(Default::default()),
-            CBinOp::ShiftLeft => BinOp::Shl(Default::default()),
-            CBinOp::ShiftRight => BinOp::Shr(Default::default()),
-            CBinOp::Less => BinOp::Lt(Default::default()),
-            CBinOp::Greater => BinOp::Gt(Default::default()),
-            CBinOp::LessEqual => BinOp::Le(Default::default()),
-            CBinOp::GreaterEqual => BinOp::Ge(Default::default()),
-            CBinOp::EqualEqual => BinOp::Eq(Default::default()),
-            CBinOp::NotEqual => BinOp::Ne(Default::default()),
-            CBinOp::BitAnd => BinOp::BitAnd(Default::default()),
-            CBinOp::BitXor => BinOp::BitXor(Default::default()),
-            CBinOp::BitOr => BinOp::BitOr(Default::default()),
-            CBinOp::And => BinOp::And(Default::default()),
-            CBinOp::Or => BinOp::Or(Default::default()),
-
-            _ => panic!("CBinOp {:?} is not a valid Rust BinOp", op),
-        }
-    }
-}
-
 impl<'c> Translation<'c> {
     pub fn convert_binary_expr(
         &self,

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -526,14 +526,8 @@ impl<'c> Translation<'c> {
             CBinOp::Add => return self.convert_addition(lhs_type, rhs_type, lhs, rhs),
             CBinOp::Subtract => return self.convert_subtraction(ty, lhs_type, rhs_type, lhs, rhs),
 
-            CBinOp::Multiply if is_unsigned_integral_type => {
-                mk().method_call_expr(lhs, "wrapping_mul", vec![rhs])
-            }
-            CBinOp::Divide if is_unsigned_integral_type => {
-                mk().method_call_expr(lhs, "wrapping_div", vec![rhs])
-            }
-            CBinOp::Modulus if is_unsigned_integral_type => {
-                mk().method_call_expr(lhs, "wrapping_rem", vec![rhs])
+            CBinOp::Multiply | CBinOp::Divide | CBinOp::Modulus if is_unsigned_integral_type => {
+                mk().method_call_expr(lhs, op.wrapping_method(), vec![rhs])
             }
 
             CBinOp::Multiply

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -541,32 +541,28 @@ impl<'c> Translation<'c> {
             CBinOp::Multiply if is_unsigned_integral_type => {
                 mk().method_call_expr(lhs, "wrapping_mul", vec![rhs])
             }
-            CBinOp::Multiply => mk().binary_expr(BinOp::Mul(Default::default()), lhs, rhs),
-
             CBinOp::Divide if is_unsigned_integral_type => {
                 mk().method_call_expr(lhs, "wrapping_div", vec![rhs])
             }
-            CBinOp::Divide => mk().binary_expr(BinOp::Div(Default::default()), lhs, rhs),
-
             CBinOp::Modulus if is_unsigned_integral_type => {
                 mk().method_call_expr(lhs, "wrapping_rem", vec![rhs])
             }
-            CBinOp::Modulus => mk().binary_expr(BinOp::Rem(Default::default()), lhs, rhs),
 
-            CBinOp::BitXor => mk().binary_expr(BinOp::BitXor(Default::default()), lhs, rhs),
-
-            CBinOp::ShiftRight => mk().binary_expr(BinOp::Shr(Default::default()), lhs, rhs),
-            CBinOp::ShiftLeft => mk().binary_expr(BinOp::Shl(Default::default()), lhs, rhs),
+            CBinOp::Multiply
+            | CBinOp::Divide
+            | CBinOp::Modulus
+            | CBinOp::BitAnd
+            | CBinOp::BitOr
+            | CBinOp::BitXor
+            | CBinOp::ShiftRight
+            | CBinOp::ShiftLeft => mk().binary_expr(BinOp::from(op), lhs, rhs),
 
             CBinOp::EqualEqual | CBinOp::NotEqual => {
                 // Using `.is_none()` and `.is_some()` for null comparison means
                 // we don't have to rely on `trait PartialEq` as much
                 // and it is also more idiomatic.
-                let (is_null, bin_op) = match op {
-                    CBinOp::EqualEqual => (true, BinOp::Eq(Default::default())),
-                    CBinOp::NotEqual => (false, BinOp::Ne(Default::default())),
-                    _ => unreachable!(),
-                };
+                let is_null = op == CBinOp::EqualEqual;
+                let bin_op = BinOp::from(op);
                 let expr = match lhs_rhs_ids {
                     Some((lhs_expr_id, _)) if self.ast_context.is_null_expr(lhs_expr_id) => {
                         self.convert_pointer_is_null(ctx, rhs_type.ctype, rhs, is_null)?
@@ -579,19 +575,9 @@ impl<'c> Translation<'c> {
 
                 bool_to_int(expr)
             }
-            CBinOp::Less => bool_to_int(mk().binary_expr(BinOp::Lt(Default::default()), lhs, rhs)),
-            CBinOp::Greater => {
-                bool_to_int(mk().binary_expr(BinOp::Gt(Default::default()), lhs, rhs))
+            CBinOp::Less | CBinOp::Greater | CBinOp::GreaterEqual | CBinOp::LessEqual => {
+                bool_to_int(mk().binary_expr(BinOp::from(op), lhs, rhs))
             }
-            CBinOp::GreaterEqual => {
-                bool_to_int(mk().binary_expr(BinOp::Ge(Default::default()), lhs, rhs))
-            }
-            CBinOp::LessEqual => {
-                bool_to_int(mk().binary_expr(BinOp::Le(Default::default()), lhs, rhs))
-            }
-
-            CBinOp::BitAnd => mk().binary_expr(BinOp::BitAnd(Default::default()), lhs, rhs),
-            CBinOp::BitOr => mk().binary_expr(BinOp::BitOr(Default::default()), lhs, rhs),
 
             op => unimplemented!("Translation of binary operator {:?}", op),
         }))

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -635,15 +635,9 @@ impl<'c> Translation<'c> {
         &self,
         ctx: ExprContext,
         ty: CQualTypeId,
-        up: bool,
+        op: CBinOp,
         arg: CExprId,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let op = if up {
-            CBinOp::AssignAdd
-        } else {
-            CBinOp::AssignSubtract
-        };
-
         let arg_type = self.ast_context[arg]
             .kind
             .get_qual_type()
@@ -691,14 +685,17 @@ impl<'c> Translation<'c> {
         &self,
         ctx: ExprContext,
         ty: CQualTypeId,
-        up: bool,
+        op: CBinOp,
         arg: CExprId,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         // If we aren't going to be using the result, may as well do a simple pre-increment
         if ctx.is_unused() {
-            return self.convert_pre_increment(ctx, ty, up, arg);
+            return self.convert_pre_increment(ctx, ty, op, arg);
         }
 
+        let op = op
+            .underlying_assignment()
+            .expect("not an valid assignment operator");
         let ty = self
             .ast_context
             .index(arg)
@@ -745,7 +742,11 @@ impl<'c> Translation<'c> {
                         one = n
                     }
 
-                    let n = if up { one } else { neg_expr(one) };
+                    let n = if op == CBinOp::Subtract {
+                        neg_expr(one)
+                    } else {
+                        one
+                    };
                     is_unsafe = true;
                     mk().method_call_expr(read, "offset", vec![n])
                 } else if self
@@ -754,15 +755,9 @@ impl<'c> Translation<'c> {
                     .kind
                     .is_unsigned_integral_type()
                 {
-                    let m = if up { "wrapping_add" } else { "wrapping_sub" };
-                    mk().method_call_expr(read, m, vec![one])
+                    mk().method_call_expr(read, op.wrapping_method(), vec![one])
                 } else {
-                    let k = if up {
-                        BinOp::Add(Default::default())
-                    } else {
-                        BinOp::Sub(Default::default())
-                    };
-                    mk().binary_expr(k, read, one)
+                    mk().binary_expr(BinOp::from(op), read, one)
                 };
 
                 // *p = *p + rhs
@@ -794,10 +789,18 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let mut unary = match name {
             CUnOp::AddressOf => self.convert_address_of(ctx, cqual_type, arg),
-            CUnOp::PreIncrement => self.convert_pre_increment(ctx, cqual_type, true, arg),
-            CUnOp::PreDecrement => self.convert_pre_increment(ctx, cqual_type, false, arg),
-            CUnOp::PostIncrement => self.convert_post_increment(ctx, cqual_type, true, arg),
-            CUnOp::PostDecrement => self.convert_post_increment(ctx, cqual_type, false, arg),
+            CUnOp::PreIncrement => {
+                self.convert_pre_increment(ctx, cqual_type, CBinOp::AssignAdd, arg)
+            }
+            CUnOp::PreDecrement => {
+                self.convert_pre_increment(ctx, cqual_type, CBinOp::AssignSubtract, arg)
+            }
+            CUnOp::PostIncrement => {
+                self.convert_post_increment(ctx, cqual_type, CBinOp::AssignAdd, arg)
+            }
+            CUnOp::PostDecrement => {
+                self.convert_post_increment(ctx, cqual_type, CBinOp::AssignSubtract, arg)
+            }
             CUnOp::Deref => self.convert_deref(ctx, cqual_type, arg),
             CUnOp::Plus => self.convert_expr(ctx.used(), arg, Some(cqual_type)), // promotion is explicit in the clang AST
 

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -473,23 +473,11 @@ impl<'c> Translation<'c> {
                         }
 
                         _ => {
-                            fn eq<Token: Default, F: Fn(Token) -> BinOp>(f: F) -> BinOp {
-                                f(Default::default())
-                            }
+                            let bin_op = op
+                                .underlying_assignment()
+                                .expect("Cannot convert non-assignment operator");
+                            let bin_op_kind = BinOp::from(op);
 
-                            let (bin_op, bin_op_kind) = match op {
-                                AssignAdd => (Add, eq(BinOp::AddAssign)),
-                                AssignSubtract => (Subtract, eq(BinOp::SubAssign)),
-                                AssignMultiply => (Multiply, eq(BinOp::MulAssign)),
-                                AssignDivide => (Divide, eq(BinOp::DivAssign)),
-                                AssignModulus => (Modulus, eq(BinOp::RemAssign)),
-                                AssignBitXor => (BitXor, eq(BinOp::BitXorAssign)),
-                                AssignShiftLeft => (ShiftLeft, eq(BinOp::ShlAssign)),
-                                AssignShiftRight => (ShiftRight, eq(BinOp::ShrAssign)),
-                                AssignBitOr => (BitOr, eq(BinOp::BitOrAssign)),
-                                AssignBitAnd => (BitAnd, eq(BinOp::BitAndAssign)),
-                                _ => panic!("Cannot convert non-assignment operator"),
-                            };
                             self.convert_assignment_operator_aux(
                                 ctx,
                                 bin_op_kind,

--- a/c2rust-transpile/src/translator/structs_unions.rs
+++ b/c2rust-transpile/src/translator/structs_unions.rs
@@ -728,39 +728,12 @@ impl<'a> Translation<'a> {
                 let lhs_expr_read = mk().method_call_expr(lhs_expr.clone(), field_name, Vec::new());
                 // Allow the value of this assignment to be used as the RHS of other assignments
                 let val = lhs_expr_read.clone();
-                let param_expr = match op {
-                    CBinOp::AssignAdd => {
-                        mk().binary_expr(BinOp::Add(Default::default()), lhs_expr_read, rhs_expr)
-                    }
-                    CBinOp::AssignSubtract => {
-                        mk().binary_expr(BinOp::Sub(Default::default()), lhs_expr_read, rhs_expr)
-                    }
-                    CBinOp::AssignMultiply => {
-                        mk().binary_expr(BinOp::Mul(Default::default()), lhs_expr_read, rhs_expr)
-                    }
-                    CBinOp::AssignDivide => {
-                        mk().binary_expr(BinOp::Div(Default::default()), lhs_expr_read, rhs_expr)
-                    }
-                    CBinOp::AssignModulus => {
-                        mk().binary_expr(BinOp::Rem(Default::default()), lhs_expr_read, rhs_expr)
-                    }
-                    CBinOp::AssignBitXor => {
-                        mk().binary_expr(BinOp::BitXor(Default::default()), lhs_expr_read, rhs_expr)
-                    }
-                    CBinOp::AssignShiftLeft => {
-                        mk().binary_expr(BinOp::Shl(Default::default()), lhs_expr_read, rhs_expr)
-                    }
-                    CBinOp::AssignShiftRight => {
-                        mk().binary_expr(BinOp::Shr(Default::default()), lhs_expr_read, rhs_expr)
-                    }
-                    CBinOp::AssignBitOr => {
-                        mk().binary_expr(BinOp::BitOr(Default::default()), lhs_expr_read, rhs_expr)
-                    }
-                    CBinOp::AssignBitAnd => {
-                        mk().binary_expr(BinOp::BitAnd(Default::default()), lhs_expr_read, rhs_expr)
-                    }
-                    CBinOp::Assign => rhs_expr,
-                    _ => panic!("Cannot convert non-assignment operator"),
+                let param_expr = if let Some(op) = op.underlying_assignment() {
+                    mk().binary_expr(BinOp::from(op), lhs_expr_read, rhs_expr)
+                } else if op == CBinOp::Assign {
+                    rhs_expr
+                } else {
+                    panic!("Cannot convert non-assignment operator")
                 };
 
                 let mut stmts = vec![];


### PR DESCRIPTION
Some relatively simple changes to make the code cleaner.