### PR TITLE
relooper: Avoid recomputing strict_reachable_from in simple case

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[[profile.default.overrides]]
+filter = "package(c2rust-transpile) and test(issue_1821_transpiles_quickly)"
+slow-timeout = { period = "30s", terminate-after = 1 }

--- a/c2rust-transpile/src/cfg/mod.rs
+++ b/c2rust-transpile/src/cfg/mod.rs
@@ -302,6 +302,21 @@ impl<S1, S2> BasicBlock<StructureLabel<S1>, S2> {
             })
             .collect()
     }
+
+    /// Check whether this block has a `GoTo` to `target`.
+    fn has_successor(&self, target: &Label) -> bool {
+        let is_target = |label: &StructureLabel<S1>| match label {
+            StructureLabel::GoTo(successor) => successor == target,
+            _ => false,
+        };
+
+        match &self.terminator {
+            End => false,
+            Jump(label) => is_target(label),
+            Branch(_, then_label, else_label) => is_target(then_label) || is_target(else_label),
+            Switch { cases, .. } => cases.iter().any(|(_, label)| is_target(label)),
+        }
+    }
 }
 
 /// Represents the control flow choices one can make when at the end of a `BasicBlock`.

--- a/c2rust-transpile/src/cfg/relooper.rs
+++ b/c2rust-transpile/src/cfg/relooper.rs
@@ -242,7 +242,7 @@ impl RelooperState {
         // body we don't want to consider back edges, which we strip before processing
         // the loop body.
         //
-        // TODO: If possible we should avoid recomputing this every time. I think the
+        // TODO: If possible we should avoid recomputing this every time `relooper` recurses. I think the
         // reachability information only meaningfully changes when we strip a back edge,
         // so in theory we should only need to recompute this after processing a loop.
         let strict_reachable_from = || flip_edges(transitive_closure(&local_successors));

--- a/c2rust-transpile/src/cfg/relooper.rs
+++ b/c2rust-transpile/src/cfg/relooper.rs
@@ -225,11 +225,6 @@ impl RelooperState {
             return;
         }
 
-        let local_successors: AdjacencyList = blocks
-            .iter()
-            .map(|(lbl, bb)| (lbl.clone(), bb.successors()))
-            .collect();
-
         // Map from each label to the set of labels that reach it. A label does not
         // count as reaching itself unless there is an explicit back edge to that label.
         //
@@ -242,18 +237,23 @@ impl RelooperState {
         // body we don't want to consider back edges, which we strip before processing
         // the loop body.
         //
-        // TODO: If possible we should avoid recomputing this every time `relooper` recurses. I think the
-        // reachability information only meaningfully changes when we strip a back edge,
-        // so in theory we should only need to recompute this after processing a loop.
-        let strict_reachable_from = || flip_edges(transitive_closure(&local_successors));
+        // TODO: If possible we should avoid recomputing this every time `relooper`
+        // recurses. I think the reachability information only meaningfully changes when
+        // we strip a back edge, so in theory we should only need to recompute this after
+        // processing a loop.
+        let strict_reachable_from = |blocks: &BasicBlocks| {
+            let local_successors = blocks
+                .iter()
+                .map(|(lbl, bb)| (lbl.clone(), bb.successors()))
+                .collect();
+            flip_edges(transitive_closure(&local_successors))
+        };
 
         // Handle our simple case of only 1 entry. If there's no back edge to the entry
         // we generate a `Simple` structure, otherwise we make a loop.
         if entries.len() == 1 {
             let entry = entries.first().unwrap();
-            let has_back_edge = local_successors
-                .values()
-                .any(|successors| successors.contains(entry));
+            let has_back_edge = blocks.values().any(|block| block.has_successor(entry));
 
             if !has_back_edge {
                 let bb = blocks
@@ -303,12 +303,12 @@ impl RelooperState {
 
                 self.relooper(new_entries, blocks, result);
             } else {
-                self.make_loop(&strict_reachable_from(), blocks, entries, result);
+                self.make_loop(&strict_reachable_from(&blocks), blocks, entries, result);
             }
             return;
         }
 
-        let strict_reachable_from = strict_reachable_from();
+        let strict_reachable_from = strict_reachable_from(&blocks);
 
         // Sanity check that we have entries that are in our current set of blocks. We
         // may have entries that aren't present in our current blocks when we're inside

--- a/c2rust-transpile/src/cfg/relooper.rs
+++ b/c2rust-transpile/src/cfg/relooper.rs
@@ -225,7 +225,7 @@ impl RelooperState {
             return;
         }
 
-        let local_successors = blocks
+        let local_successors: AdjacencyList = blocks
             .iter()
             .map(|(lbl, bb)| (lbl.clone(), bb.successors()))
             .collect();
@@ -241,13 +241,21 @@ impl RelooperState {
         // blocks. Global reachability won't work here because when we're inside a loop
         // body we don't want to consider back edges, which we strip before processing
         // the loop body.
-        let strict_reachable_from = flip_edges(transitive_closure(&local_successors));
+        //
+        // TODO: If possible we should avoid recomputing this every time. I think the
+        // reachability information only meaningfully changes when we strip a back edge,
+        // so in theory we should only need to recompute this after processing a loop.
+        let strict_reachable_from = || flip_edges(transitive_closure(&local_successors));
 
         // Handle our simple case of only 1 entry. If there's no back edge to the entry
         // we generate a `Simple` structure, otherwise we make a loop.
         if entries.len() == 1 {
             let entry = entries.first().unwrap();
-            if !strict_reachable_from.contains_key(entry) {
+            let has_back_edge = local_successors
+                .values()
+                .any(|successors| successors.contains(entry));
+
+            if !has_back_edge {
                 let bb = blocks
                     .swap_remove(entry)
                     .expect("Entry not present in current blocks");
@@ -295,10 +303,12 @@ impl RelooperState {
 
                 self.relooper(new_entries, blocks, result);
             } else {
-                self.make_loop(&strict_reachable_from, blocks, entries, result);
+                self.make_loop(&strict_reachable_from(), blocks, entries, result);
             }
             return;
         }
+
+        let strict_reachable_from = strict_reachable_from();
 
         // Sanity check that we have entries that are in our current set of blocks. We
         // may have entries that aren't present in our current blocks when we're inside

--- a/c2rust-transpile/tests/common/mod.rs
+++ b/c2rust-transpile/tests/common/mod.rs
@@ -1,0 +1,60 @@
+use std::path::PathBuf;
+
+use c2rust_rust_tools::RustEdition;
+use c2rust_transpile::{ReplaceMode, TranspilerConfig};
+
+pub fn config(edition: RustEdition) -> TranspilerConfig {
+    TranspilerConfig {
+        dump_untyped_context: false,
+        dump_typed_context: false,
+        pretty_typed_context: false,
+        dump_function_cfgs: false,
+        json_function_cfgs: false,
+        dump_cfg_liveness: false,
+        dump_structures: false,
+        verbose: false,
+        debug_ast_exporter: false,
+        emit_c_decl_map: true, // Let snapshot tests validate the C declaration map.
+        incremental_relooper: true,
+        fail_on_multiple: false,
+        filter: None,
+        debug_relooper_labels: false,
+        cross_checks: false,
+        cross_check_backend: Default::default(),
+        cross_check_configs: Default::default(),
+        prefix_function_names: None,
+        translate_asm: true,
+        use_c_loop_info: true,
+        use_c_multiple_info: true,
+        simplify_structures: true,
+        panic_on_translator_failure: false,
+        emit_modules: false,
+        fail_on_error: true,
+        replace_unsupported_decls: ReplaceMode::Extern,
+        translate_valist: true,
+        overwrite_existing: true,
+        reduce_type_annotations: false,
+        reorganize_definitions: false,
+        enabled_warnings: Default::default(),
+        emit_no_std: false,
+        output_dir: None,
+        translate_const_macros: Default::default(),
+        translate_fn_macros: Default::default(),
+        disable_rustfmt: false,
+        disable_refactoring: false,
+        preserve_unused_functions: false,
+        log_level: log::LevelFilter::Warn,
+        edition,
+        deny_unsafe_op_in_unsafe_fn: false,
+        postprocess: false,
+        emit_build_files: false,
+        binaries: Vec::new(),
+        thin_binaries: false,
+        c2rust_dir: Some(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .to_path_buf(),
+        ),
+    }
+}

--- a/c2rust-transpile/tests/relooper.rs
+++ b/c2rust-transpile/tests/relooper.rs
@@ -16,6 +16,13 @@ fn run_transpiler() {
     cfg.emit_c_decl_map = false;
     cfg.output_dir = Some(output_dir.path().to_owned());
     c2rust_transpile::transpile(cfg, &compile_commands, &[]);
+
+    let output = std::fs::read(output_dir.path().join("src/issue_1821.rs"))
+        .expect("transpiler did not produce issue_1821.rs");
+    assert!(
+        !output.is_empty(),
+        "transpiler produced an empty output file"
+    );
 }
 
 #[test]

--- a/c2rust-transpile/tests/relooper.rs
+++ b/c2rust-transpile/tests/relooper.rs
@@ -1,0 +1,39 @@
+mod common;
+
+use c2rust_rust_tools::RustEdition::Edition2021;
+
+use common::config;
+
+fn run_transpiler() {
+    let fixture =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/relooper/issue_1821.c");
+    let output_dir = c2rust_transpile::TempDir::new().unwrap();
+    let (_compile_commands_dir, compile_commands) =
+        c2rust_transpile::create_temp_compile_commands(&[fixture]);
+
+    let mut cfg = config(Edition2021);
+    cfg.disable_rustfmt = true;
+    cfg.emit_c_decl_map = false;
+    cfg.output_dir = Some(output_dir.path().to_owned());
+    c2rust_transpile::transpile(cfg, &compile_commands, &[]);
+}
+
+#[test]
+#[cfg_attr(
+    debug_assertions,
+    ignore = "the relooper exhausts its stack in debug builds"
+)]
+fn issue_1821_transpiles_quickly() {
+    // HACK: Use a thread with a larger stack size. Relooper is tail-recursive,
+    // and long functions can cause us to recurse far enough to overflow the
+    // stack. We should fix that issue, but for now we work around it in the
+    // test by using a thread with a larger stack size.
+    //
+    // See https://github.com/immunant/c2rust/issues/1908
+    std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(run_transpiler)
+        .unwrap()
+        .join()
+        .unwrap();
+}

--- a/c2rust-transpile/tests/relooper.rs
+++ b/c2rust-transpile/tests/relooper.rs
@@ -19,10 +19,6 @@ fn run_transpiler() {
 }
 
 #[test]
-#[cfg_attr(
-    debug_assertions,
-    ignore = "the relooper exhausts its stack in debug builds"
-)]
 fn issue_1821_transpiles_quickly() {
     // HACK: Use a thread with a larger stack size. Relooper is tail-recursive,
     // and long functions can cause us to recurse far enough to overflow the
@@ -31,7 +27,7 @@ fn issue_1821_transpiles_quickly() {
     //
     // See https://github.com/immunant/c2rust/issues/1908
     std::thread::Builder::new()
-        .stack_size(8 * 1024 * 1024)
+        .stack_size(64 * 1024 * 1024)
         .spawn(run_transpiler)
         .unwrap()
         .join()

--- a/c2rust-transpile/tests/relooper/issue_1821.c
+++ b/c2rust-transpile/tests/relooper/issue_1821.c
@@ -1,0 +1,285 @@
+/*
+   BLAKE reference C implementation
+
+   Copyright (c) 2012 Jean-Philippe Aumasson <jeanphilippe.aumasson@gmail.com>
+
+   To the extent possible under law, the author(s) have dedicated all copyright
+   and related and neighboring rights to this software to the public domain
+   worldwide. This software is distributed without any warranty.
+
+   You should have received a copy of the CC0 Public Domain Dedication along
+   with this software. If not, see
+   <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+#include <stdint.h>
+
+typedef struct
+{
+  unsigned int h[8];
+  unsigned int  s[4];
+  unsigned int  t[2];
+  int buflen;
+  int  nullt;
+  unsigned char buf[64];
+} blakestate256;
+
+typedef unsigned long long crypto_uint64;
+typedef unsigned int crypto_uint32;
+typedef unsigned char crypto_uint8;
+
+typedef crypto_uint64 u64;
+typedef crypto_uint32 u32;
+typedef crypto_uint8 u8; 
+
+#define U8TO32(p)					      \
+  (((uint32_t)((p)[0]) << 24) | ((uint32_t)((p)[1]) << 16) |  \
+   ((uint32_t)((p)[2]) <<  8) | ((uint32_t)((p)[3])      ))
+#define U32TO8(p, v)         \
+  (p)[0] = (uint8_t)((v) >> 24); \
+  (p)[1] = (uint8_t)((v) >> 16); \
+  (p)[2] = (uint8_t)((v) >> 8);  \
+  (p)[3] = (uint8_t)((v));
+
+static const u32 cst[16] = {
+  0x243F6A88,0x85A308D3,0x13198A2E,0x03707344,
+  0xA4093822,0x299F31D0,0x082EFA98,0xEC4E6C89,
+  0x452821E6,0x38D01377,0xBE5466CF,0x34E90C6C,
+  0xC0AC29B7,0xC97C50DD,0x3F84D5B5,0xB5470917};
+
+static const u8 padding[] =
+  {0x80,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+
+#define BLAKE256_ROT(x,n) (((x)<<(32-n))|( (x)>>(n)))
+
+void blake256_compress( blakestate256 *S, const unsigned char *block )
+{
+  u32 m0;
+  u32 m1;
+  u32 m2;
+  u32 m3;
+  u32 m4;
+  u32 m5;
+  u32 m6;
+  u32 m7;
+  u32 m8;
+  u32 m9;
+  u32 m10;
+  u32 m11;
+  u32 m12;
+  u32 m13;
+  u32 m14;
+  u32 m15;
+  u32 v0;
+  u32 v1;
+  u32 v2;
+  u32 v3;
+  u32 v4;
+  u32 v5;
+  u32 v6;
+  u32 v7;
+  u32 v8;
+  u32 v9;
+  u32 v10;
+  u32 v11;
+  u32 v12;
+  u32 v13;
+  u32 v14;
+  u32 v15;
+
+  m0 = U8TO32(block + 0);
+  m1 = U8TO32(block + 4);
+  m2 = U8TO32(block + 8);
+  m3 = U8TO32(block + 12);
+  m4 = U8TO32(block + 16);
+  m5 = U8TO32(block + 20);
+  m6 = U8TO32(block + 24);
+  m7 = U8TO32(block + 28);
+  m8 = U8TO32(block + 32);
+  m9 = U8TO32(block + 36);
+  m10 = U8TO32(block + 40);
+  m11 = U8TO32(block + 44);
+  m12 = U8TO32(block + 48);
+  m13 = U8TO32(block + 52);
+  m14 = U8TO32(block + 56);
+  m15 = U8TO32(block + 60);
+  v0 = S->h[0];
+  v1 = S->h[1];
+  v2 = S->h[2];
+  v3 = S->h[3];
+  v4 = S->h[4];
+  v5 = S->h[5];
+  v6 = S->h[6];
+  v7 = S->h[7];
+  v8 = S->s[0] ^ 0x243F6A88;
+  v9 = S->s[1] ^ 0x85A308D3;
+  v10 = S->s[2] ^ 0x13198A2E;
+  v11 = S->s[3] ^ 0x03707344;
+  v12 = 0xA4093822;
+  v13 = 0x299F31D0;
+  v14 = 0x082EFA98;
+  v15 = 0xEC4E6C89;
+  if (S->nullt == 0) { 
+    v12 ^= S->t[0];
+    v13 ^= S->t[0];
+    v14 ^= S->t[1];
+    v15 ^= S->t[1];
+  }
+
+#define ROUND(m0,c0,m1,c1,m2,c2,m3,c3,m4,c4,m5,c5,m6,c6,m7,c7,m8,c8,m9,c9,m10,c10,m11,c11,m12,c12,m13,c13,m14,c14,m15,c15) \
+    v0 += m0 ^ c0; \
+    v0 += v4; \
+    v12 ^= v0; \
+    v12 = BLAKE256_ROT( v12,16); \
+    v8 += v12; \
+    v4 ^= v8; \
+    v4 = BLAKE256_ROT( v4,12); \
+      v1 += m2 ^ c2; \
+      v1 += v5; \
+      v13 ^= v1; \
+      v13 = BLAKE256_ROT( v13,16); \
+      v9 += v13; \
+      v5 ^= v9; \
+      v5 = BLAKE256_ROT( v5,12); \
+        v2 += m4 ^ c4; \
+        v2 += v6; \
+        v14 ^= v2; \
+        v14 = BLAKE256_ROT( v14,16); \
+        v10 += v14; \
+        v6 ^= v10; \
+        v6 = BLAKE256_ROT( v6,12); \
+          v3 += m6 ^ c6; \
+          v3 += v7; \
+          v15 ^= v3; \
+          v15 = BLAKE256_ROT( v15,16); \
+          v11 += v15; \
+          v7 ^= v11; \
+          v7 = BLAKE256_ROT( v7,12); \
+        v2 += m5 ^ c5; \
+        v2 += v6; \
+        v14 ^= v2; \
+        v14 = BLAKE256_ROT( v14, 8); \
+        v10 += v14; \
+        v6 ^= v10; \
+        v6 = BLAKE256_ROT( v6, 7); \
+          v3 += m7 ^ c7; \
+          v3 += v7; \
+          v15 ^= v3; \
+          v15 = BLAKE256_ROT( v15, 8); \
+          v11 += v15; \
+          v7 ^= v11; \
+          v7 = BLAKE256_ROT( v7, 7); \
+      v1 += m3 ^ c3; \
+      v1 += v5; \
+      v13 ^= v1; \
+      v13 = BLAKE256_ROT( v13, 8); \
+      v9 += v13; \
+      v5 ^= v9; \
+      v5 = BLAKE256_ROT( v5, 7); \
+    v0 += m1 ^ c1; \
+    v0 += v4; \
+    v12 ^= v0; \
+    v12 = BLAKE256_ROT( v12, 8); \
+    v8 += v12; \
+    v4 ^= v8; \
+    v4 = BLAKE256_ROT( v4, 7); \
+            v0 += m8 ^ c8; \
+            v0 += v5; \
+            v15 ^= v0; \
+            v15 = BLAKE256_ROT( v15,16); \
+            v10 += v15; \
+            v5 ^= v10; \
+            v5 = BLAKE256_ROT( v5,12); \
+              v1 += m10 ^ c10; \
+              v1 += v6; \
+              v12 ^= v1; \
+              v12 = BLAKE256_ROT( v12,16); \
+              v11 += v12; \
+              v6 ^= v11; \
+              v6 = BLAKE256_ROT( v6,12); \
+                v2 += m12 ^ c12; \
+                v2 += v7; \
+                v13 ^= v2; \
+                v13 = BLAKE256_ROT( v13,16); \
+                v8 += v13; \
+                v7 ^= v8; \
+                v7 = BLAKE256_ROT( v7,12); \
+                  v3 += m14 ^ c14; \
+                  v3 += v4; \
+                  v14 ^= v3; \
+                  v14 = BLAKE256_ROT( v14,16); \
+                  v9 += v14; \
+                  v4 ^= v9; \
+                  v4 = BLAKE256_ROT( v4,12); \
+                v2 += m13 ^ c13; \
+                v2 += v7; \
+                v13 ^= v2; \
+                v13 = BLAKE256_ROT( v13, 8); \
+                v8 += v13; \
+                v7 ^= v8; \
+                v7 = BLAKE256_ROT( v7, 7); \
+                  v3 += m15 ^ c15; \
+                  v3 += v4; \
+                  v14 ^= v3; \
+                  v14 = BLAKE256_ROT( v14, 8); \
+                  v9 += v14; \
+                  v4 ^= v9; \
+                  v4 = BLAKE256_ROT( v4, 7); \
+              v1 += m11 ^ c11; \
+              v1 += v6; \
+              v12 ^= v1; \
+              v12 = BLAKE256_ROT( v12, 8); \
+              v11 += v12; \
+              v6 ^= v11; \
+              v6 = BLAKE256_ROT( v6, 7); \
+            v0 += m9 ^ c9; \
+            v0 += v5; \
+            v15 ^= v0; \
+            v15 = BLAKE256_ROT( v15, 8); \
+            v10 += v15; \
+            v5 ^= v10; \
+            v5 = BLAKE256_ROT( v5, 7); \
+
+  ROUND(m0,cst[1],m1,cst[0],m2,cst[3],m3,cst[2],m4,cst[5],m5,cst[4],m6,cst[7],m7,cst[6],m8,cst[9],m9,cst[8],m10,cst[11],m11,cst[10],m12,cst[13],m13,cst[12],m14,cst[15],m15,cst[14])
+  ROUND(m14,cst[10],m10,cst[14],m4,cst[8],m8,cst[4],m9,cst[15],m15,cst[9],m13,cst[6],m6,cst[13],m1,cst[12],m12,cst[1],m0,cst[2],m2,cst[0],m11,cst[7],m7,cst[11],m5,cst[3],m3,cst[5])
+  ROUND(m11,cst[8],m8,cst[11],m12,cst[0],m0,cst[12],m5,cst[2],m2,cst[5],m15,cst[13],m13,cst[15],m10,cst[14],m14,cst[10],m3,cst[6],m6,cst[3],m7,cst[1],m1,cst[7],m9,cst[4],m4,cst[9])
+  ROUND(m7,cst[9],m9,cst[7],m3,cst[1],m1,cst[3],m13,cst[12],m12,cst[13],m11,cst[14],m14,cst[11],m2,cst[6],m6,cst[2],m5,cst[10],m10,cst[5],m4,cst[0],m0,cst[4],m15,cst[8],m8,cst[15])
+  ROUND(m9,cst[0],m0,cst[9],m5,cst[7],m7,cst[5],m2,cst[4],m4,cst[2],m10,cst[15],m15,cst[10],m14,cst[1],m1,cst[14],m11,cst[12],m12,cst[11],m6,cst[8],m8,cst[6],m3,cst[13],m13,cst[3])
+  ROUND(m2,cst[12],m12,cst[2],m6,cst[10],m10,cst[6],m0,cst[11],m11,cst[0],m8,cst[3],m3,cst[8],m4,cst[13],m13,cst[4],m7,cst[5],m5,cst[7],m15,cst[14],m14,cst[15],m1,cst[9],m9,cst[1])
+  ROUND(m12,cst[5],m5,cst[12],m1,cst[15],m15,cst[1],m14,cst[13],m13,cst[14],m4,cst[10],m10,cst[4],m0,cst[7],m7,cst[0],m6,cst[3],m3,cst[6],m9,cst[2],m2,cst[9],m8,cst[11],m11,cst[8])
+  ROUND(m13,cst[11],m11,cst[13],m7,cst[14],m14,cst[7],m12,cst[1],m1,cst[12],m3,cst[9],m9,cst[3],m5,cst[0],m0,cst[5],m15,cst[4],m4,cst[15],m8,cst[6],m6,cst[8],m2,cst[10],m10,cst[2])
+  ROUND(m6,cst[15],m15,cst[6],m14,cst[9],m9,cst[14],m11,cst[3],m3,cst[11],m0,cst[8],m8,cst[0],m12,cst[2],m2,cst[12],m13,cst[7],m7,cst[13],m1,cst[4],m4,cst[1],m10,cst[5],m5,cst[10])
+  ROUND(m10,cst[2],m2,cst[10],m8,cst[4],m4,cst[8],m7,cst[6],m6,cst[7],m1,cst[5],m5,cst[1],m15,cst[11],m11,cst[15],m9,cst[14],m14,cst[9],m3,cst[12],m12,cst[3],m13,cst[0],m0,cst[13])
+  ROUND(m0,cst[1],m1,cst[0],m2,cst[3],m3,cst[2],m4,cst[5],m5,cst[4],m6,cst[7],m7,cst[6],m8,cst[9],m9,cst[8],m10,cst[11],m11,cst[10],m12,cst[13],m13,cst[12],m14,cst[15],m15,cst[14])
+  ROUND(m14,cst[10],m10,cst[14],m4,cst[8],m8,cst[4],m9,cst[15],m15,cst[9],m13,cst[6],m6,cst[13],m1,cst[12],m12,cst[1],m0,cst[2],m2,cst[0],m11,cst[7],m7,cst[11],m5,cst[3],m3,cst[5])
+  ROUND(m11,cst[8],m8,cst[11],m12,cst[0],m0,cst[12],m5,cst[2],m2,cst[5],m15,cst[13],m13,cst[15],m10,cst[14],m14,cst[10],m3,cst[6],m6,cst[3],m7,cst[1],m1,cst[7],m9,cst[4],m4,cst[9])
+  ROUND(m7,cst[9],m9,cst[7],m3,cst[1],m1,cst[3],m13,cst[12],m12,cst[13],m11,cst[14],m14,cst[11],m2,cst[6],m6,cst[2],m5,cst[10],m10,cst[5],m4,cst[0],m0,cst[4],m15,cst[8],m8,cst[15])
+
+  v0 ^= v8;
+  v1 ^= v9;
+  v2 ^= v10;
+  v3 ^= v11;
+  v4 ^= v12;
+  v5 ^= v13;
+  v6 ^= v14;
+  v7 ^= v15;
+
+  v0 ^= S->s[0];
+  v1 ^= S->s[1];
+  v2 ^= S->s[2];
+  v3 ^= S->s[3];
+  v4 ^= S->s[0];
+  v5 ^= S->s[1];
+  v6 ^= S->s[2];
+  v7 ^= S->s[3];
+
+  S->h[0] ^= v0;
+  S->h[1] ^= v1;
+  S->h[2] ^= v2;
+  S->h[3] ^= v3;
+  S->h[4] ^= v4;
+  S->h[5] ^= v5;
+  S->h[6] ^= v6;
+  S->h[7] ^= v7;
+}

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -1,7 +1,6 @@
 use std::env::current_dir;
 use std::fs;
 use std::path::Path;
-use std::path::PathBuf;
 use std::process::Command;
 
 use c2rust_ast_exporter::get_clang_major_version;
@@ -11,65 +10,11 @@ use c2rust_rust_tools::RustEdition;
 use c2rust_rust_tools::RustEdition::Edition2021;
 use c2rust_rust_tools::RustEdition::Edition2024;
 use c2rust_transpile::renamer::RUST_KEYWORDS;
-use c2rust_transpile::ReplaceMode;
 use c2rust_transpile::TranspilerConfig;
 use itertools::Itertools;
 
-fn config(edition: RustEdition) -> TranspilerConfig {
-    TranspilerConfig {
-        dump_untyped_context: false,
-        dump_typed_context: false,
-        pretty_typed_context: false,
-        dump_function_cfgs: false,
-        json_function_cfgs: false,
-        dump_cfg_liveness: false,
-        dump_structures: false,
-        verbose: false,
-        debug_ast_exporter: false,
-        emit_c_decl_map: true, // So `transpile_with_c_decl_map_snapshot` can validate C decl map.
-        incremental_relooper: true,
-        fail_on_multiple: false,
-        filter: None,
-        debug_relooper_labels: false,
-        cross_checks: false,
-        cross_check_backend: Default::default(),
-        cross_check_configs: Default::default(),
-        prefix_function_names: None,
-        translate_asm: true,
-        use_c_loop_info: true,
-        use_c_multiple_info: true,
-        simplify_structures: true,
-        panic_on_translator_failure: false,
-        emit_modules: false,
-        fail_on_error: true,
-        replace_unsupported_decls: ReplaceMode::Extern,
-        translate_valist: true,
-        overwrite_existing: true,
-        reduce_type_annotations: false,
-        reorganize_definitions: false,
-        enabled_warnings: Default::default(),
-        emit_no_std: false,
-        output_dir: None,
-        translate_const_macros: Default::default(),
-        translate_fn_macros: Default::default(),
-        disable_rustfmt: false,
-        disable_refactoring: false,
-        preserve_unused_functions: false,
-        log_level: log::LevelFilter::Warn,
-        edition,
-        deny_unsafe_op_in_unsafe_fn: false,
-        postprocess: false,
-        emit_build_files: false,
-        binaries: Vec::new(),
-        thin_binaries: false,
-        c2rust_dir: Some(
-            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .parent()
-                .unwrap()
-                .to_path_buf(),
-        ),
-    }
-}
+mod common;
+use common::config;
 
 /// Validate that the given C file compiles, then transpile it with the given config.
 fn compile_and_transpile_file(c_path: &Path, config: TranspilerConfig) {


### PR DESCRIPTION
Fixes https://github.com/immunant/c2rust/issues/1821 by avoiding computing `strict_reachable_from` in the case of linear control flow. The performance issue there was that we were recomputing `strict_reachable_from` in every call to `relooper`, which means we recompute it after processing each block in the CFG. For very long CFGs like the one in #1821 that results in a lot of redundant work, causing translation to take a very long time.

The fix for the specific case in #1821 is simple, but I suspect there are other edge cases that could cause similar quadratic behavior. I think we could be a bit smarter about when we recompute reachability info, since I think reachability only meaningfully changes when we strip back edges while processing a loop. I don't have time to experiment with that now, though, so I've added a TODO comment in there as a note to look into that in the future.