### PR TITLE
refactor: Include value namespace as well for tuple/unit structs

### DIFF
--- a/c2rust-refactor/src/context.rs
+++ b/c2rust-refactor/src/context.rs
@@ -6,7 +6,7 @@ use rustc_ast::node_id::NodeMap;
 use rustc_ast::ptr::P;
 use rustc_ast::{
     AssocItem, Expr, ExprKind, FnDecl, FnRetTy, ForeignItem, ForeignItemKind, Item, ItemKind,
-    NodeId, Path, QSelf, UseTreeKind, DUMMY_NODE_ID,
+    NodeId, Path, QSelf, UseTreeKind, VariantData, DUMMY_NODE_ID,
 };
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::unord::UnordMap;
@@ -913,7 +913,7 @@ impl<'a, 'tcx> RefactorCtxt<'a, 'tcx> {
     /// Return every namespace the given item occupies.
     ///
     /// A simple `use` may resolve in the type, value, and macro namespaces at
-    /// once. Every other named item occupies exactly one namespace. Results
+    /// once. Most other named items occupy exactly one namespace. Results
     /// preserve rustc's type/value/macro order and contain no duplicates. An
     /// empty result means the item does not occupy a tracked namespace.
     pub fn item_namespaces(&self, item: &Item) -> SmallVec<[Namespace; 3]> {
@@ -937,6 +937,11 @@ impl<'a, 'tcx> RefactorCtxt<'a, 'tcx> {
 
             ItemKind::Static(..) | ItemKind::Const(..) | ItemKind::Fn(..) => {
                 smallvec![Namespace::ValueNS]
+            }
+
+            // Tuple and unit structs occupy both namespaces: the type itself and its constructor.
+            ItemKind::Struct(VariantData::Tuple(..) | VariantData::Unit(..), _) => {
+                smallvec![Namespace::TypeNS, Namespace::ValueNS]
             }
 
             _ => smallvec![Namespace::TypeNS],

--- a/c2rust-refactor/src/transform/reorganize_definitions.rs
+++ b/c2rust-refactor/src/transform/reorganize_definitions.rs
@@ -710,8 +710,6 @@ impl<'a, 'tcx> Reorganizer<'a, 'tcx> {
                             }
                         } else {
                             let namespaces = self.cx.item_namespaces(item);
-                            // Only a `Use` can occupy multiple namespaces.
-                            assert!(namespaces.len() <= 1);
                             for namespace in namespaces {
                                 info.items[namespace].insert(item.ident);
                             }
@@ -1516,7 +1514,7 @@ struct MovedDecl {
     kind: DeclKind,
     def_id: DefId,
     /// Every namespace this declaration occupies. A simple `use` may occupy
-    /// the type, value, and macro namespaces at once; other declarations
+    /// the type, value, and macro namespaces at once; most other declarations
     /// occupy exactly one. The declaration itself is stored only once.
     namespaces: SmallVec<[Namespace; 3]>,
     loc: Option<SrcLoc>,


### PR DESCRIPTION
Parallel to #1956, this adds the value namespace for tuple/unit structs in the refactorer so that it correctly handles imports/renames of those types.