### PR TITLE
refactor: fix foreign declarations merged across an arity mismatch

### DIFF
--- a/c2rust-refactor/src/context.rs
+++ b/c2rust-refactor/src/context.rs
@@ -1378,6 +1378,16 @@ impl<'a, 'tcx, 'b> TypeCompare<'a, 'tcx, 'b> {
     /// Compare two function declarations for equivalent argument and return types,
     /// ignoring argument names.
     pub fn compatible_fn_prototypes(&self, decl1: &FnDecl, decl2: &FnDecl) -> bool {
+        // `zip` below stops at the shorter parameter list, so the lengths have
+        // to be compared separately. Otherwise a declaration is compatible
+        // with any other one that merely extends it, which is exactly the
+        // shape an unprototyped `int f()` and a prototyped `int f(int)` take
+        // after translation. A trailing `...` is a `CVarArgs` parameter, so
+        // this covers a variadic/non-variadic mismatch too.
+        if decl1.inputs.len() != decl2.inputs.len() {
+            return false;
+        }
+
         let mut args = decl1.inputs.iter().zip(decl2.inputs.iter());
         if !args.all(|(arg1, arg2)| self.structural_eq_ast_tys(&arg1.ty, &arg2.ty, true)) {
             return false;

--- a/c2rust-refactor/tests/snapshots.rs
+++ b/c2rust-refactor/tests/snapshots.rs
@@ -469,7 +469,6 @@ fn test_reorganize_bitfield_ty() {
 fn test_reorganize_foreign_fn_arity() {
     refactor("reorganize_definitions")
         .named("reorganize_foreign_fn_arity.rs")
-        .new_expect_compile_error(true)
         .test();
 }
 

--- a/c2rust-refactor/tests/snapshots.rs
+++ b/c2rust-refactor/tests/snapshots.rs
@@ -463,6 +463,16 @@ fn test_reorganize_bitfield_ty() {
         .test();
 }
 
+/// Two foreign declarations of the same function that differ in the number
+/// of parameters are not interchangeable and must not be merged.
+#[test]
+fn test_reorganize_foreign_fn_arity() {
+    refactor("reorganize_definitions")
+        .named("reorganize_foreign_fn_arity.rs")
+        .new_expect_compile_error(true)
+        .test();
+}
+
 /// A foreign item, `static` or `fn`, that is renamed to avoid a collision must
 /// keep naming the symbol it linked against before the rename.
 #[test]

--- a/c2rust-refactor/tests/snapshots/reorganize_foreign_fn_arity.rs
+++ b/c2rust-refactor/tests/snapshots/reorganize_foreign_fn_arity.rs
@@ -1,0 +1,56 @@
+#![feature(rustc_private)]
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
+extern crate libc;
+
+// The same header declares `takes_args` with a different number of
+// parameters in each translation unit, which is what a K&R-style `int f()`
+// declaration in one unit and a prototyped `int f(int, int)` in another
+// turn into. The two declarations are not interchangeable and must not be
+// merged into one.
+
+pub mod a {
+    use libc;
+
+    #[c2rust::header_src = "/home/user/some/workspace/decl.h:1"]
+    pub mod decl_h {
+        use super::libc;
+
+        extern "C" {
+            #[c2rust::src_loc = "2:0"]
+            pub fn takes_args(x: libc::c_int) -> libc::c_int;
+        }
+    }
+
+    use decl_h::takes_args;
+
+    pub unsafe fn call_one() -> libc::c_int {
+        takes_args(1)
+    }
+}
+
+pub mod b {
+    use libc;
+
+    #[c2rust::header_src = "/home/user/some/workspace/decl.h:1"]
+    pub mod decl_h {
+        use super::libc;
+
+        extern "C" {
+            #[c2rust::src_loc = "2:0"]
+            pub fn takes_args(x: libc::c_int, y: libc::c_int) -> libc::c_int;
+        }
+    }
+
+    use decl_h::takes_args;
+
+    pub unsafe fn call_two() -> libc::c_int {
+        takes_args(1, 2)
+    }
+}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_fn_arity.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_fn_arity.rs.snap
@@ -1,0 +1,46 @@
+---
+source: c2rust-refactor/tests/snapshots.rs
+expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- tests/snapshots/reorganize_foreign_fn_arity.rs --edition 2021
+---
+#![feature(rustc_private)]
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
+pub mod decl_h {
+    extern "C" {
+        pub fn takes_args(x: libc::c_int) -> libc::c_int;
+    }
+    use ::libc;
+}
+extern crate libc;
+
+// The same header declares `takes_args` with a different number of
+// parameters in each translation unit, which is what a K&R-style `int f()`
+// declaration in one unit and a prototyped `int f(int, int)` in another
+// turn into. The two declarations are not interchangeable and must not be
+// merged into one.
+
+pub mod a {
+    use libc;
+
+    use crate::decl_h::takes_args;
+
+    pub unsafe fn call_one() -> libc::c_int {
+        crate::decl_h::takes_args(1)
+    }
+}
+
+pub mod b {
+    use libc;
+
+    use crate::decl_h::takes_args;
+
+    pub unsafe fn call_two() -> libc::c_int {
+        crate::decl_h::takes_args(1, 2)
+    }
+}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_fn_arity.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_fn_arity.rs.snap
@@ -12,6 +12,9 @@ expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- t
 pub mod decl_h {
     extern "C" {
         pub fn takes_args(x: libc::c_int) -> libc::c_int;
+
+        #[link_name = "takes_args"]
+        pub fn takes_args_1(x: libc::c_int, y: libc::c_int) -> libc::c_int;
     }
     use ::libc;
 }
@@ -36,10 +39,10 @@ pub mod a {
 pub mod b {
     use libc;
 
-    use crate::decl_h::takes_args;
+    use crate::decl_h::takes_args_1;
 
     pub unsafe fn call_two() -> libc::c_int {
-        crate::decl_h::takes_args(1, 2)
+        crate::decl_h::takes_args_1(1, 2)
     }
 }
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>