### PR TITLE
Support C11 generics

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -1501,7 +1501,13 @@ class TranslateASTVisitor final
     }
 
     bool VisitGenericSelectionExpr(GenericSelectionExpr *E) {
-        printDiag(Context, DiagnosticsEngine::Warning, "Encountered unsupported generic selection expression", E);
+        if (E->isResultDependent()) {
+            printDiag(Context, DiagnosticsEngine::Warning, "Encountered unsupported generic selection expression", E);
+            return true;
+        }
+
+        std::vector<void *> childIds{E->getResultExpr()};
+        encode_entry(E, TagGenericExpr, childIds);
         return true;
     }
 

--- a/c2rust-ast-exporter/src/ast_tags.hpp
+++ b/c2rust-ast-exporter/src/ast_tags.hpp
@@ -89,6 +89,7 @@ enum ASTEntryTag {
 
     TagAtomicExpr,
     TagTypeTraitExpr,
+    TagGenericExpr,
 
     TagIntegerLiteral = 300,
     TagStringLiteral,

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -2001,6 +2001,19 @@ impl ConversionContext {
                     self.expr_possibly_as_stmt(expected_ty, new_id, node, e)
                 }
 
+                ASTEntryTag::TagGenericExpr if expected_ty & (EXPR | STMT) != 0 => {
+                    let wrapped = node.children[0].expect("Expected generic expression");
+                    let ty_old = node.type_id.expect("Expected expression to have type");
+                    let ty = self.visit_qualified_type(ty_old);
+
+                    // Use the existing `Paren` kind instead of adding a new one
+                    // that would just be a no-op wrapper around the inner
+                    // expression
+                    let expr = CExprKind::Paren(ty, self.visit_expr(wrapped));
+
+                    self.expr_possibly_as_stmt(expected_ty, new_id, node, expr);
+                }
+
                 // Declarations
                 ASTEntryTag::TagFunctionDecl if expected_ty & OTHER_DECL != 0 => {
                     let name = from_value::<String>(node.extras[0].clone())

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -375,6 +375,11 @@ fn test_fn_attrs() {
 }
 
 #[test]
+fn test_generics() {
+    transpile("generics.c").run();
+}
+
+#[test]
 fn test_gotos() {
     transpile("gotos.c").run();
 }

--- a/c2rust-transpile/tests/snapshots/generics.c
+++ b/c2rust-transpile/tests/snapshots/generics.c
@@ -1,0 +1,35 @@
+#define inc(x) (_Generic((x), \
+    float: (x) + 1.0f,        \
+    double: (x) + 1.0,        \
+    default: (x) + 1))
+
+struct s { int x; };
+struct t { int y; };
+#define cast(p) (_Generic((p), \
+    const struct s *: (const struct t *)(p), \
+    struct s *:       (struct t *)(p)))
+
+#define unqual_typeof(x) typeof(_Generic((x), \
+    int: (int)0, const int: (int)0, default: (x)))
+
+void foo() {
+    int x = inc(42);
+    double y = inc(42.0);
+    float z = inc(42.0f);
+
+    int n = 0;
+    _Generic((n++), int: n, default: n);  // n must end up 0, not 1
+
+    // No default
+    int m = 0;
+    n = _Generic((m), int: m);
+
+    struct s s;
+    struct s *p1 = &s;
+    const struct s *p2 = &s;
+    struct t *t1 = cast(p1);
+    const struct t *t2 = cast(p2);
+
+    const int cx = n;
+    unqual_typeof(x) ut_y = cx;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@generics.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@generics.c.2021.clang15.snap
@@ -1,0 +1,40 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/generics.2021.clang15.rs
+---
+#![allow(
+    clippy::missing_safety_doc,
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![feature(raw_ref_op)]
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct s {
+    pub x: ::core::ffi::c_int,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct t {
+    pub y: ::core::ffi::c_int,
+}
+#[no_mangle]
+pub unsafe extern "C" fn foo() {
+    let mut x: ::core::ffi::c_int = 42 as ::core::ffi::c_int + 1 as ::core::ffi::c_int;
+    let mut y: ::core::ffi::c_double = 42.0f64 + 1.0f64;
+    let mut z: ::core::ffi::c_float = 42.0f32 + 1.0f32;
+    let mut n: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    let mut m: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    n = m;
+    let mut s: s = s { x: 0 };
+    let mut p1: *mut s = &raw mut s;
+    let mut p2: *const s = &raw mut s;
+    let mut t1: *mut t = p1 as *mut t;
+    let mut t2: *const t = p2 as *const t;
+    let cx: ::core::ffi::c_int = n;
+    let mut ut_y: ::core::ffi::c_int = cx as ::core::ffi::c_int;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@generics.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@generics.c.2024.clang15.snap
@@ -1,0 +1,40 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/generics.2024.clang15.rs
+---
+#![allow(
+    clippy::missing_safety_doc,
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unsafe_op_in_unsafe_fn,
+    unused_assignments,
+    unused_mut
+)]
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct s {
+    pub x: ::core::ffi::c_int,
+}
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct t {
+    pub y: ::core::ffi::c_int,
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn foo() {
+    let mut x: ::core::ffi::c_int = 42 as ::core::ffi::c_int + 1 as ::core::ffi::c_int;
+    let mut y: ::core::ffi::c_double = 42.0f64 + 1.0f64;
+    let mut z: ::core::ffi::c_float = 42.0f32 + 1.0f32;
+    let mut n: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    let mut m: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    n = m;
+    let mut s: s = s { x: 0 };
+    let mut p1: *mut s = &raw mut s;
+    let mut p2: *const s = &raw mut s;
+    let mut t1: *mut t = p1 as *mut t;
+    let mut t2: *const t = p2 as *const t;
+    let cx: ::core::ffi::c_int = n;
+    let mut ut_y: ::core::ffi::c_int = cx as ::core::ffi::c_int;
+}


### PR DESCRIPTION
Add support for C11 `_Generic` generics where the result can be determined by clang at compile time so we transpile the resolved expression directly. Fixes #1786 
