### PR TITLE
postprocess: warn instead of failing on cache miss with no API key

### DIFF
--- a/c2rust-postprocess/postprocess/models/mock.py
+++ b/c2rust-postprocess/postprocess/models/mock.py
@@ -1,13 +1,13 @@
 from collections.abc import Callable, Iterable
-from typing import Any, Never
+from typing import Any
 
 from postprocess.models import AbstractGenerativeModel
 
 
 class MockGenerativeModel(AbstractGenerativeModel):
     """
-    Mock generative model for testing without an actual LLM backend.
-    Raises NotImplementedError on generation attempts.
+    Mock generative model used when no API key is available.
+    Generates no responses, so callers fall back to cached responses only.
     """
 
     def __init__(self):
@@ -18,9 +18,5 @@ class MockGenerativeModel(AbstractGenerativeModel):
         messages: list[dict[str, Any]],
         tools: Iterable[Callable[..., Any]] = (),
         max_tool_loops: int = 5,
-    ) -> Never:
-        raise NotImplementedError(
-            "MockGenerativeModel, by design, does not generate responses.\n"
-            "If this is unexpected, check if you forgot to add an API key "
-            "to your environment (e.g. `export GEMINI_API_KEY=...`)."
-        )
+    ) -> None:
+        return None

--- a/c2rust-postprocess/postprocess/transforms.py
+++ b/c2rust-postprocess/postprocess/transforms.py
@@ -12,7 +12,7 @@ from postprocess.definitions import (
     update_rust_definition,
 )
 from postprocess.exclude_list import IdentifierExcludeList
-from postprocess.models import AbstractGenerativeModel
+from postprocess.models import AbstractGenerativeModel, api_key_from_env
 from postprocess.utils import get_highlighted_c, get_highlighted_rust, remove_backticks
 
 # TODO: get from model
@@ -150,7 +150,14 @@ class CommentTransfer:
             ):
                 response = self.model.generate_with_tools(messages)
                 if response is None:
-                    logging.error("Model returned no response")
+                    if api_key_from_env(model) is None:
+                        # No API key set: skip uncached entries instead of failing.
+                        logging.warning(
+                            f"Cache miss for {identifier}; "
+                            "skipping since no API key was set..."
+                        )
+                    else:
+                        logging.error(f"Model returned no response for {identifier}")
                     continue
                 self.cache.update(
                     transform=transform,


### PR DESCRIPTION
Rather than relying on a fully-populated cache, we will populate the cache on separate, scheduled runs and allow cache misses from other CI runs so they are not forced to update the cache if codegen changes.