### PR TITLE
ci: Bootstrap daily cronjobs workflow

### DIFF
--- a/.github/workflows/daily-cronjobs.yml
+++ b/.github/workflows/daily-cronjobs.yml
@@ -1,0 +1,13 @@
+name: daily-cronjobs
+
+# Temporary placeholder workflow so the daily cronjobs file can land on the
+# default branch before the real jobs are added.
+on:
+  workflow_dispatch:
+
+jobs:
+  postprocess-test-and-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op
+        run: echo "daily cronjobs placeholder"


### PR DESCRIPTION
Adds an empty workflow for daily cronjobs with a no-op postprocess test. Github requires a workflow be on the default branch before tests in PRs under that workflow can be launched.