### PR TITLE
ci: postprocess: Test on most json-c functions

### DIFF
--- a/.github/workflows/ci-c2rust-postprocess.yml
+++ b/.github/workflows/ci-c2rust-postprocess.yml
@@ -115,7 +115,6 @@ jobs:
           # The value is expanded unquoted by postprocess.gen.sh, so no shell
           # quoting: args must not contain whitespace.
           C2RUST_POSTPROCESS_EXTRA_ARGS: >-
-            --ident-filter ^(json_object_set_userdata|json_object_to_file)$
             --cache-dir ${{ runner.temp }}/llm-cache
         run: |
           export PATH=$PWD/target/release:$PWD/c2rust-postprocess:$HOME/.local/bin:$PATH

--- a/c2rust-postprocess/postprocess/transforms/base.py
+++ b/c2rust-postprocess/postprocess/transforms/base.py
@@ -96,14 +96,14 @@ class AbstractTransform(ABC):
         for identifier, rust_definition in rust_definitions.items():
             if exclude_list.contains(path=rust_source_file, identifier=identifier):
                 logging.info(
-                    f"Skipping Rust fn {identifier} in {rust_source_file}"
+                    f"Skipping Rust fn {identifier} in {rust_source_file} "
                     f"due to exclude file {exclude_list.src_path}"
                 )
                 continue
 
             if ident_regex and not ident_regex.search(identifier):
                 logging.info(
-                    f"Skipping Rust fn {identifier} in {rust_source_file}"
+                    f"Skipping Rust fn {identifier} in {rust_source_file} "
                     f"due to ident filter {ident_filter}"
                 )
                 continue


### PR DESCRIPTION
While working on the test workflow and caching for the postprocessor, we used `--ident-filter` to limit testing to two simple functions. Lift that restriction now that everything seems to be working. Also fixes two log strings in separate commit.

Note: we do not technically test on all json-c functions since some are skipped via `postprocess-exclude.yml`.