### PR TITLE
postprocess: switch from `gemini-3-flash-preview` to `gemini-3.5-flash` for the default

### DIFF
--- a/c2rust-postprocess/postprocess/__init__.py
+++ b/c2rust-postprocess/postprocess/__init__.py
@@ -21,6 +21,8 @@ from postprocess.transforms import (
 )
 from postprocess.utils import existing_file
 
+DEFAULT_LLM_MODEL = "gemini-3.5-flash"
+
 
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -64,8 +66,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--llm-model",
         type=str,
         required=False,
-        default="gemini-3-flash-preview",
-        help="ID of the LLM model to use (default: gemini-3-flash-preview)",
+        default=DEFAULT_LLM_MODEL,
+        help=f"ID of the LLM model to use (default: {DEFAULT_LLM_MODEL})",
     )
 
     parser.add_argument(


### PR DESCRIPTION
`gemini-3.5-flash` costs roughly 3x more than the earlier `gemini-3-flash-preview` model but exhibits stronger performance in agentic workflows such as coding. It is also generally available (not in preview).

Link: https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/#gemini-3-5-flash