### PR TITLE
Security: Path traversal in get_tool_path allows arbitrary file access

### DIFF
--- a/c2rust-postprocess/postprocess/utils.py
+++ b/c2rust-postprocess/postprocess/utils.py
@@ -22,6 +22,14 @@ def check_isinstance[T](value: object, typ: type[T]) -> T:
 def get_tool_path(tool_name: str) -> Path:
     """Get the path to the given tool in the system PATH."""
 
+    # Validate tool_name to prevent path traversal
+    if os.sep in tool_name or '/' in tool_name:
+        raise ValueError(f"tool_name must not contain path separators: {tool_name!r}")
+    if '..' in tool_name:
+        raise ValueError(f"tool_name must not contain '..': {tool_name!r}")
+    if not tool_name.isidentifier():
+        raise ValueError(f"tool_name must be a valid identifier: {tool_name!r}")
+
     tool_path = which(tool_name)
     if tool_path is None:
         root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Problem

The `get_tool_path` function constructs a file path by directly interpolating the `tool_name` string into a path template without sanitization. An attacker who controls `tool_name` (e.g., through a malicious configuration file) could inject path traversal sequences (like `../`) to access or execute arbitrary files outside the intended `tools/` directory, potentially leading to code execution or sensitive file exposure.

**Severity**: `high`
**File**: `c2rust-postprocess/postprocess/utils.py`

## Solution

Sanitize `tool_name` to ensure it contains only safe characters and no path separators. Replace the vulnerable path construction with:


## Changes

- `c2rust-postprocess/postprocess/utils.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
