### PR TITLE
transpile: recognize `ssize_t` in stdio.h and unistd.h

### DIFF
--- a/c2rust-transpile/src/c_ast/conversion.rs
+++ b/c2rust-transpile/src/c_ast/conversion.rs
@@ -2249,6 +2249,10 @@ impl ConversionContext {
                         if let Some(filename) = path.file_name() {
                             if filename == "stdint.h"
                                 || filename == "types.h"
+                                // glibc also declares `ssize_t` in these headers; whichever
+                                // header a TU includes first provides the typedef.
+                                || ((filename == "stdio.h" || filename == "unistd.h")
+                                    && name == "ssize_t")
                                 || filename
                                     .to_str()
                                     .map(|s| s.starts_with("__stddef_"))

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -632,6 +632,25 @@ fn test_zero_init_typedef_reorg_imports() {
         .run();
 }
 
+#[test]
+#[cfg(target_os = "linux")]
+fn test_ssize_t_from_stdio() {
+    // `ssize_t` must translate to `isize` no matter which system header
+    // declared it in a given translation unit (glibc declares it in
+    // sys/types.h, stdio.h, unistd.h, and others, each guarded so the first
+    // one included wins); otherwise translation units within one crate
+    // disagree about what `ssize_t` is.
+    let c_path = Path::new("tests/snapshots/ssize_t_stdio.c");
+    compile_and_transpile_file(c_path, config(Edition2021));
+
+    let rs_path = c_path.with_extension("rs");
+    let rs = fs::read_to_string(&rs_path).unwrap();
+    assert!(
+        rs.contains("pub type ssize_t = isize;"),
+        "expected `ssize_t` to translate to `isize`, got:\n{rs}"
+    );
+}
+
 // arch-os-specific
 
 #[test]

--- a/c2rust-transpile/tests/snapshots/ssize_t_stdio.c
+++ b/c2rust-transpile/tests/snapshots/ssize_t_stdio.c
@@ -1,0 +1,8 @@
+/* `ssize_t` is declared here only via stdio.h (POSIX.1-2008), not via
+ * sys/types.h. Both declaration sites must map to the same Rust type, or
+ * translation units within one crate disagree about what `ssize_t` is. */
+#include <stdio.h>
+
+ssize_t zero_len(void) {
+    return 0;
+}


### PR DESCRIPTION
glibc may declare `ssize_t` in `stdio.h` or `unistd.h`, depending on header inclusion order. Recognize those declaration sites so all translation units map it consistently to `isize`.

Includes a regression test for the `stdio.h` case.