### PR TITLE
postprocess: Add basic code parity check to comment transform

### DIFF
--- a/c2rust-postprocess/postprocess/definitions/__init__.py
+++ b/c2rust-postprocess/postprocess/definitions/__init__.py
@@ -10,6 +10,7 @@ import tree_sitter_rust as tsrust
 from pygments import lex
 from pygments.lexer import RegexLexer
 from pygments.lexers.c_cpp import CLexer
+from pygments.lexers.rust import RustLexer
 from pygments.token import Comment
 from tree_sitter import Language, Node, Parser
 
@@ -203,6 +204,23 @@ def get_rust_comments(code: str) -> list[str]:
             yield from walk(child)
 
     return get_comments_text(walk(tree.root_node))
+
+
+def get_rust_code(code: str) -> list[str]:
+    """
+    Extract the Rust token stream from the given code.
+    Keep code tokens and attributes, but drop comments and whitespace.
+    """
+    code_tokens = []
+    for tok_type, tok_value in lex(code, RustLexer()):
+        if tok_value.isspace():
+            continue
+        if str(tok_type).startswith("Token.Comment") and tok_type != Comment.Preproc:
+            continue
+        if str(tok_type).startswith("Token.Literal.String.Doc"):
+            continue
+        code_tokens.append(tok_value)
+    return code_tokens
 
 
 def get_comments(code: str, lexer: RegexLexer) -> list[str]:

--- a/c2rust-postprocess/postprocess/transforms/comments.py
+++ b/c2rust-postprocess/postprocess/transforms/comments.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 from postprocess.cache import AbstractCache
 from postprocess.definitions import (
     get_c_comments,
+    get_rust_code,
     get_rust_comments,
     update_rust_definition,
 )
@@ -119,6 +120,15 @@ class CommentsTransform(AbstractTransform):
             raise TransformError(f"model returned no response for {identifier}")
 
         rust_fn = remove_backticks(response)
+
+        original_rust_code = get_rust_code(rust_definition)
+        updated_rust_code = get_rust_code(rust_fn)
+        if original_rust_code != updated_rust_code:
+            raise TransformError(
+                f"Rust code changed for {identifier}:"
+                f"\nbefore={original_rust_code!r}"
+                f"\nafter={updated_rust_code!r}"
+            )
 
         c_comments = get_c_comments(prompt.c_function)
         logging.debug(f"{c_comments=}")

--- a/c2rust-postprocess/tests/test_definitions.py
+++ b/c2rust-postprocess/tests/test_definitions.py
@@ -8,6 +8,7 @@ from postprocess import main
 from postprocess.definitions import (
     get_c_sourcefile,
     get_function_span_pairs,
+    get_rust_code,
     get_rust_function_spans,
 )
 from postprocess.utils import read_chunk
@@ -60,6 +61,39 @@ def test_get_rust_function_spans(transpile_qsort, pytestconfig):
         fn_spans, expected_fn_spans, strict=True
     ):
         assert actual_fn_span == expected_fn_span
+
+
+def test_get_rust_code_ignores_comments_but_keeps_attributes():
+    code = """\
+/* comment */
+#[no_mangle]
+pub unsafe extern "C" fn f(x: i32) {
+    // inner
+    /** doc */
+    x
+}
+"""
+    assert get_rust_code(code) == [
+        "#[",
+        "no_mangle",
+        "]",
+        "pub",
+        "unsafe",
+        "extern",
+        '"',
+        "C",
+        '"',
+        "fn",
+        "f",
+        "(",
+        "x",
+        ":",
+        "i32",
+        ")",
+        "{",
+        "x",
+        "}",
+    ]
 
 
 # TODO: this test needs a clearer scope


### PR DESCRIPTION
Adds a small token based check to ensure the llm doesn't touch the code. This is not foolproof, as adding whitespaces can slip through and still prevent building, but it is enough to prevent a fairly common class of failure (see #1869) on lower-end llms.