### PR TITLE
transpile: Add `macro_expansion_text` only for expressions

### DIFF
--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -1055,12 +1055,12 @@ impl ConversionContext {
                         .or_default()
                         .push(mac);
                 }
-            }
 
-            if let Some(text) = &node.macro_invocation_text {
-                self.typed_context
-                    .macro_expansion_text
-                    .insert(CExprId(new_id), text.clone());
+                if let Some(text) = &node.macro_invocation_text {
+                    self.typed_context
+                        .macro_expansion_text
+                        .insert(CExprId(new_id), text.clone());
+                }
             }
 
             match node.tag {


### PR DESCRIPTION
Items were being added to `macro_expansion_text` without checking for the node type, so it ended up with other kinds of ids masquerading as `CExprId`s.