### PR TITLE
tests: make cleanup_attr trace statics thread-local to fix race

### DIFF
--- a/tests/unit/cleanup_attr/src/cleanup.c
+++ b/tests/unit/cleanup_attr/src/cleanup.c
@@ -1,5 +1,7 @@
-static int trace_buf[16];
-static int trace_n;
+/* Thread-local so the parallel test harness gives each test its own trace
+ * instead of racing on shared state (both here and in the transpiled Rust). */
+static _Thread_local int trace_buf[16];
+static _Thread_local int trace_n;
 
 static void reset(void) {
     trace_n = 0;

--- a/tests/unit/cleanup_attr/src/test_cleanup.rs
+++ b/tests/unit/cleanup_attr/src/test_cleanup.rs
@@ -1,3 +1,4 @@
+//! feature_thread_local
 use crate::cleanup::{
     rust_run_early_return, rust_run_goto, rust_run_multiple, rust_run_nested, rust_run_single,
     rust_run_typedef,


### PR DESCRIPTION
The six tests share `trace_buf`/`trace_n` but libtest runs them in parallel, so they intermittently race. Marking the statics `_Thread_local` (faithfully transpiled to `#[thread_local]`) gives each test thread its own trace.

Failed run: https://github.com/immunant/c2rust/actions/runs/27427103335/job/81067618174