### PR TITLE
refactor: remove unused flamer instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "lazy_static 1.4.0",
+ "lazy_static",
  "lazycell",
  "peeking_take_while",
  "proc-macro2",
@@ -188,7 +188,7 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.10.5",
- "lazy_static 1.4.0",
+ "lazy_static",
  "lazycell",
  "log",
  "prettyplease",
@@ -454,7 +454,6 @@ dependencies = [
  "ena",
  "env_logger 0.10.0",
  "failure",
- "flame",
  "fs-err",
  "indexmap",
  "insta",
@@ -549,7 +548,7 @@ dependencies = [
  "indexmap",
  "itertools 0.10.5",
  "jobserver",
- "lazy_static 1.4.0",
+ "lazy_static",
  "lazycell",
  "libc",
  "libgit2-sys",
@@ -792,7 +791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
 dependencies = [
  "atty",
- "lazy_static 1.4.0",
+ "lazy_static",
  "winapi",
 ]
 
@@ -803,7 +802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
- "lazy_static 1.4.0",
+ "lazy_static",
  "winapi",
 ]
 
@@ -842,7 +841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "windows-sys 0.42.0",
 ]
@@ -1145,7 +1144,7 @@ checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.13",
+ "redox_syscall",
  "winapi",
 ]
 
@@ -1154,19 +1153,6 @@ name = "fixedbitset"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
-
-[[package]]
-name = "flame"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc2706461e1ee94f55cab2ed2e3d34ae9536cfa830358ef80acff1a3dacab30"
-dependencies = [
- "lazy_static 0.2.11",
- "serde",
- "serde_derive",
- "serde_json",
- "thread-id",
-]
 
 [[package]]
 name = "flate2"
