### PR TITLE
transpile: Rename and replace `convert_cast`

### DIFF
--- a/c2rust-transpile/src/translator/macros.rs
+++ b/c2rust-transpile/src/translator/macros.rs
@@ -206,16 +206,8 @@ impl<'c> Translation<'c> {
         // so we need to cast it to the `override_ty` here.
         let expr_ty = override_ty.or_else(|| expr_kind.get_qual_type());
         if let Some(expr_ty) = expr_ty {
-            self.convert_cast(
-                ctx,
-                CQualTypeId::new(macro_ty),
-                expr_ty,
-                val,
-                None,
-                None,
-                None,
-            )
-            .map(Some)
+            self.make_cast(ctx, CQualTypeId::new(macro_ty), expr_ty, val)
+                .map(Some)
         } else {
             Ok(Some(val))
         }

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3354,7 +3354,7 @@ impl<'c> Translation<'c> {
                         .ok_or_else(|| format_err!("bad source type"))?
                 };
 
-                self.convert_cast(
+                self.make_cast_full(
                     ctx,
                     source_ty,
                     target_ty,
@@ -3659,10 +3659,10 @@ impl<'c> Translation<'c> {
         target_type_id: CQualTypeId,
         val: WithStmts<Box<Expr>>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        self.convert_cast(ctx, source_type_id, target_type_id, val, None, None, None)
+        self.make_cast_full(ctx, source_type_id, target_type_id, val, None, None, None)
     }
 
-    pub fn convert_cast(
+    pub fn make_cast_full(
         &self,
         ctx: ExprContext,
         source_cty: CQualTypeId,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3652,6 +3652,16 @@ impl<'c> Translation<'c> {
         }
     }
 
+    pub fn make_cast(
+        &self,
+        ctx: ExprContext,
+        source_type_id: CQualTypeId,
+        target_type_id: CQualTypeId,
+        val: WithStmts<Box<Expr>>,
+    ) -> TranslationResult<WithStmts<Box<Expr>>> {
+        self.convert_cast(ctx, source_type_id, target_type_id, val, None, None, None)
+    }
+
     pub fn convert_cast(
         &self,
         ctx: ExprContext,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2985,7 +2985,7 @@ impl<'c> Translation<'c> {
     /// and in many cases should override it.
     pub fn convert_expr(
         &self,
-        mut ctx: ExprContext,
+        ctx: ExprContext,
         expr_id: CExprId,
         override_ty: Option<CQualTypeId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
@@ -3268,102 +3268,15 @@ impl<'c> Translation<'c> {
             Literal(ty, ref kind) => self.convert_literal(ctx, override_ty.unwrap_or(ty), kind),
 
             ImplicitCast(ty, expr, kind, opt_field_id, _)
-            | ExplicitCast(ty, expr, kind, opt_field_id, _) => {
-                let is_explicit = matches!(expr_kind, CExprKind::ExplicitCast(..));
-                // A reference must be decayed if a bitcast is required. Const casts in
-                // LLVM 8 are now NoOp casts, so we need to include it as well.
-                match kind {
-                    CastKind::IntegralToBoolean
-                    | CastKind::FloatingToBoolean
-                    | CastKind::PointerToBoolean => {
-                        return self.convert_condition(ctx, true, expr);
-                    }
-                    CastKind::BitCast | CastKind::PointerToIntegral | CastKind::NoOp => {
-                        ctx.decay_ref = DecayRef::Yes
-                    }
-                    CastKind::ArrayToPointerDecay
-                    | CastKind::FunctionToPointerDecay
-                    | CastKind::BuiltinFnToFnPtr => {
-                        ctx.needs_address = true;
-                    }
-                    _ => {}
-                }
-
-                let expr_kind = &self.ast_context.index_unwrap_parens(expr).kind;
-                let target_ty = override_ty.unwrap_or(ty);
-
-                // In general, if we are casting the result of an expression, then the inner
-                // expression should be translated to whatever type it normally would.
-                // But for literals, if we don't absolutely have to cast, we would rather the
-                // literal is translated according to the type we're expecting, and then we can
-                // skip the cast entirely.
-                if !is_explicit {
-                    let mut literal_expr_kind = expr_kind;
-                    let mut is_negated = false;
-
-                    if let &CExprKind::Unary(_, CUnOp::Negate, subexpr_id, _) = literal_expr_kind {
-                        literal_expr_kind = &self.ast_context.index_unwrap_parens(subexpr_id).kind;
-                        is_negated = true;
-                    }
-
-                    if let CExprKind::Literal(_, lit) = literal_expr_kind {
-                        if self.literal_matches_ty(lit, target_ty, is_negated) {
-                            return self.convert_expr(ctx, expr, Some(target_ty));
-                        }
-                    }
-                }
-
-                let mut val = self.convert_expr(ctx, expr, None)?;
-
-                if is_explicit {
-                    let stmts = self.compute_variable_array_sizes(ctx, ty.ctype)?;
-                    val = val.prepend_stmts(stmts);
-                }
-
-                // Shuffle Vector "function" builtins will add a cast to the output of the
-                // builtin call which is unnecessary for translation purposes
-                if self.casting_simd_builtin_call(expr, is_explicit, kind) {
-                    return Ok(val);
-                }
-
-                let source_ty = if let Some(func_decl) = self
-                    .ast_context
-                    .fn_declref_decl(expr)
-                    .filter(|_| is_explicit)
-                {
-                    // If we're casting a function, look for its declared ty to use as a more
-                    // precise source type. The AST node's type will not preserve typedef arg types
-                    // but the function's declaration will.
-                    let kind_with_declared_args =
-                        self.ast_context.fn_decl_ty_with_declared_args(func_decl);
-                    let func_ty = self
-                        .ast_context
-                        .type_for_kind(&kind_with_declared_args)
-                        .unwrap_or_else(|| panic!("no type for kind {kind_with_declared_args:?}"));
-                    let func_ptr_ty = self
-                        .ast_context
-                        .type_for_kind(&CTypeKind::Pointer(CQualTypeId::new(func_ty)))
-                        .unwrap_or_else(|| panic!("no type for kind {kind_with_declared_args:?}"));
-
-                    CQualTypeId::new(func_ptr_ty)
-                } else {
-                    self.ast_context
-                        .index_unwrap_parens(expr)
-                        .kind
-                        .get_qual_type()
-                        .ok_or_else(|| format_err!("bad source type"))?
-                };
-
-                self.make_cast_full(
-                    ctx,
-                    source_ty,
-                    target_ty,
-                    val,
-                    Some(expr),
-                    Some(kind),
-                    opt_field_id,
-                )
-            }
+            | ExplicitCast(ty, expr, kind, opt_field_id, _) => self.convert_cast(
+                ctx,
+                override_ty,
+                ty,
+                expr,
+                kind,
+                opt_field_id,
+                matches!(expr_kind, CExprKind::ExplicitCast(..)),
+            ),
 
             Unary(type_id, op, arg, _lrvalue) => {
                 self.convert_unary_operator(ctx, op, override_ty.unwrap_or(type_id), arg)
@@ -3650,6 +3563,110 @@ impl<'c> Translation<'c> {
                 }
             }
         }
+    }
+
+    pub fn convert_cast(
+        &self,
+        mut ctx: ExprContext,
+        override_ty: Option<CQualTypeId>,
+        ty: CQualTypeId,
+        expr: CExprId,
+        kind: CastKind,
+        opt_field_id: Option<CDeclId>,
+        is_explicit: bool,
+    ) -> TranslationResult<WithStmts<Box<Expr>>> {
+        // A reference must be decayed if a bitcast is required. Const casts in
+        // LLVM 8 are now NoOp casts, so we need to include it as well.
+        match kind {
+            CastKind::IntegralToBoolean
+            | CastKind::FloatingToBoolean
+            | CastKind::PointerToBoolean => {
+                return self.convert_condition(ctx, true, expr);
+            }
+            CastKind::BitCast | CastKind::PointerToIntegral | CastKind::NoOp => {
+                ctx.decay_ref = DecayRef::Yes
+            }
+            CastKind::ArrayToPointerDecay
+            | CastKind::FunctionToPointerDecay
+            | CastKind::BuiltinFnToFnPtr => {
+                ctx.needs_address = true;
+            }
+            _ => {}
+        }
+
+        let expr_kind = &self.ast_context.index_unwrap_parens(expr).kind;
+        let target_ty = override_ty.unwrap_or(ty);
+
+        // In general, if we are casting the result of an expression, then the inner
+        // expression should be translated to whatever type it normally would.
+        // But for literals, if we don't absolutely have to cast, we would rather the
+        // literal is translated according to the type we're expecting, and then we can
+        // skip the cast entirely.
+        if !is_explicit {
+            let mut literal_expr_kind = expr_kind;
+            let mut is_negated = false;
+
+            if let &CExprKind::Unary(_, CUnOp::Negate, subexpr_id, _) = literal_expr_kind {
+                literal_expr_kind = &self.ast_context.index_unwrap_parens(subexpr_id).kind;
+                is_negated = true;
+            }
+
+            if let CExprKind::Literal(_, lit) = literal_expr_kind {
+                if self.literal_matches_ty(lit, target_ty, is_negated) {
+                    return self.convert_expr(ctx, expr, Some(target_ty));
+                }
+            }
+        }
+
+        let mut val = self.convert_expr(ctx, expr, None)?;
+
+        if is_explicit {
+            let stmts = self.compute_variable_array_sizes(ctx, ty.ctype)?;
+            val = val.prepend_stmts(stmts);
+        }
+
+        // Shuffle Vector "function" builtins will add a cast to the output of the
+        // builtin call which is unnecessary for translation purposes
+        if self.casting_simd_builtin_call(expr, is_explicit, kind) {
+            return Ok(val);
+        }
+
+        let source_ty = if let Some(func_decl) = self
+            .ast_context
+            .fn_declref_decl(expr)
+            .filter(|_| is_explicit)
+        {
+            // If we're casting a function, look for its declared ty to use as a more
+            // precise source type. The AST node's type will not preserve typedef arg types
+            // but the function's declaration will.
+            let kind_with_declared_args = self.ast_context.fn_decl_ty_with_declared_args(func_decl);
+            let func_ty = self
+                .ast_context
+                .type_for_kind(&kind_with_declared_args)
+                .unwrap_or_else(|| panic!("no type for kind {kind_with_declared_args:?}"));
+            let func_ptr_ty = self
+                .ast_context
+                .type_for_kind(&CTypeKind::Pointer(CQualTypeId::new(func_ty)))
+                .unwrap_or_else(|| panic!("no type for kind {kind_with_declared_args:?}"));
+
+            CQualTypeId::new(func_ptr_ty)
+        } else {
+            self.ast_context
+                .index_unwrap_parens(expr)
+                .kind
+                .get_qual_type()
+                .ok_or_else(|| format_err!("bad source type"))?
+        };
+
+        self.make_cast_full(
+            ctx,
+            source_ty,
+            target_ty,
+            val,
+            Some(expr),
+            Some(kind),
+            opt_field_id,
+        )
     }
 
     pub fn make_cast(

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -211,14 +211,11 @@ impl<'c> Translation<'c> {
                 rhs,
             )))
         } else {
-            let lhs = self.convert_cast(
+            let lhs = self.make_cast(
                 ctx,
                 initial_lhs_type_id,
                 compute_lhs_type_id,
                 WithStmts::new_val(read.clone()),
-                None,
-                None,
-                None,
             )?;
 
             let ty = self.convert_type(compute_res_type_id.ctype)?;
@@ -234,8 +231,7 @@ impl<'c> Translation<'c> {
                 )
             })?;
 
-            let val =
-                self.convert_cast(ctx, compute_res_type_id, lhs_type_id, val, None, None, None)?;
+            let val = self.make_cast(ctx, compute_res_type_id, lhs_type_id, val)?;
 
             Ok(val.map(|val| mk().assign_expr(write.clone(), val)))
         }
@@ -423,14 +419,11 @@ impl<'c> Translation<'c> {
                         .underlying_assignment()
                         .expect("Cannot convert non-assignment operator");
 
-                    let lhs = self.convert_cast(
+                    let lhs = self.make_cast(
                         ctx,
                         initial_lhs_type_id,
                         expr_or_comp_type_id,
                         WithStmts::new_val(read.clone()),
-                        None,
-                        None,
-                        None,
                     )?;
 
                     let ty = self.convert_type(result_type_id.ctype)?;
@@ -446,14 +439,11 @@ impl<'c> Translation<'c> {
                         )
                     )?;
 
-                    let val = self.convert_cast(
+                    let val = self.make_cast(
                         ctx,
                         result_type_id,
                         expr_type_id,
                         val,
-                        None,
-                        None,
-                        None,
                     )?;
 
                     #[allow(clippy::let_and_return /* , reason = "block is large, so variable name helps" */)]


### PR DESCRIPTION
This is mostly a refactor, but having the new `convert_cast` available will allow it to be called/reused from other places too.