### PR TITLE
postprocess: Add cronjob-based testing of c2rust-postprocess

### DIFF
--- a/.github/workflows/ci-c2rust-postprocess.yml
+++ b/.github/workflows/ci-c2rust-postprocess.yml
@@ -1,0 +1,139 @@
+name: ci-c2rust-postprocess
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+
+jobs:
+  run-testsuite:
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            os: Linux
+            arch: x86_64
+            clang-version: 18
+          - runner: ubuntu-22.04
+            os: Linux
+            arch: x86_64
+            clang-version: 15
+      fail-fast: false
+    name: "postprocess-test-and-cache (${{ matrix.runner }}: ${{ matrix.os }} ${{ matrix.arch}}, Clang ${{ matrix.clang-version }})"
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.runner }}
+
+    env:
+      # TODO: Remove this when we know the cronjob works
+      C2RUST_POSTPROCESS_ARGS: --ident-filter '^(json_object_set_userdata|json_object_to_file)$'
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Working dir is /home/runner/work/c2rust/c2rust
+      - name: Checkout c2rust
+        uses: actions/checkout@v4
+        with:
+          repository: immunant/c2rust
+          # `update = none` is set, which makes this not work, so we need to update them manually.
+          # See `.gitmodules` for more info.
+          submodules: false
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --init --checkout tests/integration/tests/json-c/repo
+
+      - uses: astral-sh/setup-uv@v6
+
+      - run: uv python install
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-workspace-crates: true
+
+      - name: Install Rust toolchains
+        run: |
+          rustup toolchain install nightly-2022-11-03 \
+            --profile minimal --component rustfmt,rustc-dev
+          rustup toolchain install nightly-2023-04-15 \
+            --profile minimal --component rustfmt
+
+      - name: Provision Debian Packages
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq install    \
+              build-essential         \
+              libbrotli-dev           \
+              libbz2-dev              \
+              libclang-${{ matrix.clang-version }}-dev \
+              libdb-dev               \
+              libgcrypt20             \
+              libgdbm-dev             \
+              libreadline-dev         \
+              libidn2-dev             \
+              libldap2-dev            \
+              liblzma-dev             \
+              libnghttp2-dev          \
+              libpcre3-dev            \
+              libpsl-dev              \
+              librtmp-dev             \
+              libtool                 \
+              libzstd-dev             \
+              rcs                     \
+              tcl-dev                 \
+              tk-dev                  \
+              zlib1g-dev
+
+      # Runs a single command using the runners shell
+      # Working dir is /home/runner/work/c2rust/c2rust
+      - name: Build c2rust
+        env:
+          LLVM_CONFIG_PATH: /usr/bin/llvm-config-${{ matrix.clang-version }}
+        run: cargo build --release
+
+      - name: Build tools
+        run: |
+          (cd tools && cargo build --release --manifest-path split_rust/Cargo.toml)
+          (cd tools && cargo build --release --manifest-path merge_rust/Cargo.toml)
+
+      # Use separate restore/save steps so we still save the cache even if the
+      # testsuite fails.
+      - name: Restore postprocess cache
+        uses: actions/cache/restore@v4
+        with:
+          path: c2rust-postprocess/tests/llm-cache
+          # Restore the newest cache matching this runner/compiler prefix.
+          key: postprocess-cache-${{ matrix.runner }}-${{ matrix.arch }}-clang-${{ matrix.clang-version }}-
+
+      - name: Run c2rust testsuite
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          export PATH=$PWD/target/release:$PWD/c2rust-postprocess:$HOME/.local/bin:$PATH
+          echo "PATH=$PATH"
+          export C2RUST_DIR=$PWD
+          # Needs to be run from `tests/integration/` (or further inside)
+          # to correctly load the `pyproject.toml`.
+          (cd tests/integration && ./test.py json-c)
+
+      # Prune by `metadata.toml`'s atime so hot entries survive and stale ones
+      # disappear; GitHub cache eviction is what keeps the daily snapshot
+      # history bounded.
+      - name: Prune stale postprocess cache entries
+        run: |
+          cutoff=$(date -d '90 days ago' +%s)
+          while IFS= read -r -d '' file; do
+            atime=$(awk -F ' = ' '$1 == "atime" { print $2; exit }' "$file")
+            if [[ -n "$atime" && $atime -lt $cutoff ]]; then
+              echo "evicting ${file%/metadata.toml}"
+              rm -rf "${file%/metadata.toml}"
+            fi
+          done < <(find c2rust-postprocess/tests/llm-cache -mindepth 4 -maxdepth 4 -name metadata.toml -print0)
+
+      - name: Save postprocess cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: c2rust-postprocess/tests/llm-cache
+          # Do not use hashFiles() here; atime changes on every cron run, so a
+          # content hash would just give us a per-run key anyway.
+          key: postprocess-cache-${{ matrix.runner }}-${{ matrix.arch }}-clang-${{ matrix.clang-version }}-${{ github.run_id }}

