### PR TITLE
ast-exporter: Do not process macros for the syntactic form of `InitListExpr`

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -1411,6 +1411,14 @@ class TranslateASTVisitor final
         // if (!E->isConstantInitializer(*Context, false))
         //     return true;
 
+        if (const InitListExpr* ILE = dyn_cast<InitListExpr>(E)) {
+            // Do not process macros for the syntactic form,
+            // so that they can be processed for the semantic form.
+            if (ILE->isSyntacticForm()) {
+                return true;
+            }
+        }
+
         auto &Mgr = Context->getSourceManager();
         auto Range = E->getSourceRange();
         LLVM_DEBUG(dbgs() << "Checking expr for macro expansion: ");

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.clang15.snap
@@ -43,6 +43,11 @@ pub const LITERAL_FLOAT: ::core::ffi::c_double = 3.14f64;
 pub const LITERAL_CHAR: ::core::ffi::c_int = 'x' as ::core::ffi::c_int;
 pub const LITERAL_STR: [::core::ffi::c_char; 6] =
     unsafe { ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0") };
+pub const LITERAL_ARRAY: [::core::ffi::c_int; 3] = [
+    1 as ::core::ffi::c_int,
+    2 as ::core::ffi::c_int,
+    3 as ::core::ffi::c_int,
+];
 pub const LITERAL_STRUCT: S = S {
     i: 5 as ::core::ffi::c_int,
 };
@@ -51,6 +56,7 @@ pub const NESTED_BOOL: ::core::ffi::c_int = LITERAL_BOOL;
 pub const NESTED_FLOAT: ::core::ffi::c_double = LITERAL_FLOAT;
 pub const NESTED_CHAR: ::core::ffi::c_int = LITERAL_CHAR;
 pub const NESTED_STR: [::core::ffi::c_char; 6] = LITERAL_STR;
+pub const NESTED_ARRAY: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 pub const NESTED_STRUCT: S = LITERAL_STRUCT;
 pub const PARENS: ::core::ffi::c_int = NESTED_INT * (LITERAL_CHAR + true_0);
 pub const PTR_ARITHMETIC: *const ::core::ffi::c_char = unsafe {
@@ -69,11 +75,7 @@ pub unsafe extern "C" fn local_muts() {
     let mut literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
     let mut literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
     let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
-    let mut literal_array: [::core::ffi::c_int; 3] = [
-        1 as ::core::ffi::c_int,
-        2 as ::core::ffi::c_int,
-        3 as ::core::ffi::c_int,
-    ];
+    let mut literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let mut literal_struct: S = LITERAL_STRUCT;
     let mut nested_int: ::core::ffi::c_int = NESTED_INT;
     let mut nested_bool: bool = NESTED_BOOL != 0;
@@ -81,11 +83,7 @@ pub unsafe extern "C" fn local_muts() {
     let mut nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
     let mut nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
     let mut nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
-    let mut nested_array: [::core::ffi::c_int; 3] = [
-        1 as ::core::ffi::c_int,
-        2 as ::core::ffi::c_int,
-        3 as ::core::ffi::c_int,
-    ];
+    let mut nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
     let mut nested_struct: S = NESTED_STRUCT;
     let mut negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let mut int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
@@ -142,11 +140,7 @@ pub unsafe extern "C" fn local_consts() {
     let literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
     let literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
     let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
-    let literal_array: [::core::ffi::c_int; 3] = [
-        1 as ::core::ffi::c_int,
-        2 as ::core::ffi::c_int,
-        3 as ::core::ffi::c_int,
-    ];
+    let literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let literal_struct: S = LITERAL_STRUCT;
     let nested_int: ::core::ffi::c_int = NESTED_INT;
     let nested_bool: bool = NESTED_BOOL != 0;
@@ -154,11 +148,7 @@ pub unsafe extern "C" fn local_consts() {
     let nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
     let nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
     let nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
-    let nested_array: [::core::ffi::c_int; 3] = [
-        1 as ::core::ffi::c_int,
-        2 as ::core::ffi::c_int,
-        3 as ::core::ffi::c_int,
-    ];
+    let nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
     let nested_struct: S = NESTED_STRUCT;
     let negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
@@ -213,11 +203,7 @@ static mut global_static_const_literal_char: ::core::ffi::c_char =
     LITERAL_CHAR as ::core::ffi::c_char;
 static mut global_static_const_literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
 static mut global_static_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
-static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = [
-    1 as ::core::ffi::c_int,
-    2 as ::core::ffi::c_int,
-    3 as ::core::ffi::c_int,
-];
+static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 static mut global_static_const_literal_struct: S = LITERAL_STRUCT;
 static mut global_static_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 static mut global_static_const_nested_bool: bool = NESTED_BOOL != 0;
@@ -227,11 +213,7 @@ static mut global_static_const_nested_char: ::core::ffi::c_char =
     NESTED_CHAR as ::core::ffi::c_char;
 static mut global_static_const_nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
 static mut global_static_const_nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
-static mut global_static_const_nested_array: [::core::ffi::c_int; 3] = [
-    1 as ::core::ffi::c_int,
-    2 as ::core::ffi::c_int,
-    3 as ::core::ffi::c_int,
-];
+static mut global_static_const_nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
 static mut global_static_const_nested_struct: S = NESTED_STRUCT;
 static mut global_static_const_negative_int: ::core::ffi::c_int = -LITERAL_INT;
 static mut global_static_const_int_arithmetic: ::core::ffi::c_int =
@@ -275,11 +257,7 @@ pub static mut global_const_literal_str_ptr: *const ::core::ffi::c_char = LITERA
 #[no_mangle]
 pub static mut global_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
 #[no_mangle]
-pub static mut global_const_literal_array: [::core::ffi::c_int; 3] = [
-    1 as ::core::ffi::c_int,
-    2 as ::core::ffi::c_int,
-    3 as ::core::ffi::c_int,
-];
+pub static mut global_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 #[no_mangle]
 pub static mut global_const_literal_struct: S = LITERAL_STRUCT;
 #[no_mangle]
@@ -296,11 +274,7 @@ pub static mut global_const_nested_str_ptr: *const ::core::ffi::c_char = NESTED_
 #[no_mangle]
 pub static mut global_const_nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
 #[no_mangle]
-pub static mut global_const_nested_array: [::core::ffi::c_int; 3] = [
-    1 as ::core::ffi::c_int,
-    2 as ::core::ffi::c_int,
-    3 as ::core::ffi::c_int,
-];
+pub static mut global_const_nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
 #[no_mangle]
 pub static mut global_const_nested_struct: S = NESTED_STRUCT;
 #[no_mangle]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.clang15.snap
@@ -43,6 +43,11 @@ pub const LITERAL_FLOAT: ::core::ffi::c_double = 3.14f64;
 pub const LITERAL_CHAR: ::core::ffi::c_int = 'x' as ::core::ffi::c_int;
 pub const LITERAL_STR: [::core::ffi::c_char; 6] =
     unsafe { ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0") };
+pub const LITERAL_ARRAY: [::core::ffi::c_int; 3] = [
+    1 as ::core::ffi::c_int,
+    2 as ::core::ffi::c_int,
+    3 as ::core::ffi::c_int,
+];
 pub const LITERAL_STRUCT: S = S {
     i: 5 as ::core::ffi::c_int,
 };
@@ -51,6 +56,7 @@ pub const NESTED_BOOL: ::core::ffi::c_int = LITERAL_BOOL;
 pub const NESTED_FLOAT: ::core::ffi::c_double = LITERAL_FLOAT;
 pub const NESTED_CHAR: ::core::ffi::c_int = LITERAL_CHAR;
 pub const NESTED_STR: [::core::ffi::c_char; 6] = LITERAL_STR;
+pub const NESTED_ARRAY: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 pub const NESTED_STRUCT: S = LITERAL_STRUCT;
 pub const PARENS: ::core::ffi::c_int = NESTED_INT * (LITERAL_CHAR + true_0);
 pub const PTR_ARITHMETIC: *const ::core::ffi::c_char = unsafe {
@@ -69,11 +75,7 @@ pub unsafe extern "C" fn local_muts() {
     let mut literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
     let mut literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
     let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
-    let mut literal_array: [::core::ffi::c_int; 3] = [
-        1 as ::core::ffi::c_int,
-        2 as ::core::ffi::c_int,
-        3 as ::core::ffi::c_int,
-    ];
+    let mut literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let mut literal_struct: S = LITERAL_STRUCT;
     let mut nested_int: ::core::ffi::c_int = NESTED_INT;
     let mut nested_bool: bool = NESTED_BOOL != 0;
@@ -81,11 +83,7 @@ pub unsafe extern "C" fn local_muts() {
     let mut nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
     let mut nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
     let mut nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
-    let mut nested_array: [::core::ffi::c_int; 3] = [
-        1 as ::core::ffi::c_int,
-        2 as ::core::ffi::c_int,
-        3 as ::core::ffi::c_int,
-    ];
+    let mut nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
     let mut nested_struct: S = NESTED_STRUCT;
     let mut negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let mut int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
@@ -142,11 +140,7 @@ pub unsafe extern "C" fn local_consts() {
     let literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
     let literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
     let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
-    let literal_array: [::core::ffi::c_int; 3] = [
-        1 as ::core::ffi::c_int,
-        2 as ::core::ffi::c_int,
-        3 as ::core::ffi::c_int,
-    ];
+    let literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let literal_struct: S = LITERAL_STRUCT;
     let nested_int: ::core::ffi::c_int = NESTED_INT;
     let nested_bool: bool = NESTED_BOOL != 0;
@@ -154,11 +148,7 @@ pub unsafe extern "C" fn local_consts() {
     let nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
     let nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
     let nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
-    let nested_array: [::core::ffi::c_int; 3] = [
-        1 as ::core::ffi::c_int,
-        2 as ::core::ffi::c_int,
-        3 as ::core::ffi::c_int,
-    ];
+    let nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
     let nested_struct: S = NESTED_STRUCT;
     let negative_int: ::core::ffi::c_int = -LITERAL_INT;
     let int_arithmetic: ::core::ffi::c_int = NESTED_INT + LITERAL_INT + 1 as ::core::ffi::c_int;
@@ -213,11 +203,7 @@ static mut global_static_const_literal_char: ::core::ffi::c_char =
     LITERAL_CHAR as ::core::ffi::c_char;
 static mut global_static_const_literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
 static mut global_static_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
-static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = [
-    1 as ::core::ffi::c_int,
-    2 as ::core::ffi::c_int,
-    3 as ::core::ffi::c_int,
-];
+static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 static mut global_static_const_literal_struct: S = LITERAL_STRUCT;
 static mut global_static_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 static mut global_static_const_nested_bool: bool = NESTED_BOOL != 0;
@@ -227,11 +213,7 @@ static mut global_static_const_nested_char: ::core::ffi::c_char =
     NESTED_CHAR as ::core::ffi::c_char;
 static mut global_static_const_nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
 static mut global_static_const_nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
-static mut global_static_const_nested_array: [::core::ffi::c_int; 3] = [
-    1 as ::core::ffi::c_int,
-    2 as ::core::ffi::c_int,
-    3 as ::core::ffi::c_int,
-];
+static mut global_static_const_nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
 static mut global_static_const_nested_struct: S = NESTED_STRUCT;
 static mut global_static_const_negative_int: ::core::ffi::c_int = -LITERAL_INT;
 static mut global_static_const_int_arithmetic: ::core::ffi::c_int =
@@ -275,11 +257,7 @@ pub static mut global_const_literal_str_ptr: *const ::core::ffi::c_char = LITERA
 #[unsafe(no_mangle)]
 pub static mut global_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
 #[unsafe(no_mangle)]
-pub static mut global_const_literal_array: [::core::ffi::c_int; 3] = [
-    1 as ::core::ffi::c_int,
-    2 as ::core::ffi::c_int,
-    3 as ::core::ffi::c_int,
-];
+pub static mut global_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 #[unsafe(no_mangle)]
 pub static mut global_const_literal_struct: S = LITERAL_STRUCT;
 #[unsafe(no_mangle)]
@@ -296,11 +274,7 @@ pub static mut global_const_nested_str_ptr: *const ::core::ffi::c_char = NESTED_
 #[unsafe(no_mangle)]
 pub static mut global_const_nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
 #[unsafe(no_mangle)]
-pub static mut global_const_nested_array: [::core::ffi::c_int; 3] = [
-    1 as ::core::ffi::c_int,
-    2 as ::core::ffi::c_int,
-    3 as ::core::ffi::c_int,
-];
+pub static mut global_const_nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
 #[unsafe(no_mangle)]
 pub static mut global_const_nested_struct: S = NESTED_STRUCT;
 #[unsafe(no_mangle)]


### PR DESCRIPTION
In the exporter, the `macroCallSites` variable keeps track of which macro call sites have already been visited, so that only the outermost expression gets processed for that call site. But that depends on Clang's visiting order, and in the case of init lists, the syntactic form appears to be visited first, which then prevents macros from being associated with the semantic form. This PR skips macro processing for the syntactic form (which c2rust ignores anyway), fixing expansion for init lists in the transpiler.