### PR TITLE
transpile: Take `CQualTypeId` and return `WithStmts` in enum/pointer cast functions

### DIFF
--- a/c2rust-transpile/src/translator/enums.rs
+++ b/c2rust-transpile/src/translator/enums.rs
@@ -66,12 +66,14 @@ impl<'c> Translation<'c> {
     /// Translate a cast where the source type, but not the target type, is an `enum` type.
     pub fn convert_cast_from_enum(
         &self,
-        target_cty: CTypeId,
-        val: Box<Expr>,
-    ) -> TranslationResult<Box<Expr>> {
+        target_cty: CQualTypeId,
+        mut val: Box<Expr>,
+    ) -> TranslationResult<WithStmts<Box<Expr>>> {
         // Convert it to the expected integral type.
-        let ty = self.convert_type(target_cty)?;
-        Ok(mk().cast_expr(val, ty))
+        let ty = self.convert_type(target_cty.ctype)?;
+        val = mk().cast_expr(val, ty);
+
+        Ok(WithStmts::new_val(val))
     }
 
     /// Translate a cast where the target type is an `enum` type.
@@ -83,11 +85,11 @@ impl<'c> Translation<'c> {
     pub fn convert_cast_to_enum(
         &self,
         ctx: ExprContext,
-        enum_type_id: CTypeId,
+        enum_type_id: CQualTypeId,
         enum_id: CEnumId,
         expr: Option<CExprId>,
-        val: Box<Expr>,
-    ) -> TranslationResult<Box<Expr>> {
+        mut val: Box<Expr>,
+    ) -> TranslationResult<WithStmts<Box<Expr>>> {
         if let Some(expr) = expr {
             match self.ast_context.index_unwrap_parens(expr).kind {
                 // This is the case of finding a variable which is an `EnumConstant` of the same
@@ -102,19 +104,22 @@ impl<'c> Translation<'c> {
                     // If this DeclRef expanded to a const macro, we actually need to insert a cast,
                     // because the translation of a const macro skips implicit casts in its context.
                     if !expr_is_macro {
-                        return Ok(self.enum_constant_expr(enum_constant_id));
+                        val = self.enum_constant_expr(enum_constant_id);
+                        return Ok(WithStmts::new_val(val));
                     }
                 }
 
                 CExprKind::Literal(_, CLiteral::Integer(i, _)) => {
-                    return Ok(self.enum_for_i64(enum_type_id, i as i64));
+                    val = self.enum_for_i64(enum_type_id.ctype, i as i64);
+                    return Ok(WithStmts::new_val(val));
                 }
 
                 CExprKind::Unary(_, CUnOp::Negate, subexpr_id, _) => {
                     if let &CExprKind::Literal(_, CLiteral::Integer(i, _)) =
                         &self.ast_context.index_unwrap_parens(subexpr_id).kind
                     {
-                        return Ok(self.enum_for_i64(enum_type_id, -(i as i64)));
+                        val = self.enum_for_i64(enum_type_id.ctype, -(i as i64));
+                        return Ok(WithStmts::new_val(val));
                     }
                 }
 
@@ -122,8 +127,10 @@ impl<'c> Translation<'c> {
             }
         }
 
-        let target_ty = self.convert_type(enum_type_id)?;
-        Ok(mk().cast_expr(val, target_ty))
+        let target_ty = self.convert_type(enum_type_id.ctype)?;
+        val = mk().cast_expr(val, target_ty);
+
+        Ok(WithStmts::new_val(val))
     }
 
     /// Given an integer value this attempts to either generate the corresponding enum

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3340,7 +3340,7 @@ impl<'c> Translation<'c> {
                     CDeclKind::EnumConstant { .. } => {
                         // If the variable is actually an `EnumConstant`, we need to add a cast to
                         // the expected integral type.
-                        val = self.convert_cast_from_enum(qual_ty.ctype, val)?;
+                        return self.convert_cast_from_enum(qual_ty.ctype, val);
                     }
 
                     CDeclKind::Function { parameters, .. } => {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3340,7 +3340,7 @@ impl<'c> Translation<'c> {
                     CDeclKind::EnumConstant { .. } => {
                         // If the variable is actually an `EnumConstant`, we need to add a cast to
                         // the expected integral type.
-                        return self.convert_cast_from_enum(qual_ty.ctype, val);
+                        return self.convert_cast_from_enum(qual_ty, val);
                     }
 
                     CDeclKind::Function { parameters, .. } => {
@@ -3965,20 +3965,16 @@ impl<'c> Translation<'c> {
 
         match kind {
             CastKind::BitCast | CastKind::NoOp => {
-                self.convert_pointer_to_pointer_cast(source_cty.ctype, target_cty.ctype, val)
+                self.convert_pointer_to_pointer_cast(source_cty, target_cty, val)
             }
 
             CastKind::IntegralToPointer => {
-                self.convert_integral_to_pointer_cast(ctx, source_cty.ctype, target_cty.ctype, val)
+                self.convert_integral_to_pointer_cast(ctx, source_cty, target_cty, val)
             }
 
-            CastKind::PointerToIntegral => self.convert_pointer_to_integral_cast(
-                ctx,
-                source_cty.ctype,
-                target_cty.ctype,
-                val,
-                expr,
-            ),
+            CastKind::PointerToIntegral => {
+                self.convert_pointer_to_integral_cast(ctx, source_cty, target_cty, val, expr)
+            }
 
             CastKind::IntegralCast
             | CastKind::FloatingCast
@@ -4013,16 +4009,15 @@ impl<'c> Translation<'c> {
                 {
                     self.f128_cast_to(val, target_ty_kind)
                 } else if let &CTypeKind::Enum(enum_decl_id) = target_ty_kind {
-                    // Casts targeting `enum` types...
-                    val.try_map(|val| {
-                        self.convert_cast_to_enum(ctx, target_cty.ctype, enum_decl_id, expr, val)
+                    val.and_then_try(|val| {
+                        self.convert_cast_to_enum(ctx, target_cty, enum_decl_id, expr, val)
                     })
                 } else if target_ty_kind.is_floating_type() && source_ty_kind.is_bool() {
                     Ok(val.map(|val| {
                         mk().cast_expr(mk().cast_expr(val, mk().path_ty(vec!["u8"])), target_ty)
                     }))
                 } else if let &CTypeKind::Enum(..) = source_ty_kind {
-                    val.try_map(|val| self.convert_cast_from_enum(target_cty.ctype, val))
+                    val.and_then_try(|val| self.convert_cast_from_enum(target_cty, val))
                 } else {
                     Ok(val.map(|val| mk().cast_expr(val, target_ty)))
                 }

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -479,35 +479,35 @@ impl<'c> Translation<'c> {
 
     pub fn convert_pointer_to_pointer_cast(
         &self,
-        source_cty: CTypeId,
-        target_cty: CTypeId,
+        source_cty: CQualTypeId,
+        target_cty: CQualTypeId,
         val: WithStmts<Box<Expr>>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        if self.ast_context.is_function_pointer(target_cty)
-            || self.ast_context.is_function_pointer(source_cty)
+        if self.ast_context.is_function_pointer(target_cty.ctype)
+            || self.ast_context.is_function_pointer(source_cty.ctype)
         {
             let source_ty = self
                 .type_converter
                 .borrow_mut()
-                .convert(&self.ast_context, source_cty)?;
+                .convert(&self.ast_context, source_cty.ctype)?;
             let target_ty = self
                 .type_converter
                 .borrow_mut()
-                .convert(&self.ast_context, target_cty)?;
+                .convert(&self.ast_context, target_cty.ctype)?;
 
             if source_ty == target_ty {
                 return Ok(val);
             }
 
-            self.import_type(source_cty);
-            self.import_type(target_cty);
+            self.import_type(source_cty.ctype);
+            self.import_type(target_cty.ctype);
 
             Ok(val.and_then(|val| {
                 WithStmts::new_val(transmute_expr(source_ty, target_ty, val)).set_unsafe()
             }))
         } else {
             // Normal case
-            let target_ty = self.convert_type(target_cty)?;
+            let target_ty = self.convert_type(target_cty.ctype)?;
             Ok(val.map(|val| mk().cast_expr(val, target_ty)))
         }
     }
@@ -515,14 +515,14 @@ impl<'c> Translation<'c> {
     pub fn convert_integral_to_pointer_cast(
         &self,
         ctx: ExprContext,
-        source_cty: CTypeId,
-        target_cty: CTypeId,
+        source_cty: CQualTypeId,
+        target_cty: CQualTypeId,
         val: WithStmts<Box<Expr>>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let source_ty_kind = &self.ast_context.resolve_type(source_cty).kind;
-        let target_ty = self.convert_type(target_cty)?;
+        let source_ty_kind = &self.ast_context.resolve_type(source_cty.ctype).kind;
+        let target_ty = self.convert_type(target_cty.ctype)?;
 
-        if self.ast_context.is_function_pointer(target_cty) {
+        if self.ast_context.is_function_pointer(target_cty.ctype) {
             if ctx.is_const {
                 return Err(format_translation_err!(
                     None,
@@ -550,17 +550,18 @@ impl<'c> Translation<'c> {
                     mk().cast_expr(val, target_ty)
                 }))
             } else if let &CTypeKind::Enum(..) = source_ty_kind {
-                val.try_map(|val| self.convert_cast_from_enum(target_cty, val))
+                val.and_then_try(|val| self.convert_cast_from_enum(target_cty, val))
             } else {
                 Ok(val.map(|val| mk().cast_expr(val, target_ty)))
             }
         } else {
             // First cast the value to `usize`.
-            let source_type_kind = &self.ast_context.resolve_type(source_cty).kind;
+            let source_type_kind = &self.ast_context.resolve_type(source_cty.ctype).kind;
             let size_type_id = self.ast_context.type_for_kind(&CTypeKind::Size);
 
             let val = if let &CTypeKind::Enum(..) = source_type_kind {
-                val.try_map(|val| self.convert_cast_from_enum(size_type_id, val))?
+                let size_type_id = CQualTypeId::new(size_type_id);
+                val.and_then_try(|val| self.convert_cast_from_enum(size_type_id, val))?
             } else {
                 let size_type_rs = self.convert_type(size_type_id)?;
                 val.map(|val| mk().cast_expr(val, size_type_rs))
@@ -569,7 +570,7 @@ impl<'c> Translation<'c> {
             // Then convert the `usize` into a pointer.
             let pointee_type_id = self
                 .ast_context
-                .get_pointee_qual_type(target_cty)
+                .get_pointee_qual_type(target_cty.ctype)
                 .expect("target type must be a pointer");
             let mutability = pointee_type_id.mutability();
 
@@ -606,8 +607,8 @@ impl<'c> Translation<'c> {
     pub fn convert_pointer_to_integral_cast(
         &self,
         ctx: ExprContext,
-        source_cty: CTypeId,
-        target_cty: CTypeId,
+        source_cty: CQualTypeId,
+        target_cty: CQualTypeId,
         val: WithStmts<Box<Expr>>,
         expr: Option<CExprId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
@@ -618,10 +619,10 @@ impl<'c> Translation<'c> {
             ));
         }
 
-        let target_type_rs = self.convert_type(target_cty)?;
+        let target_type_rs = self.convert_type(target_cty.ctype)?;
 
-        if self.ast_context.is_function_pointer(source_cty) {
-            let source_ty = self.convert_type(source_cty)?;
+        if self.ast_context.is_function_pointer(source_cty.ctype) {
+            let source_ty = self.convert_type(source_cty.ctype)?;
 
             Ok(val.and_then(|val| {
                 WithStmts::new_val(transmute_expr(source_ty, target_type_rs, val)).set_unsafe()
@@ -643,10 +644,10 @@ impl<'c> Translation<'c> {
             let val = val.map(|val| mk().method_call_expr(val, method_name, vec![]));
 
             // Then cast the `usize` to the target type.
-            let target_ty_kind = &self.ast_context.resolve_type(target_cty).kind;
+            let target_ty_kind = &self.ast_context.resolve_type(target_cty.ctype).kind;
 
             if let &CTypeKind::Enum(enum_decl_id) = target_ty_kind {
-                val.try_map(|val| {
+                val.and_then_try(|val| {
                     self.convert_cast_to_enum(ctx, target_cty, enum_decl_id, expr, val)
                 })
             } else {


### PR DESCRIPTION
Some of the refactorings needed for #1620, split off so that they can be merged earlier.