### PR TITLE
transpile: emit unsafe inside const block for string transmute

### DIFF
--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -125,7 +125,7 @@ impl<'c> Translation<'c> {
                 } else {
                     // std::mem::transmute::<[u8; size], ctype>(*b"xxxx")
                     let array_ty = mk().array_ty(mk().ident_ty("u8"), mk().lit_expr(len as u128));
-                    let mut val = transmute_expr(
+                    let val = transmute_expr(
                         array_ty,
                         self.convert_type(ty.ctype)?,
                         mk().unary_expr(UnOp::Deref(Default::default()), val),
@@ -136,11 +136,16 @@ impl<'c> Translation<'c> {
                     // it will be const-promoted to 'static.
                     if ctx.needs_address {
                         self.use_feature("inline_const");
-                        let stmts = vec![mk().expr_stmt(val)];
-                        val = mk().const_block_expr(mk().const_block(stmts));
+                        // An inline `const` block is its own safety context and does not inherit
+                        // the surrounding `unsafe`, so the transmute needs an explicit `unsafe`
+                        // block inside the const block rather than relying on `set_unsafe`.
+                        let unsafe_transmute = mk().unsafe_block_expr(vec![mk().expr_stmt(val)]);
+                        let stmts = vec![mk().expr_stmt(unsafe_transmute)];
+                        let val = mk().const_block_expr(mk().const_block(stmts));
+                        Ok(WithStmts::new_val(val))
+                    } else {
+                        Ok(WithStmts::new_val(val).set_unsafe())
                     }
-
-                    Ok(WithStmts::new_val(val).set_unsafe())
                 }
             }
         }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.linux.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.linux.clang15.snap
@@ -27,10 +27,10 @@ pub static mut static_array_longer: [wchar_t; 3] =
 pub static mut static_array_shorter: [wchar_t; 1] =
     unsafe { ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0") };
 #[no_mangle]
-pub static mut static_ptr: *const wchar_t = unsafe {
-    const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-        .as_ptr() as *const wchar_t
-};
+pub static mut static_ptr: *const wchar_t = const {
+    unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+}
+.as_ptr() as *const wchar_t;
 #[no_mangle]
 pub unsafe extern "C" fn func() {
     let mut array: [wchar_t; 2] =
@@ -39,8 +39,9 @@ pub unsafe extern "C" fn func() {
         ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0");
     let mut array_shorter: [wchar_t; 1] =
         ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0");
-    let mut ptr: *const wchar_t =
-        const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-            .as_ptr() as *const wchar_t;
+    let mut ptr: *const wchar_t = const {
+        unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+    }
+    .as_ptr() as *const wchar_t;
     let mut len: size_t = wcslen(&raw mut array as *mut wchar_t) as size_t;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.linux.clang22.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.linux.clang22.snap
@@ -27,10 +27,10 @@ pub static mut static_array_longer: [wchar_t; 3] =
 pub static mut static_array_shorter: [wchar_t; 1] =
     unsafe { ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0") };
 #[no_mangle]
-pub static mut static_ptr: *const wchar_t = unsafe {
-    const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-        .as_ptr() as *const wchar_t
-};
+pub static mut static_ptr: *const wchar_t = const {
+    unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+}
+.as_ptr() as *const wchar_t;
 #[no_mangle]
 pub unsafe extern "C" fn func() {
     let mut array: [wchar_t; 2] =
@@ -39,8 +39,9 @@ pub unsafe extern "C" fn func() {
         ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0");
     let mut array_shorter: [wchar_t; 1] =
         ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0");
-    let mut ptr: *const wchar_t =
-        const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-            .as_ptr() as *const wchar_t;
+    let mut ptr: *const wchar_t = const {
+        unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+    }
+    .as_ptr() as *const wchar_t;
     let mut len: size_t = wcslen(&raw mut array as *mut wchar_t);
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.macos.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.macos.clang15.snap
@@ -27,10 +27,10 @@ pub static mut static_array_longer: [wchar_t; 3] =
 pub static mut static_array_shorter: [wchar_t; 1] =
     unsafe { ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0") };
 #[no_mangle]
-pub static mut static_ptr: *const wchar_t = unsafe {
-    const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-        .as_ptr() as *const wchar_t
-};
+pub static mut static_ptr: *const wchar_t = const {
+    unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+}
+.as_ptr() as *const wchar_t;
 #[no_mangle]
 pub unsafe extern "C" fn func() {
     let mut array: [wchar_t; 2] =
@@ -39,8 +39,9 @@ pub unsafe extern "C" fn func() {
         ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0");
     let mut array_shorter: [wchar_t; 1] =
         ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0");
-    let mut ptr: *const wchar_t =
-        const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-            .as_ptr() as *const wchar_t;
+    let mut ptr: *const wchar_t = const {
+        unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+    }
+    .as_ptr() as *const wchar_t;
     let mut len: size_t = wcslen(&raw mut array as *mut wchar_t) as size_t;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.macos.clang22.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2021.macos.clang22.snap
@@ -27,10 +27,10 @@ pub static mut static_array_longer: [wchar_t; 3] =
 pub static mut static_array_shorter: [wchar_t; 1] =
     unsafe { ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0") };
 #[no_mangle]
-pub static mut static_ptr: *const wchar_t = unsafe {
-    const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-        .as_ptr() as *const wchar_t
-};
+pub static mut static_ptr: *const wchar_t = const {
+    unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+}
+.as_ptr() as *const wchar_t;
 #[no_mangle]
 pub unsafe extern "C" fn func() {
     let mut array: [wchar_t; 2] =
@@ -39,8 +39,9 @@ pub unsafe extern "C" fn func() {
         ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0");
     let mut array_shorter: [wchar_t; 1] =
         ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0");
-    let mut ptr: *const wchar_t =
-        const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-            .as_ptr() as *const wchar_t;
+    let mut ptr: *const wchar_t = const {
+        unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+    }
+    .as_ptr() as *const wchar_t;
     let mut len: size_t = wcslen(&raw mut array as *mut wchar_t);
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.linux.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.linux.clang15.snap
@@ -27,10 +27,10 @@ pub static mut static_array_longer: [wchar_t; 3] =
 pub static mut static_array_shorter: [wchar_t; 1] =
     unsafe { ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0") };
 #[unsafe(no_mangle)]
-pub static mut static_ptr: *const wchar_t = unsafe {
-    const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-        .as_ptr() as *const wchar_t
-};
+pub static mut static_ptr: *const wchar_t = const {
+    unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+}
+.as_ptr() as *const wchar_t;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn func() {
     let mut array: [wchar_t; 2] =
@@ -39,8 +39,9 @@ pub unsafe extern "C" fn func() {
         ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0");
     let mut array_shorter: [wchar_t; 1] =
         ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0");
-    let mut ptr: *const wchar_t =
-        const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-            .as_ptr() as *const wchar_t;
+    let mut ptr: *const wchar_t = const {
+        unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+    }
+    .as_ptr() as *const wchar_t;
     let mut len: size_t = wcslen(&raw mut array as *mut wchar_t) as size_t;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.linux.clang22.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.linux.clang22.snap
@@ -27,10 +27,10 @@ pub static mut static_array_longer: [wchar_t; 3] =
 pub static mut static_array_shorter: [wchar_t; 1] =
     unsafe { ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0") };
 #[unsafe(no_mangle)]
-pub static mut static_ptr: *const wchar_t = unsafe {
-    const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-        .as_ptr() as *const wchar_t
-};
+pub static mut static_ptr: *const wchar_t = const {
+    unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+}
+.as_ptr() as *const wchar_t;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn func() {
     let mut array: [wchar_t; 2] =
@@ -39,8 +39,9 @@ pub unsafe extern "C" fn func() {
         ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0");
     let mut array_shorter: [wchar_t; 1] =
         ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0");
-    let mut ptr: *const wchar_t =
-        const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-            .as_ptr() as *const wchar_t;
+    let mut ptr: *const wchar_t = const {
+        unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+    }
+    .as_ptr() as *const wchar_t;
     let mut len: size_t = wcslen(&raw mut array as *mut wchar_t);
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.macos.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.macos.clang15.snap
@@ -27,10 +27,10 @@ pub static mut static_array_longer: [wchar_t; 3] =
 pub static mut static_array_shorter: [wchar_t; 1] =
     unsafe { ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0") };
 #[unsafe(no_mangle)]
-pub static mut static_ptr: *const wchar_t = unsafe {
-    const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-        .as_ptr() as *const wchar_t
-};
+pub static mut static_ptr: *const wchar_t = const {
+    unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+}
+.as_ptr() as *const wchar_t;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn func() {
     let mut array: [wchar_t; 2] =
@@ -39,8 +39,9 @@ pub unsafe extern "C" fn func() {
         ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0");
     let mut array_shorter: [wchar_t; 1] =
         ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0");
-    let mut ptr: *const wchar_t =
-        const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-            .as_ptr() as *const wchar_t;
+    let mut ptr: *const wchar_t = const {
+        unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+    }
+    .as_ptr() as *const wchar_t;
     let mut len: size_t = wcslen(&raw mut array as *mut wchar_t) as size_t;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.macos.clang22.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@wide_strings.c.2024.macos.clang22.snap
@@ -27,10 +27,10 @@ pub static mut static_array_longer: [wchar_t; 3] =
 pub static mut static_array_shorter: [wchar_t; 1] =
     unsafe { ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0") };
 #[unsafe(no_mangle)]
-pub static mut static_ptr: *const wchar_t = unsafe {
-    const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-        .as_ptr() as *const wchar_t
-};
+pub static mut static_ptr: *const wchar_t = const {
+    unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+}
+.as_ptr() as *const wchar_t;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn func() {
     let mut array: [wchar_t; 2] =
@@ -39,8 +39,9 @@ pub unsafe extern "C" fn func() {
         ::core::mem::transmute::<[u8; 12], [wchar_t; 3]>(*b"x\0\0\0\0\0\0\0\0\0\0\0");
     let mut array_shorter: [wchar_t; 1] =
         ::core::mem::transmute::<[u8; 4], [wchar_t; 1]>(*b"x\0\0\0");
-    let mut ptr: *const wchar_t =
-        const { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
-            .as_ptr() as *const wchar_t;
+    let mut ptr: *const wchar_t = const {
+        unsafe { ::core::mem::transmute::<[u8; 8], [::core::ffi::c_int; 2]>(*b"x\0\0\0\0\0\0\0") }
+    }
+    .as_ptr() as *const wchar_t;
     let mut len: size_t = wcslen(&raw mut array as *mut wchar_t);
 }


### PR DESCRIPTION
An inline `const` block is its own safety context and does not inherit the surrounding `unsafe`, so a string transmute that gets const-promoted (when its address is taken) needs an explicit `unsafe` block inside the `const` block rather than relying on `set_unsafe`.

Surfaced by transpiling libgit2.