### PR TITLE
transpile: Allow ternary operator in `const` context

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3310,12 +3310,6 @@ impl<'c> Translation<'c> {
             }
 
             Conditional(ty, cond, lhs, rhs) => {
-                if ctx.is_const {
-                    return Err(format_translation_err!(
-                        self.ast_context.display_loc(src_loc),
-                        "Constants cannot contain ternary expressions in Rust",
-                    ));
-                }
                 let cond = self.convert_condition(ctx, true, cond)?;
 
                 let lhs = self.convert_expr(ctx, lhs, Some(override_ty.unwrap_or(ty)))?;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.snap
@@ -373,13 +373,15 @@ pub static mut fns: fn_ptrs = fn_ptrs {
 pub static mut p: *const fn_ptrs = unsafe { &raw const fns };
 pub const ZSTD_WINDOWLOG_MAX_32: ::core::ffi::c_int = 30 as ::core::ffi::c_int;
 pub const ZSTD_WINDOWLOG_MAX_64: ::core::ffi::c_int = 31 as ::core::ffi::c_int;
-#[no_mangle]
-pub unsafe extern "C" fn test_zstd() -> U64 {
-    return (if ::core::mem::size_of::<zstd_platform_dependent_type>() as usize == 4 as usize {
+pub const ZSTD_WINDOWLOG_MAX: ::core::ffi::c_int =
+    if ::core::mem::size_of::<zstd_platform_dependent_type>() as usize == 4 as usize {
         ZSTD_WINDOWLOG_MAX_32
     } else {
         ZSTD_WINDOWLOG_MAX_64
-    }) as U64;
+    };
+#[no_mangle]
+pub unsafe extern "C" fn test_zstd() -> U64 {
+    return ZSTD_WINDOWLOG_MAX as U64;
 }
 #[no_mangle]
 pub unsafe extern "C" fn stmt_expr_inc() -> ::core::ffi::c_int {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.snap
@@ -373,13 +373,15 @@ pub static mut fns: fn_ptrs = fn_ptrs {
 pub static mut p: *const fn_ptrs = &raw const fns;
 pub const ZSTD_WINDOWLOG_MAX_32: ::core::ffi::c_int = 30 as ::core::ffi::c_int;
 pub const ZSTD_WINDOWLOG_MAX_64: ::core::ffi::c_int = 31 as ::core::ffi::c_int;
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn test_zstd() -> U64 {
-    return (if ::core::mem::size_of::<zstd_platform_dependent_type>() as usize == 4 as usize {
+pub const ZSTD_WINDOWLOG_MAX: ::core::ffi::c_int =
+    if ::core::mem::size_of::<zstd_platform_dependent_type>() as usize == 4 as usize {
         ZSTD_WINDOWLOG_MAX_32
     } else {
         ZSTD_WINDOWLOG_MAX_64
-    }) as U64;
+    };
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn test_zstd() -> U64 {
+    return ZSTD_WINDOWLOG_MAX as U64;
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn stmt_expr_inc() -> ::core::ffi::c_int {


### PR DESCRIPTION
This was allowed all the way back in Rust 1.46.