### PR TITLE
postprocess: reject comment transfers that change code

### DIFF
--- a/c2rust-postprocess/postprocess/transforms/base.py
+++ b/c2rust-postprocess/postprocess/transforms/base.py
@@ -118,11 +118,11 @@ class AbstractTransform:
         self,
         identifier: str,
         messages: list[dict[str, Any]],
-        check: Callable[[str], str],
+        validate: Callable[[str], str],
     ) -> str | None:
         """
-        Model call with caching, validation, and retries. `check` returns the
-        validated result or raises TransformError to trigger regeneration.
+        Model call with caching, validation, and retries. `validate` returns
+        the validated result or raises TransformError to trigger regeneration.
         """
         transform = self.__class__.__name__
         error: TransformError | None = None
@@ -135,7 +135,7 @@ class AbstractTransform:
         )
         if response is not None:
             try:
-                return check(response)
+                return validate(response)
             except TransformError as stale:
                 error = stale
                 logging.warning(
@@ -157,7 +157,7 @@ class AbstractTransform:
                 response = self.model.generate_with_tools(messages)
                 if response is None:
                     raise TransformError(f"model returned no response for {identifier}")
-                result = check(response)
+                result = validate(response)
             except TransformError as rejected:
                 error = rejected
                 logging.warning(

--- a/c2rust-postprocess/postprocess/transforms/comments.py
+++ b/c2rust-postprocess/postprocess/transforms/comments.py
@@ -4,8 +4,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 
+from tree_sitter import Node, Parser
+
 from postprocess.cache import AbstractCache
 from postprocess.definitions import (
+    RUST_LANGUAGE,
     CDefinition,
     demote_misplaced_doc_comments,
     get_c_comments,
@@ -21,6 +24,34 @@ from postprocess.utils import get_highlighted_rust, remove_backticks
 SYSTEM_INSTRUCTION = (
     "You are a helpful assistant that transfers comments from C code to Rust code."
 )
+
+_RUST_COMMENT_NODE_TYPES = {"line_comment", "block_comment"}
+
+
+def _non_comment_rust_tokens(code: str) -> list[tuple[str, str]]:
+    """
+    Return exact Rust leaf tokens, excluding comment subtrees and whitespace.
+
+    Keeping token text as well as tree-sitter node types catches changes to
+    identifiers, literals, and operators while allowing formatting changes.
+    """
+    code_bytes = code.encode()
+    tree = Parser(RUST_LANGUAGE).parse(code_bytes)
+    tokens = []
+
+    def walk(node: Node) -> None:
+        if node.type in _RUST_COMMENT_NODE_TYPES:
+            return
+        if not node.children:
+            tokens.append(
+                (node.type, code_bytes[node.start_byte : node.end_byte].decode())
+            )
+            return
+        for child in node.children:
+            walk(child)
+
+    walk(tree.root_node)
+    return tokens
 
 
 @dataclass(slots=True)
@@ -146,7 +177,7 @@ class CommentsTransform(AbstractTransform):
             {"role": "user", "content": str(prompt)},
         ]
 
-        def check(response: str) -> str:
+        def validate(response: str) -> str:
             rust_fn = remove_backticks(response)
 
             if rust_parse_has_errors(rust_fn):
@@ -164,9 +195,17 @@ class CommentsTransform(AbstractTransform):
                     f"\n{c_comments=}\n{rust_comments=}"
                 )
 
+            if _non_comment_rust_tokens(rust_definition) != _non_comment_rust_tokens(
+                rust_fn
+            ):
+                raise TransformError(
+                    f"non-comment Rust code changed while transferring comments "
+                    f"for {identifier}"
+                )
+
             return rust_fn
 
-        rust_fn = self.generate(identifier, messages, check)
+        rust_fn = self.generate(identifier, messages, validate)
         if rust_fn is None:
             return None
 

--- a/c2rust-postprocess/postprocess/transforms/trim.py
+++ b/c2rust-postprocess/postprocess/transforms/trim.py
@@ -108,7 +108,7 @@ class TrimTransform(AbstractTransform):
             {"role": "user", "content": prompt},
         ]
 
-        def check(response: str) -> str:
+        def validate(response: str) -> str:
             trimmed = remove_backticks(response)
 
             # A correct trim is a trailing slice of its input. This also keeps a
@@ -122,7 +122,7 @@ class TrimTransform(AbstractTransform):
             return trimmed
 
         try:
-            return self.generate(identifier, messages, check)
+            return self.generate(identifier, messages, validate)
         except TransformError as error:
             # Trimming is best-effort; callers fall back to the untrimmed input.
             logging.warning(f"{self.__class__.__name__}: {error}")

