### PR TITLE
refactor: keep the original symbol when renaming an extern declaration

### DIFF
--- a/c2rust-refactor/src/transform/reorganize_definitions.rs
+++ b/c2rust-refactor/src/transform/reorganize_definitions.rs
@@ -18,7 +18,7 @@ use rustc_hir::{self as hir, Node};
 use rustc_middle::metadata::ModChild;
 use rustc_middle::ty::{self, ParamEnv};
 use rustc_span::symbol::{kw, Ident};
-use rustc_span::{BytePos, Symbol, DUMMY_SP};
+use rustc_span::{sym, BytePos, Symbol, DUMMY_SP};
 use rustc_target::spec::abi::{self, Abi};
 use smallvec::smallvec;
 use thin_vec::ThinVec;
@@ -755,6 +755,7 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
                     let old_name = ident.name.as_str();
                     let new_name = format!("{old_name}_{idx}");
                     warn!("Renaming identifier {old_name} to {new_name} due to collision");
+                    item.preserve_link_name(ident);
                     item.ident_mut().name = Symbol::intern(&new_name);
                 }
 
@@ -1596,6 +1597,30 @@ impl MovedDecl {
         }
     }
 
+    /// Pin down the symbol an `extern` declaration links against, before its
+    /// ident is changed to resolve a collision. A foreign function or static
+    /// links against its own name unless a `#[link_name]` says otherwise, so
+    /// renaming one silently repoints it at a symbol that does not exist.
+    fn preserve_link_name(&mut self, orig: Ident) {
+        let item = match &mut self.kind {
+            DeclKind::ForeignItem(item, _) => item,
+            // A regular item is mangled under its own path, so renaming it
+            // does not change what it exports.
+            DeclKind::Item(_) => return,
+        };
+        // An `extern type` has no symbol of its own to preserve.
+        if !matches!(
+            item.kind,
+            ForeignItemKind::Fn(..) | ForeignItemKind::Static(..)
+        ) {
+            return;
+        }
+        if item.attrs.iter().any(|attr| attr.has_name(sym::link_name)) {
+            return;
+        }
+        item.attrs.push(mk_link_name_attr(orig.name));
+    }
+
     fn ident_mut(&mut self) -> &mut Ident {
         match &mut self.kind {
             DeclKind::ForeignItem(item, _) => &mut item.ident,
@@ -2262,6 +2287,26 @@ fn is_nested(tree: &UseTree) -> bool {
         true
     } else {
         false
+    }
+}
+
+/// Build a `#[link_name = "<symbol>"]` attribute.
+fn mk_link_name_attr(symbol: Symbol) -> Attribute {
+    Attribute {
+        id: AttrId::from_u32(0),
+        style: AttrStyle::Outer,
+        kind: AttrKind::Normal(P(NormalAttr {
+            item: AttrItem {
+                path: mk().path(vec![sym::link_name]),
+                args: AttrArgs::Eq(
+                    DUMMY_SP,
+                    AttrArgsEq::Ast(mk().lit_expr(mk().str_lit(symbol).as_token_lit())),
+                ),
+                tokens: None,
+            },
+            tokens: None,
+        })),
+        span: DUMMY_SP,
     }
 }
 

--- a/c2rust-refactor/tests/snapshots.rs
+++ b/c2rust-refactor/tests/snapshots.rs
@@ -463,6 +463,24 @@ fn test_reorganize_bitfield_ty() {
         .test();
 }
 
+/// An `extern` function that is renamed to avoid a collision must keep
+/// naming the symbol it linked against before the rename.
+#[test]
+fn test_reorganize_foreign_fn_rename() {
+    refactor("reorganize_definitions")
+        .named("reorganize_foreign_fn_rename.rs")
+        .test();
+}
+
+/// An `extern` static that is renamed to avoid a collision must keep
+/// naming the symbol it linked against before the rename.
+#[test]
+fn test_reorganize_foreign_static_rename() {
+    refactor("reorganize_definitions")
+        .named("reorganize_foreign_static_rename.rs")
+        .test();
+}
+
 #[test]
 fn test_reorganize_foreign_types() {
     refactor("reorganize_definitions")

--- a/c2rust-refactor/tests/snapshots/reorganize_foreign_fn_rename.rs
+++ b/c2rust-refactor/tests/snapshots/reorganize_foreign_fn_rename.rs
@@ -1,0 +1,55 @@
+#![feature(rustc_private)]
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
+extern crate libc;
+
+// Two translation units declare the same C function with incompatible
+// signatures, so the two declarations cannot be collapsed into one and the
+// second is renamed to avoid the collision. An `extern` function links
+// against its own name, so the renamed declaration has to keep naming the
+// original symbol.
+
+pub mod a {
+    use libc;
+
+    #[c2rust::header_src = "/home/user/some/workspace/decl.h:1"]
+    pub mod decl_h {
+        use super::libc;
+
+        extern "C" {
+            #[c2rust::src_loc = "2:0"]
+            pub fn compute(x: libc::c_int) -> libc::c_int;
+        }
+    }
+
+    use decl_h::compute;
+
+    pub unsafe fn call() -> libc::c_int {
+        compute(1)
+    }
+}
+
+pub mod b {
+    use libc;
+
+    #[c2rust::header_src = "/home/user/some/workspace/decl.h:1"]
+    pub mod decl_h {
+        use super::libc;
+
+        extern "C" {
+            #[c2rust::src_loc = "2:0"]
+            pub fn compute(x: libc::c_double) -> libc::c_double;
+        }
+    }
+
+    use decl_h::compute;
+
+    pub unsafe fn call() -> libc::c_double {
+        compute(1.0)
+    }
+}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/reorganize_foreign_static_rename.rs
+++ b/c2rust-refactor/tests/snapshots/reorganize_foreign_static_rename.rs
@@ -1,0 +1,69 @@
+#![feature(rustc_private)]
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
+extern crate libc;
+
+// Two translation units declare the same C global with incompatible types,
+// so the two declarations cannot be collapsed into one and the second is
+// renamed to avoid the collision. An `extern` static links against its own
+// name, so the renamed declaration has to keep naming the original symbol.
+
+pub mod a {
+    use libc;
+
+    #[c2rust::header_src = "/home/user/some/workspace/cfg.h:1"]
+    pub mod cfg_h {
+        use super::libc;
+
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        #[c2rust::src_loc = "2:0"]
+        pub struct a_t {
+            pub x: libc::c_int,
+        }
+
+        extern "C" {
+            #[c2rust::src_loc = "3:0"]
+            pub static mut cfg: a_t;
+        }
+    }
+
+    use cfg_h::cfg;
+
+    pub unsafe fn get() -> libc::c_int {
+        cfg.x
+    }
+}
+
+pub mod b {
+    use libc;
+
+    #[c2rust::header_src = "/home/user/some/workspace/cfg.h:1"]
+    pub mod cfg_h {
+        use super::libc;
+
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        #[c2rust::src_loc = "2:0"]
+        pub struct b_t {
+            pub y: libc::c_double,
+        }
+
+        extern "C" {
+            #[c2rust::src_loc = "3:0"]
+            pub static mut cfg: b_t;
+        }
+    }
+
+    use cfg_h::cfg;
+
+    pub unsafe fn get() -> libc::c_double {
+        cfg.y
+    }
+}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_fn_rename.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_fn_rename.rs.snap
@@ -12,6 +12,7 @@ pub mod decl_h {
     extern "C" {
         pub fn compute(x: libc::c_int) -> libc::c_int;
 
+        #[link_name = "compute"]
         pub fn compute_1(x: libc::c_double) -> libc::c_double;
     }
     use ::libc;

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_fn_rename.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_fn_rename.rs.snap
@@ -1,0 +1,47 @@
+---
+source: c2rust-refactor/tests/snapshots.rs
+expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- tests/snapshots/reorganize_foreign_fn_rename.rs --edition 2021
+---
+#![feature(rustc_private)]
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
+pub mod decl_h {
+    extern "C" {
+        pub fn compute(x: libc::c_int) -> libc::c_int;
+
+        pub fn compute_1(x: libc::c_double) -> libc::c_double;
+    }
+    use ::libc;
+}
+extern crate libc;
+
+// Two translation units declare the same C function with incompatible
+// signatures, so the two declarations cannot be collapsed into one and the
+// second is renamed to avoid the collision. An `extern` function links
+// against its own name, so the renamed declaration has to keep naming the
+// original symbol.
+
+pub mod a {
+    use libc;
+
+    use crate::decl_h::compute;
+
+    pub unsafe fn call() -> libc::c_int {
+        crate::decl_h::compute(1)
+    }
+}
+
+pub mod b {
+    use libc;
+
+    use crate::decl_h::compute_1;
+
+    pub unsafe fn call() -> libc::c_double {
+        crate::decl_h::compute_1(1.0)
+    }
+}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_static_rename.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_static_rename.rs.snap
@@ -1,0 +1,61 @@
+---
+source: c2rust-refactor/tests/snapshots.rs
+expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- tests/snapshots/reorganize_foreign_static_rename.rs --edition 2021
+---
+#![feature(rustc_private)]
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
+pub mod cfg_h {
+    extern "C" {
+        pub static mut cfg: crate::cfg_h::a_t;
+
+        pub static mut cfg_1: crate::cfg_h::b_t;
+    }
+    use ::libc;
+
+    #[derive(Copy, Clone)]
+    #[repr(C)]
+
+    pub struct a_t {
+        pub x: libc::c_int,
+    }
+
+    #[derive(Copy, Clone)]
+    #[repr(C)]
+
+    pub struct b_t {
+        pub y: libc::c_double,
+    }
+}
+extern crate libc;
+
+// Two translation units declare the same C global with incompatible types,
+// so the two declarations cannot be collapsed into one and the second is
+// renamed to avoid the collision. An `extern` static links against its own
+// name, so the renamed declaration has to keep naming the original symbol.
+
+pub mod a {
+    use libc;
+
+    use crate::cfg_h::cfg;
+
+    pub unsafe fn get() -> libc::c_int {
+        crate::cfg_h::cfg.x
+    }
+}
+
+pub mod b {
+    use libc;
+
+    use crate::cfg_h::cfg_1;
+
+    pub unsafe fn get() -> libc::c_double {
+        crate::cfg_h::cfg_1.y
+    }
+}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_static_rename.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_static_rename.rs.snap
@@ -13,6 +13,7 @@ pub mod cfg_h {
     extern "C" {
         pub static mut cfg: crate::cfg_h::a_t;
 
+        #[link_name = "cfg"]
         pub static mut cfg_1: crate::cfg_h::b_t;
     }
     use ::libc;


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>