### PR TITLE
postprocess: fix gpt no-tools assertion

### DIFF
--- a/c2rust-postprocess/postprocess/models/gpt.py
+++ b/c2rust-postprocess/postprocess/models/gpt.py
@@ -18,7 +18,7 @@ class GPTModel(AbstractGenerativeModel):
         max_tool_loops: int = 5,
     ) -> str:
         # TODO: implement tool calling support
-        assert tools is None, "Tool calling not yet implemented for GPTModel"
+        assert not tools, "Tool calling not yet implemented for GPTModel"
 
         response = self.client.responses.create(
             model=self.id,


### PR DESCRIPTION
`tools` defaults to `()` in the gpt case, which causes the `None` assert to fail unconditionally.