### PR TITLE
postprocess: batch rewrites and validate with cargo check

### DIFF
--- a/c2rust-postprocess/postprocess/__init__.py
+++ b/c2rust-postprocess/postprocess/__init__.py
@@ -10,14 +10,15 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from postprocess.cache import DirectoryCache, FrozenCache
-from postprocess.exclude_list import IdentifierExcludeList
+from postprocess.exclude_list import IdentifierExcludeList, format_exclude_entries
 from postprocess.models import api_key_from_env, get_model_by_id
 from postprocess.models.gpt import GPTModel
 from postprocess.models.mock import MockGenerativeModel
 from postprocess.transforms import get_transform_by_id
-from postprocess.transforms.base import TransformError
+from postprocess.transforms.base import TransformError, TransformResult
 from postprocess.transforms.comments import AbstractGenerativeModel
 from postprocess.utils import existing_file
+from postprocess.validate import BaselineError, make_validator
 
 DEFAULT_LLM_MODEL = "gemini-3.5-flash"
 
@@ -201,28 +202,44 @@ def main(argv: Sequence[str] | None = None):
             for transform_id in transform_ids
         ]
 
-        failures = 0
+        # Validate the baseline before applying any rewrites so a broken
+        # crate is never misattributed to them.
+        validator = (
+            make_validator(args.root_rust_source_file) if args.update_rust else None
+        )
+
+        result = TransformResult()
         failure_log_level = (
             logging.WARNING if args.on_error == "warn" else logging.ERROR
         )
         for transform in transforms:
-            failures += transform.apply_dir(
-                root_rust_source_file=args.root_rust_source_file,
-                exclude_list=IdentifierExcludeList(src_path=args.exclude_file),
-                ident_filter=args.ident_filter,
-                update_rust=args.update_rust,
-                keep_going=args.on_error != "abort",
-                failure_log_level=failure_log_level,
+            result.extend(
+                transform.apply_dir(
+                    root_rust_source_file=args.root_rust_source_file,
+                    exclude_list=IdentifierExcludeList(src_path=args.exclude_file),
+                    ident_filter=args.ident_filter,
+                    update_rust=args.update_rust,
+                    keep_going=args.on_error != "abort",
+                    failure_log_level=failure_log_level,
+                    validator=validator,
+                )
             )
 
-        if failures:
+        if result.failed:
+            base_dir = args.exclude_file.parent if args.exclude_file else Path.cwd()
             logging.log(
-                failure_log_level, f"Failed to transform {failures} function(s)"
+                failure_log_level,
+                f"Failed to transform {result.failures} function(s); "
+                "exclude-file entries to skip them:\n"
+                + format_exclude_entries(result.failed, base_dir),
             )
             if args.on_error != "warn":
                 return 1
 
         return 0
+    except BaselineError as error:
+        logging.error(error)
+        return 1
     except TransformError as error:
         logging.exception(f"Aborting at first transform failure: {error}")
         return 1

--- a/c2rust-postprocess/postprocess/cache.py
+++ b/c2rust-postprocess/postprocess/cache.py
@@ -65,6 +65,15 @@ class AbstractCache(ABC):
         """
         pass
 
+    @abstractmethod
+    def invalidate(self, *, transform: str, identifier: str) -> None:
+        """
+        Remove the most recently used entry for `(transform, identifier)`,
+        so a later run can regenerate the response behind a rewrite that
+        failed validation. A no-op if none was used.
+        """
+        pass
+
 
 TomlValue = Union[None, str, int, float, bool, "TomlList", "TomlDict"]
 TomlList = list[TomlValue]
@@ -109,6 +118,7 @@ class DirectoryCache(AbstractCache):
     def __init__(self, path: Path):
         super().__init__(path)
         self._path.mkdir(parents=True, exist_ok=True)
+        self._last_used: dict[tuple[str, str], Path] = {}
 
         logging.debug(f"Using cache directory: {self._path}")
 
@@ -169,6 +179,7 @@ class DirectoryCache(AbstractCache):
         logging.debug(f"Cache hit: {cache_file}:\n{toml}")
         # Mark the entry as recently used for `prune`.
         cache_file.touch()
+        self._last_used[(transform, identifier)] = cache_dir
         data = tomli.loads(toml)
 
         return data["response"]
@@ -199,7 +210,14 @@ class DirectoryCache(AbstractCache):
         response_path = cache_dir / "response.txt"
         metadata_path.write_text(toml)
         response_path.write_text(response)
+        self._last_used[(transform, identifier)] = cache_dir
         logging.debug(f"Cache updated: {cache_dir}:\n{toml}")
+
+    def invalidate(self, *, transform: str, identifier: str) -> None:
+        cache_dir = self._last_used.pop((transform, identifier), None)
+        if cache_dir is not None and cache_dir.exists():
+            shutil.rmtree(cache_dir)
+            logging.debug(f"Cache invalidated: {cache_dir}")
 
     def prune(self, max_age_days: int) -> None:
         """
@@ -252,4 +270,9 @@ class FrozenCache(AbstractCache):
         messages: list[dict[str, Any]],
         response: str,
     ) -> None:
