### PR TITLE
postprocess: Support CRISP_API_MODEL/_KEY/_BASE env var overrides

### DIFF
--- a/c2rust-postprocess/postprocess/__init__.py
+++ b/c2rust-postprocess/postprocess/__init__.py
@@ -4,6 +4,7 @@ c2rust-postprocess: Transfer comments from C functions to Rust functions using L
 
 import argparse
 import logging
+import os
 from argparse import BooleanOptionalAction
 from collections.abc import Sequence
 from pathlib import Path
@@ -13,6 +14,7 @@ from google.genai import types
 from postprocess.cache import DirectoryCache, FrozenCache
 from postprocess.exclude_list import IdentifierExcludeList
 from postprocess.models import api_key_from_env, get_model_by_id
+from postprocess.models.gpt import GPTModel
 from postprocess.models.mock import MockGenerativeModel
 from postprocess.transforms import get_transform_by_id
 from postprocess.transforms.comments import (
@@ -114,6 +116,24 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
 
 def get_model(model_id: str) -> AbstractGenerativeModel:
+    # CRISP_API_MODEL/_KEY/_BASE (see github.com/GaloisInc/Tractor-Crisp)
+    # override CLI model selection; CRISP endpoints are OpenAI-compatible.
+    if crisp_model_id := os.getenv("CRISP_API_MODEL"):
+        if not (crisp_api_key := os.getenv("CRISP_API_KEY")):
+            raise RuntimeError(
+                "`CRISP_API_MODEL` is set but `CRISP_API_KEY` is not; "
+                "set both or neither."
+            )
+        logging.info(
+            "CLI model selection overridden by `CRISP_API_MODEL` env var; "
+            f"using model {crisp_model_id}."
+        )
+        return GPTModel(
+            id=crisp_model_id,
+            api_key=crisp_api_key,
+            base_url=os.getenv("CRISP_API_BASE"),
+        )
+
     api_key = api_key_from_env(model_id)
     if api_key is None:
         logging.warning(

--- a/c2rust-postprocess/postprocess/models/gpt.py
+++ b/c2rust-postprocess/postprocess/models/gpt.py
@@ -7,9 +7,14 @@ from postprocess.models import AbstractGenerativeModel
 
 
 class GPTModel(AbstractGenerativeModel):
-    def __init__(self, id: str = "gpt-5.1", api_key: str | None = None):
+    def __init__(
+        self,
+        id: str = "gpt-5.1",
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ):
         super().__init__(id)
-        self.client = OpenAI(api_key=api_key)
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
 
     def generate_with_tools(
         self,


### PR DESCRIPTION
When CRISP_API_MODEL is set, route through the OpenAI-compatible client using the Tractor-Crisp env vars, overriding CLI model selection.