### PR TITLE
transpile: Flip comparison operators when negating in CFG

### DIFF
--- a/c2rust-transpile/src/cfg/structures.rs
+++ b/c2rust-transpile/src/cfg/structures.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use log::warn;
-use syn::{spanned::Spanned as _, ExprBreak, ExprIf, ExprUnary, Stmt};
+use syn::{spanned::Spanned as _, ExprBinary, ExprBreak, ExprIf, ExprUnary, Stmt};
 
 use crate::rust_ast::{comment_store, set_span::SetSpan, BytePos, SpanExt};
 
@@ -1048,15 +1048,33 @@ impl StructureState {
 /// Take the logical negation of an expression.
 ///
 ///   * Negating something of the form `!<expr>` produces `<expr>`
+///   * Negating a comparison operator produces the opposite operator.
 ///
 fn not(bool_expr: &Expr) -> Box<Expr> {
-    use syn::UnOp;
+    use syn::{BinOp::*, UnOp};
     match *bool_expr {
         Expr::Unary(ExprUnary {
             op: UnOp::Not(_),
             ref expr,
             ..
         }) => Box::new(unparen(expr).clone()),
+        Expr::Binary(ExprBinary {
+            ref left,
+            op: op @ (Eq(_) | Ne(_) | Gt(_) | Lt(_) | Ge(_) | Le(_)),
+            ref right,
+            ..
+        }) => {
+            let op = match op {
+                Eq(_) => Ne(Default::default()),
+                Ne(_) => Eq(Default::default()),
+                Gt(_) => Le(Default::default()),
+                Lt(_) => Ge(Default::default()),
+                Ge(_) => Lt(Default::default()),
+                Le(_) => Gt(Default::default()),
+                _ => unreachable!(),
+            };
+            mk().binary_expr(op, left.clone(), right.clone())
+        }
         _ => mk().unary_expr(UnOp::Not(Default::default()), Box::new(bool_expr.clone())),
     }
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@irreducible.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-linux@irreducible.c.snap
@@ -32,7 +32,7 @@ pub unsafe extern "C" fn irreducible(mut x: ::core::ffi::c_int) -> ::core::ffi::
                     }
                 }
                 _ => {
-                    if !(x < 20 as ::core::ffi::c_int) {
+                    if x >= 20 as ::core::ffi::c_int {
                         break 's_36;
                     }
                     x += 90 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@irreducible.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile-macos@irreducible.c.snap
@@ -32,7 +32,7 @@ pub unsafe extern "C" fn irreducible(mut x: ::core::ffi::c_int) -> ::core::ffi::
                     }
                 }
                 _ => {
-                    if !(x < 20 as ::core::ffi::c_int) {
+                    if x >= 20 as ::core::ffi::c_int {
                         break 's_36;
                     }
                     x += 90 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2021.clang15.snap
@@ -14,7 +14,7 @@ expression: cat tests/snapshots/gotos.2021.clang15.rs
 #[no_mangle]
 pub unsafe extern "C" fn sum(mut count: ::core::ffi::c_int) -> ::core::ffi::c_int {
     let mut x: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-    while !(count <= 0 as ::core::ffi::c_int) {
+    while count > 0 as ::core::ffi::c_int {
         x += count;
         count -= 1;
     }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@gotos.c.2024.clang15.snap
@@ -15,7 +15,7 @@ expression: cat tests/snapshots/gotos.2024.clang15.rs
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn sum(mut count: ::core::ffi::c_int) -> ::core::ffi::c_int {
     let mut x: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-    while !(count <= 0 as ::core::ffi::c_int) {
+    while count > 0 as ::core::ffi::c_int {
         x += count;
         count -= 1;
     }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2021.clang15.snap
@@ -20,7 +20,7 @@ pub unsafe extern "C" fn lift_const(
     mut argv: *mut *mut ::core::ffi::c_char,
 ) {
     let mut starts_with_a: ::core::ffi::c_int = 0;
-    if !(argc == 3 as ::core::ffi::c_int) {
+    if argc != 3 as ::core::ffi::c_int {
         starts_with_a = (**argv.offset(0 as ::core::ffi::c_int as isize) as ::core::ffi::c_int
             == 'a' as ::core::ffi::c_int) as ::core::ffi::c_int;
         if starts_with_a != 0 {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2024.clang15.snap
@@ -21,7 +21,7 @@ pub unsafe extern "C" fn lift_const(
     mut argv: *mut *mut ::core::ffi::c_char,
 ) {
     let mut starts_with_a: ::core::ffi::c_int = 0;
-    if !(argc == 3 as ::core::ffi::c_int) {
+    if argc != 3 as ::core::ffi::c_int {
         starts_with_a = (**argv.offset(0 as ::core::ffi::c_int as isize) as ::core::ffi::c_int
             == 'a' as ::core::ffi::c_int) as ::core::ffi::c_int;
         if starts_with_a != 0 {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@loops.c.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@loops.c.snap
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn infinite_loop(mut x: ::core::ffi::c_int) {
 pub unsafe extern "C" fn goto_loop(mut x: ::core::ffi::c_int) -> ::core::ffi::c_int {
     loop {
         x += 1 as ::core::ffi::c_int;
-        if !(x != 0) {
+        if x == 0 {
             break;
         }
     }
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn goto_loop(mut x: ::core::ffi::c_int) -> ::core::ffi::c_
 pub unsafe extern "C" fn do_while_loop(mut x: ::core::ffi::c_int) -> ::core::ffi::c_int {
     loop {
         x += 1 as ::core::ffi::c_int;
-        if !(x != 0) {
+        if x == 0 {
             break;
         }
     }
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn do_loop_single_continue(mut x: ::core::ffi::c_int) -> :
             }
             x += 1 as ::core::ffi::c_int;
         }
-        if !(x != 0) {
+        if x == 0 {
             break;
         }
     }
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn do_loop_multi_continue(mut x: ::core::ffi::c_int) -> ::
             }
             x += 2 as ::core::ffi::c_int;
         }
-        if !(x != 0) {
+        if x == 0 {
             break;
         }
     }
@@ -354,14 +354,14 @@ pub unsafe extern "C" fn goto_loops(mut x: ::core::ffi::c_int) -> ::core::ffi::c
         if x != 0 {
             loop {
                 x += 1 as ::core::ffi::c_int;
-                if !(x != 0) {
+                if x == 0 {
                     break '_D;
                 }
             }
         } else {
             loop {
                 x += 2 as ::core::ffi::c_int;
-                if !(x != 0) {
+                if x == 0 {
                     break '_D;
                 }
             }
@@ -375,14 +375,14 @@ pub unsafe extern "C" fn goto_into_loops(mut x: ::core::ffi::c_int) {
         if x != 0 {
             loop {
                 x += 1 as ::core::ffi::c_int;
-                if !(x != 0) {
+                if x == 0 {
                     break '_D;
                 }
             }
         } else {
             loop {
                 x += 2 as ::core::ffi::c_int;
-                if !(x != 0) {
+                if x == 0 {
                     break '_D;
                 }
             }
@@ -394,14 +394,14 @@ pub unsafe extern "C" fn goto_separate_loops(mut x: ::core::ffi::c_int) {
     if x != 0 {
         loop {
             x += 1 as ::core::ffi::c_int;
-            if !(x != 0) {
+            if x == 0 {
                 break;
             }
         }
     } else {
         loop {
             x += 2 as ::core::ffi::c_int;
-            if !(x != 0) {
+            if x == 0 {
                 break;
             }
         }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2021.x86_64.linux.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2021.x86_64.linux.clang15.snap
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn my_printf(mut fmt: *const ::core::ffi::c_char, mut c2ru
         match *fmt as ::core::ffi::c_int {
             37 => {
                 fmt = fmt.offset(1);
-                if !(*fmt == 0) {
+                if *fmt != 0 {
                     match *fmt as ::core::ffi::c_int {
                         105 | 100 => {
                             printf(

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2024.x86_64.linux.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@varargs.c.2024.x86_64.linux.clang15.snap
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn my_printf(mut fmt: *const ::core::ffi::c_char, mut c2ru
         match *fmt as ::core::ffi::c_int {
             37 => {
                 fmt = fmt.offset(1);
-                if !(*fmt == 0) {
+                if *fmt != 0 {
                     match *fmt as ::core::ffi::c_int {
                         105 | 100 => {
                             printf(


### PR DESCRIPTION
Produces cleaner code, with relatively small changes.