### PR TITLE
ast-exporter: Export some macro arg expansions

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -1451,17 +1451,21 @@ class TranslateASTVisitor final
         }
 
         curMacroExpansionSource =
-            Lexer::getSourceText(ExpansionStack[0], Mgr, Context->getLangOpts());
+            Lexer::getSourceText(ExpansionStack[0].range, Mgr, Context->getLangOpts());
 
-        for (auto &ExpansionRange : ExpansionStack) {
+        for (auto &elem : ExpansionStack) {
+            if (elem.isParameter) {
+                continue;
+            }
+
             StringRef name;
-            MacroInfo *mac = getMacroInfo(ExpansionRange.getBegin(), name);
+            MacroInfo *mac = getMacroInfo(elem.range.getBegin(), name);
 
             if (!mac || mac->getNumTokens() == 0) {
                 return true;
             }
 
-            if (VisitMacro(name, ExpansionRange.getBegin(), mac, E)) {
+            if (VisitMacro(name, elem.range.getBegin(), mac, E)) {
                 curMacroExpansionStack.push_back(mac);
             }
         }
@@ -1469,20 +1473,34 @@ class TranslateASTVisitor final
         return true;
     }
 
-    std::vector<CharSourceRange> getMacroExpansionStack(SourceRange Range) const {
+    struct ExpansionRange {
+        CharSourceRange range;
+        bool isParameter;
+
+        bool operator== (const ExpansionRange &rhs) const {
+            return this->range.getAsRange() == rhs.range.getAsRange()
+                && this->range.isTokenRange() == rhs.range.isTokenRange()
+                && this->isParameter == rhs.isParameter;
+        }
+    };
+
+    std::vector<ExpansionRange> getMacroExpansionStack(SourceRange Range) const {
         auto &Mgr = Context->getSourceManager();
         auto Begin = Range.getBegin();
         auto End = Range.getEnd();
-        std::vector<CharSourceRange> ExpansionStack;
+        std::vector<ExpansionRange> ExpansionStack;
 
         do {
             if (!isAtStartOfImmediateMacroExpansion(Begin)) {
                 break;
             }
 
-            auto ExpansionRange = Mgr.getImmediateExpansionRange(Begin);
-            ExpansionStack.push_back(ExpansionRange);
-            Begin = ExpansionRange.getBegin();
+            ExpansionRange elem = {
+                Mgr.getImmediateExpansionRange(Begin),
+                Mgr.isMacroArgExpansion(Begin)
+            };
+            Begin = elem.range.getBegin();
+            ExpansionStack.push_back(elem);
         } while (Begin.isMacroID());
 
         // Find the point at which `Begin` and `End` converge on the same expansion range.
@@ -1494,16 +1512,12 @@ class TranslateASTVisitor final
                 break;
             }
 
-            auto ExpansionRange = Mgr.getImmediateExpansionRange(End);
-            ConvergencePoint = std::find_if(
-                ExpansionStack.begin(),
-                ExpansionStack.end(),
-                [ExpansionRange](auto &R) {
-                    return R.getAsRange() == ExpansionRange.getAsRange() &&
-                        R.isTokenRange() == ExpansionRange.isTokenRange();
-                }
-            );
-            End = ExpansionRange.getEnd();
+            ExpansionRange elem = {
+                Mgr.getImmediateExpansionRange(End),
+                Mgr.isMacroArgExpansion(End)
+            };
+            End = elem.range.getEnd();
+            ConvergencePoint = std::find(ExpansionStack.begin(), ExpansionStack.end(), elem);
         } while (End.isMacroID() && ConvergencePoint == ExpansionStack.end());
 
         // Remove all elements before the convergence point.
@@ -1513,8 +1527,8 @@ class TranslateASTVisitor final
         auto EraseAfter = std::find_if(
             ExpansionStack.begin(),
             ExpansionStack.end(),
-            [this](auto &R) {
-                auto End = R.getEnd();
+            [this](auto &elem) {
+                auto End = elem.range.getEnd();
                 return End.isMacroID() && !isAtEndOfImmediateMacroExpansion(End);
             }
         );

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -732,10 +732,17 @@ class TranslateASTVisitor final
     std::set<std::pair<void *, ASTEntryTag>> exportedTags;
     std::unordered_map<MacroInfo*, MacroDeclInfo> macros;
 
+    struct MacroInvocationInfo {
+        uint32_t key;
+        MacroInfo* macro;
+        StringRef parameter;
+    };
+
     // This stores a raw encoding of the macro call site SourceLocation, since
     // SourceLocation isn't hashable.
-    std::unordered_set<unsigned> macroCallSites;
-    SmallVector<MacroInfo*, 1> curMacroInvocationStack;
+    // TODO: Can this be made to use `unordered_set` for speed?
+    std::set<std::pair<unsigned, const StringRef>> macroCallSites;
+    SmallVector<MacroInvocationInfo, 1> curMacroInvocationStack;
     StringRef curMacroInvocationSource;
 
     // Returns true when a new entry is added to exportedTags
@@ -822,7 +829,7 @@ class TranslateASTVisitor final
         if (encodeMacroInvocations) {
             for (auto I = curMacroInvocationStack.rbegin(), E = curMacroInvocationStack.rend();
                  I != E; ++I) {
-                cbor_encode_uint(&childEnc, uintptr_t(*I));
+                cbor_encode_uint(&childEnc, uintptr_t(I->macro));
             }
         }
         cbor_encoder_close_container(&local, &childEnc);
@@ -910,14 +917,15 @@ class TranslateASTVisitor final
                          isVaList(ast, T), encodeMacroInvocations, childIds, extra);
     }
 
