### PR TITLE
transpile: Move `ctx` modifications down in `convert_cast`

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3644,23 +3644,11 @@ impl<'c> Translation<'c> {
         opt_field_id: Option<CDeclId>,
         is_explicit: bool,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        // A reference must be decayed if a bitcast is required. Const casts in
-        // LLVM 8 are now NoOp casts, so we need to include it as well.
-        match kind {
-            CastKind::IntegralToBoolean
-            | CastKind::FloatingToBoolean
-            | CastKind::PointerToBoolean => {
-                return self.convert_condition(ctx, true, expr);
-            }
-            CastKind::BitCast | CastKind::PointerToIntegral | CastKind::NoOp => {
-                ctx.decay_ref = DecayRef::Yes
-            }
-            CastKind::ArrayToPointerDecay
-            | CastKind::FunctionToPointerDecay
-            | CastKind::BuiltinFnToFnPtr => {
-                ctx.needs_address = true;
-            }
-            _ => {}
+        if matches!(
+            kind,
+            CastKind::IntegralToBoolean | CastKind::FloatingToBoolean | CastKind::PointerToBoolean
+        ) {
+            return self.convert_condition(ctx, true, expr);
         }
 
         let expr_kind = &self.ast_context.index_unwrap_parens(expr).kind;
@@ -3685,6 +3673,20 @@ impl<'c> Translation<'c> {
                     return self.convert_expr(ctx, expr, Some(target_ty));
                 }
             }
+        }
+
+        match kind {
+            // A reference must be decayed if a bitcast is required. Const casts in
+            // LLVM 8 are now NoOp casts, so we need to include it as well.
+            CastKind::BitCast | CastKind::PointerToIntegral | CastKind::NoOp => {
+                ctx.decay_ref = DecayRef::Yes
+            }
+            CastKind::ArrayToPointerDecay
+            | CastKind::FunctionToPointerDecay
+            | CastKind::BuiltinFnToFnPtr => {
+                ctx.needs_address = true;
+            }
+            _ => {}
         }
 
         let mut val = self.convert_expr(ctx, expr, None)?;


### PR DESCRIPTION
If the cast is skipped for literals, then the modifications to `ctx` should not be propagated to `convert_expr`.