### PR TITLE
transpile: Cast character literals to provided type instead of `i32`

### DIFF
--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -35,12 +35,12 @@ impl<'c> Translation<'c> {
     pub fn literal_matches_ty(&self, lit: &CLiteral, ty: CQualTypeId, is_negated: bool) -> bool {
         let ty_kind = &self.ast_context.resolve_type(ty.ctype).kind;
         match *lit {
-            CLiteral::Integer(value, _) if ty_kind.is_integral_type() && !ty_kind.is_bool() => {
+            CLiteral::Integer(value, _) | CLiteral::Character(value)
+                if ty_kind.is_integral_type() && !ty_kind.is_bool() =>
+            {
                 ty_kind.guaranteed_integer_in_range(value)
                     && (!is_negated || ty_kind.is_signed_integral_type())
             }
-            // `convert_literal` always casts these to i32.
-            CLiteral::Character(_value) => matches!(ty_kind, CTypeKind::Int32),
             CLiteral::Floating(value, _) if ty_kind.is_floating_type() => {
                 ty_kind.guaranteed_float_in_range(value)
             }
@@ -62,25 +62,22 @@ impl<'c> Translation<'c> {
 
             CLiteral::Character(val) => {
                 let val = val as u32;
-                let expr =
-                    match char::from_u32(val) {
-                        Some(c) => {
-                            let expr = mk().lit_expr(c);
-                            let i32_type = mk().path_ty(vec!["i32"]);
-                            mk().cast_expr(expr, i32_type)
+                let expr = match char::from_u32(val) {
+                    Some(c) => mk().lit_expr(c),
+                    None => {
+                        // Fallback for characters outside of the valid Unicode range
+                        if (val as i32) < 0 {
+                            neg_expr(mk().lit_expr(
+                                mk().int_unsuffixed_lit((val as i32).unsigned_abs() as u128),
+                            ))
+                        } else {
+                            mk().lit_expr(mk().int_unsuffixed_lit(val as u128))
                         }
-                        None => {
-                            // Fallback for characters outside of the valid Unicode range
-                            if (val as i32) < 0 {
-                                neg_expr(mk().lit_expr(
-                                    mk().int_lit((val as i32).unsigned_abs() as u128, "i32"),
-                                ))
-                            } else {
-                                mk().lit_expr(mk().int_lit(val as u128, "i32"))
-                            }
-                        }
-                    };
-                Ok(WithStmts::new_val(expr))
+                    }
+                };
+
+                let type_rs = self.convert_type(ty.ctype)?;
+                Ok(WithStmts::new_val(mk().cast_expr(expr, type_rs)))
             }
 
             CLiteral::Floating(val, ref c_str) => {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.snap
@@ -67,9 +67,9 @@ pub unsafe extern "C" fn entry() {
     let mut char_with_string: [::core::ffi::c_char; 4] =
         ::core::mem::transmute::<[u8; 4], [::core::ffi::c_char; 4]>(*b"abc\0");
     let mut char_with_chars: [::core::ffi::c_char; 3] = [
-        'd' as i32 as ::core::ffi::c_char,
-        'e' as i32 as ::core::ffi::c_char,
-        'f' as i32 as ::core::ffi::c_char,
+        'd' as ::core::ffi::c_char,
+        'e' as ::core::ffi::c_char,
+        'f' as ::core::ffi::c_char,
     ];
     let mut char_with_ints: [::core::ffi::c_char; 2] = [1 as ::core::ffi::c_char, 0];
     let mut char_with_init: [::core::ffi::c_char; 5] =

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.snap
@@ -67,9 +67,9 @@ pub unsafe extern "C" fn entry() {
     let mut char_with_string: [::core::ffi::c_char; 4] =
         ::core::mem::transmute::<[u8; 4], [::core::ffi::c_char; 4]>(*b"abc\0");
     let mut char_with_chars: [::core::ffi::c_char; 3] = [
-        'd' as i32 as ::core::ffi::c_char,
-        'e' as i32 as ::core::ffi::c_char,
-        'f' as i32 as ::core::ffi::c_char,
+        'd' as ::core::ffi::c_char,
+        'e' as ::core::ffi::c_char,
+        'f' as ::core::ffi::c_char,
     ];
     let mut char_with_ints: [::core::ffi::c_char; 2] = [1 as ::core::ffi::c_char, 0];
     let mut char_with_init: [::core::ffi::c_char; 5] =

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2021.snap
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn lift_const(
     let mut starts_with_a: ::core::ffi::c_int = 0;
     if !(argc == 3 as ::core::ffi::c_int) {
         starts_with_a = (**argv.offset(0 as ::core::ffi::c_int as isize) as ::core::ffi::c_int
-            == 'a' as i32) as ::core::ffi::c_int;
+            == 'a' as ::core::ffi::c_int) as ::core::ffi::c_int;
         if starts_with_a != 0 {
             printf(b"  (arg 0 starts with 'a')\n\0".as_ptr() as *const ::core::ffi::c_char);
         }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@lift_const.c.2024.snap
@@ -23,7 +23,7 @@ pub unsafe extern "C" fn lift_const(
     let mut starts_with_a: ::core::ffi::c_int = 0;
     if !(argc == 3 as ::core::ffi::c_int) {
         starts_with_a = (**argv.offset(0 as ::core::ffi::c_int as isize) as ::core::ffi::c_int
-            == 'a' as i32) as ::core::ffi::c_int;
+            == 'a' as ::core::ffi::c_int) as ::core::ffi::c_int;
         if starts_with_a != 0 {
             printf(b"  (arg 0 starts with 'a')\n\0".as_ptr() as *const ::core::ffi::c_char);
         }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
@@ -39,7 +39,7 @@ pub const UINTPTR_MAX: ::core::ffi::c_ulong = 18446744073709551615 as ::core::ff
 pub const LITERAL_INT: ::core::ffi::c_int = 0xffff as ::core::ffi::c_int;
 pub const LITERAL_BOOL: ::core::ffi::c_int = true_0;
 pub const LITERAL_FLOAT: ::core::ffi::c_double = 3.14f64;
-pub const LITERAL_CHAR: ::core::ffi::c_int = 'x' as i32;
+pub const LITERAL_CHAR: ::core::ffi::c_int = 'x' as ::core::ffi::c_int;
 pub const LITERAL_STR: [::core::ffi::c_char; 6] =
     unsafe { ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0") };
 pub const LITERAL_STRUCT: S = S {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
@@ -39,7 +39,7 @@ pub const UINTPTR_MAX: ::core::ffi::c_ulong = 18446744073709551615 as ::core::ff
 pub const LITERAL_INT: ::core::ffi::c_int = 0xffff as ::core::ffi::c_int;
 pub const LITERAL_BOOL: ::core::ffi::c_int = true_0;
 pub const LITERAL_FLOAT: ::core::ffi::c_double = 3.14f64;
-pub const LITERAL_CHAR: ::core::ffi::c_int = 'x' as i32;
+pub const LITERAL_CHAR: ::core::ffi::c_int = 'x' as ::core::ffi::c_int;
 pub const LITERAL_STR: [::core::ffi::c_char; 6] =
     unsafe { ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0") };
 pub const LITERAL_STRUCT: S = S {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.snap
@@ -17,7 +17,7 @@ pub const true_0: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
 #[no_mangle]
 pub unsafe extern "C" fn scalar_init() {
     let mut b: bool = true_0 != 0;
-    let mut c: ::core::ffi::c_char = 'c' as i32 as ::core::ffi::c_char;
+    let mut c: ::core::ffi::c_char = 'c' as ::core::ffi::c_char;
     let mut i: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
     let mut l: ::core::ffi::c_long = 42 as ::core::ffi::c_long;
     let mut f: ::core::ffi::c_float = 42.0f32;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.snap
@@ -17,7 +17,7 @@ pub const true_0: ::core::ffi::c_int = 1 as ::core::ffi::c_int;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn scalar_init() {
     let mut b: bool = true_0 != 0;
-    let mut c: ::core::ffi::c_char = 'c' as i32 as ::core::ffi::c_char;
+    let mut c: ::core::ffi::c_char = 'c' as ::core::ffi::c_char;
     let mut i: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
     let mut l: ::core::ffi::c_long = 42 as ::core::ffi::c_long;
     let mut f: ::core::ffi::c_float = 42.0f32;


### PR DESCRIPTION
There doesn't seem to be any reason to cast these to `i32` when they are generally `int` in C. It results in a type mismatch with the rest of the code if `c_int` is ever not defined as `i32`.