+        pass
+
+    def invalidate(self, *, transform: str, identifier: str) -> None:
+        # A rejected cached response stays; later frozen runs will reject it
+        # again and report it as an unrecoverable cached failure.
         pass

--- a/c2rust-postprocess/postprocess/exclude_list.py
+++ b/c2rust-postprocess/postprocess/exclude_list.py
@@ -1,8 +1,28 @@
+import os
+from collections.abc import Iterable
 from pathlib import Path
 
 import yaml
 
 from postprocess.utils import check_isinstance
+
+
+def format_exclude_entries(
+    entries: Iterable[tuple[Path, str, str]], base_dir: Path
+) -> str:
+    """
+    Render `(path, identifier, reason)` tuples as exclude-file YAML entries,
+    with paths relative to `base_dir` (an exclude file's directory).
+    """
+    grouped: dict[str, list[str]] = {}
+    for path, identifier, reason in entries:
+        rel_path = os.path.relpath(path, base_dir)
+        grouped.setdefault(rel_path, []).append(f"  - {identifier} # {reason}")
+    lines = []
+    for rel_path in sorted(grouped):
+        lines.append(f"{rel_path}:")
+        lines.extend(grouped[rel_path])
+    return "\n".join(lines)
 
 
 class IdentifierExcludeList:

--- a/c2rust-postprocess/postprocess/transforms/base.py
+++ b/c2rust-postprocess/postprocess/transforms/base.py
@@ -1,6 +1,8 @@
 import logging
 import re
 from collections.abc import Callable
+from dataclasses import dataclass, field
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -14,10 +16,28 @@ from postprocess.definitions import (
 from postprocess.exclude_list import IdentifierExcludeList
 from postprocess.models import AbstractGenerativeModel, api_key_from_env
 from postprocess.utils import get_highlighted_c
+from postprocess.validate import BatchValidator, Candidate
 
 
 class TransformError(Exception):
     """A transform failed to process a single definition."""
+
+
+type TransformFailure = tuple[Path, str, str]
+
+
+@dataclass
+class TransformResult:
+    """Summary of applying a transform to one or more Rust definitions."""
+
+    failed: list[TransformFailure] = field(default_factory=list)
+
+    @property
+    def failures(self) -> int:
+        return len(self.failed)
+
+    def extend(self, other: "TransformResult") -> None:
+        self.failed.extend(other.failed)
 
 
 class AbstractTransform:
@@ -75,7 +95,7 @@ class AbstractTransform:
                 new_definition=new_definition,
             )
 
-        logging.info(f"{self.__class__.__name__}: Updated Rust fn {identifier}")
+        logging.info(f"{self.__class__.__name__}: Transformed Rust fn {identifier}")
         return new_definition
 
     def try_apply_ident(
@@ -168,14 +188,15 @@ class AbstractTransform:
         update_rust: bool = True,
         keep_going: bool = False,
         failure_log_level: int = logging.ERROR,
-    ) -> int:
+        validator: BatchValidator | None = None,
+    ) -> TransformResult:
         """
         Run `self.apply_file` on each `*.rs` in `dir`
         with a corresponding `*.c_decls.json`.
 
-        Returns the number of definitions that failed to transform.
+        Returns the failed and cargo-rejected definitions.
         """
-        failures = 0
+        result = TransformResult()
         root_dir = root_rust_source_file.parent
         c_decls_json_suffix = ".c_decls.json"
         for c_decls_path in root_dir.glob(f"**/*{c_decls_json_suffix}"):
@@ -183,15 +204,18 @@ class AbstractTransform:
                 c_decls_path.name.removesuffix(c_decls_json_suffix) + ".rs"
             )
             assert rs_path.exists()
-            failures += self.apply_file(
-                rust_source_file=rs_path,
-                exclude_list=exclude_list,
-                ident_filter=ident_filter,
-                update_rust=update_rust,
-                keep_going=keep_going,
-                failure_log_level=failure_log_level,
+            result.extend(
+                self.apply_file(
+                    rust_source_file=rs_path,
+                    exclude_list=exclude_list,
+                    ident_filter=ident_filter,
+                    update_rust=update_rust,
+                    keep_going=keep_going,
+                    failure_log_level=failure_log_level,
+                    validator=validator,
+                )
             )
-        return failures
+        return result
 
     def apply_file(
         self,
@@ -201,9 +225,10 @@ class AbstractTransform:
         update_rust: bool = True,
         keep_going: bool = False,
         failure_log_level: int = logging.ERROR,
-    ) -> int:
+        validator: BatchValidator | None = None,
+    ) -> TransformResult:
         ident_regex = re.compile(ident_filter) if ident_filter else None
