### PR TITLE
refactor: reorganize_definitions: keep glob imports untouched

### DIFF
--- a/c2rust-refactor/src/transform/reorganize_definitions.rs
+++ b/c2rust-refactor/src/transform/reorganize_definitions.rs
@@ -331,7 +331,11 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
             // This assume the complex uses have been split apart already
             for item in &items[..] {
                 if let ItemKind::Use(tree) = &item.kind {
-                    if used_idents.contains(&tree.ident()) {
+                    // Glob imports have no single ident to merge on and
+                    // moving them could change what they bind, so always
+                    // keep them in the header.
+                    if matches!(tree.kind, UseTreeKind::Glob) || used_idents.contains(&tree.ident())
+                    {
                         keep_items.insert(item.id);
                         continue;
                     }
@@ -1773,6 +1777,10 @@ impl<'a, 'tcx> HeaderDeclarations<'a, 'tcx> {
                 }
                 true
             }
+
+            // Glob imports have no single ident to merge on; keep them in
+            // the header module untouched.
+            ItemKind::Use(tree) if matches!(tree.kind, UseTreeKind::Glob) => false,
 
             // Keep function definitions, if any
             ItemKind::Fn(..) => false,

--- a/c2rust-refactor/tests/snapshots.rs
+++ b/c2rust-refactor/tests/snapshots.rs
@@ -470,6 +470,16 @@ fn test_reorganize_foreign_types() {
         .test();
 }
 
+/// A glob import inside a header module used to panic in
+/// `UseTree::ident()`; it must instead be kept in the header module.
+#[should_panic]
+#[test]
+fn test_reorganize_glob_import() {
+    refactor("reorganize_definitions")
+        .named("reorganize_glob_import.rs")
+        .test();
+}
+
 #[test]
 fn test_reorganize_identical_data_enums() {
     refactor("reorganize_definitions")

--- a/c2rust-refactor/tests/snapshots.rs
+++ b/c2rust-refactor/tests/snapshots.rs
@@ -472,7 +472,6 @@ fn test_reorganize_foreign_types() {
 
 /// A glob import inside a header module used to panic in
 /// `UseTree::ident()`; it must instead be kept in the header module.
-#[should_panic]
 #[test]
 fn test_reorganize_glob_import() {
     refactor("reorganize_definitions")

--- a/c2rust-refactor/tests/snapshots/reorganize_glob_import.rs
+++ b/c2rust-refactor/tests/snapshots/reorganize_glob_import.rs
@@ -1,0 +1,39 @@
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+pub mod defs {
+    #[derive(Copy, Clone)]
+    pub struct thing {
+        pub x: i32,
+    }
+
+    pub const LIMIT: i32 = 10;
+}
+
+pub mod user {
+    #[c2rust::header_src = "/home/user/some/workspace/user.h:1"]
+    pub mod user_h {
+        // A glob import in a header module. It has no single ident to merge
+        // on, so `reorganize_definitions` must keep it in the header instead
+        // of trying to move it (or panicking). Note that items moved out of
+        // this header cannot rely on the glob's bindings: bare paths that
+        // resolve through it are not canonicalized on the way out.
+        pub use crate::defs::*;
+
+        #[c2rust::src_loc = "3:0"]
+        #[derive(Copy, Clone)]
+        pub struct config {
+            pub t: crate::defs::thing,
+        }
+    }
+    use self::user_h::config;
+
+    pub fn go(c: config) -> i32 {
+        c.t.x + crate::defs::LIMIT
+    }
+}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_glob_import.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_glob_import.rs.snap
@@ -1,0 +1,41 @@
+---
+source: c2rust-refactor/tests/snapshots.rs
+expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- tests/snapshots/reorganize_glob_import.rs --edition 2021
+---
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+pub mod defs {
+    #[derive(Copy, Clone)]
+    pub struct thing {
+        pub x: i32,
+    }
+
+    pub const LIMIT: i32 = 10;
+}
+
+pub mod user {
+
+    // =============== BEGIN user_h ================
+    #[derive(Copy, Clone)]
+    pub struct config {
+        pub t: crate::defs::thing,
+    }
+    pub mod user_h {
+        // A glob import in a header module. It has no single ident to merge
+        // on, so `reorganize_definitions` must keep it in the header instead
+        // of trying to move it (or panicking). Note that items moved out of
+        // this header cannot rely on the glob's bindings: bare paths that
+        // resolve through it are not canonicalized on the way out.
+        pub use crate::defs::*;
+    }
+
+    pub fn go(c: crate::user::config) -> i32 {
+        c.t.x + crate::defs::LIMIT
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>