### PR TITLE
transpile: Override pointer difference expression type to `PtrDiff`

### DIFF
--- a/c2rust-transpile/src/c_ast/mod.rs
+++ b/c2rust-transpile/src/c_ast/mod.rs
@@ -1360,19 +1360,28 @@ impl TypedAstContext {
                         let lhs_resolved_ty = self.ast_context.resolve_type(lhs_type_id.ctype);
                         let rhs_resolved_ty = self.ast_context.resolve_type(rhs_type_id.ctype);
 
-                        let neither_ptr = !lhs_resolved_ty.kind.is_pointer()
-                            && !rhs_resolved_ty.kind.is_pointer();
+                        if op == CBinOp::Subtract
+                            && lhs_resolved_ty.kind.is_pointer()
+                            && rhs_resolved_ty.kind.is_pointer()
+                        {
+                            // Pointer difference operator should return `ptrdiff_t`.
+                            let new_type_id = self.ast_context.type_for_kind(&CTypeKind::PtrDiff);
+                            Some(CQualTypeId::new(new_type_id))
+                        } else {
+                            let neither_ptr = !lhs_resolved_ty.kind.is_pointer()
+                                && !rhs_resolved_ty.kind.is_pointer();
 
-                        if op.all_types_same() && neither_ptr {
-                            if CTypeKind::PULLBACK_KINDS.contains(&lhs_resolved_ty.kind) {
+                            if op.all_types_same() && neither_ptr {
+                                if CTypeKind::PULLBACK_KINDS.contains(&lhs_resolved_ty.kind) {
+                                    Some(lhs_type_id)
+                                } else {
+                                    Some(rhs_type_id)
+                                }
+                            } else if op.is_bitshift() {
                                 Some(lhs_type_id)
                             } else {
-                                Some(rhs_type_id)
+                                return;
                             }
-                        } else if op.is_bitshift() {
-                            Some(lhs_type_id)
-                        } else {
-                            return;
                         }
                     }
                     CExprKind::Unary(_ty, op, e, _idk) => op.expected_result_type(

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -576,7 +576,7 @@ impl<'c> Translation<'c> {
 
         if let &CTypeKind::Pointer(pointee) = rhs_type {
             let val = self.make_pointer_difference(lhs, rhs, pointee.ctype);
-            let source_type_id = self.ast_context.type_for_kind(&CTypeKind::PtrDiff).unwrap();
+            let source_type_id = self.ast_context.type_for_kind(&CTypeKind::PtrDiff);
             self.make_cast(ctx, CQualTypeId::new(source_type_id), expr_type_id, val)
         } else if let &CTypeKind::Pointer(pointee) = lhs_type {
             Ok(self.convert_pointer_offset(lhs, rhs, pointee.ctype, true, false))

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -66,8 +66,6 @@ impl<'c> Translation<'c> {
                     ctx = ctx.decay_ref();
                 }
 
-                let ty = self.convert_type(expr_type_id.ctype)?;
-
                 let lhs_kind = &self.ast_context.index_unwrap_parens(lhs).kind;
                 let mut lhs_type_id = lhs_kind.get_qual_type().ok_or_else(|| {
                     format_translation_err!(
@@ -174,9 +172,9 @@ impl<'c> Translation<'c> {
 
                     lhs_val.zip(rhs_val).and_then_try(|(lhs_val, rhs_val)| {
                         self.convert_binary_operator(
+                            ctx,
+                            expr_type_id,
                             op,
-                            ty,
-                            expr_type_id.ctype,
                             lhs_type_id,
                             rhs_type_id,
                             lhs_val,
@@ -218,12 +216,11 @@ impl<'c> Translation<'c> {
                 WithStmts::new_val(read.clone()),
             )?;
 
-            let ty = self.convert_type(compute_res_type_id.ctype)?;
             let val = lhs.and_then_try(|lhs| {
                 self.convert_binary_operator(
+                    ctx,
+                    compute_res_type_id,
                     bin_op,
-                    ty,
-                    compute_res_type_id.ctype,
                     compute_lhs_type_id,
                     rhs_type_id,
                     lhs,
@@ -426,12 +423,11 @@ impl<'c> Translation<'c> {
                         WithStmts::new_val(read.clone()),
                     )?;
 
-                    let ty = self.convert_type(result_type_id.ctype)?;
                     let val = lhs.and_then_try(|lhs|
                         self.convert_binary_operator(
+                            ctx,
+                            result_type_id,
                             op,
-                            ty,
-                            result_type_id.ctype,
                             expr_or_comp_type_id,
                             rhs_type_id,
                             lhs,
@@ -503,9 +499,9 @@ impl<'c> Translation<'c> {
     /// arguments be usable as rvalues.
     fn convert_binary_operator(
         &self,
+        ctx: ExprContext,
+        expr_type_id: CQualTypeId,
         op: CBinOp,
-        ty: Box<Type>,
-        ctype: CTypeId,
         lhs_type: CQualTypeId,
         rhs_type: CQualTypeId,
         lhs: Box<Expr>,
@@ -513,13 +509,15 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let is_unsigned_integral_type = self
             .ast_context
-            .resolve_type(ctype)
+            .resolve_type(expr_type_id.ctype)
             .kind
             .is_unsigned_integral_type();
 
         Ok(WithStmts::new_val(match op {
             CBinOp::Add => return self.convert_addition(lhs_type, rhs_type, lhs, rhs),
-            CBinOp::Subtract => return self.convert_subtraction(ty, lhs_type, rhs_type, lhs, rhs),
+            CBinOp::Subtract => {
+                return self.convert_subtraction(ctx, expr_type_id, lhs_type, rhs_type, lhs, rhs)
+            }
 
             op if op.is_arithmetic() && is_unsigned_integral_type => {
                 mk().method_call_expr(lhs, op.wrapping_method(), vec![rhs])
@@ -566,7 +564,8 @@ impl<'c> Translation<'c> {
 
     fn convert_subtraction(
         &self,
-        ty: Box<Type>,
+        ctx: ExprContext,
+        expr_type_id: CQualTypeId,
         lhs_type_id: CQualTypeId,
         rhs_type_id: CQualTypeId,
         lhs: Box<Expr>,
@@ -577,7 +576,8 @@ impl<'c> Translation<'c> {
 
         if let &CTypeKind::Pointer(pointee) = rhs_type {
             let val = self.make_pointer_difference(lhs, rhs, pointee.ctype);
-            Ok(val.map(|val| mk().cast_expr(val, ty)))
+            let source_type_id = self.ast_context.type_for_kind(&CTypeKind::PtrDiff).unwrap();
+            self.make_cast(ctx, CQualTypeId::new(source_type_id), expr_type_id, val)
         } else if let &CTypeKind::Pointer(pointee) = lhs_type {
             Ok(self.convert_pointer_offset(lhs, rhs, pointee.ctype, true, false))
         } else if lhs_type.is_unsigned_integral_type() {

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -576,14 +576,8 @@ impl<'c> Translation<'c> {
         let rhs_type = &self.ast_context.resolve_type(rhs_type_id.ctype).kind;
 
         if let &CTypeKind::Pointer(pointee) = rhs_type {
-            let mut offset = mk().method_call_expr(lhs, "offset_from", vec![rhs]);
-
-            if let Some(sz) = self.compute_size_of_expr(pointee.ctype) {
-                let div = cast_int(sz, "isize", false);
-                offset = mk().binary_expr(BinOp::Div(Default::default()), offset, div);
-            }
-
-            Ok(WithStmts::new_val(mk().cast_expr(offset, ty)).set_unsafe())
+            let val = self.make_pointer_difference(lhs, rhs, pointee.ctype);
+            Ok(val.map(|val| mk().cast_expr(val, ty)))
         } else if let &CTypeKind::Pointer(pointee) = lhs_type {
             Ok(self.convert_pointer_offset(lhs, rhs, pointee.ctype, true, false))
         } else if lhs_type.is_unsigned_integral_type() {

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -395,6 +395,26 @@ impl<'c> Translation<'c> {
         WithStmts::new_val(res).set_unsafe()
     }
 
+    /// Creates a pointer difference expression. Returns an expression of type `isize`.
+    pub(crate) fn make_pointer_difference(
+        &self,
+        lhs_rs: Box<Expr>,
+        rhs_rs: Box<Expr>,
+        pointee_type_id: CTypeId,
+    ) -> WithStmts<Box<Expr>> {
+        let mut expr_rs = mk().method_call_expr(lhs_rs, "offset_from", vec![rhs_rs]);
+
+        // If the pointee is a variable array type, the actual pointee type used by `offset_from`
+        // will be its element type rather than the whole array. So we need to divide by the
+        // variable holding the length of the array.
+        if let Some(sz) = self.compute_size_of_expr(pointee_type_id) {
+            let div_rs = cast_int(sz, "isize", false);
+            expr_rs = mk().binary_expr(BinOp::Div(Default::default()), expr_rs, div_rs);
+        }
+
+        WithStmts::new_val(expr_rs).set_unsafe()
+    }
+
     /// Construct an expression for a NULL at any type, including forward declarations,
     /// function pointers, and normal pointers.
     pub fn null_ptr(&self, type_id: CTypeId) -> TranslationResult<Box<Expr>> {

--- a/c2rust-transpile/tests/snapshots/arrays.c
+++ b/c2rust-transpile/tests/snapshots/arrays.c
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include <stddef.h>
 
 char static_char_array[] = "mystring";
 char *static_char_ptr = "mystring";
@@ -56,4 +56,26 @@ void short_initializer() {
 
     struct {short x; int y;} single_struct[1] = { { 1, 2 } };
     struct {short x; int y;} many_struct[3] = { { 1, 2 } };
+}
+
+void variable_length(void) {
+    size_t length = 5;
+    int arr[length];
+    size_t size = sizeof(arr);
+
+    for (size_t i = 0; i < length; ++i) {
+        arr[i] = i;
+    }
+
+    int nested[2][length];
+    size_t nested_size = sizeof(nested);
+
+    for (size_t i = 0; i < length; ++i) {
+        nested[0][i] = i;
+        nested[1][i] = i;
+    }
+
+    int (*first)[length] = &nested[1];
+    int (*second)[length] = first + 1;
+    ptrdiff_t diff = second - first;
 }

--- a/c2rust-transpile/tests/snapshots/exprs.c
+++ b/c2rust-transpile/tests/snapshots/exprs.c
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 int puts(const char *str);
 
 static int side_effect(){
@@ -96,4 +98,13 @@ void statement_expr() {
     });
 
     puts("should be unreachable!");
+}
+
+void pointer_arithmetic(void) {
+    int i1[] = { 0, 1 };
+    int i2[] = { 10, 11 };
+    int *p1 = i1;
+    int *p2 = i2;
+    ptrdiff_t diff = p1 - p2;
+    int diff_int = p1 - p2;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.clang15.snap
@@ -12,6 +12,8 @@ expression: cat tests/snapshots/arrays.2021.clang15.rs
     unused_mut
 )]
 #![feature(raw_ref_op)]
+pub type ptrdiff_t = isize;
+pub type size_t = usize;
 pub type int_t = ::core::ffi::c_int;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -124,4 +126,41 @@ pub unsafe extern "C" fn short_initializer() {
         C2Rust_Unnamed_1 { x: 0, y: 0 },
         C2Rust_Unnamed_1 { x: 0, y: 0 },
     ];
+}
+#[no_mangle]
+pub unsafe extern "C" fn variable_length() {
+    let mut length: size_t = 5 as size_t;
+    let vla = length as usize;
+    let mut arr: Vec<::core::ffi::c_int> = ::std::vec::from_elem(0, vla);
+    let mut size: size_t = vla * ::core::mem::size_of::<::core::ffi::c_int>();
+    let mut i: size_t = 0 as size_t;
+    while i < length {
+        *arr.as_mut_ptr().offset(i as isize) = i as ::core::ffi::c_int;
+        i = i.wrapping_add(1);
+    }
+    let vla_0 = 2 as ::core::ffi::c_int as usize;
+    let vla_1 = length as usize;
+    let mut nested: Vec<::core::ffi::c_int> = ::std::vec::from_elem(0, vla_0 * vla_1);
+    let mut nested_size: size_t = vla_0 * vla_1 * ::core::mem::size_of::<::core::ffi::c_int>();
+    let mut i_0: size_t = 0 as size_t;
+    while i_0 < length {
+        *nested
+            .as_mut_ptr()
+            .offset(0 as ::core::ffi::c_int as isize * vla_1 as isize)
+            .offset(i_0 as isize) = i_0 as ::core::ffi::c_int;
+        *nested
+            .as_mut_ptr()
+            .offset(1 as ::core::ffi::c_int as isize * vla_1 as isize)
+            .offset(i_0 as isize) = i_0 as ::core::ffi::c_int;
+        i_0 = i_0.wrapping_add(1);
+    }
+    let vla_2 = length as usize;
+    let mut first: *mut ::core::ffi::c_int = nested
+        .as_mut_ptr()
+        .offset(1 as ::core::ffi::c_int as isize * vla_1 as isize)
+        as *mut ::core::ffi::c_int;
+    let vla_3 = length as usize;
+    let mut second: *mut ::core::ffi::c_int =
+        first.offset(1 as ::core::ffi::c_int as isize * vla_2 as isize) as *mut ::core::ffi::c_int;
+    let mut diff: ptrdiff_t = (second.offset_from(first) / vla_2 as isize) as ptrdiff_t;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.clang15.snap
@@ -162,5 +162,5 @@ pub unsafe extern "C" fn variable_length() {
     let vla_3 = length as usize;
     let mut second: *mut ::core::ffi::c_int =
         first.offset(1 as ::core::ffi::c_int as isize * vla_2 as isize) as *mut ::core::ffi::c_int;
-    let mut diff: ptrdiff_t = (second.offset_from(first) / vla_2 as isize) as ptrdiff_t;
+    let mut diff: ptrdiff_t = second.offset_from(first) / vla_2 as isize;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.clang15.snap
@@ -162,5 +162,5 @@ pub unsafe extern "C" fn variable_length() {
     let vla_3 = length as usize;
     let mut second: *mut ::core::ffi::c_int =
         first.offset(1 as ::core::ffi::c_int as isize * vla_2 as isize) as *mut ::core::ffi::c_int;
-    let mut diff: ptrdiff_t = (second.offset_from(first) / vla_2 as isize) as ptrdiff_t;
+    let mut diff: ptrdiff_t = second.offset_from(first) / vla_2 as isize;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.clang15.snap
@@ -12,6 +12,8 @@ expression: cat tests/snapshots/arrays.2024.clang15.rs
     unused_assignments,
     unused_mut
 )]
+pub type ptrdiff_t = isize;
+pub type size_t = usize;
 pub type int_t = ::core::ffi::c_int;
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -124,4 +126,41 @@ pub unsafe extern "C" fn short_initializer() {
         C2Rust_Unnamed_1 { x: 0, y: 0 },
         C2Rust_Unnamed_1 { x: 0, y: 0 },
     ];
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn variable_length() {
+    let mut length: size_t = 5 as size_t;
+    let vla = length as usize;
+    let mut arr: Vec<::core::ffi::c_int> = ::std::vec::from_elem(0, vla);
+    let mut size: size_t = vla * ::core::mem::size_of::<::core::ffi::c_int>();
+    let mut i: size_t = 0 as size_t;
+    while i < length {
+        *arr.as_mut_ptr().offset(i as isize) = i as ::core::ffi::c_int;
+        i = i.wrapping_add(1);
+    }
+    let vla_0 = 2 as ::core::ffi::c_int as usize;
+    let vla_1 = length as usize;
+    let mut nested: Vec<::core::ffi::c_int> = ::std::vec::from_elem(0, vla_0 * vla_1);
+    let mut nested_size: size_t = vla_0 * vla_1 * ::core::mem::size_of::<::core::ffi::c_int>();
+    let mut i_0: size_t = 0 as size_t;
+    while i_0 < length {
+        *nested
+            .as_mut_ptr()
+            .offset(0 as ::core::ffi::c_int as isize * vla_1 as isize)
+            .offset(i_0 as isize) = i_0 as ::core::ffi::c_int;
+        *nested
+            .as_mut_ptr()
+            .offset(1 as ::core::ffi::c_int as isize * vla_1 as isize)
+            .offset(i_0 as isize) = i_0 as ::core::ffi::c_int;
+        i_0 = i_0.wrapping_add(1);
+    }
+    let vla_2 = length as usize;
+    let mut first: *mut ::core::ffi::c_int = nested
+        .as_mut_ptr()
+        .offset(1 as ::core::ffi::c_int as isize * vla_1 as isize)
+        as *mut ::core::ffi::c_int;
+    let vla_3 = length as usize;
+    let mut second: *mut ::core::ffi::c_int =
+        first.offset(1 as ::core::ffi::c_int as isize * vla_2 as isize) as *mut ::core::ffi::c_int;
+    let mut diff: ptrdiff_t = (second.offset_from(first) / vla_2 as isize) as ptrdiff_t;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.clang15.snap
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn pointer_arithmetic() {
     let mut i2: [::core::ffi::c_int; 2] = [10 as ::core::ffi::c_int, 11 as ::core::ffi::c_int];
     let mut p1: *mut ::core::ffi::c_int = &raw mut i1 as *mut ::core::ffi::c_int;
     let mut p2: *mut ::core::ffi::c_int = &raw mut i2 as *mut ::core::ffi::c_int;
-    let mut diff: ptrdiff_t = p1.offset_from(p2) as ptrdiff_t;
+    let mut diff: ptrdiff_t = p1.offset_from(p2);
     let mut diff_int: ::core::ffi::c_int =
         p1.offset_from(p2) as ::core::ffi::c_long as ::core::ffi::c_int;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.clang15.snap
@@ -132,6 +132,5 @@ pub unsafe extern "C" fn pointer_arithmetic() {
     let mut p1: *mut ::core::ffi::c_int = &raw mut i1 as *mut ::core::ffi::c_int;
     let mut p2: *mut ::core::ffi::c_int = &raw mut i2 as *mut ::core::ffi::c_int;
     let mut diff: ptrdiff_t = p1.offset_from(p2);
-    let mut diff_int: ::core::ffi::c_int =
-        p1.offset_from(p2) as ::core::ffi::c_long as ::core::ffi::c_int;
+    let mut diff_int: ::core::ffi::c_int = p1.offset_from(p2) as ::core::ffi::c_int;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.clang15.snap
@@ -15,6 +15,7 @@ expression: cat tests/snapshots/exprs.2021.clang15.rs
 extern "C" {
     fn puts(str: *const ::core::ffi::c_char) -> ::core::ffi::c_int;
 }
+pub type ptrdiff_t = isize;
 pub type E = ::core::ffi::c_uint;
 pub const EA: E = 0;
 pub type int_t = ::core::ffi::c_int;
@@ -123,4 +124,14 @@ pub unsafe extern "C" fn statement_expr() {
         return;
     };
     puts(b"should be unreachable!\0".as_ptr() as *const ::core::ffi::c_char);
+}
+#[no_mangle]
+pub unsafe extern "C" fn pointer_arithmetic() {
+    let mut i1: [::core::ffi::c_int; 2] = [0 as ::core::ffi::c_int, 1 as ::core::ffi::c_int];
+    let mut i2: [::core::ffi::c_int; 2] = [10 as ::core::ffi::c_int, 11 as ::core::ffi::c_int];
+    let mut p1: *mut ::core::ffi::c_int = &raw mut i1 as *mut ::core::ffi::c_int;
+    let mut p2: *mut ::core::ffi::c_int = &raw mut i2 as *mut ::core::ffi::c_int;
+    let mut diff: ptrdiff_t = p1.offset_from(p2) as ptrdiff_t;
+    let mut diff_int: ::core::ffi::c_int =
+        p1.offset_from(p2) as ::core::ffi::c_long as ::core::ffi::c_int;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.clang15.snap
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn pointer_arithmetic() {
     let mut i2: [::core::ffi::c_int; 2] = [10 as ::core::ffi::c_int, 11 as ::core::ffi::c_int];
     let mut p1: *mut ::core::ffi::c_int = &raw mut i1 as *mut ::core::ffi::c_int;
     let mut p2: *mut ::core::ffi::c_int = &raw mut i2 as *mut ::core::ffi::c_int;
-    let mut diff: ptrdiff_t = p1.offset_from(p2) as ptrdiff_t;
+    let mut diff: ptrdiff_t = p1.offset_from(p2);
     let mut diff_int: ::core::ffi::c_int =
         p1.offset_from(p2) as ::core::ffi::c_long as ::core::ffi::c_int;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.clang15.snap
@@ -15,6 +15,7 @@ expression: cat tests/snapshots/exprs.2024.clang15.rs
 unsafe extern "C" {
     unsafe fn puts(str: *const ::core::ffi::c_char) -> ::core::ffi::c_int;
 }
+pub type ptrdiff_t = isize;
 pub type E = ::core::ffi::c_uint;
 pub const EA: E = 0;
 pub type int_t = ::core::ffi::c_int;
@@ -123,4 +124,14 @@ pub unsafe extern "C" fn statement_expr() {
         return;
     };
     puts(b"should be unreachable!\0".as_ptr() as *const ::core::ffi::c_char);
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pointer_arithmetic() {
+    let mut i1: [::core::ffi::c_int; 2] = [0 as ::core::ffi::c_int, 1 as ::core::ffi::c_int];
+    let mut i2: [::core::ffi::c_int; 2] = [10 as ::core::ffi::c_int, 11 as ::core::ffi::c_int];
+    let mut p1: *mut ::core::ffi::c_int = &raw mut i1 as *mut ::core::ffi::c_int;
+    let mut p2: *mut ::core::ffi::c_int = &raw mut i2 as *mut ::core::ffi::c_int;
+    let mut diff: ptrdiff_t = p1.offset_from(p2) as ptrdiff_t;
+    let mut diff_int: ::core::ffi::c_int =
+        p1.offset_from(p2) as ::core::ffi::c_long as ::core::ffi::c_int;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.clang15.snap
@@ -132,6 +132,5 @@ pub unsafe extern "C" fn pointer_arithmetic() {
     let mut p1: *mut ::core::ffi::c_int = &raw mut i1 as *mut ::core::ffi::c_int;
     let mut p2: *mut ::core::ffi::c_int = &raw mut i2 as *mut ::core::ffi::c_int;
     let mut diff: ptrdiff_t = p1.offset_from(p2);
-    let mut diff_int: ::core::ffi::c_int =
-        p1.offset_from(p2) as ::core::ffi::c_long as ::core::ffi::c_int;
+    let mut diff_int: ::core::ffi::c_int = p1.offset_from(p2) as ::core::ffi::c_int;
 }


### PR DESCRIPTION
- Depends on #1850
- Fixes #1837