-        failures = 0
+        result = TransformResult()
 
         rust_definitions = get_rust_definitions(rust_source_file)
         c_definitions = get_c_definitions(rust_source_file)
@@ -211,6 +236,9 @@ class AbstractTransform:
         logging.info(f"Loaded {len(rust_definitions)} Rust definitions")
         logging.info(f"Loaded {len(c_definitions)} C definitions")
 
+        # Collect candidates without touching the file; application and
+        # validation happen per batch below.
+        candidates: list[Candidate] = []
         for identifier, rust_definition in rust_definitions.items():
             if exclude_list.contains(path=rust_source_file, identifier=identifier):
                 logging.info(
@@ -238,12 +266,12 @@ class AbstractTransform:
             )
 
             try:
-                self.apply_ident(
+                new_definition = self.apply_ident(
                     rust_source_file=rust_source_file,
                     rust_definition=rust_definition,
                     c_definition=c_definition,
                     identifier=identifier,
-                    update_rust=update_rust,
+                    update_rust=False,
                 )
             except TransformError as error:
                 if not keep_going:
@@ -252,9 +280,62 @@ class AbstractTransform:
                     failure_log_level,
                     f"Transform failed for {identifier} in {rust_source_file}: {error}",
                 )
-                failures += 1
+                result.failed.append(
+                    (rust_source_file, identifier, "failed to transform")
+                )
+                continue
 
-        return failures
+            if new_definition is None:
+                continue
+
+            candidates.append(
+                Candidate(
+                    identifier=identifier,
+                    files=(rust_source_file,),
+                    apply=partial(
+                        update_rust_definition,
+                        root_rust_source_file=rust_source_file,
+                        identifier=identifier,
+                        new_definition=new_definition,
+                    ),
+                    invalidate=partial(
+                        self.cache.invalidate,
+                        transform=self.__class__.__name__,
+                        identifier=identifier,
+                    ),
+                )
+            )
+
+        if not update_rust or not candidates:
+            return result
+
+        if validator is None:
+            for candidate in candidates:
+                candidate.apply()
+            return result
+
+        logging.info(
+            f"Validating {len(candidates)} rewrite(s) in {rust_source_file} "
+            "with cargo check"
+        )
+        _, rejected = validator.validate(candidates)
+        for candidate, error in rejected:
+            candidate.invalidate()
+            result.failed.append(
+                (rust_source_file, candidate.identifier, "rejected by cargo check")
+            )
+            logging.log(
+                failure_log_level,
+                f"cargo check rejected rewrite of {candidate.identifier} "
+                f"in {rust_source_file}:\n{error}",
+            )
+        if rejected and not keep_going:
+            raise TransformError(
+                f"cargo check rejected rewrite of {rejected[0][0].identifier} "
+                f"in {rust_source_file}"
+            )
+
+        return result
 
 
 # TODO: We probably want a an interface that generates validators specialized to

