### PR TITLE
transpile: Fix wrong type from #1856

### DIFF
--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -471,7 +471,7 @@ impl<'c> Translation<'c> {
                 let lhs = self.make_cast(
                     ctx.used(),
                     lhs_type_id,
-                    compute_res_type_id,
+                    compute_lhs_type_id,
                     WithStmts::new_val(read.clone()),
                 )?;
 


### PR DESCRIPTION
Casting to `compute_lhs` should happen before the operation, and the cast to `compute_res` after it.