### PR TITLE
tests: integration: curl: add bear config file

### DIFF
--- a/tests/integration/tests/curl/bear.yml
+++ b/tests/integration/tests/curl/bear.yml
@@ -1,0 +1,4 @@
+schema: "4.1"
+duplicates:
+  match_on:
+    - output


### PR DESCRIPTION
bear 4.0 switched to a brand new Rust rewrite which handles duplicates differently.
Add a new `bear.yml` configuration file for the curl test that fixes issues with that test.