--- a/c2rust-postprocess/postprocess/validate.py
+++ b/c2rust-postprocess/postprocess/validate.py
@@ -1,0 +1,161 @@
+"""Transactional validation of applied rewrites via `cargo check`."""
+
+import json
+import logging
+import subprocess
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """
+    One atomic rewrite: applies itself and declares the files it touches.
+    Bisection splits batches only at candidate boundaries, so a candidate
+    spanning multiple files stays atomic.
+    """
+
+    identifier: str
+    files: tuple[Path, ...]
+    apply: Callable[[], None]
+    invalidate: Callable[[], None]
+
+
+class BatchValidator:
+    """
+    Applies candidate batches, keeping only those that pass `check`.
+    `check` returns None if the current on-disk state is valid,
+    or an error description otherwise.
+
+    Bisection assumes a candidate that fails against the current validated
+    state cannot be repaired by applying another candidate later.
+    """
+
+    def __init__(self, check: Callable[[], str | None]):
+        self._check = check
+
+    def validate(
+        self, candidates: Sequence[Candidate]
+    ) -> tuple[list[Candidate], list[tuple[Candidate, str]]]:
+        """
+        Return `(accepted, rejected)`; rejected candidates are paired with
+        their error. Accepted candidates remain applied, rejected ones are
+        rolled back, so the files are always left in the last state that
+        passed `check`.
+        """
+        if not candidates:
+            return [], []
+
+        snapshots = {
+            path: path.read_bytes()
+            for candidate in candidates
+            for path in candidate.files
+        }
+        ok = False
+        try:
+            for candidate in candidates:
+                candidate.apply()
+            error = self._check()
+            ok = error is None
+        finally:
+            # `finally` rather than `except Exception` so KeyboardInterrupt
+            # also restores the last validated state.
+            if not ok:
+                for path, data in snapshots.items():
+                    path.write_bytes(data)
+
+        if ok:
+            return list(candidates), []
+
+        if len(candidates) == 1:
+            return [], [(candidates[0], error)]
+
+        # Each half is checked against the state left by previously accepted
+        # candidates, so interacting candidates are isolated correctly.
+        logging.info(f"Check failed for batch of {len(candidates)}; bisecting")
+        mid = len(candidates) // 2
+        accepted, rejected = self.validate(candidates[:mid])
+        right_accepted, right_rejected = self.validate(candidates[mid:])
+        return accepted + right_accepted, rejected + right_rejected
+
+
+class CargoChecker:
+    """
+    Checks a crate with `cargo check --release`.
+    """
+
+    def __init__(self, manifest_path: Path):
+        self.manifest_path = manifest_path
+
+    def __call__(self) -> str | None:
+        result = subprocess.run(
+            [
+                "cargo",
+                "check",
+                "--release",
+                "--message-format=json",
+                "--manifest-path",
+                str(self.manifest_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return None
+
+        errors = []
+        for line in result.stdout.splitlines():
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if message.get("reason") != "compiler-message":
+                continue
+            compiler_message = message.get("message") or {}
+            if compiler_message.get("level") == "error":
+                rendered = compiler_message.get("rendered")
+                if rendered:
+                    errors.append(rendered.rstrip("\n"))
+        # No parsed errors means cargo itself failed (e.g. a manifest error).
+        return "\n".join(errors) if errors else result.stderr
+
+
+def find_manifest(rust_source_file: Path) -> Path | None:
+    """Return the nearest Cargo.toml at or above the file's directory."""
+    for directory in rust_source_file.resolve().parents:
+        manifest = directory / "Cargo.toml"
+        if manifest.is_file():
+            return manifest
+    return None
+
+
+class BaselineError(Exception):
+    """The crate failed cargo check before any rewrites were applied."""
+
+
+def make_validator(rust_source_file: Path) -> BatchValidator | None:
+    """
+    Build a validator for the crate containing `rust_source_file`, checking
+    first that the baseline compiles so a broken crate is not misattributed
+    to the rewrites. Returns None when there is no Cargo.toml to check
+    against; raises BaselineError when the baseline does not compile.
+    """
+    manifest_path = find_manifest(rust_source_file)
+    if manifest_path is None:
+        logging.warning(
+            f"No Cargo.toml found above {rust_source_file}; "
+            "applying rewrites without cargo validation"
+        )
+        return None
+
+    check = CargoChecker(manifest_path)
+    logging.info(f"Running baseline cargo check for {manifest_path}...")
+    error = check()
+    if error is not None:
+        raise BaselineError(
+            "Crate does not compile before postprocessing; "
+            f"aborting without applying rewrites:\n{error}"
+        )
+    return BatchValidator(check)

--- a/c2rust-postprocess/tests/test_apply_file.py
+++ b/c2rust-postprocess/tests/test_apply_file.py
@@ -1,0 +1,283 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from test_validate import make_crate, needs_cargo
+
+from postprocess.cache import AbstractCache
+from postprocess.definitions import CDefinition
+from postprocess.exclude_list import IdentifierExcludeList, format_exclude_entries
+from postprocess.models.mock import MockGenerativeModel
+from postprocess.transforms import base
+from postprocess.transforms.base import AbstractTransform, TransformError
+from postprocess.utils import get_tool_path
+from postprocess.validate import BatchValidator, CargoChecker
+
+C_DEFINITION = CDefinition(
+    definition="""\
+/* file prologue */
+
+/* doc for enabled */
+int enabled(void) {
+    return 1; /* one */
+}
+""",
+    preprocessed_definition=None,
+    decl_line=3,
+)
+
+TRIM_RESPONSE = """\
+/* doc for enabled */
+int enabled(void) {
+    return 1; /* one */
+}
+"""
+
+RUST_DEFINITION = """\
+pub unsafe extern "C" fn enabled() -> libc::c_int {
+    return 1 as libc::c_int;
+}
+"""
+
+COMMENTS_RESPONSE = """\
+/// doc for enabled
+pub unsafe extern "C" fn enabled() -> libc::c_int {
+    return 1 as libc::c_int; // one
+}
+"""
+
+
+class CannedCache(AbstractCache):
+    """Canned per-transform responses; records invalidations."""
+
+    def __init__(self, responses: dict[str, str]):
+        super().__init__(Path())
+        self.responses = responses
+        self.invalidations: list[tuple[str, str]] = []
+
+    def lookup(
+        self,
+        *,
+        transform: str,
+        identifier: str,
+        model: str,
+        messages: list[dict[str, Any]],
+    ) -> str | None:
+        return self.responses.get(transform)
+
+    def update(
+        self,
+        *,
+        transform: str,
+        identifier: str,
+        model: str,
+        messages: list[dict[str, Any]],
+        response: str,
+    ) -> None:
+        raise AssertionError("cached response should not be updated")
+
+    def invalidate(self, *, transform: str, identifier: str) -> None:
+        self.invalidations.append((transform, identifier))
+
+
+def make_comments_transform():
+    from postprocess.transforms.comments import CommentsTransform
+
+    cache = CannedCache(
+        {"TrimTransform": TRIM_RESPONSE, "CommentsTransform": COMMENTS_RESPONSE}
+    )
+    return cache, CommentsTransform(cache=cache, model=MockGenerativeModel())
+
+
+@pytest.fixture
+def rust_file(tmp_path: Path) -> Path:
+    path = tmp_path / "lib.rs"
+    path.write_text("original\n")
+    return path
+
+
+@pytest.fixture
+def patched_io(monkeypatch, rust_file: Path) -> None:
+    monkeypatch.setattr(
+        base, "get_rust_definitions", lambda path: {"enabled": RUST_DEFINITION}
+    )
+    monkeypatch.setattr(
+        base, "get_c_definitions", lambda path: {"enabled": C_DEFINITION}
+    )
+
+    def fake_update(*, root_rust_source_file, identifier, new_definition):
+        root_rust_source_file.write_text(new_definition)
+
+    monkeypatch.setattr(base, "update_rust_definition", fake_update)
+
+
+def test_accepted_batch_is_applied(patched_io, rust_file: Path) -> None:
+    cache, transform = make_comments_transform()
+
+    result = transform.apply_file(
+        rust_source_file=rust_file,
+        exclude_list=IdentifierExcludeList(None),
+        keep_going=True,
+        validator=BatchValidator(lambda: None),
+    )
+
+    assert result.failed == []
+    assert "/// doc for enabled" in rust_file.read_text()
+    assert cache.invalidations == []
+
+
+def test_rejection_counts_failure_and_invalidates_final_response(
+    patched_io, rust_file: Path
+) -> None:
+    cache, transform = make_comments_transform()
+
+    result = transform.apply_file(
+        rust_source_file=rust_file,
+        exclude_list=IdentifierExcludeList(None),
+        keep_going=True,
+        validator=BatchValidator(lambda: "type error"),
+    )
+
+    assert result.failed == [(rust_file, "enabled", "rejected by cargo check")]
+    assert rust_file.read_text() == "original\n"
+    # Only the final rewrite's entry is invalidated; the trim helper's
+    # cached C-only result stays valid.
+    assert cache.invalidations == [("CommentsTransform", "enabled")]
+
+
+def test_rejection_raises_without_keep_going(patched_io, rust_file: Path) -> None:
+    cache, transform = make_comments_transform()
+
+    with pytest.raises(TransformError, match="cargo check rejected"):
+        transform.apply_file(
+            rust_source_file=rust_file,
+            exclude_list=IdentifierExcludeList(None),
+            keep_going=False,
+            validator=BatchValidator(lambda: "type error"),
+        )
+
+    assert rust_file.read_text() == "original\n"
+    assert cache.invalidations == [("CommentsTransform", "enabled")]
+
+
+def test_no_update_rust_is_purely_generative(patched_io, rust_file: Path) -> None:
+    cache, transform = make_comments_transform()
+
+    def exploding_check() -> str | None:
+        raise AssertionError("validator must not run")
+
+    result = transform.apply_file(
+        rust_source_file=rust_file,
+        exclude_list=IdentifierExcludeList(None),
+        update_rust=False,
+        keep_going=True,
+        validator=BatchValidator(exploding_check),
+    )
+
+    assert result.failures == 0
+    assert rust_file.read_text() == "original\n"
+
+
+def test_without_validator_candidates_are_applied(patched_io, rust_file: Path) -> None:
+    cache, transform = make_comments_transform()
+
+    result = transform.apply_file(
+        rust_source_file=rust_file,
+        exclude_list=IdentifierExcludeList(None),
+        keep_going=True,
+        validator=None,
+    )
+
+    assert result.failures == 0
+    assert "/// doc for enabled" in rust_file.read_text()
+
+
+def test_format_exclude_entries_groups_by_file(tmp_path: Path) -> None:
+    entries = [
+        (tmp_path / "repo" / "src" / "a.rs", "f", "rejected by cargo check"),
+        (tmp_path / "repo" / "src" / "b.rs", "g", "failed to transform"),
+        (tmp_path / "repo" / "src" / "a.rs", "h", "failed to transform"),
+    ]
+    assert format_exclude_entries(entries, tmp_path) == (
+        "repo/src/a.rs:\n"
+        "  - f # rejected by cargo check\n"
+        "  - h # failed to transform\n"
+        "repo/src/b.rs:\n"
+        "  - g # failed to transform"
+    )
+
+
+class CannedTransform(AbstractTransform):
+    """Returns canned rewrites without calling a model."""
+
+    def __init__(self, rewrites: dict[str, str]):
+        super().__init__("", CannedCache({}), MockGenerativeModel())
+        self.rewrites = rewrites
+
+    def try_apply_ident(
+        self,
+        rust_source_file: Path,
+        rust_definition: str,
+        c_definition: CDefinition,
+        identifier: str,
+    ) -> str | None:
+        return self.rewrites.get(identifier)
+
+
+def split_merge_tools_available() -> bool:
+    try:
+        get_tool_path("split_rust")
+        get_tool_path("merge_rust")
+        return True
+    except (FileNotFoundError, PermissionError):
+        return False
+
+
+@needs_cargo
+def test_end_to_end_type_invalid_rewrite_is_isolated(tmp_path: Path) -> None:
+    """
+    A syntactically valid but type-invalid rewrite is rejected by cargo and
+    rolled back while a neighboring valid rewrite remains applied.
+    """
+    if not split_merge_tools_available():
+        pytest.skip("split_rust/merge_rust binaries not built")
+
+    manifest = make_crate(
+        tmp_path,
+        "pub fn good() -> i32 { 1 }\n\npub fn bad() -> i32 { 2 }\n",
+    )
+    lib_rs = tmp_path / "lib.rs"
+    (tmp_path / "lib.c_decls.json").write_text(
+        json.dumps(
+            {
+                "definitions": {
+                    "good": {"definition": "int good(void) { return 1; }"},
+                    "bad": {"definition": "int bad(void) { return 2; }"},
+                }
+            }
+        )
+    )
+
+    transform = CannedTransform(
+        {
+            "good": "// validated comment\npub fn good() -> i32 { 1 }",
+            "bad": 'pub fn bad() -> i32 { "oops" }',
+        }
+    )
+    checker = CargoChecker(manifest)
+    assert checker() is None  # baseline
+
+    result = transform.apply_file(
+        rust_source_file=lib_rs,
+        exclude_list=IdentifierExcludeList(None),
+        keep_going=True,
+        validator=BatchValidator(checker),
+    )
+
+    content = lib_rs.read_text()
+    assert "// validated comment" in content
+    assert "oops" not in content
+    assert "pub fn bad() -> i32 { 2 }" in content
+    assert result.failed == [(lib_rs, "bad", "rejected by cargo check")]
+    assert checker() is None  # final state still compiles

--- a/c2rust-postprocess/tests/test_cache.py
+++ b/c2rust-postprocess/tests/test_cache.py
@@ -2,7 +2,7 @@ import os
 import time
 from pathlib import Path
 
-from postprocess.cache import DirectoryCache
+from postprocess.cache import AbstractCache, DirectoryCache, FrozenCache
 
 MESSAGES = [{"role": "user", "content": "hello"}]
 
@@ -20,7 +20,7 @@ def add_entry(cache: DirectoryCache, identifier: str) -> Path:
     )
 
 
-def lookup(cache: DirectoryCache, identifier: str) -> str | None:
+def lookup(cache: AbstractCache, identifier: str) -> str | None:
     return cache.lookup(
         transform="CommentTransfer",
         identifier=identifier,
@@ -62,6 +62,45 @@ def test_prune_removes_only_stale_entries(tmp_path: Path) -> None:
     cache.prune(max_age_days=90)
     assert not stale.exists()
     assert fresh.exists()
+
+
+def invalidate(cache: AbstractCache, identifier: str) -> None:
+    cache.invalidate(transform="CommentTransfer", identifier=identifier)
+
+
+def test_invalidate_removes_updated_entry(tmp_path: Path) -> None:
+    cache = DirectoryCache(tmp_path)
+    entry = add_entry(cache, "foo")
+    invalidate(cache, "foo")
+    assert not entry.exists()
+    assert lookup(cache, "foo") is None
+
+
+def test_invalidate_removes_looked_up_entry(tmp_path: Path) -> None:
+    entry = add_entry(DirectoryCache(tmp_path), "foo")
+    # A fresh cache instance has no memory of past use...
+    cache = DirectoryCache(tmp_path)
+    invalidate(cache, "foo")
+    assert entry.exists()
+    # ...until the entry is looked up.
+    lookup(cache, "foo")
+    invalidate(cache, "foo")
+    assert not entry.exists()
+
+
+def test_invalidate_unused_entry_is_noop(tmp_path: Path) -> None:
+    cache = DirectoryCache(tmp_path)
+    invalidate(cache, "absent")
+
+
+def test_frozen_cache_ignores_invalidate(tmp_path: Path) -> None:
+    inner = DirectoryCache(tmp_path)
+    entry = add_entry(inner, "foo")
+    frozen = FrozenCache(inner)
+    assert lookup(frozen, "foo") == "response for foo"
+    invalidate(frozen, "foo")
+    assert entry.exists()
+    assert lookup(frozen, "foo") == "response for foo"
 
 
 def test_lookup_keeps_entry_alive_across_prune(tmp_path: Path) -> None:

--- a/c2rust-postprocess/tests/test_comments_transform.py
+++ b/c2rust-postprocess/tests/test_comments_transform.py
@@ -43,6 +43,9 @@ class StaticCache(AbstractCache):
     ) -> None:
         raise AssertionError("cached response should not be updated")
 
+    def invalidate(self, *, transform: str, identifier: str) -> None:
+        raise AssertionError("no invalidation expected")
+
 
 def test_directive_line_comment_survives_preprocessed_check() -> None:
     c_definition = CDefinition(
@@ -185,6 +188,9 @@ class RecordingCache(AbstractCache):
         response: str,
     ) -> None:
         self.updates.append((messages, response))
+
+    def invalidate(self, *, transform: str, identifier: str) -> None:
+        raise AssertionError("no invalidation expected")
 
 
 class QueuedModel(MockGenerativeModel):

--- a/c2rust-postprocess/tests/test_trim_transform.py
+++ b/c2rust-postprocess/tests/test_trim_transform.py
@@ -103,6 +103,9 @@ class RecordingCache(AbstractCache):
     ) -> None:
         self.updates += 1
 
+    def invalidate(self, *, transform: str, identifier: str) -> None:
+        raise AssertionError("no invalidation expected")
+
 
 def apply_trim(c_definition: CDefinition, cache: AbstractCache) -> str | None:
     transform = TrimTransform(cache=cache, model=MockGenerativeModel())

--- a/c2rust-postprocess/tests/test_validate.py
+++ b/c2rust-postprocess/tests/test_validate.py
@@ -1,0 +1,172 @@
+import shutil
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from postprocess.validate import (
+    BatchValidator,
+    Candidate,
+    CargoChecker,
+    find_manifest,
+)
+
+
+def append_candidate(path: Path, line: str) -> Candidate:
+    def apply() -> None:
+        path.write_text(path.read_text() + line + "\n")
+
+    return Candidate(
+        identifier=line, files=(path,), apply=apply, invalidate=lambda: None
+    )
+
+
+class ContentCheck:
+    """Fails when the bad marker is present in the file."""
+
+    def __init__(self, path: Path, bad: str = "BAD"):
+        self.path = path
+        self.bad = bad
+        self.calls = 0
+
+    def __call__(self) -> str | None:
+        self.calls += 1
+        if self.bad in self.path.read_text():
+            return f"found {self.bad}"
+        return None
+
+
+@pytest.fixture
+def source(tmp_path: Path) -> Path:
+    path = tmp_path / "lib.rs"
+    path.write_text("baseline\n")
+    return path
+
+
+def test_valid_batch_is_retained_with_one_check(source: Path) -> None:
+    check = ContentCheck(source)
+    candidates = [append_candidate(source, "a"), append_candidate(source, "b")]
+
+    accepted, rejected = BatchValidator(check).validate(candidates)
+
+    assert accepted == candidates
+    assert rejected == []
+    assert check.calls == 1
+    assert source.read_text() == "baseline\na\nb\n"
+
+
+def test_mixed_batch_retains_only_valid_candidates(source: Path) -> None:
+    check = ContentCheck(source)
+    candidates = [
+        append_candidate(source, "a"),
+        append_candidate(source, "BAD"),
+        append_candidate(source, "c"),
+        append_candidate(source, "d"),
+    ]
+
+    accepted, rejected = BatchValidator(check).validate(candidates)
+
+    assert [c.identifier for c in accepted] == ["a", "c", "d"]
+    assert [(c.identifier, error) for c, error in rejected] == [("BAD", "found BAD")]
+    assert source.read_text() == "baseline\na\nc\nd\n"
+
+
+def test_single_rejected_candidate_restores_baseline_exactly(source: Path) -> None:
+    accepted, rejected = BatchValidator(ContentCheck(source)).validate(
+        [append_candidate(source, "BAD")]
+    )
+
+    assert accepted == []
+    assert [c.identifier for c, _ in rejected] == ["BAD"]
+    assert source.read_text() == "baseline\n"
+
+
+def test_interacting_candidates_reject_only_one(source: Path) -> None:
+    # x and y are individually fine but invalid together; the retained x
+    # becomes part of the baseline that isolates y.
+    def check() -> str | None:
+        content = source.read_text()
+        if "x" in content and "y" in content:
+            return "x and y conflict"
+        return None
+
+    accepted, rejected = BatchValidator(check).validate(
+        [append_candidate(source, "x"), append_candidate(source, "y")]
+    )
+
+    assert [c.identifier for c in accepted] == ["x"]
+    assert [c.identifier for c, _ in rejected] == ["y"]
+    assert source.read_text() == "baseline\nx\n"
+
+
+def test_check_exception_restores_file(source: Path) -> None:
+    def check() -> str | None:
+        raise RuntimeError("cargo crashed")
+
+    with pytest.raises(RuntimeError, match="cargo crashed"):
+        BatchValidator(check).validate([append_candidate(source, "a")])
+    assert source.read_text() == "baseline\n"
+
+
+def test_apply_exception_restores_file(source: Path) -> None:
+    def broken_apply() -> None:
+        source.write_text("garbage")
+        raise RuntimeError("merge failed")
+
+    candidate = Candidate(
+        identifier="a", files=(source,), apply=broken_apply, invalidate=lambda: None
+    )
+    with pytest.raises(RuntimeError, match="merge failed"):
+        BatchValidator(ContentCheck(source)).validate([candidate])
+    assert source.read_text() == "baseline\n"
+
+
+def test_empty_batch_runs_no_check(source: Path) -> None:
+    check = ContentCheck(source)
+    assert BatchValidator(check).validate([]) == ([], [])
+    assert check.calls == 0
+
+
+def test_find_manifest_returns_nearest(tmp_path: Path) -> None:
+    (tmp_path / "Cargo.toml").write_text("")
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    lib_rs = src_dir / "lib.rs"
+    lib_rs.write_text("")
+    assert find_manifest(lib_rs) == (tmp_path / "Cargo.toml").resolve()
+
+
+needs_cargo = pytest.mark.skipif(
+    shutil.which("cargo") is None, reason="cargo not installed"
+)
+
+
+def make_crate(crate_dir: Path, lib_rs: str) -> Path:
+    (crate_dir / "Cargo.toml").write_text(
+        textwrap.dedent("""\
+            [package]
+            name = "validate-test"
+            version = "0.0.0"
+            edition = "2021"
+
+            [lib]
+            path = "lib.rs"
+        """)
+    )
+    (crate_dir / "lib.rs").write_text(lib_rs)
+    return crate_dir / "Cargo.toml"
+
+
+@needs_cargo
+def test_cargo_checker_passes_valid_crate(tmp_path: Path) -> None:
+    manifest = make_crate(tmp_path, "pub fn f() -> i32 { 1 }\n")
+    assert CargoChecker(manifest)() is None
+
+
+@needs_cargo
+def test_cargo_checker_reports_type_error(tmp_path: Path) -> None:
+    manifest = make_crate(tmp_path, 'pub fn f() -> i32 { "oops" }\n')
+    error = CargoChecker(manifest)()
+    assert error is not None
+    assert "mismatched types" in error
+

--- a/c2rust-postprocess/tests/test_validate.py
+++ b/c2rust-postprocess/tests/test_validate.py
@@ -170,3 +170,13 @@ def test_cargo_checker_reports_type_error(tmp_path: Path) -> None:
     assert error is not None
     assert "mismatched types" in error
 
+
+@needs_cargo
+def test_main_aborts_on_broken_baseline(tmp_path: Path) -> None:
+    from postprocess import main
+
+    lib_rs = 'pub fn f() -> i32 { "oops" }\n'
+    make_crate(tmp_path, lib_rs)
+    exit_code = main([str(tmp_path / "lib.rs"), "--cache-dir", str(tmp_path / "cache")])
+    assert exit_code == 1
+    assert (tmp_path / "lib.rs").read_text() == lib_rs

--- a/tests/integration/tests/python2/conf.yml
+++ b/tests/integration/tests/python2/conf.yml
@@ -44,3 +44,10 @@ refactor:
 cargo.refactor:
   autogen: true
   rustflags: "-C link-args=-Wl,-export-dynamic"
+
+postprocess:
+  autogen: true
+
+cargo.postprocess:
+  autogen: true
+  rustflags: "-C link-args=-Wl,-export-dynamic"


### PR DESCRIPTION
LLM-generated Rust can be syntactically valid while still failing type checking, so the existing lightweight validation is not sufficient. This PR adds `cargo check --release` validation, first checking the crate’s baseline and then batching rewrites so the happy path requires one Cargo check per Rust file.

When a batch fails, the validator bisects the independent rewrite candidates, retains those that compile, rolls back rejected rewrites, and invalidates their cache entries so they can be regenerated later.