### PR TITLE
transpile: Fix renaming bug with locally declared types

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2602,6 +2602,12 @@ impl<'c> Translation<'c> {
         };
 
         match self.ast_context.index(decl_id).kind {
+            // These are emitted globally in `translate`.
+            CDeclKind::Struct { .. }
+            | CDeclKind::Union { .. }
+            | CDeclKind::Enum { .. }
+            | CDeclKind::Typedef { .. } => Ok(cfg::DeclStmtInfo::new(vec![], vec![], vec![])),
+
             CDeclKind::Variable {
                 has_static_duration: false,
                 has_thread_duration: false,
@@ -2759,39 +2765,29 @@ impl<'c> Translation<'c> {
                 // TODO: We need this because we can have multiple 'extern' decls of the same variable.
                 //       When we do, we must make sure to insert into the renamer the first time, and
                 //       then skip subsequent times.
-                use CDeclKind::*;
-                let skip = match decl {
-                    Variable { .. } => !inserted,
-                    Struct { .. } => true,
-                    Union { .. } => true,
-                    Enum { .. } => true,
-                    Typedef { .. } => true,
-                    _ => false,
+                if matches!(decl, CDeclKind::Variable { .. }) && !inserted {
+                    return Ok(cfg::DeclStmtInfo::new(vec![], vec![], vec![]));
+                }
+
+                use ConvertedDecl::*;
+                let items = match self.convert_decl(ctx, decl_id)? {
+                    Item(item) => vec![item],
+                    ForeignItem(item) => {
+                        vec![mk()
+                            .unsafety(extern_block_unsafety(self.tcfg.edition))
+                            .extern_("C")
+                            .foreign_items(vec![*item])]
+                    }
+                    Items(items) => items,
+                    NoItem => return Ok(cfg::DeclStmtInfo::empty()),
                 };
 
-                if skip {
-                    Ok(cfg::DeclStmtInfo::new(vec![], vec![], vec![]))
-                } else {
-                    use ConvertedDecl::*;
-                    let items = match self.convert_decl(ctx, decl_id)? {
-                        Item(item) => vec![item],
-                        ForeignItem(item) => {
-                            vec![mk()
-                                .unsafety(extern_block_unsafety(self.tcfg.edition))
-                                .extern_("C")
-                                .foreign_items(vec![*item])]
-                        }
-                        Items(items) => items,
-                        NoItem => return Ok(cfg::DeclStmtInfo::empty()),
-                    };
-
-                    let item_stmt = |item| mk().item_stmt(item);
-                    Ok(cfg::DeclStmtInfo::new(
-                        items.iter().cloned().map(item_stmt).collect(),
-                        vec![],
-                        items.into_iter().map(item_stmt).collect(),
-                    ))
-                }
+                let item_stmt = |item| mk().item_stmt(item);
+                Ok(cfg::DeclStmtInfo::new(
+                    items.iter().cloned().map(item_stmt).collect(),
+                    vec![],
+                    items.into_iter().map(item_stmt).collect(),
+                ))
             }
         }
     }

--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -438,6 +438,11 @@ fn test_ref_ub() {
 }
 
 #[test]
+fn test_renamer() {
+    transpile("renamer.c").run();
+}
+
+#[test]
 fn test_rotate() {
     transpile("rotate.c").run();
 }

--- a/c2rust-transpile/tests/snapshots/renamer.c
+++ b/c2rust-transpile/tests/snapshots/renamer.c
@@ -1,0 +1,4 @@
+void local_type(void) {
+    struct foo {};
+    int foo;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@renamer.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@renamer.c.2021.clang15.snap
@@ -1,0 +1,20 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/renamer.2021.clang15.rs
+---
+#![allow(
+    clippy::missing_safety_doc,
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct foo {}
+#[no_mangle]
+pub unsafe extern "C" fn local_type() {
+    let mut foo_0: ::core::ffi::c_int = 0;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@renamer.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@renamer.c.2021.clang15.snap
@@ -16,5 +16,5 @@ expression: cat tests/snapshots/renamer.2021.clang15.rs
 pub struct foo {}
 #[no_mangle]
 pub unsafe extern "C" fn local_type() {
-    let mut foo_0: ::core::ffi::c_int = 0;
+    let mut foo: ::core::ffi::c_int = 0;
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@renamer.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@renamer.c.2024.clang15.snap
@@ -1,0 +1,21 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/renamer.2024.clang15.rs
+---
+#![allow(
+    clippy::missing_safety_doc,
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unsafe_op_in_unsafe_fn,
+    unused_assignments,
+    unused_mut
+)]
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct foo {}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn local_type() {
+    let mut foo_0: ::core::ffi::c_int = 0;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@renamer.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@renamer.c.2024.clang15.snap
@@ -17,5 +17,5 @@ expression: cat tests/snapshots/renamer.2024.clang15.rs
 pub struct foo {}
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn local_type() {
-    let mut foo_0: ::core::ffi::c_int = 0;
+    let mut foo: ::core::ffi::c_int = 0;
 }


### PR DESCRIPTION
There was a bug in the handling of local decls, where type decls would be inserted into the renamer at local scope, even though they are emitted at global scope by c2rust. This would then trigger renaming of subsequent variables with the same name.