### PR TITLE
refactor: allow removable self-import destinations

### DIFF
--- a/c2rust-refactor/src/transform/reorganize_definitions.rs
+++ b/c2rust-refactor/src/transform/reorganize_definitions.rs
@@ -98,6 +98,11 @@ struct ModuleInfo {
 
     /// Set of item idents defined in this module, per namespace
     items: PerNS<HashSet<Ident>>,
+
+    /// Targets of simple imports in this module, per namespace. This lets
+    /// destination selection distinguish a real name conflict from an import
+    /// of the declaration being moved into the module.
+    import_targets: PerNS<HashMap<Ident, DefId>>,
 }
 
 impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
@@ -184,43 +189,82 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
         }
     }
 
-    /// Pick a destination module for a header item
-    fn find_destination_id(&mut self, declaration: &MovedDecl) -> NodeId {
+    /// Pick a destination module for a header item.
+    ///
+    /// `matching_defs` maps duplicate declarations to the definition retained
+    /// in their place, allowing imports and moved declarations to be compared
+    /// through their canonical targets.
+    fn find_destination_id(
+        &mut self,
+        declaration: &MovedDecl,
+        matching_defs: &HashMap<DefId, DefId>,
+    ) -> NodeId {
         if declaration.parent_header.is_std() {
             let mod_info = self.modules.get(&self.stdlib_id).unwrap();
             return mod_info.id;
         }
 
+        let mut declaration_targets: PerNS<Option<DefId>> = PerNS::default();
+        match &declaration.kind {
+            DeclKind::Item(item) if matches!(item.kind, ItemKind::Use(_)) => {
+                for (namespace, resolution) in self.cx.resolved_imports_for_item(item) {
+                    declaration_targets[namespace] = resolution.opt_def_id();
+                }
+            }
+            _ => {
+                for &namespace in &declaration.namespaces {
+                    declaration_targets[namespace] = Some(declaration.def_id);
+                }
+            }
+        }
+        let canonical = |mut def_id: DefId| {
+            while let Some(&next) = matching_defs.get(&def_id) {
+                def_id = next;
+            }
+            def_id
+        };
+
         // Try to find an existing module to put this item in
-        let dest_module =
-            self.modules.values().find(|dest_module_info| {
-                if dest_module_info.has_main {
-                    return false;
-                }
-                // TODO: This is a simple naive heuristic,
-                // and should be improved upon.
-                if !dest_module_info
-                    .headers
-                    .contains(&declaration.parent_header.path)
-                {
-                    return false;
-                }
+        let dest_module = self.modules.values().find(|dest_module_info| {
+            if dest_module_info.has_main {
+                return false;
+            }
+            // TODO: This is a simple naive heuristic,
+            // and should be improved upon.
+            if !dest_module_info
+                .headers
+                .contains(&declaration.parent_header.path)
+            {
+                return false;
+            }
 
-                if declaration.namespaces.iter().any(|&namespace| {
-                    dest_module_info.items[namespace].contains(&declaration.ident())
-                }) {
+            let conflicts = declaration.namespaces.iter().any(|&namespace| {
+                if !dest_module_info.items[namespace].contains(&declaration.ident()) {
                     return false;
                 }
-
-                let header_ident = declaration.parent_header.ident.as_str();
-                let module_ident = dest_module_info.orig_ident.as_str();
-                if header_ident.len() >= module_ident.len() {
-                    let (base, ext) = header_ident.split_at(module_ident.len());
-                    base == &*module_ident && (ext.is_empty() || ext == "_h")
-                } else {
-                    false
+                match (
+                    dest_module_info.import_targets[namespace].get(&declaration.ident()),
+                    declaration_targets[namespace],
+                ) {
+                    (Some(&import_target), Some(declaration_target)) => {
+                        canonical(import_target) != canonical(declaration_target)
+                    }
+                    _ => true,
                 }
             });
+            if conflicts {
+                return false;
+            }
+
+            let header_ident = declaration.parent_header.ident.as_str();
+            let module_ident = dest_module_info.orig_ident.as_str();
+            if header_ident.len() >= module_ident.len() {
+                let (base, ext) = header_ident.split_at(module_ident.len());
+                base == &*module_ident && (ext.is_empty() || ext == "_h")
+            } else {
+                false
+            }
+        });
         let dest_module = match dest_module {
             Some(m) => m,
             None => {
@@ -626,8 +670,13 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
                         } else if let ItemKind::Use(tree) = &item.kind {
                             if matches!(tree.kind, UseTreeKind::Simple(..)) {
                                 let ident = tree.ident();
-                                for (namespace, _) in self.cx.resolved_imports_for_item(item) {
+                                for (namespace, resolution) in
+                                    self.cx.resolved_imports_for_item(item)
+                                {
                                     info.items[namespace].insert(ident);
+                                    if let Some(def_id) = resolution.opt_def_id() {
+                                        info.import_targets[namespace].insert(ident, def_id);
+                                    }
                                 }
                             }
                         } else {
@@ -677,7 +726,7 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
                     item.ident_mut().name = Symbol::intern(&new_name);
                 }
 
-                let dest_module_id = self.find_destination_id(&item);
+                let dest_module_id = self.find_destination_id(&item, &matching_defs);
 
                 let ident = item.ident();
                 let dest_module_info = self.modules.get_mut(&dest_module_id).unwrap();
@@ -704,7 +753,7 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
         // Move unnamed items into module_items
         for item in unnamed_items.into_iter() {
             let ident = item.ident();
-            let parent = self.find_destination_id(&item);
+            let parent = self.find_destination_id(&item, &matching_defs);
 
             let dest_module_info = &self.modules[&parent];
             let mut path_segments = dest_module_info.path.clone();
@@ -1248,6 +1297,7 @@ impl ModuleInfo {
             header_lines: HashMap::new(),
             headers: HashSet::new(),
             items: PerNS::default(),
+            import_targets: PerNS::default(),
         }
     }
 
@@ -1291,6 +1341,7 @@ impl ModuleInfo {
             header_lines,
             headers,
             items: PerNS::default(),
+            import_targets: PerNS::default(),
         }
     }
 }

--- a/c2rust-refactor/tests/snapshots.rs
+++ b/c2rust-refactor/tests/snapshots.rs
@@ -474,6 +474,13 @@ fn test_reorganize_multi_namespace() {
 }
 
 #[test]
+fn test_reorganize_self_import_destination() {
+    refactor("reorganize_definitions")
+        .named("reorganize_self_import_destination.rs")
+        .test();
+}
+
+#[test]
 fn test_reorganize_split_namespace_imports() {
     refactor("reorganize_definitions")
         .named("reorganize_split_namespace_imports.rs")

--- a/c2rust-refactor/tests/snapshots/reorganize_self_import_destination.rs
+++ b/c2rust-refactor/tests/snapshots/reorganize_self_import_destination.rs
@@ -1,0 +1,28 @@
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+pub mod dest {
+    #[c2rust::header_src = "/home/user/some/workspace/dest.h:1"]
+    pub mod dest_h {
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        #[c2rust::src_loc = "2:0"]
+        pub struct item {
+            pub x: i32,
+        }
+    }
+
+    // This import resolves to the declaration above. It must not block that
+    // declaration from moving directly into this module; once moved, the
+    // import is a self-import and must disappear.
+    use self::dest_h::item;
+
+    pub fn get(v: item) -> i32 {
+        v.x
+    }
+}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_forward_decl_with_local_definition.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_forward_decl_with_local_definition.rs.snap
@@ -9,16 +9,14 @@ expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- t
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 
-pub mod repository_h {
+pub mod repository {
+
+    // =============== BEGIN repository_h ================
     #[derive(Copy, Clone)]
     #[repr(C)]
     pub struct git_repository {
         pub attrcache: *mut crate::attrcache::git_attr_cache,
     }
-}
-pub mod repository {
-
-    use crate::repository_h::git_repository;
 }
 
 pub mod attrcache {
@@ -30,13 +28,13 @@ pub mod attrcache {
         use crate::attrcache::git_attr_cache;
 
         pub unsafe extern "C" fn git_repository_attr_cache(
-            repo: *mut crate::repository_h::git_repository,
+            repo: *mut crate::repository::git_repository,
         ) -> *mut git_attr_cache {
             (*repo).attrcache
         }
     }
 
-    use crate::repository_h::git_repository;
+    use crate::repository::git_repository;
 
     #[derive(Copy, Clone)]
     #[repr(C)]
@@ -45,7 +43,7 @@ pub mod attrcache {
     }
 
     unsafe extern "C" fn attrcache_source_function(
-        repo: *mut crate::repository_h::git_repository,
+        repo: *mut crate::repository::git_repository,
     ) -> *mut git_attr_cache {
         repository_h::git_repository_attr_cache(repo)
     }

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_self_import_destination.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_self_import_destination.rs.snap
@@ -1,0 +1,25 @@
+---
+source: c2rust-refactor/tests/snapshots.rs
+expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- tests/snapshots/reorganize_self_import_destination.rs --edition 2021
+---
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+pub mod dest {
+
+    // =============== BEGIN dest_h ================
+    #[derive(Copy, Clone)]
+    #[repr(C)]
+    pub struct item {
+        pub x: i32,
+    }
+
+    pub fn get(v: crate::dest::item) -> i32 {
+        v.x
+    }
+}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions.rs.snap
@@ -22,24 +22,12 @@ pub mod compat_h {
         pub y: libc::c_char,
     }
 }
-pub mod bar_h {
-    use ::libc;
-    // Comment on bar_t
-    #[derive(Copy, Clone)]
-    #[repr(C)]
-
-    pub struct bar_t {
-        //test1
-        pub alloc: *mut libc::c_char,
-        pub data: *mut libc::c_char,
-        pub i: outside,
-    }
-}
 extern crate libc;
 
 type outside = i32;
 
 pub mod bar {
+
     extern "C" {
         pub fn statvfs(path: *const libc::c_char, buf: *mut crate::bar::statvfs) -> libc::c_int;
     }
@@ -47,6 +35,8 @@ pub mod bar {
 
     // Test relative paths
     use crate::outside;
+    //test2
+    use ::libc;
     // Import both the statfs64 type and function declaration from
     // libc exactly as they are defined in that crate. However, since
     // both definitions have a private field, the transform shouldn't
@@ -87,14 +77,21 @@ pub mod bar {
     }
     //test1
     type OtherInt = i32;
+    // Comment on bar_t
+    #[derive(Copy, Clone)]
+    #[repr(C)]
+
+    pub struct bar_t {
+        //test1
+        pub alloc: *mut libc::c_char,
+        pub data: *mut libc::c_char,
+        pub i: outside,
+    }
 
     type FooInt = i32;
-    use libc;
-
-    use crate::bar_h::bar_t;
 
     #[no_mangle]
-    static mut Bar: crate::bar_h::bar_t = crate::bar_h::bar_t {
+    static mut Bar: crate::bar::bar_t = crate::bar::bar_t {
         alloc: 0 as *mut libc::c_char,
         data: 0 as *mut libc::c_char,
         i: 0,
@@ -104,8 +101,8 @@ pub mod bar {
 pub mod foo {
     use libc;
 
+    use crate::bar::bar_t;
     use crate::bar::Bar;
-    use crate::bar_h::bar_t;
     use crate::compat_h::conflicting_1;
 
     // Comment on foo_t
@@ -116,7 +113,7 @@ pub mod foo {
         pub data: *mut libc::c_char,
     }
 
-    unsafe fn foo() -> *const crate::bar_h::bar_t {
+    unsafe fn foo() -> *const crate::bar::bar_t {
         // Use the local definitions.
         let mut buf = unsafe { std::mem::zeroed::<crate::bar::statvfs>() };
         crate::bar::statvfs(core::ptr::null(), &mut buf);
@@ -141,7 +138,7 @@ pub mod foo {
         );
 
         let _c = crate::compat_h::conflicting_1 { y: 10 };
-        &crate::bar::Bar as *const crate::bar_h::bar_t
+        &crate::bar::Bar as *const crate::bar::bar_t
     }
 }
 


### PR DESCRIPTION
An existing same-name import normally prevents a declaration from moving into a destination module. That should not happen when the import resolves to the declaration being moved: path rewriting will turn it into a self-import and remove it.

Track simple-import targets per namespace in `ModuleInfo`, compare them with the moved declaration's canonical target through the transitive `matching_defs` mapping, and apply the exception independently in each namespace. Imports of a different declaration continue to block movement.

Add a regression in which a header declaration moves directly into its destination module and the resulting self-import disappears.