### PR TITLE
ast-exporter, transpile: Unify handling of attributes

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -1121,10 +1121,15 @@ class TranslateASTVisitor final
     bool VisitAttributedStmt(AttributedStmt *S) {
         std::vector<void*> childIds { S->getSubStmt() };
         encode_entry(S, TagAttributedStmt, childIds,
-                     [S](CborEncoder *array){
+                     [S](CborEncoder *local){
+                         CborEncoder array;
+                         cbor_encoder_create_array(local, &array, CborIndefiniteLength);
+
                          for (auto s: S->getAttrs()) {
-                             cbor_encode_text_stringz(array, s->getSpelling());
+                             cbor_encode_text_stringz(&array, s->getSpelling());
                          }
+
+                         cbor_encoder_close_container(local, &array);
         });
         return true;
     }

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -303,8 +303,12 @@ private:
                 tag = "nullable";
                 break;
             }
+
             if (tag) {
-                cbor_encode_text_stringz(local, tag);
+                CborEncoder attr_info;
+                cbor_encoder_create_array(local, &attr_info, 1);
+                cbor_encode_text_stringz(&attr_info, tag);
+                cbor_encoder_close_container(local, &attr_info);
             } else {
                 cbor_encode_null(local);
             }

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -2623,8 +2623,11 @@ class TranslateASTVisitor final
         const Attr *attr,
         std::function<void(CborEncoder *)> extra
     ) {
-        cbor_encode_text_stringz(array, attr->getSpelling());
-        extra(array);
+        CborEncoder attr_info;
+        cbor_encoder_create_array(array, &attr_info, CborIndefiniteLength);
+        cbor_encode_text_stringz(&attr_info, attr->getSpelling());
+        extra(&attr_info);
+        cbor_encoder_close_container(array, &attr_info);
     }
 
     //

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -1121,12 +1121,12 @@ class TranslateASTVisitor final
     bool VisitAttributedStmt(AttributedStmt *S) {
         std::vector<void*> childIds { S->getSubStmt() };
         encode_entry(S, TagAttributedStmt, childIds,
-                     [S](CborEncoder *local){
+                     [this, S](CborEncoder *local){
                          CborEncoder array;
                          cbor_encoder_create_array(local, &array, CborIndefiniteLength);
 
                          for (auto s: S->getAttrs()) {
-                             cbor_encode_text_stringz(&array, s->getSpelling());
+                             encodeAttribute(&array, s);
                          }
 
                          cbor_encoder_close_container(local, &array);
@@ -2190,30 +2190,19 @@ class TranslateASTVisitor final
                 cbor_encode_boolean(array, is_inline_externally_visible);
 
                 // Encode attribute names and relevant info if supported
-                CborEncoder attr_info;
-                bool has_attrs = def ? def->hasAttrs() : FD->hasAttrs();
+                CborEncoder attr_array;
+                cbor_encoder_create_array(array, &attr_array, CborIndefiniteLength);
+                auto attr_decl = def ? def : FD;
 
-                cbor_encoder_create_array(array, &attr_info,
-                                          CborIndefiniteLength);
-
-                if (has_attrs) {
-                    auto attrs = def ? def->getAttrs() : FD->getAttrs();
+                if (attr_decl->hasAttrs()) {
+                    auto attrs = attr_decl->getAttrs();
 
                     for (auto attr : attrs) {
-                        cbor_encode_text_stringz(&attr_info,
-                                                 attr->getSpelling());
-
-                        if (auto *aa = dyn_cast<AliasAttr>(attr)) {
-                            cbor_encode_text_stringz(
-                                &attr_info, aa->getAliasee().str().c_str());
-                        } else if (auto *va = dyn_cast<VisibilityAttr>(attr)) {
-                            const char *vis = VisibilityAttr::ConvertVisibilityTypeToStr(va->getVisibility());
-                            cbor_encode_text_stringz(&attr_info, vis);
-                        }
+                        encodeAttribute(&attr_array, attr);
                     }
                 }
 
-                cbor_encoder_close_container(array, &attr_info);
+                cbor_encoder_close_container(array, &attr_array);
             });
         typeEncoder.VisitQualTypeOf(functionType, paramsFD);
 
@@ -2295,38 +2284,16 @@ class TranslateASTVisitor final
                 cbor_encode_boolean(array, is_defn);
 
                 // Encode attribute names and relevant info if supported
-                CborEncoder attr_info;
+                CborEncoder attr_array;
+                cbor_encoder_create_array(array, &attr_array, CborIndefiniteLength);
 
-                cbor_encoder_create_array(array, &attr_info,
-                                          CborIndefiniteLength);
-
-                bool has_attrs = def->hasAttrs();
-
-                if (has_attrs) {
+                if (def->hasAttrs()) {
                     for (auto attr : def->attrs()) {
-                        cbor_encode_text_stringz(&attr_info,
-                                                 attr->getSpelling());
-
-                        if (auto *sa = dyn_cast<SectionAttr>(attr)) {
-                            cbor_encode_text_stringz(
-                                &attr_info, sa->getName().str().c_str());
-                        } else if (auto *aa = dyn_cast<AliasAttr>(attr)) {
-                            cbor_encode_text_stringz(
-                                &attr_info, aa->getAliasee().str().c_str());
-                        } else if (auto *ca = dyn_cast<CleanupAttr>(attr)) {
-                            cbor_encode_uint(
-                                &attr_info,
-                                uintptr_t(ca->getFunctionDecl()->getCanonicalDecl()));
-                        } else {
-                            printDiag(Context, DiagnosticsEngine::Warning,
-                                      std::string("ignoring unsupported variable attribute: ") +
-                                          attr->getSpelling(),
-                                      def);
-                        }
+                        encodeAttribute(&attr_array, attr);
                     }
                 }
 
-                cbor_encoder_close_container(array, &attr_info);
+                cbor_encoder_close_container(array, &attr_array);
             });
 
         typeEncoder.VisitQualTypeOf(T, def);
@@ -2348,15 +2315,14 @@ class TranslateASTVisitor final
             // we emit them too.
             std::vector<void *> childIds = {D->getCanonicalDecl()};
             encode_entry(D, TagNonCanonicalDecl, D->getSourceRange(), childIds, QualType(),
-                [D](CborEncoder *local) {
+                [this, D](CborEncoder *local) {
                 // 1. Attributes stored as an array of attribute names
-                CborEncoder attrs;
-                size_t attrs_n = D->hasAttrs() ? D->getAttrs().size() : 0;
-                cbor_encoder_create_array(local, &attrs, attrs_n);
+                CborEncoder attr_array;
+                cbor_encoder_create_array(local, &attr_array, CborIndefiniteLength);
                 for (auto a : D->attrs()) {
-                    cbor_encode_text_stringz(&attrs, a->getSpelling());
+                    encodeAttribute(&attr_array, a);
                 }
-                cbor_encoder_close_container(local, &attrs);
+                cbor_encoder_close_container(local, &attr_array);
             });
             return true;
         }
@@ -2393,7 +2359,7 @@ class TranslateASTVisitor final
 
         encode_entry(
             D, tag, loc, childIds, QualType(),
-            [D, def, recordAlignment, byteSize](CborEncoder *local) {
+            [this, D, def, recordAlignment, byteSize](CborEncoder *local) {
                 // 1. Encode name or null
                 auto name = D->getNameAsString();
                 if (name.empty()) {
@@ -2406,13 +2372,12 @@ class TranslateASTVisitor final
                 cbor_encode_boolean(local, !!def);
 
                 // 3. Attributes stored as an array of attribute names
-                CborEncoder attrs;
-                size_t attrs_n = D->hasAttrs() ? D->getAttrs().size() : 0;
-                cbor_encoder_create_array(local, &attrs, attrs_n);
+                CborEncoder attr_array;
+                cbor_encoder_create_array(local, &attr_array, CborIndefiniteLength);
                 for (auto a : D->attrs()) {
-                    cbor_encode_text_stringz(&attrs, a->getSpelling());
+                    encodeAttribute(&attr_array, a);
                 }
-                cbor_encoder_close_container(local, &attrs);
+                cbor_encoder_close_container(local, &attr_array);
 
                 // 4. Encode manually specified alignment
                 auto align = D->getMaxAlignment();
@@ -2601,6 +2566,65 @@ class TranslateASTVisitor final
         typeEncoder.VisitQualTypeOf(typeForDecl, D);
 
         return true;
+    }
+
+    void encodeAttribute(CborEncoder *array, const Attr *attr) {
+        std::function<void(CborEncoder *)> extra = [](CborEncoder *) {};
+
+        switch (attr->getKind()) {
+            case attr::Alias:
+                extra = [attr](CborEncoder *local) {
+                    auto *alias_attr = dyn_cast<AliasAttr>(attr);
+                    cbor_encode_text_stringz(
+                        local,
+                        alias_attr->getAliasee().str().c_str()
+                    );    
+                };
+                break;
+
+            case attr::Cleanup:
+                extra = [attr](CborEncoder *local) {
+                    auto *cleanup_attr = dyn_cast<CleanupAttr>(attr);
+                    cbor_encode_uint(
+                        local,
+                        uintptr_t(cleanup_attr->getFunctionDecl()->getCanonicalDecl())
+                    );
+                };
+                break;
+
+            case attr::Section:
+                extra = [attr](CborEncoder *local) {
+                    auto *section_attr = dyn_cast<SectionAttr>(attr);
+                    cbor_encode_text_stringz(
+                        local,
+                        section_attr->getName().str().c_str()
+                    );
+                };
+                break;
+
+            case attr::Visibility:
+                extra = [attr](CborEncoder *local) {
+                    auto *visibility_attr = dyn_cast<VisibilityAttr>(attr);
+                    cbor_encode_text_stringz(
+                        local,
+                        VisibilityAttr::ConvertVisibilityTypeToStr(
+                            visibility_attr->getVisibility()
+                        )
+                    );
+                };
+                break;
+        }
+
+        encodeAttributeRaw(array, attr, extra);
+    }
+
+    void encodeAttributeRaw(
+        CborEncoder *array,
+        const Attr *attr,
+        std::function<void(CborEncoder *)> extra
+    ) {
+        cbor_encode_text_stringz(array, attr->getSpelling());
+        extra(array);
     }
 
     //

--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -2617,6 +2617,21 @@ class TranslateASTVisitor final
                     );
                 };
                 break;
+
+            case attr::AlwaysInline:
+            case attr::Cold:
+            case attr::FallThrough:
+            case attr::GNUInline:
+            case attr::NoInline:
+            case attr::NoReturn:
+            case attr::TypeNonNull:
+            case attr::TypeNullable:
+            case attr::Packed:
+            case attr::Used:
+                break;
+
+            default:
+                return;
         }
 
         encodeAttributeRaw(array, attr, extra);

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -171,79 +171,59 @@ fn parse_cast_kind(kind: &str) -> CastKind {
 impl ConversionContext {
     fn parse_attributes(&mut self, attributes: Vec<Value>) -> IndexSet<Attribute> {
         let mut attrs = IndexSet::new();
-        let mut expect_section_value = false;
-        let mut expect_alias_value = false;
-        let mut expect_visibility_value = false;
-        let mut expect_cleanup_id = false;
 
         for attr in attributes.into_iter() {
-            if expect_cleanup_id {
-                expect_cleanup_id = false;
-                match from_value::<ClangId>(attr) {
-                    Ok(func_id) => {
-                        attrs.insert(Attribute::Cleanup(self.visit_decl(func_id)));
-                    }
-                    Err(_) => {
-                        diag!(
-                            Diagnostic::ClangAst,
-                            "cleanup attribute is missing its function decl id",
-                        );
-                        self.invalid_clang_ast = true;
-                    }
-                }
-                continue;
-            }
+            let attr_info =
+                from_value::<Vec<Value>>(attr).expect("Expected to find attribute info array");
 
-            let attr_str = from_value::<String>(attr).expect("Decl attributes should be strings");
-
-            match attr_str.as_str() {
-                "alias" => expect_alias_value = true,
-                "always_inline" => {
-                    attrs.insert(Attribute::AlwaysInline);
-                }
-                "cleanup" => expect_cleanup_id = true,
-                "cold" => {
-                    attrs.insert(Attribute::Cold);
-                }
-                "fallthrough" | "__fallthrough__" => {
-                    attrs.insert(Attribute::Fallthrough);
-                }
-                "gnu_inline" => {
-                    attrs.insert(Attribute::GnuInline);
-                }
-                "noinline" => {
-                    attrs.insert(Attribute::NoInline);
-                }
-                "packed" => {
-                    attrs.insert(Attribute::Packed);
-                }
-                "used" => {
-                    attrs.insert(Attribute::Used);
-                }
-                "visibility" => expect_visibility_value = true,
-                "section" => expect_section_value = true,
-                s if expect_section_value => {
-                    attrs.insert(Attribute::Section(s.into()));
-
-                    expect_section_value = false;
-                }
-                s if expect_alias_value => {
-                    attrs.insert(Attribute::Alias(s.into()));
-
-                    expect_alias_value = false;
-                }
-                s if expect_visibility_value => {
-                    attrs.insert(Attribute::Visibility(s.into()));
-
-                    expect_visibility_value = false;
-                }
-                s => {
-                    diag!(Diagnostic::ClangAst, "unrecognized attribute: {}", s);
-                }
+            if let Some(attr) = self.parse_attribute(attr_info) {
+                attrs.insert(attr);
             }
         }
 
         attrs
+    }
+
+    fn parse_attribute(&mut self, attr_info: Vec<Value>) -> Option<Attribute> {
+        let attr_str =
+            from_value::<String>(attr_info[0].clone()).expect("Decl attributes should be strings");
+
+        match attr_str.as_str() {
+            "alias" => {
+                let alias = from_value(attr_info[1].clone()).expect("alias name not found");
+                Some(Attribute::Alias(alias))
+            }
+            "always_inline" => Some(Attribute::AlwaysInline),
+            "cleanup" => match from_value::<ClangId>(attr_info[1].clone()) {
+                Ok(func_id) => Some(Attribute::Cleanup(self.visit_decl(func_id))),
+                Err(_) => {
+                    diag!(
+                        Diagnostic::ClangAst,
+                        "cleanup attribute is missing its function decl id",
+                    );
+                    self.invalid_clang_ast = true;
+                    None
+                }
+            },
+            "cold" => Some(Attribute::Cold),
+            "fallthrough" | "__fallthrough__" => Some(Attribute::Fallthrough),
+            "gnu_inline" => Some(Attribute::GnuInline),
+            "noinline" => Some(Attribute::NoInline),
+            "packed" => Some(Attribute::Packed),
+            "section" => {
+                let section = from_value(attr_info[1].clone()).expect("section name not found");
+                Some(Attribute::Section(section))
+            }
+            "used" => Some(Attribute::Used),
+            "visibility" => {
+                let vis = from_value(attr_info[1].clone()).expect("visibility kind not found");
+                Some(Attribute::Visibility(vis))
+            }
+            s => {
+                diag!(Diagnostic::ClangAst, "unrecognized attribute: {}", s);
+                None
+            }
+        }
     }
 }
 

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -205,14 +205,17 @@ impl ConversionContext {
                 "cold" => {
                     attrs.insert(Attribute::Cold);
                 }
-                "gnu_inline" => {
-                    attrs.insert(Attribute::GnuInline);
-                }
                 "fallthrough" | "__fallthrough__" => {
                     attrs.insert(Attribute::Fallthrough);
                 }
+                "gnu_inline" => {
+                    attrs.insert(Attribute::GnuInline);
+                }
                 "noinline" => {
                     attrs.insert(Attribute::NoInline);
+                }
+                "packed" => {
+                    attrs.insert(Attribute::Packed);
                 }
                 "used" => {
                     attrs.insert(Attribute::Used);
@@ -272,13 +275,6 @@ fn display_loc(ctx: &AstContext, loc: &Option<SrcSpan>) -> Option<DisplaySrcSpan
         file: ctx.files[loc.fileid as usize].path.clone(),
         loc: *loc,
     })
-}
-
-fn has_packed_attribute(attrs: Vec<Value>) -> bool {
-    attrs
-        .into_iter()
-        .map(|attr| from_value::<String>(attr).expect("Record attributes should be strings"))
-        .any(|attr_name| attr_name == "packed")
 }
 
 impl ConversionContext {
@@ -2361,6 +2357,7 @@ impl ConversionContext {
                         .expect("Expected to find whether decl is definition");
                     let attributes = from_value::<Vec<Value>>(node.extras[5].clone())
                         .expect("Expected attribute array on var decl");
+                    let attrs = self.parse_attributes(attributes);
 
                     assert!(
                         has_static_duration || has_thread_duration || !is_externally_visible,
@@ -2381,8 +2378,6 @@ impl ConversionContext {
                         .expect("Expected to find type on variable declaration");
                     let typ = self.visit_qualified_type(typ_id);
 
-                    let attrs = self.parse_attributes(attributes);
-
                     let variable_decl = CDeclKind::Variable {
                         has_static_duration,
                         has_thread_duration,
@@ -2402,8 +2397,9 @@ impl ConversionContext {
                     let name = expect_opt_str(&node.extras[0]).unwrap().map(str::to_string);
                     let has_def = from_value(node.extras[1].clone())
                         .expect("Expected has_def flag on struct");
-                    let attrs = from_value::<Vec<Value>>(node.extras[2].clone())
+                    let attributes = from_value::<Vec<Value>>(node.extras[2].clone())
                         .expect("Expected attribute array on record");
+                    let attrs = self.parse_attributes(attributes);
                     let manual_alignment =
                         expect_opt_u64(&node.extras[3]).expect("Expected struct alignment");
                     let max_field_alignment =
@@ -2422,7 +2418,7 @@ impl ConversionContext {
                         None
                     };
 
-                    let is_packed = has_packed_attribute(attrs);
+                    let is_packed = attrs.contains(&Attribute::Packed);
 
                     let record = CDeclKind::Struct {
                         name,
@@ -2442,8 +2438,9 @@ impl ConversionContext {
                     let name = expect_opt_str(&node.extras[0]).unwrap().map(str::to_string);
                     let has_def = from_value(node.extras[1].clone())
                         .expect("Expected has_def flag on struct");
-                    let attrs = from_value::<Vec<Value>>(node.extras[2].clone())
+                    let attributes = from_value::<Vec<Value>>(node.extras[2].clone())
                         .expect("Expected attribute array on record");
+                    let attrs = self.parse_attributes(attributes);
                     let fields: Option<Vec<CDeclId>> = if has_def {
                         Some(
                             self.visit_record_children(untyped_context, node, new_id)
@@ -2453,7 +2450,7 @@ impl ConversionContext {
                         None
                     };
 
-                    let is_packed = has_packed_attribute(attrs);
+                    let is_packed = attrs.contains(&Attribute::Packed);
 
                     let record = CDeclKind::Union {
                         name,
@@ -2529,16 +2526,29 @@ impl ConversionContext {
                     // Look up the canonical declaration and see if it declares a
                     // struct. If so, check attributes of the non-canonical declaration
                     // and potentially update its `is_packed` property.
-                    if let Some(v) = self.typed_context.c_decls.get_mut(&canonical_decl) {
-                        match &mut v.kind {
+                    let is_record = self
+                        .typed_context
+                        .c_decls
+                        .get(&canonical_decl)
+                        .map_or(false, |v| {
+                            matches!(v.kind, CDeclKind::Struct { .. } | CDeclKind::Union { .. })
+                        });
+
+                    if is_record {
+                        let attributes = from_value::<Vec<Value>>(node.extras[0].clone())
+                            .expect("Expected attribute array on non-canonical record decl");
+                        let attrs = self.parse_attributes(attributes);
+
+                        match &mut self
+                            .typed_context
+                            .c_decls
+                            .get_mut(&canonical_decl)
+                            .unwrap()
+                            .kind
+                        {
                             CDeclKind::Struct { is_packed, .. }
                             | CDeclKind::Union { is_packed, .. } => {
-                                let attrs = from_value::<Vec<Value>>(node.extras[0].clone())
-                                    .expect(
-                                        "Expected attribute array on non-canonical record decl",
-                                    );
-
-                                *is_packed = has_packed_attribute(attrs);
+                                *is_packed = attrs.contains(&Attribute::Packed);
                             }
                             _ => {}
                         }

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -1186,17 +1186,9 @@ impl ConversionContext {
 
                 ASTEntryTag::TagAttributedStmt if expected_ty & OTHER_STMT != 0 => {
                     let substatement = node.children[0].map(|id| self.visit_stmt(id)).unwrap();
-                    let mut attributes = IndexSet::new();
-
-                    match expect_opt_str(&node.extras[0])
-                        .expect("Attributed statement kind not found")
-                    {
-                        Some("fallthrough") | Some("__fallthrough__") => {
-                            attributes.insert(Attribute::Fallthrough)
-                        }
-                        Some(str) => panic!("Unknown statement attribute: {}", str),
-                        None => panic!("Invalid statement attribute"),
-                    };
+                    let attributes = from_value::<Vec<Value>>(node.extras[0].clone())
+                        .expect("Expected to find attributes");
+                    let attributes = self.parse_attributes(attributes);
 
                     let astmt = CStmtKind::Attributed {
                         attributes,

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -208,6 +208,9 @@ impl ConversionContext {
                 "gnu_inline" => {
                     attrs.insert(Attribute::GnuInline);
                 }
+                "fallthrough" | "__fallthrough__" => {
+                    attrs.insert(Attribute::Fallthrough);
+                }
                 "noinline" => {
                     attrs.insert(Attribute::NoInline);
                 }
@@ -1183,13 +1186,13 @@ impl ConversionContext {
 
                 ASTEntryTag::TagAttributedStmt if expected_ty & OTHER_STMT != 0 => {
                     let substatement = node.children[0].map(|id| self.visit_stmt(id)).unwrap();
-                    let mut attributes = vec![];
+                    let mut attributes = IndexSet::new();
 
                     match expect_opt_str(&node.extras[0])
                         .expect("Attributed statement kind not found")
                     {
                         Some("fallthrough") | Some("__fallthrough__") => {
-                            attributes.push(Attribute::Fallthrough)
+                            attributes.insert(Attribute::Fallthrough)
                         }
                         Some(str) => panic!("Unknown statement attribute: {}", str),
                         None => panic!("Invalid statement attribute"),

--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -209,6 +209,9 @@ impl ConversionContext {
             "fallthrough" | "__fallthrough__" => Some(Attribute::Fallthrough),
             "gnu_inline" => Some(Attribute::GnuInline),
             "noinline" => Some(Attribute::NoInline),
+            "noreturn" => Some(Attribute::NoReturn),
+            "notnull" => Some(Attribute::NotNull),
+            "nullable" => Some(Attribute::Nullable),
             "packed" => Some(Attribute::Packed),
             "section" => {
                 let section = from_value(attr_info[1].clone()).expect("section name not found");
@@ -896,17 +899,13 @@ impl ConversionContext {
                         .expect("Attributed type child not found");
                     let ty = self.visit_qualified_type(ty_id);
 
-                    let kind = match expect_opt_str(&ty_node.extras[1])
-                        .expect("Attributed type kind not found")
-                    {
-                        None => None,
-                        Some("noreturn") => Some(Attribute::NoReturn),
-                        Some("nullable") => Some(Attribute::Nullable),
-                        Some("notnull") => Some(Attribute::NotNull),
-                        Some(other) => panic!("Unknown type attribute: {}", other),
+                    let attribute = match ty_node.extras[1] {
+                        Value::Null => None,
+                        Value::Array(ref value) => self.parse_attribute(value.clone()),
+                        _ => panic!("Expected to find attribute"),
                     };
 
-                    let ty = CTypeKind::Attributed(ty, kind);
+                    let ty = CTypeKind::Attributed(ty, attribute);
                     self.add_type(new_id, not_located(ty));
                     self.processed_nodes.insert(new_id, TYPE);
                 }

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -2971,6 +2971,7 @@ pub enum Attribute {
     NoReturn,
     NotNull,
     Nullable,
+    Packed,
     /// __attribute__((section("foo"), __section__("foo")))
     Section(String),
     /// __attribute__((used, __used__))

--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -2470,7 +2470,7 @@ pub enum CStmtKind {
     // statement in case of __attribute__((__fallthrough__)) at the end of a
     // case statement
     Attributed {
-        attributes: Vec<Attribute>,
+        attributes: IndexSet<Attribute>,
         substatement: CStmtId,
     },
 


### PR DESCRIPTION
All attributes now pass through `encodeAttribute` on the C++ side, and `parse_attribute[s]` on the Rust side. The last commit fixes the issue mentioned [here](https://github.com/immunant/c2rust/pull/1815#issuecomment-4583411264).