### PR TITLE
transpile: Translate enums in `switch` as their own type instead of integers

### DIFF
--- a/c2rust-ast-builder/src/builder.rs
+++ b/c2rust-ast-builder/src/builder.rs
@@ -1233,6 +1233,20 @@ impl Builder {
         })
     }
 
+    pub fn tuple_struct_pat<Pa>(self, path: Pa, qself: Option<QSelf>, elems: Vec<Pat>) -> Pat
+    where
+        Pa: Make<Path>,
+    {
+        let path = path.make(&self);
+        Pat::TupleStruct(PatTupleStruct {
+            attrs: self.attrs,
+            qself,
+            path,
+            paren_token: token::Paren(self.span),
+            elems: punct(elems),
+        })
+    }
+
     // Types
 
     pub fn barefn_ty(self, decl: BareFnTyParts) -> Box<Type> {

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -448,7 +448,6 @@ impl GenTerminator<StructureLabel<StmtOrDecl>> {
 pub struct SwitchCases {
     cases: Vec<(Pat, Label)>,
     default: Option<Label>,
-    #[allow(unused)]
     expected_type_id: Option<CQualTypeId>,
 }
 
@@ -1936,8 +1935,19 @@ impl CfgBuilder {
                 self.add_wip_block(wip, Jump(this_label.clone()));
 
                 // Case
+                let switch_case = self.switch_expr_cases.last_mut().ok_or_else(|| {
+                    format_err!(
+                        "Cannot find the 'switch' wrapping this ({:?}) 'case' statement",
+                        stmt_id,
+                    )
+                })?;
+
                 let pat = translator
-                    .convert_expr(ctx.const_().pattern().used(), case_expr, None)
+                    .convert_expr_with_optional_cast(
+                        ctx.const_().pattern().used(),
+                        switch_case.expected_type_id,
+                        case_expr,
+                    )
                     .map_err(|err| ("convert_expr", err.to_string()))
                     .and_then(|val| {
                         val.to_pure_expr()
@@ -1954,22 +1964,25 @@ impl CfgBuilder {
                             err
                         );
 
-                        match cie {
+                        let mut pat = match cie {
                             ConstIntExpr::U(n) => mk().lit_pat(mk().int_unsuffixed_lit(n)),
                             ConstIntExpr::I(n) => mk().lit_pat(mk().int_unsuffixed_lit(n)),
+                        };
+
+                        if let Some(expected_type_id) = switch_case.expected_type_id {
+                            if let CTypeKind::Enum(enum_id) = translator
+                                .ast_context
+                                .resolve_type(expected_type_id.ctype)
+                                .kind
+                            {
+                                pat = translator.enum_constructor_pat(enum_id, pat);
+                            }
                         }
+
+                        pat
                     });
 
-                self.switch_expr_cases
-                    .last_mut()
-                    .ok_or_else(|| {
-                        format_err!(
-                            "Cannot find the 'switch' wrapping this ({:?}) 'case' statement",
-                            stmt_id,
-                        )
-                    })?
-                    .cases
-                    .push((pat, this_label.clone()));
+                switch_case.cases.push((pat, this_label.clone()));
 
                 // Sub stmt
                 let sub_stmt_next = self.convert_stmt_help(
@@ -2038,7 +2051,7 @@ impl CfgBuilder {
                 }
 
                 let (stmts, val) = translator
-                    .convert_expr(ctx.used(), scrutinee, None)?
+                    .convert_expr_with_optional_cast(ctx.used(), expected_type_id, scrutinee)?
                     .discard_unsafe();
                 wip.extend(stmts);
 

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -448,6 +448,8 @@ impl GenTerminator<StructureLabel<StmtOrDecl>> {
 pub struct SwitchCases {
     cases: Vec<(Pat, Label)>,
     default: Option<Label>,
+    #[allow(unused)]
+    expected_type_id: Option<CQualTypeId>,
 }
 
 /// A Rust statement, or a C declaration, or a comment
@@ -2013,6 +2015,28 @@ impl CfgBuilder {
                 let body_label = self.fresh_label();
 
                 // Convert the condition
+
+                let mut expected_type_id = None;
+
+                // If the condition is an implicit cast from an enum to its integral type,
+                // override the type to that of the enum.
+                if let CExprKind::ImplicitCast(target_type_id, castee_id, ..) =
+                    translator.ast_context.index_unwrap_parens(scrutinee).kind
+                {
+                    let castee_kind = &translator.ast_context.index_unwrap_parens(castee_id).kind;
+                    let castee_type_id = castee_kind.get_qual_type().unwrap();
+                    let castee_type_kind = &translator
+                        .ast_context
+                        .resolve_type(castee_type_id.ctype)
+                        .kind;
+
+                    if let CTypeKind::Enum(enum_id) = *castee_type_kind {
+                        if target_type_id == translator.enum_integral_type(enum_id) {
+                            expected_type_id = Some(castee_type_id);
+                        }
+                    }
+                }
+
                 let (stmts, val) = translator
                     .convert_expr(ctx.used(), scrutinee, None)?
                     .discard_unsafe();
@@ -2026,7 +2050,10 @@ impl CfgBuilder {
                 let saw_unmatched_case = self.last_per_stmt_mut().saw_unmatched_case;
                 let saw_unmatched_default = self.last_per_stmt_mut().saw_unmatched_default;
                 self.break_labels.push(next_label.clone());
-                self.switch_expr_cases.push(SwitchCases::default());
+                self.switch_expr_cases.push(SwitchCases {
+                    expected_type_id,
+                    ..Default::default()
+                });
 
                 let body_stuff = self.convert_stmt_help(
                     translator,

--- a/c2rust-transpile/src/translator/enums.rs
+++ b/c2rust-transpile/src/translator/enums.rs
@@ -6,7 +6,7 @@ use crate::{
     diagnostics::TranslationResult,
     translator::{signed_int_expr, ConvertedDecl, ExprContext, Translation},
     with_stmts::WithStmts,
-    CDeclKind, CEnumConstantId, CEnumId, CExprId, CExprKind, CQualTypeId, CTypeKind, ConstIntExpr,
+    CDeclKind, CEnumConstantId, CEnumId, CQualTypeId, CTypeId, CTypeKind, ConstIntExpr,
 };
 
 impl<'c> Translation<'c> {
@@ -76,6 +76,10 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let val = self.enum_constant_expr(enum_constant_id);
 
+        if self.enum_constant_matches_type(expr_type_id.ctype, enum_constant_id) {
+            return Ok(WithStmts::new_val(val));
+        }
+
         // Add a cast to the expected integral type.
         let enum_id = self.ast_context.parents[&enum_constant_id];
         self.convert_cast_from_enum(ctx, enum_id, expr_type_id, val)
@@ -108,32 +112,8 @@ impl<'c> Translation<'c> {
         ctx: ExprContext,
         mut source_cty: CQualTypeId,
         enum_id: CEnumId,
-        expr: Option<CExprId>,
         mut val: Box<Expr>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        if let Some(expr) = expr {
-            match self.ast_context.index_unwrap_parens(expr).kind {
-                // This is the case of finding a variable which is an `EnumConstant` of the same
-                // enum we are casting to. Here, we can just remove the extraneous cast instead of
-                // generating a new one.
-                CExprKind::DeclRef(_, enum_constant_id, _)
-                    if self.is_variant_of_enum(enum_id, enum_constant_id) =>
-                {
-                    // `enum`s shouldn't need portable `override_ty`s.
-                    let expr_is_macro = self.expr_is_expanded_macro(ctx, expr, None);
-
-                    // If this DeclRef expanded to a const macro, we actually need to insert a cast,
-                    // because the translation of a const macro skips implicit casts in its context.
-                    if !expr_is_macro {
-                        val = self.enum_constant_expr(enum_constant_id);
-                        return Ok(WithStmts::new_val(val));
-                    }
-                }
-
-                _ => {}
-            }
-        }
-
         // We could be casting from enum to enum...
         if let CTypeKind::Enum(source_enum_id) =
             self.ast_context.resolve_type(source_cty.ctype).kind
@@ -208,13 +188,16 @@ impl<'c> Translation<'c> {
         mk().call_expr(mk().ident_expr(enum_name), vec![value])
     }
 
-    fn is_variant_of_enum(&self, enum_id: CEnumId, enum_constant_id: CEnumConstantId) -> bool {
-        let variants = match self.ast_context[enum_id].kind {
-            CDeclKind::Enum { ref variants, .. } => variants,
-            _ => panic!("{:?} does not point to an `enum` declaration", enum_id),
+    pub(crate) fn enum_constant_matches_type(
+        &self,
+        type_id: CTypeId,
+        enum_constant_id: CEnumConstantId,
+    ) -> bool {
+        let CTypeKind::Enum(type_enum_id) = self.ast_context.resolve_type(type_id).kind else {
+            return false;
         };
-
-        variants.contains(&enum_constant_id)
+        let constant_enum_id = self.ast_context.parents[&enum_constant_id];
+        type_enum_id == constant_enum_id
     }
 
     pub(crate) fn enum_integral_type(&self, enum_id: CEnumId) -> CQualTypeId {

--- a/c2rust-transpile/src/translator/enums.rs
+++ b/c2rust-transpile/src/translator/enums.rs
@@ -5,7 +5,7 @@ use syn::Expr;
 use crate::c_ast::iterators::SomeId;
 use crate::{
     diagnostics::TranslationResult,
-    translator::{signed_int_expr, ConvertedDecl, ExprContext, Translation},
+    translator::{signed_int_expr, ConvertedDecl, ExprContext, Translation, TranslationError},
     with_stmts::WithStmts,
     CDeclKind, CEnumConstantId, CEnumId, CQualTypeId, CTypeId, CTypeKind, ConstIntExpr,
 };
@@ -110,6 +110,12 @@ impl<'c> Translation<'c> {
         target_cty: CQualTypeId,
         mut val: Box<Expr>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
+        if ctx.is_pattern {
+            return Err(TranslationError::generic(
+                "cast from enum is not supported in patterns",
+            ));
+        }
+
         // First extract the enum's inner type...
         val = self.integer_from_enum(val);
 
@@ -138,6 +144,12 @@ impl<'c> Translation<'c> {
             // Casting to ourselves, the audacity!
             if source_enum_id == enum_id {
                 return Ok(WithStmts::new_val(val));
+            }
+
+            if ctx.is_pattern {
+                return Err(TranslationError::generic(
+                    "cast from enum is not supported in patterns",
+                ));
             }
 
             // Enum-to-enum casts need to be translated via the inner value as an intermediate.

--- a/c2rust-transpile/src/translator/enums.rs
+++ b/c2rust-transpile/src/translator/enums.rs
@@ -1,6 +1,6 @@
 use c2rust_ast_builder::mk;
 use proc_macro2::Span;
-use syn::Expr;
+use syn::{Expr, Pat};
 
 use crate::c_ast::iterators::SomeId;
 use crate::{
@@ -236,6 +236,17 @@ impl<'c> Translation<'c> {
         };
 
         mk().call_expr(func, vec![value])
+    }
+
+    pub(crate) fn enum_constructor_pat(&self, enum_id: CEnumId, value: Pat) -> Pat {
+        let enum_name = self
+            .type_converter
+            .borrow()
+            .resolve_decl_name(enum_id)
+            .unwrap();
+        self.add_import(enum_id, &enum_name);
+
+        mk().tuple_struct_pat(enum_name.as_str(), None, vec![value])
     }
 
     pub(crate) fn enum_constant_matches_type(

--- a/c2rust-transpile/src/translator/enums.rs
+++ b/c2rust-transpile/src/translator/enums.rs
@@ -27,7 +27,7 @@ impl<'c> Translation<'c> {
         let field = mk().pub_().enum_field(integral_type_rs);
         let enum_item = mk()
             .span(span)
-            .call_attr("derive", vec!["Clone", "Copy"])
+            .call_attr("derive", vec!["Clone", "Copy", "PartialEq", "Eq"])
             .call_attr("repr", vec!["transparent"])
             .pub_()
             .struct_item(enum_name, vec![field], true);

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3932,6 +3932,18 @@ impl<'c> Translation<'c> {
         }
 
         let expr_kind = &self.ast_context.index_unwrap_parens(expr_id).kind;
+
+        if let &CExprKind::DeclRef(_, decl_id, _) = expr_kind {
+            if let CDeclKind::EnumConstant { .. } = self.ast_context[decl_id].kind {
+                // In C, `EnumConstant`s have some integral type, _not_ the enum type.
+                // However, if we then immediately have a cast to convert this variable back into
+                // the enum type, we would like to produce Rust with _no_ casts.
+                if self.enum_constant_matches_type(target_type_id.ctype, decl_id) {
+                    return true;
+                }
+            }
+        }
+
         let mut literal_expr_kind = expr_kind;
         let mut is_negated = false;
 
@@ -3998,7 +4010,7 @@ impl<'c> Translation<'c> {
             }
 
             CastKind::PointerToIntegral => {
-                self.convert_pointer_to_integral_cast(ctx, source_cty, target_cty, val, expr)
+                self.convert_pointer_to_integral_cast(ctx, source_cty, target_cty, val)
             }
 
             CastKind::IntegralCast
@@ -4034,9 +4046,7 @@ impl<'c> Translation<'c> {
                 {
                     self.f128_cast_to(val, target_ty_kind)
                 } else if let &CTypeKind::Enum(enum_id) = target_ty_kind {
-                    val.and_then_try(|val| {
-                        self.convert_cast_to_enum(ctx, source_cty, enum_id, expr, val)
-                    })
+                    val.and_then_try(|val| self.convert_cast_to_enum(ctx, source_cty, enum_id, val))
                 } else if target_ty_kind.is_floating_type() && source_ty_kind.is_bool() {
                     Ok(val.map(|val| {
                         mk().cast_expr(mk().cast_expr(val, mk().path_ty(vec!["u8"])), target_ty)

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3848,28 +3848,15 @@ impl<'c> Translation<'c> {
             return self.convert_condition(ctx, true, expr);
         }
 
-        let expr_kind = &self.ast_context.index_unwrap_parens(expr).kind;
         let target_ty = override_ty.unwrap_or(ty);
 
         // In general, if we are casting the result of an expression, then the inner
         // expression should be translated to whatever type it normally would.
-        // But for literals, if we don't absolutely have to cast, we would rather the
-        // literal is translated according to the type we're expecting, and then we can
-        // skip the cast entirely.
-        if !is_explicit {
-            let mut literal_expr_kind = expr_kind;
-            let mut is_negated = false;
-
-            if let &CExprKind::Unary(_, CUnOp::Negate, subexpr_id, _) = literal_expr_kind {
-                literal_expr_kind = &self.ast_context.index_unwrap_parens(subexpr_id).kind;
-                is_negated = true;
-            }
-
-            if let CExprKind::Literal(_, lit) = literal_expr_kind {
-                if self.literal_matches_ty(lit, target_ty, is_negated) {
-                    return self.convert_expr(ctx, expr, Some(target_ty));
-                }
-            }
+        // But for some expression types, if we don't absolutely have to cast,
+        // we would rather the expression is translated according to the type we're
+        // expecting, and then we can skip the cast entirely.
+        if self.can_propagate_cast(expr, target_ty, is_explicit) {
+            return self.convert_expr(ctx, expr, Some(target_ty));
         }
 
         match kind {
@@ -3931,6 +3918,36 @@ impl<'c> Translation<'c> {
             Some(kind),
             opt_field_id,
         )
+    }
+
+    fn can_propagate_cast(
+        &self,
+        expr_id: CExprId,
+        target_type_id: CQualTypeId,
+        is_explicit: bool,
+    ) -> bool {
+        // Always preserve explicit casts.
+        if is_explicit {
+            return false;
+        }
+
+        let expr_kind = &self.ast_context.index_unwrap_parens(expr_id).kind;
+        let mut literal_expr_kind = expr_kind;
+        let mut is_negated = false;
+
+        if let &CExprKind::Unary(_, CUnOp::Negate, subexpr_id, _) = literal_expr_kind {
+            literal_expr_kind = &self.ast_context.index_unwrap_parens(subexpr_id).kind;
+            is_negated = true;
+        }
+
+        if let CExprKind::Literal(_, lit) = literal_expr_kind {
+            // Does the inner literal fit in the type we're casting to?
+            if self.literal_matches_ty(lit, target_type_id, is_negated) {
+                return true;
+            }
+        }
+
+        false
     }
 
     pub fn make_cast(

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3941,6 +3941,18 @@ impl<'c> Translation<'c> {
                 if self.enum_constant_matches_type(target_type_id.ctype, decl_id) {
                     return true;
                 }
+
+                let source_enum_id = self.ast_context.parents[&decl_id];
+                let source_integral_type_id = self.enum_integral_type(source_enum_id);
+                let target_type_resolved_id = self
+                    .ast_context
+                    .resolve_type_id_no_typedef(target_type_id.ctype);
+
+                // Likewise, if we are casting to the inner integral type of the enum, then
+                // translate the enum constant directly as that.
+                if target_type_resolved_id == source_integral_type_id.ctype {
+                    return true;
+                }
             }
         }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3228,6 +3228,7 @@ impl<'c> Translation<'c> {
                 expr_kind,
                 CExprKind::Paren(..)
                     | CExprKind::ConstantExpr(..)
+                    | CExprKind::DeclRef(..)
                     | CExprKind::Literal(..)
                     | CExprKind::ImplicitCast(..)
                     | CExprKind::ExplicitCast(..)
@@ -3663,6 +3664,12 @@ impl<'c> Translation<'c> {
             );
         }
 
+        if ctx.is_pattern {
+            return Err(TranslationError::generic(
+                "non-EnumConstant DeclRefs are not supported in patterns",
+            ));
+        }
+
         let varname = decl.get_name().expect("expected variable name").to_owned();
 
         let rustname = self
@@ -4082,7 +4089,12 @@ impl<'c> Translation<'c> {
             return Ok(val);
         }
 
-        if ctx.is_pattern && !matches!(kind, CastKind::ToVoid | CastKind::ConstCast) {
+        if ctx.is_pattern
+            && !matches!(
+                kind,
+                CastKind::ToVoid | CastKind::ConstCast | CastKind::IntegralCast
+            )
+        {
             return Err(TranslationError::generic(
                 "cast kind is not supported in patterns",
             ));
@@ -4107,6 +4119,12 @@ impl<'c> Translation<'c> {
             | CastKind::IntegralToFloating
             | CastKind::BooleanToSignedIntegral => {
                 let target_ty = self.convert_type(target_cty.ctype)?;
+
+                if ctx.is_pattern && !target_ty_kind.is_enum() {
+                    return Err(TranslationError::generic(
+                        "integral casts to non-enums are not supported in patterns",
+                    ));
+                }
 
                 if let CTypeKind::LongDouble | CTypeKind::Float128 = target_ty_kind {
                     if let CTypeKind::LongDouble | CTypeKind::Float128 =

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -4023,27 +4023,53 @@ impl<'c> Translation<'c> {
             }
         }
 
-        if let &CExprKind::DeclRef(_, decl_id, _) = expr_kind {
-            if let CDeclKind::EnumConstant { .. } = self.ast_context[decl_id].kind {
-                // In C, `EnumConstant`s have some integral type, _not_ the enum type.
-                // However, if we then immediately have a cast to convert this variable back into
-                // the enum type, we would like to produce Rust with _no_ casts.
-                if self.enum_constant_matches_type(target_type_id.ctype, decl_id) {
-                    return true;
-                }
+        match *expr_kind {
+            // The inner expression is also an implicit cast. See if we can combine the casts.
+            CExprKind::ImplicitCast(source_type_id, _, cast_kind, _, _) => {
+                let source_type_kind = &self.ast_context.resolve_type(source_type_id.ctype).kind;
+                let target_type_kind = &self.ast_context.resolve_type(target_type_id.ctype).kind;
 
-                let source_enum_id = self.ast_context.parents[&decl_id];
-                let source_integral_type_id = self.enum_integral_type(source_enum_id);
-                let target_type_resolved_id = self
-                    .ast_context
-                    .resolve_type_id_no_typedef(target_type_id.ctype);
+                if let CTypeKind::Enum(target_enum_id) = *target_type_kind {
+                    let target_integral_type_id = self.enum_integral_type(target_enum_id);
+                    let target_integral_type_kind = &self
+                        .ast_context
+                        .resolve_type(target_integral_type_id.ctype)
+                        .kind;
 
-                // Likewise, if we are casting to the inner integral type of the enum, then
-                // translate the enum constant directly as that.
-                if target_type_resolved_id == source_integral_type_id.ctype {
-                    return true;
+                    // We are casting to an enum type, from its underlying integral type.
+                    // Skip the cast to the integral type and cast to the enum type directly.
+                    if cast_kind == CastKind::IntegralCast
+                        && source_type_kind == target_integral_type_kind
+                    {
+                        return true;
+                    }
                 }
             }
+
+            CExprKind::DeclRef(_, decl_id, _) => {
+                if let CDeclKind::EnumConstant { .. } = self.ast_context[decl_id].kind {
+                    // In C, `EnumConstant`s have some integral type, _not_ the enum type.
+                    // However, if we then immediately have a cast to convert this variable back into
+                    // the enum type, we would like to produce Rust with _no_ casts.
+                    if self.enum_constant_matches_type(target_type_id.ctype, decl_id) {
+                        return true;
+                    }
+
+                    let source_enum_id = self.ast_context.parents[&decl_id];
+                    let source_integral_type_id = self.enum_integral_type(source_enum_id);
+                    let target_type_resolved_id = self
+                        .ast_context
+                        .resolve_type_id_no_typedef(target_type_id.ctype);
+
+                    // Likewise, if we are casting to the inner integral type of the enum, then
+                    // translate the enum constant directly as that.
+                    if target_type_resolved_id == source_integral_type_id.ctype {
+                        return true;
+                    }
+                }
+            }
+
+            _ => {}
         }
 
         let mut literal_expr_kind = expr_kind;

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -295,7 +295,7 @@ pub struct Translation<'c> {
     extern_crates: RefCell<CrateSet>,
 
     // Translation state and utilities
-    type_converter: RefCell<TypeConverter>,
+    pub(crate) type_converter: RefCell<TypeConverter>,
     renamer: Rc<RefCell<Renamer<CDeclId>>>,
     zero_inits: RefCell<ZeroInits>,
     function_context: RefCell<FuncContext>,
@@ -3619,6 +3619,19 @@ impl<'c> Translation<'c> {
         });
 
         self.convert_cast(ctx, None, target_type_id, expr_id, kind, None, false)
+    }
+
+    pub(crate) fn convert_expr_with_optional_cast(
+        &self,
+        ctx: ExprContext,
+        target_type_id: Option<CQualTypeId>,
+        expr_id: CExprId,
+    ) -> TranslationResult<WithStmts<Box<Expr>>> {
+        if let Some(target_type_id) = target_type_id {
+            self.convert_expr_with_cast(ctx, target_type_id, expr_id)
+        } else {
+            self.convert_expr(ctx, expr_id, None)
+        }
     }
 
     fn convert_decl_ref(

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -611,7 +611,6 @@ impl<'c> Translation<'c> {
         source_cty: CQualTypeId,
         target_cty: CQualTypeId,
         val: WithStmts<Box<Expr>>,
-        expr: Option<CExprId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         if ctx.is_const {
             return Err(format_translation_err!(
@@ -654,7 +653,6 @@ impl<'c> Translation<'c> {
                         ctx,
                         CQualTypeId::new(size_type_id),
                         enum_decl_id,
-                        expr,
                         val,
                     )
                 })

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
@@ -52,8 +52,7 @@ pub unsafe extern "C" fn test_enums() {
     foo = Foo(c2rust_fresh1.0 as ::core::ffi::c_uint);
     let mut e: Foo = Foo1;
     let mut enum_enum: ::core::ffi::c_int = (e.0 == foo.0) as ::core::ffi::c_int;
-    let mut enum_constant: ::core::ffi::c_int =
-        (e.0 == Foo0.0 as ::core::ffi::c_int as ::core::ffi::c_uint) as ::core::ffi::c_int;
+    let mut enum_constant: ::core::ffi::c_int = (e.0 == Foo0.0) as ::core::ffi::c_int;
     let mut wrong_enum_enum: ::core::ffi::c_int =
         (e.0 == bar.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
     let mut wrong_enum_constant: ::core::ffi::c_int =

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
@@ -61,10 +61,10 @@ pub unsafe extern "C" fn test_enums() {
         (e.0 == bar.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
     let mut wrong_enum_constant: ::core::ffi::c_int =
         (e.0 == Bar::Bar0.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
-    match Foo(foo.0) {
-        Foo(0) | Foo(FOO1_MACRO) | Foo(2) | Foo(3) | Foo(42) | Foo(4294967254) | _ => {}
+    match foo {
+        Foo::Foo0 | Foo(FOO1_MACRO) | Foo(2) | Foo(3) | Foo(42) | Foo(4294967254) | _ => {}
     }
-    match Bar(bar.0) {
+    match bar {
         Bar::Bar0 | Bar(BAR1_MACRO) | Bar(2) | Bar(3) | Bar::BarN1 | Bar(42) | Bar(-42) | _ => {}
     };
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
@@ -61,10 +61,10 @@ pub unsafe extern "C" fn test_enums() {
         (e.0 == bar.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
     let mut wrong_enum_constant: ::core::ffi::c_int =
         (e.0 == Bar::Bar0.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
-    match foo.0 {
-        0 | FOO1_MACRO | 2 | 3 | 42 | 4294967254 | _ => {}
+    match Foo(foo.0) {
+        Foo(0) | Foo(FOO1_MACRO) | Foo(2) | Foo(3) | Foo(42) | Foo(4294967254) | _ => {}
     }
-    match bar.0 {
-        0 | BAR1_MACRO | 2 | 3 | -1 | 42 | -42 | _ => {}
+    match Bar(bar.0) {
+        Bar::Bar0 | Bar(BAR1_MACRO) | Bar(2) | Bar(3) | Bar::BarN1 | Bar(42) | Bar(-42) | _ => {}
     };
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
@@ -11,7 +11,7 @@ expression: cat tests/snapshots/enums.2021.clang15.rs
     unused_assignments,
     unused_mut
 )]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Foo(pub ::core::ffi::c_uint);
 impl Foo {
@@ -20,7 +20,7 @@ impl Foo {
     pub const Foo2: Self = Self(2);
     pub const Foo3: Self = Self(3);
 }
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Bar(pub ::core::ffi::c_int);
 impl Bar {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
@@ -53,8 +53,7 @@ pub unsafe extern "C" fn test_enums() {
     foo = Foo(c2rust_fresh1.0 as ::core::ffi::c_uint);
     let mut e: Foo = Foo1;
     let mut enum_enum: ::core::ffi::c_int = (e.0 == foo.0) as ::core::ffi::c_int;
-    let mut enum_constant: ::core::ffi::c_int =
-        (e.0 == Foo0.0 as ::core::ffi::c_int as ::core::ffi::c_uint) as ::core::ffi::c_int;
+    let mut enum_constant: ::core::ffi::c_int = (e.0 == Foo0.0) as ::core::ffi::c_int;
     let mut wrong_enum_enum: ::core::ffi::c_int =
         (e.0 == bar.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
     let mut wrong_enum_constant: ::core::ffi::c_int =

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
@@ -62,10 +62,10 @@ pub unsafe extern "C" fn test_enums() {
         (e.0 == bar.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
     let mut wrong_enum_constant: ::core::ffi::c_int =
         (e.0 == Bar::Bar0.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
-    match Foo(foo.0) {
-        Foo(0) | Foo(FOO1_MACRO) | Foo(2) | Foo(3) | Foo(42) | Foo(4294967254) | _ => {}
+    match foo {
+        Foo::Foo0 | Foo(FOO1_MACRO) | Foo(2) | Foo(3) | Foo(42) | Foo(4294967254) | _ => {}
     }
-    match Bar(bar.0) {
+    match bar {
         Bar::Bar0 | Bar(BAR1_MACRO) | Bar(2) | Bar(3) | Bar::BarN1 | Bar(42) | Bar(-42) | _ => {}
     };
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
@@ -62,10 +62,10 @@ pub unsafe extern "C" fn test_enums() {
         (e.0 == bar.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
     let mut wrong_enum_constant: ::core::ffi::c_int =
         (e.0 == Bar::Bar0.0 as ::core::ffi::c_uint) as ::core::ffi::c_int;
-    match foo.0 {
-        0 | FOO1_MACRO | 2 | 3 | 42 | 4294967254 | _ => {}
+    match Foo(foo.0) {
+        Foo(0) | Foo(FOO1_MACRO) | Foo(2) | Foo(3) | Foo(42) | Foo(4294967254) | _ => {}
     }
-    match bar.0 {
-        0 | BAR1_MACRO | 2 | 3 | -1 | 42 | -42 | _ => {}
+    match Bar(bar.0) {
+        Bar::Bar0 | Bar(BAR1_MACRO) | Bar(2) | Bar(3) | Bar::BarN1 | Bar(42) | Bar(-42) | _ => {}
     };
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
@@ -12,7 +12,7 @@ expression: cat tests/snapshots/enums.2024.clang15.rs
     unused_assignments,
     unused_mut
 )]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Foo(pub ::core::ffi::c_uint);
 impl Foo {
@@ -21,7 +21,7 @@ impl Foo {
     pub const Foo2: Self = Self(2);
     pub const Foo3: Self = Self(3);
 }
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Bar(pub ::core::ffi::c_int);
 impl Bar {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.clang15.snap
@@ -17,14 +17,14 @@ extern "C" {
 }
 pub type ptrdiff_t = isize;
 pub type size_t = usize;
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct E(pub ::core::ffi::c_uint);
 impl E {
     pub const EA: Self = Self(0);
 }
 pub type int_t = ::core::ffi::c_int;
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct C2Rust_Unnamed(pub ::core::ffi::c_uint);
 impl C2Rust_Unnamed {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.clang15.snap
@@ -17,14 +17,14 @@ unsafe extern "C" {
 }
 pub type ptrdiff_t = isize;
 pub type size_t = usize;
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct E(pub ::core::ffi::c_uint);
 impl E {
     pub const EA: Self = Self(0);
 }
 pub type int_t = ::core::ffi::c_int;
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct C2Rust_Unnamed(pub ::core::ffi::c_uint);
 impl C2Rust_Unnamed {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2021.clang15.snap
@@ -11,7 +11,7 @@ expression: cat tests/snapshots/macrocase.2021.clang15.rs
     unused_assignments,
     unused_mut
 )]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct ZSTD_dParameter(pub ::core::ffi::c_uint);
 impl ZSTD_dParameter {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2021.clang15.snap
@@ -22,8 +22,8 @@ pub const ZSTD_d_format: ::core::ffi::c_uint = 1000 as ::core::ffi::c_uint;
 #[no_mangle]
 pub unsafe extern "C" fn ZSTD_dParam_getBounds(mut dParam: ZSTD_dParameter) -> ::core::ffi::c_int {
     let mut bounds: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-    match ZSTD_dParameter(dParam.0) {
-        ZSTD_dParameter(100) => {
+    match dParam {
+        ZSTD_dParameter::ZSTD_d_windowLogMax => {
             bounds = 1 as ::core::ffi::c_int;
             return bounds;
         }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2021.clang15.snap
@@ -22,12 +22,12 @@ pub const ZSTD_d_format: ::core::ffi::c_uint = 1000 as ::core::ffi::c_uint;
 #[no_mangle]
 pub unsafe extern "C" fn ZSTD_dParam_getBounds(mut dParam: ZSTD_dParameter) -> ::core::ffi::c_int {
     let mut bounds: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-    match dParam.0 {
-        100 => {
+    match ZSTD_dParameter(dParam.0) {
+        ZSTD_dParameter(100) => {
             bounds = 1 as ::core::ffi::c_int;
             return bounds;
         }
-        ZSTD_d_format => {
+        ZSTD_dParameter(ZSTD_d_format) => {
             bounds = 5 as ::core::ffi::c_int;
             return bounds;
         }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2024.clang15.snap
@@ -23,8 +23,8 @@ pub const ZSTD_d_format: ::core::ffi::c_uint = 1000 as ::core::ffi::c_uint;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ZSTD_dParam_getBounds(mut dParam: ZSTD_dParameter) -> ::core::ffi::c_int {
     let mut bounds: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-    match ZSTD_dParameter(dParam.0) {
-        ZSTD_dParameter(100) => {
+    match dParam {
+        ZSTD_dParameter::ZSTD_d_windowLogMax => {
             bounds = 1 as ::core::ffi::c_int;
             return bounds;
         }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2024.clang15.snap
@@ -23,12 +23,12 @@ pub const ZSTD_d_format: ::core::ffi::c_uint = 1000 as ::core::ffi::c_uint;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ZSTD_dParam_getBounds(mut dParam: ZSTD_dParameter) -> ::core::ffi::c_int {
     let mut bounds: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-    match dParam.0 {
-        100 => {
+    match ZSTD_dParameter(dParam.0) {
+        ZSTD_dParameter(100) => {
             bounds = 1 as ::core::ffi::c_int;
             return bounds;
         }
-        ZSTD_d_format => {
+        ZSTD_dParameter(ZSTD_d_format) => {
             bounds = 5 as ::core::ffi::c_int;
             return bounds;
         }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macrocase.c.2024.clang15.snap
@@ -12,7 +12,7 @@ expression: cat tests/snapshots/macrocase.2024.clang15.rs
     unused_assignments,
     unused_mut
 )]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct ZSTD_dParameter(pub ::core::ffi::c_uint);
 impl ZSTD_dParameter {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@raw_keywords.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@raw_keywords.c.2021.clang15.snap
@@ -12,7 +12,7 @@ expression: cat tests/snapshots/raw_keywords.2021.clang15.rs
     unused_mut
 )]
 pub type r#type = ::core::ffi::c_int;
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct r#as(pub ::core::ffi::c_uint);
 impl r#as {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@raw_keywords.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@raw_keywords.c.2024.clang15.snap
@@ -13,7 +13,7 @@ expression: cat tests/snapshots/raw_keywords.2024.clang15.rs
     unused_mut
 )]
 pub type r#type = ::core::ffi::c_int;
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct r#as(pub ::core::ffi::c_uint);
 impl r#as {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@records.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@records.c.2021.clang15.snap
@@ -14,7 +14,7 @@ expression: cat tests/snapshots/records.2021.clang15.rs
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct AnonEnumInStruct {}
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct C2Rust_Unnamed(pub ::core::ffi::c_uint);
 impl C2Rust_Unnamed {
@@ -44,7 +44,7 @@ pub struct InsideStruct {
 pub union AnonEnumInUnion {
     pub a: ::core::ffi::c_int,
 }
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct C2Rust_Unnamed_1(pub ::core::ffi::c_uint);
 impl C2Rust_Unnamed_1 {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@records.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@records.c.2024.clang15.snap
@@ -15,7 +15,7 @@ expression: cat tests/snapshots/records.2024.clang15.rs
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct AnonEnumInStruct {}
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct C2Rust_Unnamed(pub ::core::ffi::c_uint);
 impl C2Rust_Unnamed {
@@ -45,7 +45,7 @@ pub struct InsideStruct {
 pub union AnonEnumInUnion {
     pub a: ::core::ffi::c_int,
 }
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct C2Rust_Unnamed_1(pub ::core::ffi::c_uint);
 impl C2Rust_Unnamed_1 {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2021.clang15.snap
@@ -12,7 +12,7 @@ expression: cat tests/snapshots/scalar_init.2021.clang15.rs
     unused_mut
 )]
 #![feature(raw_ref_op)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct E(pub ::core::ffi::c_uint);
 impl E {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@scalar_init.c.2024.clang15.snap
@@ -12,7 +12,7 @@ expression: cat tests/snapshots/scalar_init.2024.clang15.rs
     unused_assignments,
     unused_mut
 )]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct E(pub ::core::ffi::c_uint);
 impl E {


### PR DESCRIPTION
- Depends on #1620
- Depends on #1770
- Depends on #1776
- Fixes #1775

Enum constant names are now preserved in match arms where present, which significantly improves code fidelity.