--- a/c2rust-postprocess/tests/test_comments_transform.py
+++ b/c2rust-postprocess/tests/test_comments_transform.py
@@ -158,6 +158,50 @@ pub unsafe extern "C" fn f( -> libc::c_int {
         )
 
 
+def test_response_that_changes_non_comment_code_is_rejected() -> None:
+    response = """\
+pub unsafe extern "C" fn f() -> libc::c_int {
+    /// @note a body comment
+}
+"""
+    cache = StaticCache(response)
+    transform = CommentsTransform(cache=cache, model=MockGenerativeModel())
+
+    with pytest.raises(TransformError, match="non-comment Rust code changed"):
+        transform.apply_ident(
+            rust_source_file=Path("unused.rs"),
+            rust_definition=RUST_DEFINITION_NO_COMMENTS,
+            c_definition=C_DEFINITION_BODY_COMMENT,
+            identifier="f",
+            update_rust=False,
+        )
+
+
+def test_response_may_reformat_non_comment_code() -> None:
+    response = """\
+pub unsafe extern "C" fn f(
+) -> libc::c_int
+{
+    /// @note a body comment
+    return 1
+        as libc::c_int;
+}
+"""
+    cache = StaticCache(response)
+    transform = CommentsTransform(cache=cache, model=MockGenerativeModel())
+
+    result = transform.apply_ident(
+        rust_source_file=Path("unused.rs"),
+        rust_definition=RUST_DEFINITION_NO_COMMENTS,
+        c_definition=C_DEFINITION_BODY_COMMENT,
+        identifier="f",
+        update_rust=False,
+    )
+
+    assert result is not None
+    assert "// @note a body comment" in result
+
+
 class RecordingCache(AbstractCache):
     """Cache with a fixed `CommentsTransform` response that records updates."""
 
@@ -211,6 +255,11 @@ pub unsafe extern "C" fn f( -> libc::c_int {
     /// @note a body comment
     return 1 as libc::c_int;
 """
+BAD_CODE_RESPONSE = """\
+pub unsafe extern "C" fn f() -> libc::c_int {
+    /// @note a body comment
+}
+"""
 GOOD_RESPONSE = """\
 pub unsafe extern "C" fn f() -> libc::c_int {
     /// @note a body comment
@@ -258,6 +307,20 @@ def test_invalid_cached_response_is_regenerated(monkeypatch) -> None:
     assert result is not None
     assert model.calls == 1
     # The stale entry is overwritten under the same key.
+    [(messages, response)] = cache.updates
+    assert len(messages) == 1
+    assert response == GOOD_RESPONSE
+
+
+def test_code_changing_cached_response_is_regenerated(monkeypatch) -> None:
+    monkeypatch.setattr(base, "api_key_from_env", lambda model_id: "test-key")
+    cache = RecordingCache(BAD_CODE_RESPONSE)
+    model = QueuedModel([GOOD_RESPONSE])
+
+    result = apply_to_body_comment_fn(cache, model)
+
+    assert result is not None
+    assert model.calls == 1
     [(messages, response)] = cache.updates
     assert len(messages) == 1
     assert response == GOOD_RESPONSE

--- a/tests/integration/tests/lua/postprocess-exclude.yml
+++ b/tests/integration/tests/lua/postprocess-exclude.yml
@@ -6,9 +6,14 @@ repo/src/lua.rs:
 
 repo/src/lstrlib.rs:
   - match_0 # repeated comment-order failures
+  - end_capture # rejected by cargo check
 
 repo/src/ldo.rs:
   - luaD_call # repeated comment-order failures
+  - luaD_shrinkstack # rejected by cargo check
 
 repo/src/lvm.rs:
   - luaV_execute # main interpreter loop; invalid Rust output
+
+repo/src/lmem.rs:
+  - tryagain # rejected by cargo check

--- a/tests/integration/tests/python2/postprocess-exclude.yml
+++ b/tests/integration/tests/python2/postprocess-exclude.yml
@@ -1,0 +1,45 @@
+repo/src/Modules/_sre.rs:
+  - sre_match # failed to transform
+  - sre_umatch # failed to transform
+  - match_copy # rejected by cargo check
+repo/src/Objects/listobject.rs:
+  - gallop_left # failed to transform
+  - gallop_right # failed to transform
+repo/src/Objects/longobject.rs:
+  - long_true_divide # failed to transform
+repo/src/Objects/obmalloc.rs:
+  - PyObject_Malloc # failed to transform
+  - PyObject_Free # rejected by cargo check
+repo/src/Objects/stringobject.rs:
+  - PyString_DecodeEscape # failed to transform
+repo/src/Objects/typeobject.rs:
+  - subtype_dealloc # failed to transform
+  - inherit_slots # rejected by cargo check
+  - super_descr_get # rejected by cargo check
+repo/src/Objects/unicodeobject.rs:
+  - PyUnicodeUCS2_RichCompare # failed to transform
+  - _PyUnicode_New # failed to transform
+  - PyUnicodeUCS2_DecodeUnicodeEscape # failed to transform
+repo/src/Parser/tokenizer.rs:
+  - tok_get # failed to transform
+  - tok_nextc # failed to transform
+repo/src/Python/ast.rs:
+  - ast_for_testlist # rejected by cargo check
+repo/src/Python/ceval.rs:
+  - PyEval_EvalFrameEx # failed to transform
+repo/src/Python/dtoa.rs:
+  - _Py_dg_strtod # failed to transform
+repo/src/Python/errors.rs:
+  - PyErr_NormalizeException # failed to transform
+repo/src/Python/getargs.rs:
+  - convertsimple # failed to transform
+repo/src/Python/peephole.rs:
+  - PyCode_Optimize # failed to transform
+repo/src/Python/pystrtod.rs:
+  - PyOS_double_to_string # failed to transform
+  - ensure_decimal_point # failed to transform
+  - format_float_short # rejected by cargo check
+repo/src/Python/pythonrun.rs:
+  - handle_system_exit # rejected by cargo check
+repo/src/Python/structmember.rs:
+  - PyMember_SetOne # failed to transform


### PR DESCRIPTION
Also adjusts excluded entries for lua and python2