### PR TITLE
tests: integration: add `libgit2`

### DIFF
--- a/.github/workflows/internal-testsuite.yml
+++ b/.github/workflows/internal-testsuite.yml
@@ -47,6 +47,7 @@ jobs:
       run: |
         git submodule update --init --checkout tests/integration/tests/curl/repo
         git submodule update --init --checkout tests/integration/tests/json-c/repo
+        git submodule update --init --checkout tests/integration/tests/libgit2/repo
         git submodule update --init --checkout tests/integration/tests/lua/repo
         git submodule update --init --checkout tests/integration/tests/nginx/repo
         git submodule update --init --checkout tests/integration/tests/zstd/repo
@@ -75,6 +76,7 @@ jobs:
         sudo apt-get -qq install    \
             bear                    \
             build-essential         \
+            cmake                   \
             libbrotli-dev           \
             libbz2-dev              \
             libclang-${{ matrix.clang-version }}-dev \
@@ -91,6 +93,7 @@ jobs:
             librtmp-dev             \
             libtool                 \
             libzstd-dev             \
+            pkg-config              \
             rcs                     \
             tcl-dev                 \
             tk-dev                  \
@@ -125,7 +128,7 @@ jobs:
         export PATH=$PWD/target/release:$PWD/c2rust-postprocess:$HOME/.local/bin:$PATH
         echo "PATH=$PATH"
         export C2RUST_DIR=$PWD
-        ./tests/integration/test.py curl json-c lua nginx zstd libxml2 python2 libmcs
+        ./tests/integration/test.py curl json-c libgit2 lua nginx zstd libxml2 python2 libmcs
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -101,3 +101,8 @@
 	path = tests/integration/tests/libmcs/repo
 	url = https://gitlab.com/gtd-gmbh/libmcs
 	update = none
+[submodule "tests/integration/tests/libgit2"]
+	path = tests/integration/tests/libgit2/repo
+	url = https://github.com/libgit2/libgit2
+	ignore = all
+	update = none

--- a/tests/integration/tests/libgit2/cmake.sh
+++ b/tests/integration/tests/libgit2/cmake.sh
@@ -10,7 +10,7 @@ rm -f compile_commands.json
 cmake -S "$SCRIPT_DIR/repo" -B "$BUILD_DIR" \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DBUILD_SHARED_LIBS=OFF \
-    -DBUILD_TESTS=OFF \
+    -DBUILD_TESTS=ON \
     -DBUILD_CLI=OFF \
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_FUZZERS=OFF \
@@ -24,9 +24,10 @@ cmake -S "$SCRIPT_DIR/repo" -B "$BUILD_DIR" \
     -DUSE_ICONV=OFF \
     2>&1 | tee "$LOG_FILE"
 
-# Configuring is enough: it generates compile_commands.json and every header
-# that transpilation needs (e.g. gen_headers/{experimental,git2_features}.h).
-# Building the library is not required to transpile, so we skip it.
-
 # The test runner expects compile_commands.json in the fixture directory.
 ln -sf repo/build/compile_commands.json compile_commands.json
+
+# clar generates `clar_suite.h` at build time, so the test sources can't be
+# transpiled until the test target is built.
+cmake --build "$BUILD_DIR" --target libgit2_tests --parallel "$(nproc)" \
+    2>&1 | tee -a "$LOG_FILE"

--- a/tests/integration/tests/libgit2/cmake.sh
+++ b/tests/integration/tests/libgit2/cmake.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e; set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0" )" && pwd)"
+LOG_FILE="$(basename "$0")".log
+BUILD_DIR="$SCRIPT_DIR/repo/build"
+
+rm -f compile_commands.json
+
+cmake -S "$SCRIPT_DIR/repo" -B "$BUILD_DIR" \
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_CLI=OFF \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_FUZZERS=OFF \
+    -DUSE_HTTPS=OFF \
+    -DUSE_SSH=OFF \
+    -DUSE_SHA256=builtin \
+    -DUSE_HTTP_PARSER=builtin \
+    -DREGEX_BACKEND=builtin \
+    -DUSE_BUNDLED_ZLIB=ON \
+    -DUSE_NTLMCLIENT=OFF \
+    -DUSE_ICONV=OFF \
+    2>&1 | tee "$LOG_FILE"
+
+# Configuring is enough: it generates compile_commands.json and every header
+# that transpilation needs (e.g. gen_headers/{experimental,git2_features}.h).
+# Building the library is not required to transpile, so we skip it.
+
+# The test runner expects compile_commands.json in the fixture directory.
+ln -sf repo/build/compile_commands.json compile_commands.json

--- a/tests/integration/tests/libgit2/conf.yml
+++ b/tests/integration/tests/libgit2/conf.yml
@@ -19,3 +19,15 @@ transpile:
 
 cargo.transpile:
   autogen: true
+
+refactor:
+  autogen: true
+  transforms:
+    - rename_unnamed
+    - reorganize_definitions
+    - shorten_imported_paths
+    - remove_unused_labels
+    - remove_literal_suffixes
+
+cargo.refactor:
+  autogen: true

--- a/tests/integration/tests/libgit2/conf.yml
+++ b/tests/integration/tests/libgit2/conf.yml
@@ -1,0 +1,14 @@
+transpile:
+  autogen: true
+  tflags: --reorganize-definitions --disable-refactoring
+  # libgit2 builds its tests with GIT_DEPRECATE_HARD but not the library
+  # itself (which implements the deprecated APIs), so the same struct has two
+  # incompatible declarations across TUs (e.g. git_remote_callbacks.update_tips
+  # vs .reserved_update_tips). That breaks the refactor stage's
+  # reorganize_definitions pass, which merges declarations by name. Undefine
+  # the macro during transpilation so every TU sees one consistent view; the
+  # structs are layout-identical and the tests don't use deprecated APIs.
+  cflags: -UGIT_DEPRECATE_HARD
+
+cargo.transpile:
+  autogen: true

--- a/tests/integration/tests/libgit2/conf.yml
+++ b/tests/integration/tests/libgit2/conf.yml
@@ -1,3 +1,10 @@
+requirements:
+  ubuntu:
+    apt:
+      packages:
+        - cmake
+        - pkg-config
+
 transpile:
   autogen: true
   tflags: --reorganize-definitions --disable-refactoring

--- a/tests/integration/tests/libgit2/conf.yml
+++ b/tests/integration/tests/libgit2/conf.yml
@@ -7,6 +7,7 @@ requirements:
 
 transpile:
   autogen: true
+  binary: main # clar test runner's `main()` lives in tests/clar/main.c
   tflags: --reorganize-definitions --disable-refactoring
   # libgit2 builds its tests with GIT_DEPRECATE_HARD but not the library
   # itself (which implements the deprecated APIs), so the same struct has two

--- a/tests/integration/tests/libgit2/test.sh
+++ b/tests/integration/tests/libgit2/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e; set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0" )" && pwd)"
+
+(cd "$SCRIPT_DIR/repo" && \
+    cargo run --release 2>&1 \
+    | tee "$SCRIPT_DIR/$(basename "$0")".log)


### PR DESCRIPTION
This code base surfaced transpiler and refactorer issues fixed in PRs #1858 and #1859. Adding `libgit2` helps us test the correctness of the fixes and catch regressions.