### PR TITLE
postprocess: Tighten model input handling

### DIFF
--- a/c2rust-postprocess/postprocess/__init__.py
+++ b/c2rust-postprocess/postprocess/__init__.py
@@ -120,11 +120,12 @@ def get_model(model_id: str) -> AbstractGenerativeModel:
             f"API key for model {model_id} not found in env; "
             "using cached responses only."
         )
-        return MockGenerativeModel()
+        return MockGenerativeModel(id=model_id)
 
     # TODO: remove google specific API bits
     return get_model_by_id(
         model_id,
+        api_key=api_key,
         generation_config={
             "system_instruction": types.Content(
                 role="system", parts=[types.Part.from_text(text=SYSTEM_INSTRUCTION)]
@@ -170,3 +171,6 @@ def main(argv: Sequence[str] | None = None):
     except KeyboardInterrupt:
         logging.warning("Interrupted by user, terminating...")
         return 130  # 128 + SIGINT(2)
+    except ValueError as error:
+        logging.error(error)
+        return 1

--- a/c2rust-postprocess/postprocess/models/__init__.py
+++ b/c2rust-postprocess/postprocess/models/__init__.py
@@ -11,14 +11,19 @@ def api_key_from_env(model_id: str) -> str | None:
         return os.getenv("GEMINI_API_KEY")
     elif model_id.startswith("gpt"):
         return os.getenv("OPENAI_API_KEY")
-    return None
+
+    raise ValueError(f"Unsupported model identifier: {model_id}")
 
 
-def get_model_by_id(id: str, generation_config: dict | None) -> AbstractGenerativeModel:
+def get_model_by_id(
+    id: str, api_key: str, generation_config: dict | None
+) -> AbstractGenerativeModel:
     """Factory function to get model instance by ID."""
     if id.startswith("gemini"):
-        return GoogleGenerativeModel(id=id, generation_config=generation_config)
+        return GoogleGenerativeModel(
+            id=id, api_key=api_key, generation_config=generation_config
+        )
     elif id.startswith("gpt"):
-        return GPTModel(id=id)
+        return GPTModel(id=id, api_key=api_key)
 
     raise ValueError(f"Unsupported model identifier: {id}")

--- a/c2rust-postprocess/postprocess/models/base.py
+++ b/c2rust-postprocess/postprocess/models/base.py
@@ -8,12 +8,17 @@ class AbstractGenerativeModel(ABC):
     Abstract base class for LLM clients using Native Function Calling.
     """
 
-    def __init__(self, id: str):
+    def __init__(self, id: str, cache_only: bool = False):
         self._id = id
+        self._cache_only = cache_only
 
     @property
     def id(self) -> str:
         return self._id
+
+    @property
+    def cache_only(self) -> bool:
+        return self._cache_only
 
     # @abstractmethod
     # async def agenerate_with_tools(

--- a/c2rust-postprocess/postprocess/models/mock.py
+++ b/c2rust-postprocess/postprocess/models/mock.py
@@ -10,8 +10,8 @@ class MockGenerativeModel(AbstractGenerativeModel):
     Generates no responses, so callers fall back to cached responses only.
     """
 
-    def __init__(self):
-        super().__init__(id="mock-llm")
+    def __init__(self, id: str = "mock-llm"):
+        super().__init__(id=id, cache_only=True)
 
     def generate_with_tools(
         self,

--- a/c2rust-postprocess/postprocess/transforms/comments.py
+++ b/c2rust-postprocess/postprocess/transforms/comments.py
@@ -8,7 +8,7 @@ from postprocess.definitions import (
     get_rust_comments,
     update_rust_definition,
 )
-from postprocess.models import AbstractGenerativeModel, api_key_from_env
+from postprocess.models import AbstractGenerativeModel
 from postprocess.transforms.base import AbstractTransform
 from postprocess.utils import get_highlighted_rust, remove_backticks
 
@@ -110,7 +110,7 @@ class CommentsTransform(AbstractTransform):
         response = self.model.generate_with_tools(messages)
 
         if response is None:
-            if api_key_from_env(model) is None:
+            if self.model.cache_only:
                 # No API key set: skip uncached entries instead of failing.
                 logging.warning(
                     f"Cache miss for {identifier}; skipping since no API key was set..."


### PR DESCRIPTION
Adds guards for model selection, as well as cleans up an env read that happened deeper than it needed to; env reading now happens in __init__ and is passed down.

I think it wouldn't be a bad idea to combine `GEMINI_API_KEY` with `OPENAI_API_KEY` here too, but it would depend on what else uses this API already. 