### PR TITLE
transpile: Add `CExprKind::ImaginaryLiteral`

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -2588,7 +2588,8 @@ class TranslateASTVisitor final
 #endif // CLANG_VERSION_MAJOR
 
     bool VisitImaginaryLiteral(ImaginaryLiteral *L) {
-        printDiag(Context, DiagnosticsEngine::Warning, "Encountered unsupported imaginary literal", L);
+        std::vector<void *> childIds{L->getSubExpr()};
+        encode_entry(L, TagImaginaryLiteral, childIds);
         return true;
     }
 

--- a/c2rust-ast-exporter/src/ast_tags.hpp
+++ b/c2rust-ast-exporter/src/ast_tags.hpp
@@ -95,6 +95,7 @@ enum ASTEntryTag {
     TagStringLiteral,
     TagCharacterLiteral,
     TagFloatingLiteral,
+    TagImaginaryLiteral,
 };
 
 enum TypeTag {

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -1450,6 +1450,16 @@ impl ConversionContext {
                     self.expr_possibly_as_stmt(expected_ty, new_id, node, floating_literal);
                 }
 
+                ASTEntryTag::TagImaginaryLiteral if expected_ty & (EXPR | STMT) != 0 => {
+                    let wrapped = node.children[0].expect("Expected inner literal expression");
+                    let ty_old = node.type_id.expect("Expected expression to have type");
+                    let ty = self.visit_qualified_type(ty_old);
+
+                    let expr = CExprKind::ImaginaryLiteral(ty, self.visit_expr(wrapped));
+
+                    self.expr_possibly_as_stmt(expected_ty, new_id, node, expr);
+                }
+
                 ASTEntryTag::TagUnaryOperator if expected_ty & (EXPR | STMT) != 0 => {
                     let prefix =
                         from_value(node.extras[1].clone()).expect("Expected prefix information");

--- a/c2rust-transpile/src/c_ast/iterators.rs
+++ b/c2rust-transpile/src/c_ast/iterators.rs
@@ -77,6 +77,7 @@ fn immediate_expr_children(kind: &CExprKind) -> Vec<SomeId> {
         | Member(_, e, _, _, _)
         | Paren(_, e)
         | CompoundLiteral(_, e)
+        | ImaginaryLiteral(_, e)
         | Predefined(_, e)
         | VAArg(_, e) => intos![e],
         Statements(_, s) => vec![s.into()],
@@ -137,6 +138,7 @@ fn immediate_expr_children_all_types(kind: &CExprKind) -> Vec<SomeId> {
         | ImplicitCast(qty, e, _, _, _)
         | Paren(qty, e)
         | CompoundLiteral(qty, e)
+        | ImaginaryLiteral(qty, e)
         | VAArg(qty, e) => {
             intos![qty.ctype, e]
         }

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -906,6 +906,7 @@ impl TypedAstContext {
             Member(_, e, _, _, _) |
             Paren(_, e) |
             CompoundLiteral(_, e) |
+            ImaginaryLiteral(_, e) |
             Unary(_, _, e, _) => pure(e),
 
             Binary(_, op, _, _, _, _) if op.underlying_assignment().is_some() => false,
@@ -990,6 +991,7 @@ impl TypedAstContext {
             ImplicitValueInit(_) => true,
             Paren(_, expr) => is_const(expr),
             CompoundLiteral(_, expr) => is_const(expr),
+            ImaginaryLiteral(_, expr) => is_const(expr),
             Predefined(_, expr) => is_const(expr),
             Statements(_, stmt) => self.is_const_stmt(stmt),
             VAArg(_, expr) => is_const(expr),
@@ -1778,6 +1780,9 @@ pub enum CExprKind {
     /// Compound literal.
     CompoundLiteral(CQualTypeId, CExprId),
 
+    /// Imaginary literal.
+    ImaginaryLiteral(CQualTypeId, CExprId),
+
     /// Predefined expression.
     Predefined(CQualTypeId, CExprId),
 
@@ -1862,6 +1867,7 @@ impl CExprKind {
             | CExprKind::ImplicitValueInit(ty)
             | CExprKind::Paren(ty, _)
             | CExprKind::CompoundLiteral(ty, _)
+            | CExprKind::ImaginaryLiteral(ty, _)
             | CExprKind::Predefined(ty, _)
             | CExprKind::Statements(ty, _)
             | CExprKind::VAArg(ty, _)

--- a/c2rust-transpile/src/c_ast/print.rs
+++ b/c2rust-transpile/src/c_ast/print.rs
@@ -231,6 +231,10 @@ impl<W: Write> Printer<W> {
                 self.writer.write_all(b")")?;
                 self.print_expr(val, context)?;
             }
+            &ImaginaryLiteral(_, val) => {
+                self.print_expr(val, context)?;
+                self.writer.write_all(b"i")?;
+            }
             &Predefined(_, val) => {
                 self.print_expr(val, context)?;
             }

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3464,6 +3464,10 @@ impl<'c> Translation<'c> {
 
             CompoundLiteral(qty, val) => self.convert_compound_literal(ctx, qty, val, override_ty),
 
+            ImaginaryLiteral(_qty, _subexpr) => {
+                Err(TranslationError::generic("imaginary literal not supported"))
+            }
+
             InitList(ty, ref ids, opt_union_field_id, _) => {
                 self.convert_init_list(ctx, ty, ids, opt_union_field_id)
             }

--- a/scripts/cborpp.py
+++ b/scripts/cborpp.py
@@ -87,6 +87,7 @@ TAGS = {
     301: "TagStringLiteral",
     302: "TagCharacterLiteral",
     303: "TagFloatingLiteral",
+    304: "TagImaginaryLiteral",
 
     400: "TagTypeUnknown",
 


### PR DESCRIPTION
- Fixes #1802

This doesn't actually enable support for complex numbers. It just lays down some groundwork so that the AST stuff is there, ready for a future implementation.