-    bool VisitMacro(StringRef name, SourceLocation loc, MacroInfo *mac, Expr *E) {
+    bool VisitMacro(StringRef name, StringRef parameter, SourceLocation loc, MacroInfo *mac, Expr *E) {
         // TODO: handle builtin macros
         if (mac->isBuiltinMacro())
             return false;
         // If this isn't the first time we've seen this macro call site, we
         // shouldn't associate this expression with the macro as it is a subexpr
         // of a previously seen expression.
-        if (!macroCallSites.insert(loc.getRawEncoding()).second)
+        std::pair<unsigned, StringRef> key { loc.getRawEncoding(), parameter };
+        if (!macroCallSites.insert(key).second)
             return false;
         auto &info = macros[mac];
         if (info.Name.empty())
@@ -1420,11 +1428,20 @@ class TranslateASTVisitor final
             Lexer::getSourceText(ExpansionStack[0].range, Mgr, Context->getLangOpts());
 
         for (auto &elem : ExpansionStack) {
+            auto loc = elem.range.getBegin();
+            StringRef parameter;
+
             if (elem.isParameter) {
-                continue;
+                auto IdentifierInfo = getIdentifierInfo(loc);
+
+                if (!IdentifierInfo) {
+                    return true;
+                }
+
+                parameter = IdentifierInfo->getName();
+                loc = Mgr.getImmediateExpansionRange(loc).getBegin();
             }
 
-            auto loc = elem.range.getBegin();
             auto IdentifierInfo = getIdentifierInfo(loc);
 
             if (!IdentifierInfo) {
@@ -1437,8 +1454,9 @@ class TranslateASTVisitor final
                 return true;
             }
 
-            if (VisitMacro(IdentifierInfo->getName(), loc, MacroInfo, E)) {
-                curMacroInvocationStack.push_back(MacroInfo);
+            if (VisitMacro(IdentifierInfo->getName(), parameter, loc, MacroInfo, E)) {
+                MacroInvocationInfo info = { loc.getRawEncoding(), MacroInfo, parameter };
+                curMacroInvocationStack.push_back(info);
             }
         }
 

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -718,7 +718,7 @@ private:
 class TranslateASTVisitor final
     : public RecursiveASTVisitor<TranslateASTVisitor> {
 
-    struct MacroExpansionInfo {
+    struct MacroDeclInfo {
         StringRef Name;
     };
 
@@ -730,13 +730,13 @@ class TranslateASTVisitor final
     // Mapping from SourceManager FileID to index in files
     DenseMap<FileID, size_t> file_id_mapping;
     std::set<std::pair<void *, ASTEntryTag>> exportedTags;
-    std::unordered_map<MacroInfo*, MacroExpansionInfo> macros;
+    std::unordered_map<MacroInfo*, MacroDeclInfo> macros;
 
     // This stores a raw encoding of the macro call site SourceLocation, since
     // SourceLocation isn't hashable.
     std::unordered_set<unsigned> macroCallSites;
-    SmallVector<MacroInfo*, 1> curMacroExpansionStack;
-    StringRef curMacroExpansionSource;
+    SmallVector<MacroInfo*, 1> curMacroInvocationStack;
+    StringRef curMacroInvocationSource;
 
     // Returns true when a new entry is added to exportedTags
     bool markForExport(void *ptr, ASTEntryTag tag) {
@@ -776,7 +776,7 @@ class TranslateASTVisitor final
     // Template required because Decl and Stmt don't share a common base class
     void encode_entry_raw(void *ast, ASTEntryTag tag, SourceRange loc,
                           const QualType ty, bool rvalue,
-                          bool isVaList, bool encodeMacroExpansions,
+                          bool isVaList, bool encodeMacroInvocations,
                           const std::vector<void *> &childIds,
                           std::function<void(CborEncoder *)> extra) {
         if (!markForExport(ast, tag))
@@ -815,21 +815,21 @@ class TranslateASTVisitor final
         // 9 - Is Rvalue (only for expressions)
         cbor_encode_boolean(&local, rvalue);
 
-        // 10 - Macro expansion stack, starting with initial macro call and ending
+        // 10 - Macro invocation stack, starting with initial macro call and ending
         // with the innermost replacement.
         cbor_encoder_create_array(&local, &childEnc,
-                                  encodeMacroExpansions ? curMacroExpansionStack.size() : 0);
-        if (encodeMacroExpansions) {
-            for (auto I = curMacroExpansionStack.rbegin(), E = curMacroExpansionStack.rend();
+                                  encodeMacroInvocations ? curMacroInvocationStack.size() : 0);
+        if (encodeMacroInvocations) {
+            for (auto I = curMacroInvocationStack.rbegin(), E = curMacroInvocationStack.rend();
                  I != E; ++I) {
                 cbor_encode_uint(&childEnc, uintptr_t(*I));
             }
         }
         cbor_encoder_close_container(&local, &childEnc);
 
-        // 11 - Macro expansion source string, if applicable.
-        if (!curMacroExpansionSource.empty()) {
-            cbor_encode_string(&local, curMacroExpansionSource.str());
+        // 11 - Macro invocation source string, if applicable.
+        if (!curMacroInvocationSource.empty()) {
+            cbor_encode_string(&local, curMacroInvocationSource.str());
         } else {
             cbor_encode_null(&local);
         }
@@ -853,7 +853,7 @@ class TranslateASTVisitor final
         std::function<void(CborEncoder *)> extra = [](CborEncoder *) {}) {
         auto ty = ast->getType();
         auto isVaList = false;
-        auto encodeMacroExpansions = true;
+        auto encodeMacroInvocations = true;
 #if CLANG_VERSION_MAJOR < 13
         bool isRValue = ast->isRValue();
 #else
@@ -867,7 +867,7 @@ class TranslateASTVisitor final
         auto span = ast->getSourceRange();
         expandSpanToFinalChar(span, Context);
         encode_entry_raw(ast, tag, span, ty, isRValue, isVaList,
-                         encodeMacroExpansions, childIds, extra);
+                         encodeMacroInvocations, childIds, extra);
         typeEncoder.VisitQualTypeOf(ty, ast);
     }
 
@@ -877,11 +877,11 @@ class TranslateASTVisitor final
         QualType s = QualType(static_cast<clang::Type *>(nullptr), 0);
         auto rvalue = false;
         auto isVaList = false;
-        auto encodeMacroExpansions = false;
+        auto encodeMacroInvocations = false;
         auto span = ast->getSourceRange();
         expandSpanToFinalChar(span, Context);
         encode_entry_raw(ast, tag, span, s, rvalue, isVaList,
-                         encodeMacroExpansions, childIds, extra);
+                         encodeMacroInvocations, childIds, extra);
     }
 
     void encode_entry(
@@ -889,11 +889,11 @@ class TranslateASTVisitor final
         const QualType T,
         std::function<void(CborEncoder *)> extra = [](CborEncoder *) {}) {
         auto rvalue = false;
-        auto encodeMacroExpansions = false;
+        auto encodeMacroInvocations = false;
         auto span = ast->getSourceRange();
         expandSpanToFinalChar(span, Context);
         encode_entry_raw(ast, tag, span, T, rvalue,
-                         isVaList(ast, T), encodeMacroExpansions, childIds, extra);
+                         isVaList(ast, T), encodeMacroInvocations, childIds, extra);
     }
 
     /// Explicitly override the source location of this decl for cases where the
@@ -904,10 +904,10 @@ class TranslateASTVisitor final
         const std::vector<void *> &childIds, const QualType T,
         std::function<void(CborEncoder *)> extra = [](CborEncoder *) {}) {
         auto rvalue = false;
-        auto encodeMacroExpansions = false;
+        auto encodeMacroInvocations = false;
         expandSpanToFinalChar(loc, Context);
         encode_entry_raw(ast, tag, loc, T, rvalue,
-                         isVaList(ast, T), encodeMacroExpansions, childIds, extra);
+                         isVaList(ast, T), encodeMacroInvocations, childIds, extra);
     }
 
     bool VisitMacro(StringRef name, SourceLocation loc, MacroInfo *mac, Expr *E) {
@@ -980,11 +980,11 @@ class TranslateASTVisitor final
 
     void encodeMacros() {
         // Sort macros by source location
-        std::vector<std::pair<MacroInfo *, MacroExpansionInfo>> macro_vec(
+        std::vector<std::pair<MacroInfo *, MacroDeclInfo>> macro_vec(
             macros.begin(), macros.end());
         std::sort(macro_vec.begin(), macro_vec.end(),
-                  [](const std::pair<MacroInfo *, MacroExpansionInfo> &a,
-                     const std::pair<MacroInfo *, MacroExpansionInfo> &b) {
+                  [](const std::pair<MacroInfo *, MacroDeclInfo> &a,
+                     const std::pair<MacroInfo *, MacroDeclInfo> &b) {
                       return a.first->getDefinitionLoc() <
                              b.first->getDefinitionLoc();
                   });
@@ -1381,8 +1381,8 @@ class TranslateASTVisitor final
     //
 
     bool VisitExpr(Expr *E) {
-        curMacroExpansionStack.clear();
-        curMacroExpansionSource = StringRef();
+        curMacroInvocationStack.clear();
+        curMacroInvocationSource = StringRef();
 
         // We only translate constant macro objects to Rust consts, so this
         // expression must be constant.
@@ -1416,7 +1416,7 @@ class TranslateASTVisitor final
             return true;
         }
 
-        curMacroExpansionSource =
+        curMacroInvocationSource =
             Lexer::getSourceText(ExpansionStack[0].range, Mgr, Context->getLangOpts());
 
         for (auto &elem : ExpansionStack) {
@@ -1438,7 +1438,7 @@ class TranslateASTVisitor final
             }
 
             if (VisitMacro(IdentifierInfo->getName(), loc, MacroInfo, E)) {
-                curMacroExpansionStack.push_back(MacroInfo);
+                curMacroInvocationStack.push_back(MacroInfo);
             }
         }
 

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -1424,15 +1424,21 @@ class TranslateASTVisitor final
                 continue;
             }
 
-            StringRef name;
-            MacroInfo *mac = getMacroInfo(elem.range.getBegin(), name);
+            auto loc = elem.range.getBegin();
+            auto IdentifierInfo = getIdentifierInfo(loc);
 
-            if (!mac || mac->getNumTokens() == 0) {
+            if (!IdentifierInfo) {
                 return true;
             }
 
-            if (VisitMacro(name, elem.range.getBegin(), mac, E)) {
-                curMacroExpansionStack.push_back(mac);
+            auto MacroInfo = getMacroInfo(loc, IdentifierInfo);
+
+            if (!MacroInfo || MacroInfo->getNumTokens() == 0) {
+                return true;
+            }
+
+            if (VisitMacro(IdentifierInfo->getName(), loc, MacroInfo, E)) {
+                curMacroExpansionStack.push_back(MacroInfo);
             }
         }
 
@@ -1519,38 +1525,52 @@ class TranslateASTVisitor final
         return Mgr.isAtEndOfImmediateMacroExpansion(loc.getLocWithOffset(len));
     }
 
-    MacroInfo* getMacroInfo(SourceLocation loc, StringRef &name) const {
+    IdentifierInfo *getIdentifierInfo(SourceLocation loc) const {
         auto &Mgr = Context->getSourceManager();
         Token Result;
-        if (!Lexer::getRawToken(Mgr.getSpellingLoc(loc), Result,
-                                Mgr, Context->getLangOpts(), false)) {
+
+        if (!Lexer::getRawToken(
+            Mgr.getSpellingLoc(loc),
+            Result,
+            Mgr,
+            Context->getLangOpts(),
+            false
+        )) {
             if (Result.is(tok::raw_identifier)) {
                 PP.LookUpIdentifierInfo(Result);
             }
-            IdentifierInfo *IdentifierInfo = Result.getIdentifierInfo();
-            if (IdentifierInfo && IdentifierInfo->hadMacroDefinition()) {
-                std::pair<FileID, unsigned int> DecLoc =
-                    Mgr.getDecomposedExpansionLoc(loc);
-                // Get the definition just before the searched location
-                // so that a macro referenced in a '#undef MACRO' can
-                // still be found.
-                SourceLocation BeforeSearchedLocation =
-                    Mgr.getMacroArgExpandedLocation(
-                        Mgr.getLocForStartOfFile(DecLoc.first)
-                            .getLocWithOffset(DecLoc.second - 1));
-                MacroDefinition MacroDef = PP.getMacroDefinitionAtLoc(
-                    IdentifierInfo, BeforeSearchedLocation);
-                MacroInfo *MacroInf = MacroDef.getMacroInfo();
-                if (MacroInf) {
-                    LLVM_DEBUG(dbgs() << IdentifierInfo->getName() << "\n");
-                    LLVM_DEBUG(MacroInf->dump());
-                    LLVM_DEBUG(dbgs() << "\n");
-                    name = IdentifierInfo->getName();
-                    return MacroInf;
-                }
-            }
+
+            return Result.getIdentifierInfo();
         }
+
         return nullptr;
+    }
+
+    MacroInfo* getMacroInfo(SourceLocation loc, IdentifierInfo *IdentifierInfo) const {
+        if (!IdentifierInfo->hadMacroDefinition()) {
+            return nullptr;
+        }
+
+        auto &Mgr = Context->getSourceManager();
+        std::pair<FileID, unsigned int> DecLoc = Mgr.getDecomposedExpansionLoc(loc);
+        // Get the definition just before the searched location
+        // so that a macro referenced in a '#undef MACRO' can
+        // still be found.
+        SourceLocation BeforeSearchedLocation = Mgr.getMacroArgExpandedLocation(
+            Mgr.getLocForStartOfFile(DecLoc.first).getLocWithOffset(DecLoc.second - 1));
+        MacroDefinition MacroDef = PP.getMacroDefinitionAtLoc(
+            IdentifierInfo, BeforeSearchedLocation);
+        MacroInfo *MacroInf = MacroDef.getMacroInfo();
+
+        if (!MacroInf) {
+            return nullptr;
+        }
+
+        LLVM_DEBUG(dbgs() << IdentifierInfo->getName() << "\n");
+        LLVM_DEBUG(MacroInf->dump());
+        LLVM_DEBUG(dbgs() << "\n");
+
+        return MacroInf;
     }
 
     bool VisitVAArgExpr(VAArgExpr *E) {

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -910,40 +910,6 @@ class TranslateASTVisitor final
                          isVaList(ast, T), encodeMacroExpansions, childIds, extra);
     }
 
-    MacroInfo* getMacroInfo(SourceLocation loc, StringRef &name) const {
-        auto &Mgr = Context->getSourceManager();
-        Token Result;
-        if (!Lexer::getRawToken(Mgr.getSpellingLoc(loc), Result,
-                                Mgr, Context->getLangOpts(), false)) {
-            if (Result.is(tok::raw_identifier)) {
-                PP.LookUpIdentifierInfo(Result);
-            }
-            IdentifierInfo *IdentifierInfo = Result.getIdentifierInfo();
-            if (IdentifierInfo && IdentifierInfo->hadMacroDefinition()) {
-                std::pair<FileID, unsigned int> DecLoc =
-                    Mgr.getDecomposedExpansionLoc(loc);
-                // Get the definition just before the searched location
-                // so that a macro referenced in a '#undef MACRO' can
-                // still be found.
-                SourceLocation BeforeSearchedLocation =
-                    Mgr.getMacroArgExpandedLocation(
-                        Mgr.getLocForStartOfFile(DecLoc.first)
-                            .getLocWithOffset(DecLoc.second - 1));
-                MacroDefinition MacroDef = PP.getMacroDefinitionAtLoc(
-                    IdentifierInfo, BeforeSearchedLocation);
-                MacroInfo *MacroInf = MacroDef.getMacroInfo();
-                if (MacroInf) {
-                    LLVM_DEBUG(dbgs() << IdentifierInfo->getName() << "\n");
-                    LLVM_DEBUG(MacroInf->dump());
-                    LLVM_DEBUG(dbgs() << "\n");
-                    name = IdentifierInfo->getName();
-                    return MacroInf;
-                }
-            }
-        }
-        return nullptr;
-    }
-
     bool VisitMacro(StringRef name, SourceLocation loc, MacroInfo *mac, Expr *E) {
         // TODO: handle builtin macros
         if (mac->isBuiltinMacro())
@@ -1551,6 +1517,40 @@ class TranslateASTVisitor final
         auto spellingLoc = Mgr.getSpellingLoc(loc);
         auto len = Lexer::MeasureTokenLength(spellingLoc, Mgr, Context->getLangOpts());
         return Mgr.isAtEndOfImmediateMacroExpansion(loc.getLocWithOffset(len));
+    }
+
+    MacroInfo* getMacroInfo(SourceLocation loc, StringRef &name) const {
+        auto &Mgr = Context->getSourceManager();
+        Token Result;
+        if (!Lexer::getRawToken(Mgr.getSpellingLoc(loc), Result,
+                                Mgr, Context->getLangOpts(), false)) {
+            if (Result.is(tok::raw_identifier)) {
+                PP.LookUpIdentifierInfo(Result);
+            }
+            IdentifierInfo *IdentifierInfo = Result.getIdentifierInfo();
+            if (IdentifierInfo && IdentifierInfo->hadMacroDefinition()) {
+                std::pair<FileID, unsigned int> DecLoc =
+                    Mgr.getDecomposedExpansionLoc(loc);
+                // Get the definition just before the searched location
+                // so that a macro referenced in a '#undef MACRO' can
+                // still be found.
+                SourceLocation BeforeSearchedLocation =
+                    Mgr.getMacroArgExpandedLocation(
+                        Mgr.getLocForStartOfFile(DecLoc.first)
+                            .getLocWithOffset(DecLoc.second - 1));
+                MacroDefinition MacroDef = PP.getMacroDefinitionAtLoc(
+                    IdentifierInfo, BeforeSearchedLocation);
+                MacroInfo *MacroInf = MacroDef.getMacroInfo();
+                if (MacroInf) {
+                    LLVM_DEBUG(dbgs() << IdentifierInfo->getName() << "\n");
+                    LLVM_DEBUG(MacroInf->dump());
+                    LLVM_DEBUG(dbgs() << "\n");
+                    name = IdentifierInfo->getName();
+                    return MacroInf;
+                }
+            }
+        }
+        return nullptr;
     }
 
     bool VisitVAArgExpr(VAArgExpr *E) {

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -829,7 +829,19 @@ class TranslateASTVisitor final
         if (encodeMacroInvocations) {
             for (auto I = curMacroInvocationStack.rbegin(), E = curMacroInvocationStack.rend();
                  I != E; ++I) {
-                cbor_encode_uint(&childEnc, uintptr_t(I->macro));
+                CborEncoder expansionEnc;
+                cbor_encoder_create_array(&childEnc, &expansionEnc, 3);
+
+                cbor_encode_uint(&expansionEnc, I->key);
+                cbor_encode_uint(&expansionEnc, uintptr_t(I->macro));
+
+                if (!I->parameter.empty()) {
+                    cbor_encode_string(&expansionEnc, I->parameter.str());
+                } else {
+                    cbor_encode_null(&expansionEnc);
+                }
+
+                cbor_encoder_close_container(&childEnc, &expansionEnc);
             }
         }
         cbor_encoder_close_container(&local, &childEnc);

--- a/c2rust-ast-exporter/src/clang_ast.rs
+++ b/c2rust-ast-exporter/src/clang_ast.rs
@@ -108,8 +108,8 @@ pub struct AstNode {
     // Stack of macros this node was expanded from, beginning with the initial
     // macro call and ending with the leaf. This needs to be a stack for nested
     // macro definitions.
-    pub macro_expansions: Vec<u64>,
-    pub macro_expansion_text: Option<String>,
+    pub macro_invocations: Vec<u64>,
+    pub macro_invocation_text: Option<String>,
     pub extras: Vec<Value>,
 }
 
@@ -260,9 +260,9 @@ pub fn process(items: Value) -> error::Result<AstContext> {
             };
 
             // entry[10]
-            let macro_expansions = from_value::<Vec<u64>>(entry.pop_front().unwrap()).unwrap();
+            let macro_invocations = from_value::<Vec<u64>>(entry.pop_front().unwrap()).unwrap();
 
-            let macro_expansion_text = expect_opt_str(&entry.pop_front().unwrap())
+            let macro_invocation_text = expect_opt_str(&entry.pop_front().unwrap())
                 .unwrap()
                 .map(|s| s.to_string());
 
@@ -278,8 +278,8 @@ pub fn process(items: Value) -> error::Result<AstContext> {
                 },
                 type_id,
                 rvalue,
-                macro_expansions,
-                macro_expansion_text,
+                macro_invocations,
+                macro_invocation_text,
                 extras: entry.into_iter().collect(),
             };
 

--- a/c2rust-ast-exporter/src/clang_ast.rs
+++ b/c2rust-ast-exporter/src/clang_ast.rs
@@ -1,3 +1,4 @@
+use serde::Deserialize;
 use serde_bytes::ByteBuf;
 use serde_cbor::error;
 use std::collections::{HashMap, VecDeque};
@@ -108,9 +109,16 @@ pub struct AstNode {
     // Stack of macros this node was expanded from, beginning with the initial
     // macro call and ending with the leaf. This needs to be a stack for nested
     // macro definitions.
-    pub macro_invocations: Vec<u64>,
+    pub macro_invocations: Vec<MacroInvocationInfoRaw>,
     pub macro_invocation_text: Option<String>,
     pub extras: Vec<Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MacroInvocationInfoRaw {
+    pub key: u32,
+    pub macro_id: u64,
+    pub parameter: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -260,7 +268,8 @@ pub fn process(items: Value) -> error::Result<AstContext> {
             };
 
             // entry[10]
-            let macro_invocations = from_value::<Vec<u64>>(entry.pop_front().unwrap()).unwrap();
+            let macro_invocations =
+                from_value::<Vec<MacroInvocationInfoRaw>>(entry.pop_front().unwrap()).unwrap();
 
             let macro_invocation_text = expect_opt_str(&entry.pop_front().unwrap())
                 .unwrap()

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -1047,8 +1047,8 @@ impl ConversionContext {
             };
 
             if expected_ty & EXPR != 0 {
-                for mac_id in &node.macro_invocations {
-                    let mac = CDeclId(self.visit_node_type(*mac_id, MACRO_DECL));
+                for info in &node.macro_invocations {
+                    let mac = CDeclId(self.visit_node_type(info.macro_id, MACRO_DECL));
                     self.typed_context
                         .macro_invocations
                         .entry(CExprId(new_id))

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -1047,7 +1047,7 @@ impl ConversionContext {
             };
 
             if expected_ty & EXPR != 0 {
-                for mac_id in &node.macro_expansions {
+                for mac_id in &node.macro_invocations {
                     let mac = CDeclId(self.visit_node_type(*mac_id, MACRO_DECL));
                     self.typed_context
                         .macro_invocations
@@ -1057,7 +1057,7 @@ impl ConversionContext {
                 }
             }
 
-            if let Some(text) = &node.macro_expansion_text {
+            if let Some(text) = &node.macro_invocation_text {
                 self.typed_context
                     .macro_expansion_text
                     .insert(CExprId(new_id), text.clone());

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -391,6 +391,11 @@ fn test_lift_const() {
 }
 
 #[test]
+fn test_macro_fns() {
+    transpile("macro_fns.c").run();
+}
+
+#[test]
 fn test_macrocase() {
     transpile("macrocase.c").run();
 }

--- a/c2rust-transpile/tests/snapshots/macro_fns.c
+++ b/c2rust-transpile/tests/snapshots/macro_fns.c
@@ -1,0 +1,27 @@
+#define CONST 42
+
+#define ID(x) x
+#define PAREN(x) (x)
+#define LIT_ID ID(42)
+#define LIT_PAREN PAREN(42)
+#define CONST_ID ID(CONST)
+#define CONST_PAREN PAREN(CONST)
+#define NESTED_ID(x) ID(x)
+#define NESTED_PAREN(x) PAREN(x)
+
+void basic(void) {
+    int lit_id = LIT_ID;
+    int lit_paren = LIT_PAREN;
+    int const_id = CONST_ID;
+    int const_paren = CONST_PAREN;
+
+    int id_with_lit = ID(42);
+    int paren_with_lit = PAREN(42);
+    int id_with_const = ID(CONST);
+    int paren_with_const = PAREN(CONST);
+
+    int nested_id_with_lit = NESTED_ID(42);
+    int nested_paren_with_lit = NESTED_PAREN(42);
+    int nested_id_with_const = NESTED_ID(CONST);
+    int nested_paren_with_const = NESTED_PAREN(CONST);
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macro_fns.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macro_fns.c.2021.clang15.snap
@@ -11,13 +11,15 @@ expression: cat tests/snapshots/macro_fns.2021.clang15.rs
     unused_assignments,
     unused_mut
 )]
+pub const LIT_ID: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
 pub const LIT_PAREN: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+pub const CONST_ID: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
 pub const CONST_PAREN: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
 #[no_mangle]
 pub unsafe extern "C" fn basic() {
-    let mut lit_id: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut lit_id: ::core::ffi::c_int = LIT_ID;
     let mut lit_paren: ::core::ffi::c_int = LIT_PAREN;
-    let mut const_id: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut const_id: ::core::ffi::c_int = CONST_ID;
     let mut const_paren: ::core::ffi::c_int = CONST_PAREN;
     let mut id_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
     let mut paren_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macro_fns.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macro_fns.c.2021.clang15.snap
@@ -1,0 +1,30 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/macro_fns.2021.clang15.rs
+---
+#![allow(
+    clippy::missing_safety_doc,
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+pub const LIT_PAREN: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+pub const CONST_PAREN: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+#[no_mangle]
+pub unsafe extern "C" fn basic() {
+    let mut lit_id: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut lit_paren: ::core::ffi::c_int = LIT_PAREN;
+    let mut const_id: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut const_paren: ::core::ffi::c_int = CONST_PAREN;
+    let mut id_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut paren_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut id_with_const: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut paren_with_const: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut nested_id_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut nested_paren_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut nested_id_with_const: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut nested_paren_with_const: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macro_fns.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macro_fns.c.2024.clang15.snap
@@ -12,13 +12,15 @@ expression: cat tests/snapshots/macro_fns.2024.clang15.rs
     unused_assignments,
     unused_mut
 )]
+pub const LIT_ID: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
 pub const LIT_PAREN: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+pub const CONST_ID: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
 pub const CONST_PAREN: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn basic() {
-    let mut lit_id: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut lit_id: ::core::ffi::c_int = LIT_ID;
     let mut lit_paren: ::core::ffi::c_int = LIT_PAREN;
-    let mut const_id: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut const_id: ::core::ffi::c_int = CONST_ID;
     let mut const_paren: ::core::ffi::c_int = CONST_PAREN;
     let mut id_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
     let mut paren_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macro_fns.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macro_fns.c.2024.clang15.snap
@@ -1,0 +1,31 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/macro_fns.2024.clang15.rs
+---
+#![allow(
+    clippy::missing_safety_doc,
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unsafe_op_in_unsafe_fn,
+    unused_assignments,
+    unused_mut
+)]
+pub const LIT_PAREN: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+pub const CONST_PAREN: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn basic() {
+    let mut lit_id: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut lit_paren: ::core::ffi::c_int = LIT_PAREN;
+    let mut const_id: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut const_paren: ::core::ffi::c_int = CONST_PAREN;
+    let mut id_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut paren_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut id_with_const: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut paren_with_const: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut nested_id_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut nested_paren_with_lit: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut nested_id_with_const: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut nested_paren_with_const: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+}


### PR DESCRIPTION
- Depends on #1795

The "chain" of expansions is a little different for macros with args (that is, functional macros). This PR does two things:
- Handles arg expansions differently, so that const macros that call functional macros are now expanded.
- Exports the arg info to the Rust side to be used to hopefully make functional macros possible later.

Not all macro args are currently handled by this because of technical limitations. This code is only able to "see" macro args in the macro where they were expanded into tokens. They are not visible in macros that take an arg and then pass it on to another macro call in an arg. Maybe a solution will eventually be found for that. For now at least, the AST on the Rust side contains expressions that are macro arg expansions!