### PR TITLE
tests: integration: json-c: Fix configure step

### DIFF
--- a/tests/integration/tests/json-c/configure.sh
+++ b/tests/integration/tests/json-c/configure.sh
@@ -3,6 +3,7 @@ set -e; set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0" )" && pwd)"
 
+export CFLAGS="-Wno-calloc-transposed-args -Wno-implicit-function-declaration"
 export LDFLAGS="-pthread -lquadmath -Wl,--no-as-needed -ldl"
 
 (cd "${SCRIPT_DIR}/repo" && ./configure --disable-shared 2>&1 \


### PR DESCRIPTION
Don't treat calloc-transposed-args and implicit-function-declaration lints as an errors. Issue encountered on Ubuntu 26.04/GCC 15.