### PR TITLE
transpile: Use a single global `Renamer` with namespacing

### DIFF
--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -34,7 +34,7 @@ impl TypeConverter {
         TypeConverter {
             edition: tcfg.edition,
             translate_valist: tcfg.translate_valist,
-            renamer: Renamer::type_namespace(),
+            renamer: Renamer::keywords_and_prelude(),
             fields: HashMap::new(),
             suffix_names: HashMap::new(),
             features: HashSet::new(),
@@ -92,7 +92,7 @@ impl TypeConverter {
 
         self.fields
             .entry(record_id)
-            .or_insert_with(|| Renamer::keywords())
+            .or_insert_with(Renamer::keywords)
             .insert(FieldKey::Field(field_id), name, Namespaces::values())
             .expect("Field already declared")
     }
@@ -101,7 +101,7 @@ impl TypeConverter {
         let field = self
             .fields
             .entry(record_id)
-            .or_insert_with(|| Renamer::keywords());
+            .or_insert_with(Renamer::keywords);
         let key = FieldKey::Padding(padding_idx);
         if let Some(name) = field.get(&key) {
             name

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -56,7 +56,7 @@ impl TypeConverter {
 
     pub fn declare_decl_name(&mut self, decl_id: CDeclId, name: &str) -> String {
         self.renamer
-            .insert(decl_id, name)
+            .insert(decl_id, name, Namespaces::types())
             .expect("Name already assigned")
     }
 
@@ -73,7 +73,8 @@ impl TypeConverter {
         self.suffix_names.entry(key).or_insert_with(|| {
             let name = self.renamer.get(&decl_id);
             let name = name.as_deref().unwrap_or("Unnamed");
-            self.renamer.pick_name(&format!("C2Rust_{name}_{suffix}"))
+            self.renamer
+                .pick_name(&format!("C2Rust_{name}_{suffix}"), Namespaces::types())
         })
     }
 
@@ -92,7 +93,7 @@ impl TypeConverter {
         self.fields
             .entry(record_id)
             .or_insert_with(|| Renamer::keywords())
-            .insert(FieldKey::Field(field_id), name)
+            .insert(FieldKey::Field(field_id), name, Namespaces::values())
             .expect("Field already declared")
     }
 
@@ -105,7 +106,9 @@ impl TypeConverter {
         if let Some(name) = field.get(&key) {
             name
         } else {
-            field.insert(key, "c2rust_padding").unwrap()
+            field
+                .insert(key, "c2rust_padding", Namespaces::values())
+                .unwrap()
         }
     }
 

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -9,8 +9,10 @@ use c2rust_ast_builder::mk;
 use c2rust_rust_tools::RustEdition;
 use failure::format_err;
 use indexmap::IndexSet;
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::ops::Index;
+use std::rc::Rc;
 use syn::*;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
@@ -22,7 +24,7 @@ enum FieldKey {
 pub struct TypeConverter {
     pub edition: RustEdition,
     pub translate_valist: bool,
-    renamer: Renamer<CDeclId>,
+    renamer: Rc<RefCell<Renamer<CDeclId>>>,
     fields: HashMap<CDeclId, Renamer<FieldKey>>,
     suffix_names: HashMap<(CDeclId, &'static str), String>,
     features: HashSet<&'static str>,
@@ -30,11 +32,11 @@ pub struct TypeConverter {
 }
 
 impl TypeConverter {
-    pub fn new(tcfg: &TranspilerConfig) -> TypeConverter {
+    pub fn new(tcfg: &TranspilerConfig, renamer: Rc<RefCell<Renamer<CDeclId>>>) -> TypeConverter {
         TypeConverter {
             edition: tcfg.edition,
             translate_valist: tcfg.translate_valist,
-            renamer: Renamer::keywords_and_prelude(),
+            renamer,
             fields: HashMap::new(),
             suffix_names: HashMap::new(),
             features: HashSet::new(),
@@ -56,24 +58,26 @@ impl TypeConverter {
 
     pub fn declare_decl_name(&mut self, decl_id: CDeclId, name: &str) -> String {
         self.renamer
+            .borrow_mut()
             .insert(decl_id, name, Namespaces::types())
             .expect("Name already assigned")
     }
 
     pub fn alias_decl_name(&mut self, new_decl_id: CDeclId, old_decl_id: CDeclId) {
-        self.renamer.alias(new_decl_id, &old_decl_id)
+        self.renamer.borrow_mut().alias(new_decl_id, &old_decl_id)
     }
 
     pub fn resolve_decl_name(&self, decl_id: CDeclId) -> Option<String> {
-        self.renamer.get(&decl_id)
+        self.renamer.borrow().get(&decl_id)
     }
 
     pub fn resolve_decl_suffix_name(&mut self, decl_id: CDeclId, suffix: &'static str) -> &str {
         let key = (decl_id, suffix);
         self.suffix_names.entry(key).or_insert_with(|| {
-            let name = self.renamer.get(&decl_id);
+            let name = self.renamer.borrow().get(&decl_id);
             let name = name.as_deref().unwrap_or("Unnamed");
             self.renamer
+                .borrow_mut()
                 .pick_name(&format!("C2Rust_{name}_{suffix}"), Namespaces::types())
         })
     }

--- a/c2rust-transpile/src/convert_type.rs
+++ b/c2rust-transpile/src/convert_type.rs
@@ -56,17 +56,6 @@ impl TypeConverter {
         &self.extern_crates
     }
 
-    pub fn declare_decl_name(&mut self, decl_id: CDeclId, name: &str) -> String {
-        self.renamer
-            .borrow_mut()
-            .insert(decl_id, name, Namespaces::types())
-            .expect("Name already assigned")
-    }
-
-    pub fn alias_decl_name(&mut self, new_decl_id: CDeclId, old_decl_id: CDeclId) {
-        self.renamer.borrow_mut().alias(new_decl_id, &old_decl_id)
-    }
-
     pub fn resolve_decl_name(&self, decl_id: CDeclId) -> Option<String> {
         self.renamer.borrow().get(&decl_id)
     }

--- a/c2rust-transpile/src/renamer.rs
+++ b/c2rust-transpile/src/renamer.rs
@@ -1,21 +1,17 @@
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::hash::Hash;
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign};
 
 struct Scope<T> {
     name_map: HashMap<T, String>,
-    used: HashSet<String>,
+    used: HashMap<String, Namespaces>,
 }
 
 impl<T: Clone + Eq + Hash> Scope<T> {
     pub fn new() -> Self {
-        Self::new_with_reserved(HashSet::new())
-    }
-
-    pub fn new_with_reserved(reserved: HashSet<String>) -> Self {
         Scope {
             name_map: HashMap::new(),
-            used: reserved,
+            used: HashMap::new(),
         }
     }
 
@@ -27,12 +23,14 @@ impl<T: Clone + Eq + Hash> Scope<T> {
         self.name_map.contains_key(key)
     }
 
-    pub fn contains_value(&self, val: &str) -> bool {
-        self.used.contains(val)
+    pub fn contains_value(&self, val: &str, ns: Namespaces) -> bool {
+        self.used
+            .get(val)
+            .is_some_and(|val_ns| val_ns.intersects(ns))
     }
 
-    pub fn reserve(&mut self, val: String) {
-        self.used.insert(val);
+    pub fn reserve(&mut self, val: &str, ns: Namespaces) {
+        *self.used.entry(val.to_owned()).or_default() |= ns;
     }
 }
 
@@ -178,32 +176,50 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
     /// Creates a new renaming environment with a single, empty scope. The given set of
     /// reserved names will exclude those names from being chosen as the mangled names from
     /// the insert method.
-    pub fn new(reserved_names: &[&[&str]]) -> Self {
-        let set = reserved_names
-            .iter()
-            .flat_map(|&names| names)
-            .map(|&s| s.to_owned())
-            .collect::<HashSet<_>>();
+    pub fn new<'a>(reserved_names: impl IntoIterator<Item = (&'a str, Namespaces)>) -> Self {
+        let mut global_scope = Scope::new();
+
+        for (name, ns) in reserved_names {
+            global_scope.reserve(name, ns);
+        }
+
         Renamer {
-            scopes: vec![Scope::new_with_reserved(set)],
+            scopes: vec![global_scope],
             next_fresh: 0,
         }
     }
 
     pub fn keywords() -> Self {
-        Renamer::new(&[RUST_KEYWORDS])
+        let keywords = RUST_KEYWORDS.iter().map(|&name| (name, Namespaces::all()));
+        Renamer::new(keywords)
     }
 
     pub fn type_namespace() -> Self {
-        Renamer::new(&[RUST_KEYWORDS, PRELUDE_TYPE_NAMESPACE])
+        let keywords = RUST_KEYWORDS.iter().map(|&name| (name, Namespaces::all()));
+        let prelude_types = PRELUDE_TYPE_NAMESPACE
+            .iter()
+            .map(|&name| (name, Namespaces::types()));
+        Renamer::new(keywords.chain(prelude_types))
     }
 
     pub fn value_namespace() -> Self {
-        Renamer::new(&[RUST_KEYWORDS, PRELUDE_VALUE_NAMESPACE])
+        let keywords = RUST_KEYWORDS.iter().map(|&name| (name, Namespaces::all()));
+        let prelude_values = PRELUDE_VALUE_NAMESPACE
+            .iter()
+            .map(|&name| (name, Namespaces::values()));
+        Renamer::new(keywords.chain(prelude_values))
     }
 
     pub fn global_value_namespace() -> Self {
-        Renamer::new(&[RUST_KEYWORDS, PRELUDE_VALUE_NAMESPACE, &["main"]])
+        let keywords = RUST_KEYWORDS.iter().map(|&name| (name, Namespaces::all()));
+        let prelude_values = PRELUDE_VALUE_NAMESPACE
+            .iter()
+            .map(|&name| (name, Namespaces::values()));
+        Renamer::new(
+            keywords
+                .chain(prelude_values)
+                .chain([("main", Namespaces::values())]),
+        )
     }
 
     /// Introduces a new name binding scope
@@ -229,20 +245,23 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
     }
 
     /// Is the mangled name currently in use
-    fn is_target_used(&self, key: &str) -> bool {
-        let key = key.to_string();
-
-        self.scopes.iter().any(|x| x.contains_value(&key))
+    fn is_target_used(&self, key: &str, ns: Namespaces) -> bool {
+        self.scopes.iter().any(|x| x.contains_value(key, ns))
     }
 
     /// Assigns a name that doesn't collide with anything in the context of a particular
     /// scope, defaulting to the current scope if None is provided
-    fn pick_name_in_scope(&mut self, basename: &str, scope: Option<usize>) -> String {
+    fn pick_name_in_scope(
+        &mut self,
+        basename: &str,
+        ns: Namespaces,
+        scope: Option<usize>,
+    ) -> String {
         let mut target =
             Self::raw_identifier_if_reserved_name(basename).unwrap_or_else(|| basename.to_string());
 
         for i in 0.. {
-            if self.is_target_used(&target) {
+            if self.is_target_used(&target, ns) {
                 target = format!("{}_{}", basename, i);
             } else {
                 break;
@@ -250,8 +269,8 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
         }
 
         match scope {
-            Some(scope_index) => self.scopes[scope_index].reserve(target.clone()),
-            None => self.current_scope_mut().reserve(target.clone()),
+            Some(scope_index) => self.scopes[scope_index].reserve(&target, ns),
+            None => self.current_scope_mut().reserve(&target, ns),
         }
 
         target
@@ -259,20 +278,26 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
 
     pub fn pick_name(&mut self, basename: &str) -> String {
         check_c2rust_name(basename);
-        self.pick_name_in_scope(basename, None)
+        self.pick_name_in_scope(basename, Namespaces::all(), None)
     }
 
     /// Permanently assign a name that doesn't collide with anything
     /// currently in scope, and also never goes out of scope
     pub fn pick_name_root(&mut self, basename: &str) -> String {
         check_c2rust_name(basename);
-        self.pick_name_in_scope(basename, Some(0))
+        self.pick_name_in_scope(basename, Namespaces::all(), Some(0))
     }
 
     /// Introduce a new name binding into a particular scope or the current one if None is provided.
     /// If the key is unbound in the scope then Some of the resulting mangled name is returned,
     /// otherwise None.
-    fn insert_in_scope(&mut self, key: T, basename: &str, scope: Option<usize>) -> Option<String> {
+    fn insert_in_scope(
+        &mut self,
+        key: T,
+        basename: &str,
+        ns: Namespaces,
+        scope: Option<usize>,
+    ) -> Option<String> {
         let contains_key = match scope {
             Some(scope_index) => self.scopes[scope_index].contains_key(&key),
             None => self.current_scope().contains_key(&key),
@@ -282,7 +307,7 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
             return None;
         }
 
-        let target = self.pick_name_in_scope(basename, scope);
+        let target = self.pick_name_in_scope(basename, ns, scope);
 
         match scope {
             Some(scope_index) => self.scopes[scope_index].insert(key, target.clone()),
@@ -296,14 +321,14 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
     /// the current scope then Some of the resulting mangled name is returned, otherwise
     /// None.
     pub fn insert(&mut self, key: T, basename: &str) -> Option<String> {
-        self.insert_in_scope(key, basename, None)
+        self.insert_in_scope(key, basename, Namespaces::all(), None)
     }
 
     /// Introduce a new name binding into the root scope. If the key is unbound in
     /// the root scope then Some of the resulting mangled name is returned, otherwise
     /// None.
     pub fn insert_root(&mut self, key: T, basename: &str) -> Option<String> {
-        self.insert_in_scope(key, basename, Some(0))
+        self.insert_in_scope(key, basename, Namespaces::all(), Some(0))
     }
 
     /// Assign a name in the current scope without reservation or checking for overlap.
@@ -341,6 +366,77 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
     }
 }
 
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+pub struct Namespaces {
+    pub types: bool,
+    pub values: bool,
+}
+
+impl Namespaces {
+    pub fn all() -> Self {
+        Self {
+            types: true,
+            values: true,
+        }
+    }
+
+    pub fn types() -> Self {
+        Self {
+            types: true,
+            ..Default::default()
+        }
+    }
+
+    pub fn values() -> Self {
+        Self {
+            values: true,
+            ..Default::default()
+        }
+    }
+
+    pub fn is_empty(self) -> bool {
+        self == Self::default()
+    }
+
+    pub fn intersects(self, other: Self) -> bool {
+        !(self & other).is_empty()
+    }
+}
+
+impl BitAnd for Namespaces {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self {
+            types: self.types && rhs.types,
+            values: self.values && rhs.values,
+        }
+    }
+}
+
+impl BitAndAssign for Namespaces {
+    fn bitand_assign(&mut self, rhs: Self) {
+        *self = *self & rhs;
+    }
+}
+
+impl BitOr for Namespaces {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self {
+            types: self.types || rhs.types,
+            values: self.values || rhs.values,
+        }
+    }
+}
+
+impl BitOrAssign for Namespaces {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = *self | rhs;
+    }
+}
+
 fn check_c2rust_name(basename: &str) {
     assert!(basename.starts_with("c2rust_") || basename.starts_with("C2Rust_"));
 }
@@ -351,7 +447,7 @@ mod tests {
 
     #[test]
     fn simple() {
-        let mut renamer = Renamer::new(&[&["reserved"]]);
+        let mut renamer = Renamer::new([("reserved", Namespaces::all())]);
 
         let one1 = renamer.insert(1, "one").unwrap();
         let one2 = renamer.get(&1).unwrap();
@@ -365,7 +461,7 @@ mod tests {
 
     #[test]
     fn scoped() {
-        let mut renamer = Renamer::new(&[]);
+        let mut renamer = Renamer::new([]);
 
         let one1 = renamer.insert(10, "one").unwrap();
         renamer.add_scope();
@@ -386,7 +482,7 @@ mod tests {
 
     #[test]
     fn forgets() {
-        let mut renamer = Renamer::new(&[]);
+        let mut renamer = Renamer::new([]);
         assert_eq!(renamer.get(&1), None);
         renamer.add_scope();
         renamer.insert(1, "example");
@@ -396,7 +492,7 @@ mod tests {
 
     #[test]
     fn raw_identifier() {
-        let mut renamer = Renamer::new(&[RUST_KEYWORDS]);
+        let mut renamer = Renamer::new(RUST_KEYWORDS.iter().map(|&name| (name, Namespaces::all())));
 
         // A reserved keyword that can be expressed as a raw identifier
         let reserved1 = renamer.insert(1, "dyn").unwrap();

--- a/c2rust-transpile/src/renamer.rs
+++ b/c2rust-transpile/src/renamer.rs
@@ -194,31 +194,21 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
         Renamer::new(keywords)
     }
 
-    pub fn type_namespace() -> Self {
+    pub fn keywords_and_prelude() -> Self {
         let keywords = RUST_KEYWORDS.iter().map(|&name| (name, Namespaces::all()));
         let prelude_types = PRELUDE_TYPE_NAMESPACE
             .iter()
             .map(|&name| (name, Namespaces::types()));
-        Renamer::new(keywords.chain(prelude_types))
-    }
-
-    pub fn value_namespace() -> Self {
-        let keywords = RUST_KEYWORDS.iter().map(|&name| (name, Namespaces::all()));
         let prelude_values = PRELUDE_VALUE_NAMESPACE
             .iter()
             .map(|&name| (name, Namespaces::values()));
-        Renamer::new(keywords.chain(prelude_values))
-    }
-
-    pub fn global_value_namespace() -> Self {
-        let keywords = RUST_KEYWORDS.iter().map(|&name| (name, Namespaces::all()));
-        let prelude_values = PRELUDE_VALUE_NAMESPACE
-            .iter()
-            .map(|&name| (name, Namespaces::values()));
+        // TODO: Do not include "main" for most renamings.
+        let main = [("main", Namespaces::values())];
         Renamer::new(
             keywords
+                .chain(prelude_types)
                 .chain(prelude_values)
-                .chain([("main", Namespaces::values())]),
+                .chain(main),
         )
     }
 

--- a/c2rust-transpile/src/renamer.rs
+++ b/c2rust-transpile/src/renamer.rs
@@ -363,6 +363,10 @@ pub struct Namespaces {
 }
 
 impl Namespaces {
+    pub fn none() -> Self {
+        Default::default()
+    }
+
     pub fn all() -> Self {
         Self {
             types: true,

--- a/c2rust-transpile/src/renamer.rs
+++ b/c2rust-transpile/src/renamer.rs
@@ -276,16 +276,16 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
         target
     }
 
-    pub fn pick_name(&mut self, basename: &str) -> String {
+    pub fn pick_name(&mut self, basename: &str, ns: Namespaces) -> String {
         check_c2rust_name(basename);
-        self.pick_name_in_scope(basename, Namespaces::all(), None)
+        self.pick_name_in_scope(basename, ns, None)
     }
 
     /// Permanently assign a name that doesn't collide with anything
     /// currently in scope, and also never goes out of scope
-    pub fn pick_name_root(&mut self, basename: &str) -> String {
+    pub fn pick_name_root(&mut self, basename: &str, ns: Namespaces) -> String {
         check_c2rust_name(basename);
-        self.pick_name_in_scope(basename, Namespaces::all(), Some(0))
+        self.pick_name_in_scope(basename, ns, Some(0))
     }
 
     /// Introduce a new name binding into a particular scope or the current one if None is provided.
@@ -320,15 +320,15 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
     /// Introduce a new name binding into the current scope. If the key is unbound in
     /// the current scope then Some of the resulting mangled name is returned, otherwise
     /// None.
-    pub fn insert(&mut self, key: T, basename: &str) -> Option<String> {
-        self.insert_in_scope(key, basename, Namespaces::all(), None)
+    pub fn insert(&mut self, key: T, basename: &str, ns: Namespaces) -> Option<String> {
+        self.insert_in_scope(key, basename, ns, None)
     }
 
     /// Introduce a new name binding into the root scope. If the key is unbound in
     /// the root scope then Some of the resulting mangled name is returned, otherwise
     /// None.
-    pub fn insert_root(&mut self, key: T, basename: &str) -> Option<String> {
-        self.insert_in_scope(key, basename, Namespaces::all(), Some(0))
+    pub fn insert_root(&mut self, key: T, basename: &str, ns: Namespaces) -> Option<String> {
+        self.insert_in_scope(key, basename, ns, Some(0))
     }
 
     /// Assign a name in the current scope without reservation or checking for overlap.
@@ -351,10 +351,10 @@ impl<T: Clone + Eq + Hash> Renamer<T> {
         None
     }
 
-    pub fn fresh(&mut self) -> String {
+    pub fn fresh(&mut self, ns: Namespaces) -> String {
         let fresh = self.next_fresh;
         self.next_fresh += 1;
-        self.pick_name(&format!("c2rust_fresh{fresh}"))
+        self.pick_name(&format!("c2rust_fresh{fresh}"), ns)
     }
 
     fn raw_identifier_if_reserved_name(basename: &str) -> Option<String> {
@@ -449,11 +449,11 @@ mod tests {
     fn simple() {
         let mut renamer = Renamer::new([("reserved", Namespaces::all())]);
 
-        let one1 = renamer.insert(1, "one").unwrap();
+        let one1 = renamer.insert(1, "one", Namespaces::all()).unwrap();
         let one2 = renamer.get(&1).unwrap();
         assert_eq!(one1, one2);
 
-        let reserved1 = renamer.insert(2, "reserved").unwrap();
+        let reserved1 = renamer.insert(2, "reserved", Namespaces::all()).unwrap();
         let reserved2 = renamer.get(&2).unwrap();
         assert_eq!(reserved1, "reserved_0");
         assert_eq!(reserved2, "reserved_0");
@@ -463,13 +463,13 @@ mod tests {
     fn scoped() {
         let mut renamer = Renamer::new([]);
 
-        let one1 = renamer.insert(10, "one").unwrap();
+        let one1 = renamer.insert(10, "one", Namespaces::all()).unwrap();
         renamer.add_scope();
 
         let one2 = renamer.get(&10).unwrap();
         assert_eq!(one1, one2);
 
-        let one3 = renamer.insert(20, "one").unwrap();
+        let one3 = renamer.insert(20, "one", Namespaces::all()).unwrap();
         let one4 = renamer.get(&20).unwrap();
         assert_eq!(one3, one4);
         assert_ne!(one3, one2);
@@ -485,7 +485,7 @@ mod tests {
         let mut renamer = Renamer::new([]);
         assert_eq!(renamer.get(&1), None);
         renamer.add_scope();
-        renamer.insert(1, "example");
+        renamer.insert(1, "example", Namespaces::all());
         renamer.drop_scope();
         assert_eq!(renamer.get(&1), None);
     }
@@ -495,19 +495,19 @@ mod tests {
         let mut renamer = Renamer::new(RUST_KEYWORDS.iter().map(|&name| (name, Namespaces::all())));
 
         // A reserved keyword that can be expressed as a raw identifier
-        let reserved1 = renamer.insert(1, "dyn").unwrap();
+        let reserved1 = renamer.insert(1, "dyn", Namespaces::all()).unwrap();
         let reserved2 = renamer.get(&1).unwrap();
         assert_eq!(reserved1, "r#dyn");
         assert_eq!(reserved2, "r#dyn");
 
         // A reserved keyword that is already bound and therefore does not need the "#r" prefix
-        let reserved1 = renamer.insert(2, "dyn").unwrap();
+        let reserved1 = renamer.insert(2, "dyn", Namespaces::all()).unwrap();
         let reserved2 = renamer.get(&2).unwrap();
         assert_eq!(reserved1, "dyn_0");
         assert_eq!(reserved2, "dyn_0");
 
         // A reserved that cannot be used as a raw identifier because it can be used in a path
-        let reserved1 = renamer.insert(3, "self").unwrap();
+        let reserved1 = renamer.insert(3, "self", Namespaces::all()).unwrap();
         let reserved2 = renamer.get(&3).unwrap();
         assert_eq!(reserved1, "self_0");
         assert_eq!(reserved2, "self_0");

--- a/c2rust-transpile/src/translator/assembly.rs
+++ b/c2rust-transpile/src/translator/assembly.rs
@@ -898,7 +898,10 @@ impl<'c> Translation<'c> {
 
                     // Convert `x` into `let c2rust_output = &raw mut x; *x`
                     self.use_feature("raw_ref_op");
-                    let output_name = self.renamer.borrow_mut().pick_name("c2rust_output");
+                    let output_name = self
+                        .renamer
+                        .borrow_mut()
+                        .pick_name("c2rust_output", Namespaces::values());
                     let output_local = mk().local(
                         mk().ident_pat(&output_name),
                         None,
@@ -907,7 +910,10 @@ impl<'c> Translation<'c> {
                     stmts.push(mk().local_stmt(Box::new(output_local)));
 
                     // `let mut c2rust_inner;`
-                    let inner_name = self.renamer.borrow_mut().pick_name("c2rust_inner");
+                    let inner_name = self
+                        .renamer
+                        .borrow_mut()
+                        .pick_name("c2rust_inner", Namespaces::values());
                     let inner_local = mk().local(mk().ident_pat(&inner_name), None, None);
                     stmts.push(mk().local_stmt(Box::new(inner_local)));
 
@@ -939,7 +945,10 @@ impl<'c> Translation<'c> {
 
                     let (output_name, inner_name) = operand_renames.get(tied_operand).unwrap();
 
-                    let input_name = self.renamer.borrow_mut().pick_name("c2rust_input");
+                    let input_name = self
+                        .renamer
+                        .borrow_mut()
+                        .pick_name("c2rust_input", Namespaces::values());
                     let input_local = mk().local(mk().ident_pat(&input_name), None, Some(in_expr));
                     stmts.push(mk().local_stmt(Box::new(input_local)));
 

--- a/c2rust-transpile/src/translator/atomics.rs
+++ b/c2rust-transpile/src/translator/atomics.rs
@@ -317,7 +317,10 @@ impl<'c> Translation<'c> {
                             self.atomic_intrinsic_cxchg_expr(weak, order, order_fail);
                         let call =
                             mk().call_expr(atomic_cxchg, vec![ptr, expected.clone(), desired]);
-                        let res_name = self.renamer.borrow_mut().pick_name("c2rust_result");
+                        let res_name = self
+                            .renamer
+                            .borrow_mut()
+                            .pick_name("c2rust_result", Namespaces::values());
                         let res_let = mk().local_stmt(Box::new(mk().local(
                             mk().ident_pat(&res_name),
                             None,
@@ -404,14 +407,20 @@ impl<'c> Translation<'c> {
             // Since the value of `arg1` is used twice, we need to copy
             // it into a local temporary so we don't duplicate any side-effects
             // To preserve ordering of side-effects, we also do this for arg0
-            let arg0_name = self.renamer.borrow_mut().pick_name("c2rust_lhs");
+            let arg0_name = self
+                .renamer
+                .borrow_mut()
+                .pick_name("c2rust_lhs", Namespaces::values());
             let arg0_let = mk().local_stmt(Box::new(mk().local(
                 mk().ident_pat(&arg0_name),
                 None,
                 Some(dst),
             )));
 
-            let arg1_name = self.renamer.borrow_mut().pick_name("c2rust_rhs");
+            let arg1_name = self
+                .renamer
+                .borrow_mut()
+                .pick_name("c2rust_rhs", Namespaces::values());
             let arg1_let = mk().local_stmt(Box::new(mk().local(
                 mk().ident_pat(&arg1_name),
                 None,

--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -388,7 +388,7 @@ impl<'c> Translation<'c> {
                         &*fn_ctx.alloca_allocations_name.get_or_insert_with(|| {
                             self.renamer
                                 .borrow_mut()
-                                .pick_name("c2rust_alloca_allocations")
+                                .pick_name("c2rust_alloca_allocations", Namespaces::values())
                         });
 
                     // c2rust_alloca_allocations.push(std::vec::from_elem(0, count));
@@ -734,8 +734,14 @@ impl<'c> Translation<'c> {
                 (cast_int(a, "i128", true), cast_int(b, "i128", true))
             };
             let overflowing = mk().method_call_expr(a, method_name, vec![b]);
-            let result_name = self.renamer.borrow_mut().pick_name("c2rust_result");
-            let over_name = self.renamer.borrow_mut().pick_name("c2rust_overflowed");
+            let result_name = self
+                .renamer
+                .borrow_mut()
+                .pick_name("c2rust_result", Namespaces::values());
+            let over_name = self
+                .renamer
+                .borrow_mut()
+                .pick_name("c2rust_overflowed", Namespaces::values());
             let mut stmts = vec![mk().local_stmt(Box::new(mk().local(
                 mk().tuple_pat(vec![
                     mk().ident_pat(&result_name),
@@ -753,7 +759,10 @@ impl<'c> Translation<'c> {
                 // truncation lost information -- overflow distinct from
                 // `overflowing`'s own flag, which only fires when even `i128`
                 // cannot hold the result.
-                let narrow_name = self.renamer.borrow_mut().pick_name("c2rust_result_narrow");
+                let narrow_name = self
+                    .renamer
+                    .borrow_mut()
+                    .pick_name("c2rust_result_narrow", Namespaces::values());
                 stmts.push(mk().local_stmt(Box::new(mk().local(
                     mk().ident_pat(&narrow_name),
                     None,

--- a/c2rust-transpile/src/translator/functions.rs
+++ b/c2rust-transpile/src/translator/functions.rs
@@ -134,7 +134,7 @@ impl<'c> Translation<'c> {
                     let new_var = self
                         .renamer
                         .borrow_mut()
-                        .insert(decl_id, var.as_str())
+                        .insert(decl_id, var.as_str(), Namespaces::values())
                         .unwrap_or_else(|| {
                             panic!(
                                 "Failed to insert argument '{}' while converting '{}'",

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -187,7 +187,10 @@ impl<'c> Translation<'c> {
             return self.convert_expr(ctx, val, override_ty);
         }
 
-        let fresh_name = self.renamer.borrow_mut().pick_name("c2rust_lvalue");
+        let fresh_name = self
+            .renamer
+            .borrow_mut()
+            .pick_name("c2rust_lvalue", Namespaces::values());
         let fresh_ty = self.convert_type(override_ty.unwrap_or(qty).ctype)?;
 
         // Translate the expression to be assigned to the fresh variable.

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -1671,8 +1671,7 @@ impl<'c> Translation<'c> {
             type_converter: RefCell::new(type_converter),
             ast_context,
             tcfg,
-            // TODO: Use Renamer::value_namespace() for most renamings.
-            renamer: RefCell::new(Renamer::global_value_namespace()),
+            renamer: RefCell::new(Renamer::keywords_and_prelude()),
             zero_inits: RefCell::new(IndexMap::new()),
             function_context: RefCell::new(FuncContext::new()),
             potential_flexible_array_members: RefCell::new(IndexSet::new()),

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -40,7 +40,7 @@ use crate::c_ast::iterators::{DFExpr, SomeId};
 use crate::c_ast::*;
 use crate::cfg;
 use crate::convert_type::TypeConverter;
-use crate::renamer::Renamer;
+use crate::renamer::{Namespaces, Renamer};
 use crate::with_stmts::WithStmts;
 use crate::{c_ast, format_translation_err};
 use crate::{ExternCrate, TranspilerConfig};
@@ -441,7 +441,10 @@ fn prefix_names(translation: &mut Translation, prefix: &str) {
 
                 name.insert_str(0, prefix);
 
-                translation.renamer.borrow_mut().insert(decl_id, name);
+                translation
+                    .renamer
+                    .borrow_mut()
+                    .insert(decl_id, name, Namespaces::values());
             }
             CDeclKind::Variable {
                 ref mut ident,
@@ -952,7 +955,9 @@ pub fn translate(
                         .declare_decl_name(decl_id, name);
                 }
                 Name::Var(name) => {
-                    t.renamer.borrow_mut().insert(decl_id, name);
+                    t.renamer
+                        .borrow_mut()
+                        .insert(decl_id, name, Namespaces::values());
                 }
             }
         }
@@ -1998,7 +2003,7 @@ impl<'c> Translation<'c> {
         let fn_name = self
             .renamer
             .borrow_mut()
-            .pick_name("c2rust_run_static_initializers");
+            .pick_name("c2rust_run_static_initializers", Namespaces::values());
         let fn_ty = ReturnType::Default;
         let fn_decl = mk().fn_decl(fn_name.clone(), vec![], None, fn_ty.clone());
         let fn_bare_decl = (vec![], None, fn_ty);
@@ -2403,7 +2408,10 @@ impl<'c> Translation<'c> {
         let mut cfg_info = cfg::structures::CfgInfo::default();
         cfg::structures::gather_cfg_info(&relooped, &mut cfg_info);
 
-        let current_block_ident = self.renamer.borrow_mut().pick_name("c2rust_current_block");
+        let current_block_ident = self
+            .renamer
+            .borrow_mut()
+            .pick_name("c2rust_current_block", Namespaces::values());
         let current_block = mk().ident_expr(&current_block_ident);
         let mut stmts: Vec<Stmt> = lifted_stmts;
         if !cfg_info.checked_entries.is_empty() {
@@ -2572,7 +2580,7 @@ impl<'c> Translation<'c> {
                 let ident2 = self
                     .renamer
                     .borrow_mut()
-                    .insert_root(decl_id, ident)
+                    .insert_root(decl_id, ident, Namespaces::values())
                     .ok_or_else(|| {
                         TranslationError::generic(
                             "Unable to rename function scoped static initializer",
@@ -2627,7 +2635,7 @@ impl<'c> Translation<'c> {
                 let rust_name = self
                     .renamer
                     .borrow_mut()
-                    .insert(decl_id, ident)
+                    .insert(decl_id, ident, Namespaces::values())
                     .unwrap_or_else(|| panic!("Failed to insert variable '{}'", ident));
 
                 if self.ast_context.is_va_list(typ.ctype) {
@@ -2757,7 +2765,10 @@ impl<'c> Translation<'c> {
 
             ref decl => {
                 let inserted = if let Some(ident) = decl.get_name() {
-                    self.renamer.borrow_mut().insert(decl_id, ident).is_some()
+                    self.renamer
+                        .borrow_mut()
+                        .insert(decl_id, ident, Namespaces::values())
+                        .is_some()
                 } else {
                     false
                 };
@@ -3038,7 +3049,7 @@ impl<'c> Translation<'c> {
                             let name = self
                                 .renamer
                                 .borrow_mut()
-                                .insert(CDeclId(expr_id.0), "vla")
+                                .insert(CDeclId(expr_id.0), "vla", Namespaces::values())
                                 .unwrap(); // try using declref name?
                                            // TODO: store the name corresponding to expr_id
 
@@ -3560,7 +3571,7 @@ impl<'c> Translation<'c> {
                     let lhs = self
                         .convert_expr(ctx.used(), lhs, None)?
                         .merge_unsafe(rhs.is_unsafe());
-                    let fresh_name = self.renamer.borrow_mut().fresh();
+                    let fresh_name = self.renamer.borrow_mut().fresh(Namespaces::values());
 
                     lhs.and_then_try(|lhs| {
                         let fresh_stmt = mk().local_stmt(Box::new(mk().local(
@@ -3751,7 +3762,10 @@ impl<'c> Translation<'c> {
                 let result_id = substmt_ids[n - 1];
 
                 let name = format!("<stmt-expr_{:?}>", compound_stmt_id);
-                let lbl_ident = self.renamer.borrow_mut().pick_name("c2rust_label");
+                let lbl_ident = self
+                    .renamer
+                    .borrow_mut()
+                    .pick_name("c2rust_label", Namespaces::values());
                 let lbl = cfg::Label::FromC(compound_stmt_id, Some(Rc::from(lbl_ident)));
 
                 let mut stmts = match self.ast_context[result_id].kind {

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -888,33 +888,27 @@ pub fn translate(
         // in the presence of typedefs.
         t.ast_context.bubble_expr_types();
 
-        enum Name<'a> {
-            Var(&'a str),
-            Type(&'a str),
-            Anonymous,
-            None,
-        }
-
-        fn some_type_name(s: Option<&str>) -> Name<'_> {
-            match s {
-                None => Name::Anonymous,
-                Some(r) => Name::Type(r),
-            }
-        }
-
         // Used for testing; so that we don't overlap with C function names
         if let Some(ref prefix) = t.tcfg.prefix_function_names {
             prefix_names(&mut t, prefix);
         }
 
+        fn ns_for_decl(decl_kind: &CDeclKind) -> Namespaces {
+            use CDeclKind::*;
+            match decl_kind {
+                Struct { .. } | Union { .. } | Enum { .. } | Typedef { .. } => Namespaces::types(),
+                Function { .. } | EnumConstant { .. } | Variable { .. } | MacroObject { .. } => {
+                    Namespaces::values()
+                }
+                _ => Namespaces::none(),
+            }
+        }
+
         for (&decl_id, &subdecl_id) in &t.ast_context.prenamed_decls {
             if let CDeclKind::Typedef { ref name, .. } = t.ast_context[decl_id].kind {
-                t.type_converter
-                    .borrow_mut()
-                    .declare_decl_name(decl_id, name);
-                t.type_converter
-                    .borrow_mut()
-                    .alias_decl_name(subdecl_id, decl_id);
+                let ns = ns_for_decl(&t.ast_context[subdecl_id].kind);
+                t.renamer.borrow_mut().insert(decl_id, name, ns);
+                t.renamer.borrow_mut().alias(subdecl_id, &decl_id);
             }
         }
 
@@ -927,38 +921,24 @@ pub fn translate(
 
         // Populate renamer with top-level names
         for (&decl_id, decl) in t.ast_context.iter_decls() {
-            use CDeclKind::*;
-            let decl_name = match decl.kind {
-                _ if contains(&t.ast_context.prenamed_decls, &decl_id) => Name::None,
-                Struct { ref name, .. } => some_type_name(name.as_ref().map(String::as_str)),
-                Enum { ref name, .. } => some_type_name(name.as_ref().map(String::as_str)),
-                Union { ref name, .. } => some_type_name(name.as_ref().map(String::as_str)),
-                Typedef { ref name, .. } => Name::Type(name),
-                Function { ref name, .. } => Name::Var(name),
-                EnumConstant { ref name, .. } => Name::Var(name),
-                Variable { ref ident, .. } if t.ast_context.c_decls_top.contains(&decl_id) => {
-                    Name::Var(ident)
-                }
-                MacroObject { ref name, .. } => Name::Var(name),
-                _ => Name::None,
-            };
-            match decl_name {
-                Name::None => (),
-                Name::Anonymous => {
-                    t.type_converter
-                        .borrow_mut()
-                        .declare_decl_name(decl_id, "C2Rust_Unnamed");
-                }
-                Name::Type(name) => {
-                    t.type_converter
-                        .borrow_mut()
-                        .declare_decl_name(decl_id, name);
-                }
-                Name::Var(name) => {
-                    t.renamer
-                        .borrow_mut()
-                        .insert(decl_id, name, Namespaces::values());
-                }
+            if contains(&t.ast_context.prenamed_decls, &decl_id) {
+                continue;
+            }
+
+            if matches!(decl.kind, CDeclKind::Variable { .. })
+                && !t.ast_context.c_decls_top.contains(&decl_id)
+            {
+                continue;
+            }
+
+            let ns = ns_for_decl(&decl.kind);
+
+            if !ns.is_empty() {
+                let name = &decl
+                    .kind
+                    .get_name()
+                    .map_or("C2Rust_Unnamed", String::as_str);
+                t.renamer.borrow_mut().insert(decl_id, name, ns);
             }
         }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -280,7 +280,7 @@ pub struct Translation<'c> {
 
     // Translation state and utilities
     type_converter: RefCell<TypeConverter>,
-    renamer: RefCell<Renamer<CDeclId>>,
+    renamer: Rc<RefCell<Renamer<CDeclId>>>,
     zero_inits: RefCell<ZeroInits>,
     function_context: RefCell<FuncContext>,
     potential_flexible_array_members: RefCell<IndexSet<CDeclId>>,
@@ -1659,7 +1659,8 @@ impl<'c> Translation<'c> {
         main_file: &Path,
     ) -> Self {
         let comment_context = CommentContext::new(&mut ast_context);
-        let type_converter = TypeConverter::new(tcfg);
+        let renamer = Rc::new(RefCell::new(Renamer::keywords_and_prelude()));
+        let type_converter = TypeConverter::new(tcfg, renamer.clone());
 
         let main_file = ast_context
             .find_file_id(main_file)
@@ -1671,7 +1672,7 @@ impl<'c> Translation<'c> {
             type_converter: RefCell::new(type_converter),
             ast_context,
             tcfg,
-            renamer: RefCell::new(Renamer::keywords_and_prelude()),
+            renamer,
             zero_inits: RefCell::new(IndexMap::new()),
             function_context: RefCell::new(FuncContext::new()),
             potential_flexible_array_members: RefCell::new(IndexSet::new()),

--- a/c2rust-transpile/src/translator/named_references.rs
+++ b/c2rust-transpile/src/translator/named_references.rs
@@ -105,7 +105,10 @@ impl<'c> Translation<'c> {
             } else {
                 // This is the case where we explicitly need to factor out possible side-effects.
 
-                let ptr_name = self.renamer.borrow_mut().pick_name("c2rust_lvalue_ptr");
+                let ptr_name = self
+                    .renamer
+                    .borrow_mut()
+                    .pick_name("c2rust_lvalue_ptr", Namespaces::values());
 
                 // let p = &raw mut lhs;
                 // Use a raw pointer here so that it doesn't create borrow conflicts and

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -775,7 +775,7 @@ impl<'c> Translation<'c> {
         } else {
             self.name_reference_write_read(ctx, arg)?
                 .and_then(|lhs| {
-                    let val_name = self.renamer.borrow_mut().fresh();
+                    let val_name = self.renamer.borrow_mut().fresh(Namespaces::values());
                     let save_old_val = mk().local_stmt(Box::new(mk().local(
                         mk().ident_pat(&val_name),
                         None,

--- a/c2rust-transpile/src/translator/structs_unions.rs
+++ b/c2rust-transpile/src/translator/structs_unions.rs
@@ -11,6 +11,7 @@ use crate::c_ast::{
     CUnOp, MemberKind,
 };
 use crate::diagnostics::TranslationResult;
+use crate::renamer::Namespaces;
 use crate::translator::variadic::mk_va_list_ty;
 use crate::translator::{ConvertedDecl, ExprContext, Translation, PADDING_SUFFIX};
 use crate::with_stmts::WithStmts;
@@ -761,7 +762,10 @@ impl<'a> Translation<'a> {
                         stmts.push(mk().semi_stmt(method_call));
                     }
                     _ if contains_block(&param_expr) => {
-                        let name = self.renamer.borrow_mut().pick_name("c2rust_rhs");
+                        let name = self
+                            .renamer
+                            .borrow_mut()
+                            .pick_name("c2rust_rhs", Namespaces::values());
                         let name_ident = mk().mutbl().ident_pat(name.clone());
                         let temporary_stmt = mk().local(name_ident, None, Some(param_expr.clone()));
                         let assignment_expr = mk().method_call_expr(

--- a/c2rust-transpile/src/translator/variadic.rs
+++ b/c2rust-transpile/src/translator/variadic.rs
@@ -265,7 +265,10 @@ impl<'c> Translation<'c> {
     pub fn register_va_decls(&self, body: CStmtId) -> String {
         self.use_feature("c_variadic");
 
-        let va_list_arg_name = self.renamer.borrow_mut().pick_name("c2rust_args");
+        let va_list_arg_name = self
+            .renamer
+            .borrow_mut()
+            .pick_name("c2rust_args", Namespaces::values());
 
         // collect `va_list` variables that are `va_start`ed, `va_end`ed, or `va_copied`.
         let mut va_list_decl_ids: IndexSet<CDeclId> = IndexSet::new();


### PR DESCRIPTION
- Depends on #1957 

Some names in Rust exist in multiple namespaces at once. Tuple structs for example create a name in both the types and the values namespace. Thus, a tuple struct named `Foo` will conflict with a type alias `Foo` but also with a function named `Foo`, which is a problem for #1620 because it uses tuple structs.

The current `Renamer` setup, with entirely different instances for the types and values namespaces, doesn't handle that situation. This PR adds a `Namespaces` mask to `Scope`, and then makes everything else specify the correct mask when querying/inserting names into `Renamer`. Finally, a single `Renamer` instance is now shared between `Translator` and `TypeConverter`, so that names inserted into one will conflict with those in the other, if they share a namespace.