--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -14,6 +14,8 @@ jobs:
   # This workflow contains a single job called "build"
   run-testsuite:
     strategy:
+      # ci-c2rust-postprocess.yml generates postprocess caches for this matrix.
+      # Keep both matrices in sync so this workflow can restore those caches.
       matrix:
         include:
           - runner: ubuntu-latest
@@ -28,6 +30,11 @@ jobs:
     name: "run-testsuite (${{ matrix.runner }}: ${{ matrix.os }} ${{ matrix.arch}}, Clang ${{ matrix.clang-version }})"
     # The type of runner that the job will run on
     runs-on: ${{ matrix.runner }}
+
+    env:
+      # Uses cache-only responses; skips uncached work and exercises cached
+      # postprocess output usage.
+      C2RUST_POSTPROCESS_ARGS: --on-error warn
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -105,6 +112,13 @@ jobs:
         # `cd tools` to pick up `tools/rust-toolchain.toml` (stable, for `edition = "2024"`)
         (cd tools && cargo build --release --manifest-path split_rust/Cargo.toml)
         (cd tools && cargo build --release --manifest-path merge_rust/Cargo.toml)
+
+    - name: Restore postprocess cache
+      uses: actions/cache/restore@v4
+      with:
+        path: c2rust-postprocess/tests/llm-cache
+        # Restore the newest available cache entry that matches this prefix.
+        key: postprocess-cache-${{ matrix.runner }}-${{ matrix.arch }}-clang-${{ matrix.clang-version }}-
 
     - name: Run c2rust testsuite
       run: |

--- a/c2rust-postprocess/postprocess/cache.py
+++ b/c2rust-postprocess/postprocess/cache.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from abc import ABC, abstractmethod
 from hashlib import sha256
 from pathlib import Path
@@ -187,6 +188,8 @@ class DirectoryCache(AbstractCache):
             return None
         logging.debug(f"Cache hit: {cache_file}:\n{toml}")
         data = tomli.loads(toml)
+        data["atime"] = int(time.time())
+        cache_file.write_text(to_multiline_toml(data))
 
         return data["response"]
 
@@ -205,6 +208,7 @@ class DirectoryCache(AbstractCache):
             "model": model,
             "messages": messages,
             "response": response,
+            "atime": int(time.time()),
         }
         toml = to_multiline_toml(data)
 

--- a/tests/integration/tests/templates.py
+++ b/tests/integration/tests/templates.py
@@ -199,17 +199,21 @@ def autogen_postprocess(
     if not (ag and isinstance(ag, bool)):
         return
 
-    params = {"args": ""}
+    args: list[str] = []
 
     exclude_file = conf.with_name("postprocess-exclude.yml")
     if exclude_file.exists():
         # args are relative to script dir
-        params["args"] = shlex.join(
-            ["--exclude-file", str(exclude_file.relative_to(conf.parent))]
-        )
+        args.extend(["--exclude-file", str(exclude_file.relative_to(conf.parent))])
+
+    extra_args = os.getenv("C2RUST_POSTPROCESS_ARGS")
+    if extra_args:
+        args.extend(shlex.split(extra_args))
 
     if verbose:
-        params["args"] = f"--log-level DEBUG {params['args']}".rstrip()
+        args[0:0] = ["--log-level", "DEBUG"]
+
+    params = {"args": shlex.join(args)}
 
     out_path = conf.with_name("postprocess.gen.sh")
     render_script(POSTPROCESS_SH, out_path, params)


### PR DESCRIPTION
Test PR c2rust-postprocess testing in CI.

The basic idea is to run a daily cronjob that runs c2rust-postprocess on json-c with a real API key and `--on-error keep-going`, generating new cache entries. PR CI runners will run their postprocess tests with cache-only mode and `--on-error warn`. This has the side effect that breaking changes to c2rust-postprocess that still work under `--on-error warn` will only become apparent during the daily cronjob. 

In addition, the daily cronjob will prune its inner cache entries after 90 days. Note that the consumer job is restore-only, and cannot update these values; ie only the cronjob may decide when a cache entry has been recently-used.