@@ -1434,7 +1420,7 @@ checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
 dependencies = [
  "crossbeam-utils",
  "globset",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "memchr",
  "regex",
@@ -1578,12 +1564,6 @@ checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
 dependencies = [
  "static_assertions",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 
 [[package]]
 name = "lazy_static"
@@ -2145,12 +2125,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
@@ -2287,7 +2261,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "windows-sys 0.36.1",
 ]
 
@@ -2386,7 +2360,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -2587,17 +2561,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "thread-id"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
-dependencies = [
- "libc",
- "redox_syscall 0.1.57",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,6 @@ dependencies = [
  "env_logger 0.10.0",
  "failure",
  "flame",
- "flamer",
  "fs-err",
  "indexmap",
  "insta",
@@ -1167,17 +1166,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thread-id",
-]
-
-[[package]]
-name = "flamer"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b732da54fd4ea34452f2431cf464ac7be94ca4b339c9cd3d3d12eb06fe7aab"
-dependencies = [
- "flame",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/c2rust-refactor/Cargo.toml
+++ b/c2rust-refactor/Cargo.toml
@@ -29,7 +29,6 @@ slotmap = {version = "1.0.7", features = ["unstable"]}
 derive_more = "=0.99.17"
 c2rust-macros = { path = "../c2rust-macros", version = "0.22.1" }
 flame = { version = "0.2.2", optional = true }
-flamer = { version = "0.4", optional = true }
 failure = "0.1"
 bincode = "1.0.1"
 petgraph = "0.4"
@@ -51,7 +50,7 @@ itertools = "0.14.0"
 
 [features]
 default = []
-profile = ["flame", "flamer"]
+profile = ["flame"]
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/c2rust-refactor/Cargo.toml
+++ b/c2rust-refactor/Cargo.toml
@@ -28,7 +28,6 @@ rlua = "0.17"
 slotmap = {version = "1.0.7", features = ["unstable"]}
 derive_more = "=0.99.17"
 c2rust-macros = { path = "../c2rust-macros", version = "0.22.1" }
-flame = { version = "0.2.2", optional = true }
 failure = "0.1"
 bincode = "1.0.1"
 petgraph = "0.4"
@@ -50,7 +49,6 @@ itertools = "0.14.0"
 
 [features]
 default = []
-profile = ["flame"]
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/c2rust-refactor/src/ast_manip/remove_paren.rs
+++ b/c2rust-refactor/src/ast_manip/remove_paren.rs
@@ -31,7 +31,6 @@ impl MutVisitor for RemoveParen {
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn remove_paren<T: MutVisit>(x: &mut T) {
     x.visit(&mut RemoveParen)
 }

--- a/c2rust-refactor/src/collapse/mod.rs
+++ b/c2rust-refactor/src/collapse/mod.rs
@@ -43,7 +43,6 @@ pub struct CollapseInfo<'ast> {
 }
 
 impl<'ast> CollapseInfo<'ast> {
-    #[cfg_attr(feature = "profile", flame)]
     pub fn collect(
         unexpanded: &'ast Crate,
         expanded: &'ast Crate,
@@ -69,7 +68,6 @@ impl<'ast> CollapseInfo<'ast> {
         }
     }
 
-    #[cfg_attr(feature = "profile", flame)]
     pub fn collapse(self, node_map: &mut NodeMap, cs: &CommandState) {
         // Collapse macros + update node_map.  The cfg_attr step requires the updated node_map
         // TODO: we should be able to skip some of these steps if `!cmd_state.krate_changed()`

--- a/c2rust-refactor/src/command.rs
+++ b/c2rust-refactor/src/command.rs
@@ -168,7 +168,6 @@ pub struct RefactorState {
     tcx_gen: TyCtxtGeneration,
 }
 
-// #[cfg_attr(feature = "profile", flame)]
 // fn parse_crate(queries: &interface::Compiler) -> Crate {
 //     let mut krate = queries.parse().unwrap().take();
 //     remove_paren(&mut krate);
@@ -180,7 +179,6 @@ pub const FRESH_NODE_ID_START: u32 = 0x8000_0000;
 
 impl DiskState {
     /// Initialization shared between new() and load_crate()
-    #[cfg_attr(feature = "profile", flame)]
     fn new(
         krate: Crate,
         source_map: &SourceMap,
@@ -207,7 +205,6 @@ impl DiskState {
 }
 
 impl RefactorState {
-    #[cfg_attr(feature = "profile", flame)]
     pub fn new(
         config: interface::Config,
         cmd_reg: Registry,
@@ -252,7 +249,6 @@ impl RefactorState {
 
     /// Load the crate from disk.  This also resets a bunch of internal state, since we won't be
     /// rewriting with the previous `orig_crate` any more.
-    #[cfg_attr(feature = "profile", flame)]
     pub fn load_crate(&mut self) {
         self.compiler = driver::make_compiler(&self.config, self.file_io.clone());
         self.disk_state = None;
@@ -268,7 +264,6 @@ impl RefactorState {
     /// Note that we allow multiple calls to `save_crate` with no intervening `load_crate`.  The
     /// later `save_crate`s will simply keep using the original source text (even if it no longer
     /// matches the text on disk) as the basis for rewriting.
-    #[cfg_attr(feature = "profile", flame)]
     pub fn save_crate(&mut self) {
         if let None = self.krate {
             return;
@@ -298,7 +293,6 @@ impl RefactorState {
         files::rewrite_files_with(self.source_map(), &rw, &*self.file_io).unwrap();
     }
 
-    #[cfg_attr(feature = "profile", flame)]
     pub fn transform_crate<F, R>(&mut self, phase: Phase, f: F) -> interface::Result<R>
     where
         F: FnOnce(&CommandState, &RefactorCtxt) -> R,
@@ -513,7 +507,6 @@ impl RefactorState {
         })
     }
 
-    #[cfg_attr(feature = "profile", flame)]
     fn rebuild_session(&mut self) {
         // // Ensure we've take the expansion result if we're in phase 2 or 3 since
         // // we need later queries to rebuild it.
@@ -574,7 +567,6 @@ impl RefactorState {
         *Lrc::get_mut(&mut compiler.codegen_backend).unwrap() = new_codegen_backend;
     }
 
-    #[cfg_attr(feature = "profile", flame)]
     pub fn run_typeck_loop<F>(&mut self, mut func: F) -> Result<(), &'static str>
     where
         F: FnMut(&mut Crate, &CommandState, &RefactorCtxt) -> TypeckLoopResult,
@@ -604,7 +596,6 @@ impl RefactorState {
     }
 
     /// Invoke a registered command with the given command name and arguments.
-    #[cfg_attr(feature = "profile", flame)]
     pub fn run<S: AsRef<str>>(&mut self, cmd_name: &str, args: &[S]) -> Result<(), String> {
         let args = args
             .iter()

--- a/c2rust-refactor/src/command.rs
+++ b/c2rust-refactor/src/command.rs
@@ -39,7 +39,6 @@ use crate::rewrite;
 use crate::rewrite::files;
 use crate::span_fix;
 use crate::RefactorCtxt;
-use crate::{profile_end, profile_start};
 
 fn update_dollar_crate_names(tcx: TyCtxt<'_>) {
     hygiene::update_dollar_crate_names(|ctxt: SyntaxContext| {
@@ -311,7 +310,6 @@ impl RefactorState {
 
         self.compiler.enter(|queries| {
             // Replace current parse query results
-            profile_start!("Replace compiler crate");
             let mut parse = queries.parse()?;
 
             // Initialize initial parsed crate if not previously parsed
@@ -362,21 +360,18 @@ impl RefactorState {
 
             *parse.get_mut() = cs.krate().clone();
             drop(parse);
-            profile_end!("Replace compiler crate");
 
             let mut max_crate_node_id = None;
             match phase {
                 Phase::Phase1 => {}
 
                 Phase::Phase2 | Phase::Phase3 => {
-                    profile_start!("Expand crate");
                     let (expanded, next_node_id) = queries.global_ctxt()?.enter(|tcx| {
                         let resolver = tcx.resolver_for_lowering(()).borrow();
                         (resolver.1.as_ref().clone(), resolver.0.next_node_id)
                     });
                     cs.krate.replace(expanded);
                     max_crate_node_id = Some(next_node_id);
-                    profile_end!("Expand crate");
                     remove_paren(cs.krate.get_mut());
                 }
             }
@@ -402,7 +397,6 @@ impl RefactorState {
                     }
 
                     Phase::Phase2 => {
-                        profile_start!("Lower to HIR");
                         let r = queries.global_ctxt()?.enter(|tcx| {
                             let (
                                 partial_res_map,
@@ -429,7 +423,6 @@ impl RefactorState {
                                 GenerationalTyCtxt(tcx, tcx_gen.clone()),
                                 AstSpanMaps::new(&expanded),
                             );
-                            profile_end!("Lower to HIR");
 
                             let result = f(&cs, &cx);
                             // rustc's hygiene tables outlive each rebuilt session. Resolve any
@@ -443,7 +436,6 @@ impl RefactorState {
                     }
 
                     Phase::Phase3 => {
-                        profile_start!("Compiler Phase 3");
                         let r = queries.global_ctxt()?.enter(|tcx| {
                             let (
                                 partial_res_map,
@@ -472,7 +464,6 @@ impl RefactorState {
                                 GenerationalTyCtxt(tcx, tcx_gen.clone()),
                                 AstSpanMaps::new(&expanded),
                             );
-                            profile_end!("Compiler Phase 3");
 
                             let result = f(&cs, &cx);
                             // See the Phase 2 path above.
@@ -616,9 +607,7 @@ impl RefactorState {
             }
             e
         })?;
-        profile_start!(format!("Command {}", cmd_name));
         cmd.run(self);
-        profile_end!(format!("Command {}", cmd_name));
         Ok(())
     }
 

--- a/c2rust-refactor/src/driver.rs
+++ b/c2rust-refactor/src/driver.rs
@@ -175,7 +175,6 @@ pub fn create_config(args: &[String]) -> interface::Config {
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn run_compiler<F, R>(
     mut config: interface::Config,
     file_loader: Option<Box<dyn FileLoader + Send + Sync>>,
@@ -193,7 +192,6 @@ where
     interface::run_compiler(config, f)
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn run_refactoring<F, R>(
     mut config: interface::Config,
     cmd_reg: Registry,
@@ -282,7 +280,6 @@ pub fn emit_and_panic(mut db: DiagnosticBuilder<ErrorGuaranteed>, what: &str) ->
 }
 
 // Helper functions for parsing source code in an existing `Session`.
-#[cfg_attr(feature = "profile", flame)]
 pub fn parse_expr(sess: &Session, src: &str) -> P<Expr> {
     let mut p = make_parser(sess, src);
     match p.parse_expr() {
@@ -294,7 +291,6 @@ pub fn parse_expr(sess: &Session, src: &str) -> P<Expr> {
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn parse_pat(sess: &Session, src: &str) -> P<Pat> {
     let mut p = make_parser(sess, src);
     // TODO: do we want to allow top-level or-patterns here?
@@ -307,7 +303,6 @@ pub fn parse_pat(sess: &Session, src: &str) -> P<Pat> {
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn parse_ty(sess: &Session, src: &str) -> P<Ty> {
     let mut p = make_parser(sess, src);
     match p.parse_ty() {
@@ -319,7 +314,6 @@ pub fn parse_ty(sess: &Session, src: &str) -> P<Ty> {
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn parse_stmts(sess: &Session, src: &str) -> Vec<Stmt> {
     let mut p = make_parser(sess, src);
     let mut stmts = Vec::new();
@@ -336,7 +330,6 @@ pub fn parse_stmts(sess: &Session, src: &str) -> Vec<Stmt> {
     stmts
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn parse_items(sess: &Session, src: &str) -> Vec<P<Item>> {
     let mut p = make_parser(sess, src);
     let mut items = Vec::new();
@@ -353,7 +346,6 @@ pub fn parse_items(sess: &Session, src: &str) -> Vec<P<Item>> {
     items
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn parse_impl_items(sess: &Session, src: &str) -> Vec<P<AssocItem>> {
     // TODO: rustc no longer exposes `parse_impl_item_`. `parse_item` is a hacky
     // workaround that may cause suboptimal error messages.
@@ -367,7 +359,6 @@ pub fn parse_impl_items(sess: &Session, src: &str) -> Vec<P<AssocItem>> {
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn parse_foreign_items(sess: &Session, src: &str) -> Vec<P<ForeignItem>> {
     // TODO: rustc no longer exposes a method for parsing ForeignItems. `parse_item` is a hacky
     // workaround that may cause suboptimal error messages.
@@ -381,7 +372,6 @@ pub fn parse_foreign_items(sess: &Session, src: &str) -> Vec<P<ForeignItem>> {
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn parse_block(sess: &Session, src: &str) -> P<Block> {
     let mut p = make_parser(sess, src);
 
@@ -422,7 +412,6 @@ fn parse_arg_inner<'a>(p: &mut Parser<'a>) -> PResult<'a, Param> {
     })
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn parse_arg(sess: &Session, src: &str) -> Param {
     let mut p = make_parser(sess, src);
     match parse_arg_inner(&mut p) {
@@ -434,7 +423,6 @@ pub fn parse_arg(sess: &Session, src: &str) -> Param {
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn run_parser<F, R>(sess: &Session, src: &str, f: F) -> R
 where
     F: for<'a> FnOnce(&mut Parser<'a>) -> PResult<'a, R>,
@@ -446,7 +434,6 @@ where
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn run_parser_tts<F, R>(sess: &Session, tts: Vec<TokenTree>, f: F) -> R
 where
     F: for<'a> FnOnce(&mut Parser<'a>) -> PResult<'a, R>,
@@ -462,7 +449,6 @@ where
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn try_run_parser<F, R>(sess: &Session, src: &str, f: F) -> Option<R>
 where
     F: for<'a> FnOnce(&mut Parser<'a>) -> PResult<'a, R>,
@@ -477,7 +463,6 @@ where
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn try_run_parser_tts<F, R>(sess: &Session, tts: Vec<TokenTree>, f: F) -> Option<R>
 where
     F: for<'a> FnOnce(&mut Parser<'a>) -> PResult<'a, R>,

--- a/c2rust-refactor/src/lib.rs
+++ b/c2rust-refactor/src/lib.rs
@@ -14,10 +14,6 @@
     never_type
 )]
 
-#[cfg(feature = "profile")]
-#[macro_use]
-extern crate flamer;
-
 extern crate rustc_arena;
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
@@ -548,15 +544,5 @@ fn main_impl(opts: Options) -> interface::Result<()> {
         }
     }
 
-    dump_profile();
-
     Ok(())
 }
-
-#[cfg(feature = "profile")]
-fn dump_profile() {
-    flame::dump_html(&mut std::fs::File::create("flame-graph.html").unwrap()).unwrap();
-}
-
-#[cfg(not(feature = "profile"))]
-fn dump_profile() {}

--- a/c2rust-refactor/src/lib.rs
+++ b/c2rust-refactor/src/lib.rs
@@ -13,7 +13,6 @@
     let_chains,
     never_type
 )]
-#![cfg_attr(feature = "profile", feature(proc_macro_hygiene))]
 
 #[cfg(feature = "profile")]
 #[macro_use]
@@ -188,7 +187,6 @@ pub struct Options {
 
 /// Try to find the rustup installation that provides the rustc at the given path.  The input path
 /// should be normalized already.
-#[cfg_attr(feature = "profile", flame)]
 fn get_rustup_path(rustc: &Path) -> Option<PathBuf> {
     use std::ffi::OsStr;
     use std::fs;
@@ -211,7 +209,6 @@ fn get_rustup_path(rustc: &Path) -> Option<PathBuf> {
     None
 }
 
-#[cfg_attr(feature = "profile", flame)]
 fn get_rustc_executable(path: &Path) -> String {
     use std::process::{Command, Stdio};
 
@@ -232,7 +229,6 @@ fn get_rustc_executable(path: &Path) -> String {
     resolved.to_str().unwrap().to_owned()
 }
 
-#[cfg_attr(feature = "profile", flame)]
 fn get_rustc_arg_strings(src: RustcArgSource) -> Vec<RustcArgs> {
     match src {
         RustcArgSource::CmdLine(mut args) => {
@@ -282,7 +278,6 @@ fn setup_cargo<'cfg>(config: &'cfg Config) -> (CompileOptions, Workspace<'cfg>) 
     (compile_opts, ws)
 }
 
-#[cfg_attr(feature = "profile", flame)]
 fn get_rustc_cargo_args(target_type: CargoTarget) -> Vec<RustcArgs> {
     let config = cargo_config();
     let (compile_opts, ws) = setup_cargo(&config);
@@ -432,7 +427,6 @@ fn init() {
 
 static INIT: Once = Once::new();
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn lib_main(opts: Options) -> interface::Result<()> {
     INIT.call_once(init);
     rustc_driver::catch_fatal_errors(move || main_impl(opts)).and_then(|x| x)

--- a/c2rust-refactor/src/macros.rs
+++ b/c2rust-refactor/src/macros.rs
@@ -46,31 +46,3 @@ macro_rules! matches {
         }
     };
 }
-
-#[macro_export]
-#[cfg(feature = "profile")]
-macro_rules! profile_start {
-    ($msg:expr) => {
-        flame::start($msg)
-    };
-}
-
-#[macro_export]
-#[cfg(not(feature = "profile"))]
-macro_rules! profile_start {
-    ($msg:expr) => {};
-}
-
-#[macro_export]
-#[cfg(feature = "profile")]
-macro_rules! profile_end {
-    ($msg:expr) => {
-        flame::end($msg)
-    };
-}
-
-#[macro_export]
-#[cfg(not(feature = "profile"))]
-macro_rules! profile_end {
-    ($msg:expr) => {};
-}

--- a/c2rust-refactor/src/span_fix.rs
+++ b/c2rust-refactor/src/span_fix.rs
@@ -180,7 +180,6 @@ impl MutVisitor for FixAttrs {
     }
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn fix_format<T: MutVisit>(node: &mut T) {
     let mut fix_format = FixFormat {
         ctxt: FormatCtxt::new(DUMMY_SP),
@@ -188,7 +187,6 @@ pub fn fix_format<T: MutVisit>(node: &mut T) {
     node.visit(&mut fix_format)
 }
 
-#[cfg_attr(feature = "profile", flame)]
 pub fn fix_attr_spans<T: MutVisit>(node: &mut T) {
     node.visit(&mut FixAttrs)
 }


### PR DESCRIPTION
Remove the broken `flamer` attribute instrumentation and dependency while retaining manual `flame` profiling.