### PR TITLE
refactor: keep the original symbol when renaming an extern declaration


### DIFF
--- a/c2rust-refactor/src/transform/reorganize_definitions.rs
+++ b/c2rust-refactor/src/transform/reorganize_definitions.rs
@@ -18,7 +18,7 @@ use rustc_hir::{self as hir, Node};
 use rustc_middle::metadata::ModChild;
 use rustc_middle::ty::{self, ParamEnv};
 use rustc_span::symbol::{kw, Ident};
-use rustc_span::{BytePos, Symbol, DUMMY_SP};
+use rustc_span::{sym, BytePos, Symbol, DUMMY_SP};
 use rustc_target::spec::abi::{self, Abi};
 use smallvec::smallvec;
 use thin_vec::ThinVec;
@@ -752,7 +752,7 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
                     // multiple items with the same name in a namespace.
                     let old_name = ident.name.as_str();
                     let new_name = format!("{old_name}_{idx}");
-                    warn!("Renaming identifier {old_name} to {new_name} due to collision");
+                    item.preserve_link_name(ident);
                     item.ident_mut().name = Symbol::intern(&new_name);
                 }
 
@@ -1590,6 +1590,40 @@ impl MovedDecl {
                 }
             }
         }
+    }
+
+    fn preserve_link_name(&mut self, orig: Ident) {
+        let item = match &mut self.kind {
+            DeclKind::ForeignItem(item, _) => item,
+            // A regular item is mangled under its own path, so renaming it
+            // does not change what it exports.
+            DeclKind::Item(_) => return,
+        };
+        // An `extern type` has no symbol of its own to preserve.
+        if !matches!(
+            item.kind,
+            ForeignItemKind::Fn(..) | ForeignItemKind::Static(..)
+        ) {
+            warn!(
+                "`#[link_name]` attribute not needed on renamed foreign item {}",
+                orig,
+            );
+            return;
+        }
+        if item.attrs.iter().any(|attr| attr.has_name(sym::link_name)) {
+            warn!(
+                "`#[link_name]` attribute already exists on renamed item {}, keeping the existing one",
+                orig,
+            );
+            return;
+        }
+        item.attrs
+            .extend(mk().str_attr(vec![sym::link_name], orig.name).into_attrs());
+
+        warn!(
+            "`#[link_name]` attribute added to preserve link name on renamed item {}",
+            orig,
+        );
     }
 
     fn ident_mut(&mut self) -> &mut Ident {

--- a/c2rust-refactor/tests/snapshots.rs
+++ b/c2rust-refactor/tests/snapshots.rs
@@ -463,6 +463,15 @@ fn test_reorganize_bitfield_ty() {
         .test();
 }
 
+/// A foreign item, `static` or `fn`, that is renamed to avoid a collision must
+/// keep naming the symbol it linked against before the rename.
+#[test]
+fn test_reorganize_foreign_item_rename() {
+    refactor("reorganize_definitions")
+        .named("reorganize_foreign_item_rename.rs")
+        .test();
+}
+
 #[test]
 fn test_reorganize_foreign_types() {
     refactor("reorganize_definitions")

--- a/c2rust-refactor/tests/snapshots/reorganize_foreign_item_rename.rs
+++ b/c2rust-refactor/tests/snapshots/reorganize_foreign_item_rename.rs
@@ -1,0 +1,99 @@
+#![allow(clippy::missing_safety_doc)]
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_assignments)]
+#![allow(unused_mut)]
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+
+// Transpiled from two translation units that include the same header with
+// different `-D` flags:
+//
+//     /* foreign.h */
+//     #ifdef FOREIGN_ALT
+//     typedef int cfg_int;
+//     extern cfg_int cfg;
+//     int compute(int (*p)[4]);
+//     #else
+//     extern int cfg;
+//     int compute(int (*p)[]);
+//     #endif
+//
+//     /* a.c, compiled without `-DFOREIGN_ALT` */
+//     #include "foreign.h"
+//
+//     int a_use(int (*p)[4]) {
+//         return cfg + compute(p);
+//     }
+//
+//     /* b.c, compiled with `-DFOREIGN_ALT` */
+//     #include "foreign.h"
+//
+//     int b_use(int (*p)[4]) {
+//         return cfg + compute(p);
+//     }
+//
+// The C is strictly conforming. `cfg_int` is an alias for `int`, not a distinct
+// type, so both declarations of `cfg` give it the same type. The two `compute`
+// signatures are compatible as well: an array type of unknown size is
+// compatible with any array type of the same element type (C11 6.7.6.2p6), and
+// pointers are compatible when their pointees are, so `int (*)[]` matches
+// `int (*)[4]`. Every declaration of `cfg` and of `compute` therefore satisfies
+// C11 6.2.7p2 ("All declarations that refer to the same object or function
+// shall have compatible type").
+//
+// Both declarations of each item come from the same header, so they land in the
+// same header module. Neither pair can be collapsed there. The two `cfg`
+// declarations spell the same type differently, one through the alias, so they
+// are not syntactically identical. C's incomplete array type has no Rust
+// equivalent and is transpiled as a zero-length array, so the two `compute`
+// declarations are not interchangeable either. The second of each pair is
+// therefore renamed to clear the collision. Since an `extern` static or
+// function links against its own name, the renamed declarations have to keep
+// naming the original symbols.
+//
+// The two pairs survive for different reasons: the transform compares statics
+// syntactically, which the alias defeats, but resolves types for functions,
+// which collapses the alias and leaves the array sizes to keep the pair apart.
+
+pub mod a {
+    #[c2rust::header_src = "/home/user/some/workspace/foreign.h:1"]
+    pub mod foreign_h {
+        extern "C" {
+            #[c2rust::src_loc = "6:1"]
+            pub static mut cfg: ::core::ffi::c_int;
+            #[c2rust::src_loc = "7:1"]
+            pub fn compute(p: *mut [::core::ffi::c_int; 0]) -> ::core::ffi::c_int;
+        }
+    }
+    use self::foreign_h::{cfg, compute};
+    #[no_mangle]
+    #[c2rust::src_loc = "3:1"]
+    pub unsafe extern "C" fn a_use(mut p: *mut [::core::ffi::c_int; 4]) -> ::core::ffi::c_int {
+        return cfg + compute(p as *mut [::core::ffi::c_int; 0]);
+    }
+}
+
+pub mod b {
+    #[c2rust::header_src = "/home/user/some/workspace/foreign.h:1"]
+    pub mod foreign_h {
+        #[c2rust::src_loc = "2:1"]
+        pub type cfg_int = ::core::ffi::c_int;
+        extern "C" {
+            #[c2rust::src_loc = "3:1"]
+            pub static mut cfg: cfg_int;
+            #[c2rust::src_loc = "4:1"]
+            pub fn compute(p: *mut [::core::ffi::c_int; 4]) -> ::core::ffi::c_int;
+        }
+    }
+    pub use self::foreign_h::{cfg, cfg_int, compute};
+    #[no_mangle]
+    #[c2rust::src_loc = "3:1"]
+    pub unsafe extern "C" fn b_use(mut p: *mut [::core::ffi::c_int; 4]) -> ::core::ffi::c_int {
+        return cfg as ::core::ffi::c_int + compute(p);
+    }
+}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_item_rename.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_item_rename.rs.snap
@@ -1,0 +1,101 @@
+---
+source: c2rust-refactor/tests/snapshots.rs
+expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- tests/snapshots/reorganize_foreign_item_rename.rs --edition 2021
+---
+#![allow(clippy::missing_safety_doc)]
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(unused_assignments)]
+#![allow(unused_mut)]
+#![feature(register_tool)]
+#![register_tool(c2rust)]
+
+// Transpiled from two translation units that include the same header with
+// different `-D` flags:
+//
+//     /* foreign.h */
+//     #ifdef FOREIGN_ALT
+//     typedef int cfg_int;
+//     extern cfg_int cfg;
+//     int compute(int (*p)[4]);
+//     #else
+//     extern int cfg;
+//     int compute(int (*p)[]);
+//     #endif
+//
+//     /* a.c, compiled without `-DFOREIGN_ALT` */
+//     #include "foreign.h"
+//
+//     int a_use(int (*p)[4]) {
+//         return cfg + compute(p);
+//     }
+//
+//     /* b.c, compiled with `-DFOREIGN_ALT` */
+//     #include "foreign.h"
+//
+//     int b_use(int (*p)[4]) {
+//         return cfg + compute(p);
+//     }
+//
+// The C is strictly conforming. `cfg_int` is an alias for `int`, not a distinct
+// type, so both declarations of `cfg` give it the same type. The two `compute`
+// signatures are compatible as well: an array type of unknown size is
+// compatible with any array type of the same element type (C11 6.7.6.2p6), and
+// pointers are compatible when their pointees are, so `int (*)[]` matches
+// `int (*)[4]`. Every declaration of `cfg` and of `compute` therefore satisfies
+// C11 6.2.7p2 ("All declarations that refer to the same object or function
+// shall have compatible type").
+//
+// Both declarations of each item come from the same header, so they land in the
+// same header module. Neither pair can be collapsed there. The two `cfg`
+// declarations spell the same type differently, one through the alias, so they
+// are not syntactically identical. C's incomplete array type has no Rust
+// equivalent and is transpiled as a zero-length array, so the two `compute`
+// declarations are not interchangeable either. The second of each pair is
+// therefore renamed to clear the collision. Since an `extern` static or
+// function links against its own name, the renamed declarations have to keep
+// naming the original symbols.
+//
+// The two pairs survive for different reasons: the transform compares statics
+// syntactically, which the alias defeats, but resolves types for functions,
+// which collapses the alias and leaves the array sizes to keep the pair apart.
+
+pub mod foreign_h {
+    extern "C" {
+        pub static mut cfg_1: crate::foreign_h::cfg_int;
+
+        pub fn compute_1(p: *mut [::core::ffi::c_int; 4]) -> ::core::ffi::c_int;
+
+        pub static mut cfg: ::core::ffi::c_int;
+
+        pub fn compute(p: *mut [::core::ffi::c_int; 0]) -> ::core::ffi::c_int;
+    }
+    pub type cfg_int = ::core::ffi::c_int;
+}
+pub mod a {
+
+    use crate::foreign_h::cfg;
+    use crate::foreign_h::compute;
+    #[no_mangle]
+
+    pub unsafe extern "C" fn a_use(mut p: *mut [::core::ffi::c_int; 4]) -> ::core::ffi::c_int {
+        return crate::foreign_h::cfg
+            + crate::foreign_h::compute(p as *mut [::core::ffi::c_int; 0]);
+    }
+}
+
+pub mod b {
+
+    pub use crate::foreign_h::cfg_1;
+    pub use crate::foreign_h::cfg_int;
+    pub use crate::foreign_h::compute_1;
+    #[no_mangle]
+
+    pub unsafe extern "C" fn b_use(mut p: *mut [::core::ffi::c_int; 4]) -> ::core::ffi::c_int {
+        return crate::foreign_h::cfg_1 as ::core::ffi::c_int + crate::foreign_h::compute_1(p);
+    }
+}
+
+fn main() {}

--- a/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_item_rename.rs.snap
+++ b/c2rust-refactor/tests/snapshots/snapshots__refactor-reorganize_definitions-reorganize_foreign_item_rename.rs.snap
@@ -64,8 +64,10 @@ expression: c2rust-refactor reorganize_definitions --rewrite-mode alongside -- t
 
 pub mod foreign_h {
     extern "C" {
+        #[link_name = "cfg"]
         pub static mut cfg_1: crate::foreign_h::cfg_int;
 
+        #[link_name = "compute"]
         pub fn compute_1(p: *mut [::core::ffi::c_int; 4]) -> ::core::ffi::c_int;
 
         pub static mut cfg: ::core::ffi::c_int;


### PR DESCRIPTION
Fresh copy of #1935 since I closed that one.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>