### PR TITLE
transpile: Refactor and simplify assignment operator handling

### DIFF
--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -316,33 +316,18 @@ impl<'c> Translation<'c> {
             return self.convert_bitfield_assignment_op_with_rhs(ctx, op, lhs, rhs_expr, field_id);
         }
 
-        let is_volatile = lhs_type_id.qualifiers.is_volatile;
-        let is_volatile_compound_assign = op.underlying_assignment().is_some() && is_volatile;
-
-        let lhs_type_kind = &self.ast_context.resolve_type(lhs_type_id.ctype).kind;
         let compute_res_type_id = compute_res_type_id.unwrap_or(lhs_type_id);
         let compute_lhs_type_id = compute_lhs_type_id.unwrap_or(lhs_type_id);
-        let compute_lhs_type_kind = &self
-            .ast_context
-            .resolve_type(compute_lhs_type_id.ctype)
-            .kind;
+        let compound_assignment_needs_desugaring =
+            op.underlying_assignment().is_some_and(|underlying_op| {
+                self.compound_assignment_needs_desugaring(
+                    underlying_op,
+                    lhs_type_id,
+                    compute_lhs_type_id,
+                )
+            });
 
-        let pointer_lhs = match lhs_type_kind {
-            &CTypeKind::Pointer(pointee) => Some(pointee),
-            _ => None,
-        };
-
-        let is_unsigned_arith = op
-            .underlying_assignment()
-            .map_or(false, |op| op.is_arithmetic())
-            && compute_lhs_type_kind.is_unsigned_integral_type();
-
-        let lhs_translation = if lhs_type_id.ctype != compute_lhs_type_id.ctype
-            || ctx.is_used()
-            || pointer_lhs.is_some()
-            || is_volatile_compound_assign
-            || is_unsigned_arith
-        {
+        let lhs_translation = if ctx.is_used() || compound_assignment_needs_desugaring {
             self.name_reference_write_read(ctx, lhs)?
         } else {
             self.name_reference_write(ctx, lhs)?.map(|named_ref| {
@@ -384,20 +369,6 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let is_volatile = lhs_type_id.qualifiers.is_volatile;
 
-        let lhs_type_kind = &self.ast_context.resolve_type(lhs_type_id.ctype).kind;
-        let compute_lhs_type_kind = &self
-            .ast_context
-            .resolve_type(compute_lhs_type_id.ctype)
-            .kind;
-        let is_unsigned_arith = op
-            .underlying_assignment()
-            .map_or(false, |op| op.is_arithmetic())
-            && compute_lhs_type_kind.is_unsigned_integral_type();
-        let pointer_lhs = match lhs_type_kind {
-            &CTypeKind::Pointer(pointee) => Some(pointee),
-            _ => None,
-        };
-
         let NamedReference {
             lvalue: write,
             rvalue: read,
@@ -407,14 +378,11 @@ impl<'c> Translation<'c> {
         let assign_stmt = if let Some(underlying_op) = op.underlying_assignment() {
             // Compound assignment
 
-            if is_volatile
-                || is_unsigned_arith
-                || underlying_op.is_pointer_arithmetic() && pointer_lhs.is_some()
-                || self.ast_context.resolve_type_id(compute_lhs_type_id.ctype)
-                    != self.ast_context.resolve_type_id(lhs_type_id.ctype)
-            {
-                // Some operations, including anything volatile, need to be desugared into a
-                // regular assignment with the underlying non-assignment operator.
+            if self.compound_assignment_needs_desugaring(
+                underlying_op,
+                lhs_type_id,
+                compute_lhs_type_id,
+            ) {
                 // Cast the lhs to the compute lhs type, do the compute, and then
                 // cast the compute result to the final lhs type.
                 let lhs = self.make_cast(
@@ -473,6 +441,35 @@ impl<'c> Translation<'c> {
             .and_then(|(assign_stmt, assign_result)| {
                 WithStmts::new(vec![mk().semi_stmt(assign_stmt)], assign_result)
             }))
+    }
+
+    /// Returns whether a compound assignment operation needs to be desugared into a regular
+    /// assignment with the underlying non-assignment operator.
+    fn compound_assignment_needs_desugaring(
+        &self,
+        underlying_op: CBinOp,
+        lhs_type_id: CQualTypeId,
+        compute_lhs_type_id: CQualTypeId,
+    ) -> bool {
+        let is_volatile = lhs_type_id.qualifiers.is_volatile;
+
+        let lhs_type_kind = &self.ast_context.resolve_type(lhs_type_id.ctype).kind;
+        let compute_lhs_type_kind = &self
+            .ast_context
+            .resolve_type(compute_lhs_type_id.ctype)
+            .kind;
+        let is_unsigned_arith =
+            underlying_op.is_arithmetic() && compute_lhs_type_kind.is_unsigned_integral_type();
+        let pointer_lhs = match lhs_type_kind {
+            &CTypeKind::Pointer(pointee) => Some(pointee),
+            _ => None,
+        };
+
+        is_volatile
+            || is_unsigned_arith
+            || underlying_op.is_pointer_arithmetic() && pointer_lhs.is_some()
+            || self.ast_context.resolve_type_id(compute_lhs_type_id.ctype)
+                != self.ast_context.resolve_type_id(lhs_type_id.ctype)
     }
 
     /// Translate a non-assignment binary operator. It is expected that the `lhs` and `rhs`

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -452,82 +452,73 @@ impl<'c> Translation<'c> {
 
         // Assignment expression itself
         use CBinOp::*;
-        let assign_stmt = match op {
-            // Regular (possibly volatile) assignment
-            Assign if !is_volatile => WithStmts::new_val(mk().assign_expr(write, rhs)),
-            Assign => {
-                WithStmts::new_val(self.volatile_write(write, lhs_type_id, rhs)?).set_unsafe()
-            }
+        let assign_stmt = if op == Assign && !is_volatile {
+            WithStmts::new_val(mk().assign_expr(write, rhs))
+        } else if op == Assign {
+            WithStmts::new_val(self.volatile_write(write, lhs_type_id, rhs)?).set_unsafe()
+        } else if is_volatile || is_unsigned_arith {
+            // Anything volatile needs to be desugared into explicit reads and writes.
+            // Cast the lhs to the compute lhs type, do the compute, and then
+            // cast the compute result to the final lhs type.
 
-            // Anything volatile needs to be desugared into explicit reads and writes
-            op if is_volatile || is_unsigned_arith => {
-                // Cast the lhs to the compute lhs type, do the compute, and then
-                // cast the compute result to the final lhs type.
+            let op = op
+                .underlying_assignment()
+                .expect("Cannot convert non-assignment operator");
 
-                let op = op
-                    .underlying_assignment()
-                    .expect("Cannot convert non-assignment operator");
+            let lhs = self.make_cast(
+                ctx.used(),
+                lhs_type_id,
+                compute_lhs_type_id,
+                WithStmts::new_val(read.clone()),
+            )?;
 
-                let lhs = self.make_cast(
-                    ctx.used(),
-                    lhs_type_id,
-                    compute_lhs_type_id,
-                    WithStmts::new_val(read.clone()),
-                )?;
-
-                let val = lhs.and_then_try(|lhs| {
-                    self.convert_binary_operator(
-                        ctx,
-                        compute_res_type_id,
-                        op,
-                        compute_lhs_type_id,
-                        rhs_type_id,
-                        lhs,
-                        rhs,
-                    )
-                })?;
-
-                let val = self.make_cast(ctx, compute_res_type_id, lhs_type_id, val)?;
-
-                if is_volatile {
-                    val.try_map(|val| self.volatile_write(write, lhs_type_id, val))?
-                        .set_unsafe()
-                } else {
-                    val.map(|val| mk().assign_expr(write, val))
-                }
-            }
-
-            // Everything else
-            AssignAdd | AssignSubtract if pointer_lhs.is_some() => {
-                let ptr = self.convert_pointer_offset(
-                    write.clone(),
-                    rhs,
-                    pointer_lhs.unwrap().ctype,
-                    op == AssignSubtract,
-                    false,
-                );
-                ptr.map(|ptr| mk().assign_expr(write, ptr))
-            }
-
-            _ => {
-                let bin_op = op
-                    .underlying_assignment()
-                    .expect("Cannot convert non-assignment operator");
-                let bin_op_kind = BinOp::from(op);
-
-                self.convert_assignment_operator_aux(
+            let val = lhs.and_then_try(|lhs| {
+                self.convert_binary_operator(
                     ctx,
-                    bin_op_kind,
-                    bin_op,
-                    read.clone(),
-                    write,
-                    rhs,
-                    lhs_type_id,
-                    compute_lhs_type_id,
                     compute_res_type_id,
+                    op,
+                    compute_lhs_type_id,
                     rhs_type_id,
-                )?
+                    lhs,
+                    rhs,
+                )
+            })?;
+
+            let val = self.make_cast(ctx, compute_res_type_id, lhs_type_id, val)?;
+
+            if is_volatile {
+                val.try_map(|val| self.volatile_write(write, lhs_type_id, val))?
+                    .set_unsafe()
+            } else {
+                val.map(|val| mk().assign_expr(write, val))
             }
+        } else if matches!(op, AssignAdd | AssignSubtract) && pointer_lhs.is_some() {
+            let ptr = self.convert_pointer_offset(
+                write.clone(),
+                rhs,
+                pointer_lhs.unwrap().ctype,
+                op == AssignSubtract,
+                false,
+            );
+            ptr.map(|ptr| mk().assign_expr(write, ptr))
+        } else {
+            let bin_op = op
+                .underlying_assignment()
+                .expect("Cannot convert non-assignment operator");
+            let bin_op_kind = BinOp::from(op);
+
+            self.convert_assignment_operator_aux(
+                ctx,
+                bin_op_kind,
+                bin_op,
+                read.clone(),
+                write,
+                rhs,
+                lhs_type_id,
+                compute_lhs_type_id,
+                compute_res_type_id,
+                rhs_type_id,
+            )?
         };
 
         let assign_result = if ctx.is_used() {

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -410,6 +410,8 @@ impl<'c> Translation<'c> {
             if is_volatile
                 || is_unsigned_arith
                 || underlying_op.is_pointer_arithmetic() && pointer_lhs.is_some()
+                || self.ast_context.resolve_type_id(compute_lhs_type_id.ctype)
+                    != self.ast_context.resolve_type_id(lhs_type_id.ctype)
             {
                 // Some operations, including anything volatile, need to be desugared into a
                 // regular assignment with the underlying non-assignment operator.
@@ -442,33 +444,8 @@ impl<'c> Translation<'c> {
                 } else {
                     val.map(|val| mk().assign_expr(write, val))
                 }
-            } else if self.ast_context.resolve_type_id(compute_lhs_type_id.ctype)
-                == self.ast_context.resolve_type_id(lhs_type_id.ctype)
-            {
-                WithStmts::new_val(mk().assign_op_expr(BinOp::from(op), write, rhs))
             } else {
-                let lhs = self.make_cast(
-                    ctx.used(),
-                    lhs_type_id,
-                    compute_lhs_type_id,
-                    WithStmts::new_val(read.clone()),
-                )?;
-
-                let val = lhs.and_then_try(|lhs| {
-                    self.convert_binary_operator(
-                        ctx,
-                        compute_res_type_id,
-                        underlying_op,
-                        compute_lhs_type_id,
-                        rhs_type_id,
-                        lhs,
-                        rhs,
-                    )
-                })?;
-
-                let val = self.make_cast(ctx.used(), compute_res_type_id, lhs_type_id, val)?;
-
-                val.map(|val| mk().assign_expr(write.clone(), val))
+                WithStmts::new_val(mk().assign_op_expr(BinOp::from(op), write, rhs))
             }
         } else {
             // Regular assignment

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -190,53 +190,6 @@ impl<'c> Translation<'c> {
         }
     }
 
-    fn convert_assignment_operator_aux(
-        &self,
-        ctx: ExprContext,
-        bin_op_kind: BinOp,
-        bin_op: CBinOp,
-        read: Box<Expr>,
-        write: Box<Expr>,
-        rhs: Box<Expr>,
-        lhs_type_id: CQualTypeId,
-        compute_lhs_type_id: CQualTypeId,
-        compute_res_type_id: CQualTypeId,
-        rhs_type_id: CQualTypeId,
-    ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        if self.ast_context.resolve_type_id(compute_lhs_type_id.ctype)
-            == self.ast_context.resolve_type_id(lhs_type_id.ctype)
-        {
-            Ok(WithStmts::new_val(mk().assign_op_expr(
-                bin_op_kind,
-                write,
-                rhs,
-            )))
-        } else {
-            let lhs = self.make_cast(
-                ctx.used(),
-                lhs_type_id,
-                compute_lhs_type_id,
-                WithStmts::new_val(read.clone()),
-            )?;
-
-            let val = lhs.and_then_try(|lhs| {
-                self.convert_binary_operator(
-                    ctx,
-                    compute_res_type_id,
-                    bin_op,
-                    compute_lhs_type_id,
-                    rhs_type_id,
-                    lhs,
-                    rhs,
-                )
-            })?;
-
-            let val = self.make_cast(ctx.used(), compute_res_type_id, lhs_type_id, val)?;
-
-            Ok(val.map(|val| mk().assign_expr(write.clone(), val)))
-        }
-    }
-
     /// Translate an assignment binary operator.
     ///
     /// `compute_lhs_type_id` and `compute_res_type_id` correspond to Clang's
@@ -489,19 +442,33 @@ impl<'c> Translation<'c> {
                 } else {
                     val.map(|val| mk().assign_expr(write, val))
                 }
+            } else if self.ast_context.resolve_type_id(compute_lhs_type_id.ctype)
+                == self.ast_context.resolve_type_id(lhs_type_id.ctype)
+            {
+                WithStmts::new_val(mk().assign_op_expr(BinOp::from(op), write, rhs))
             } else {
-                self.convert_assignment_operator_aux(
-                    ctx,
-                    BinOp::from(op),
-                    underlying_op,
-                    read.clone(),
-                    write,
-                    rhs,
+                let lhs = self.make_cast(
+                    ctx.used(),
                     lhs_type_id,
                     compute_lhs_type_id,
-                    compute_res_type_id,
-                    rhs_type_id,
-                )?
+                    WithStmts::new_val(read.clone()),
+                )?;
+
+                let val = lhs.and_then_try(|lhs| {
+                    self.convert_binary_operator(
+                        ctx,
+                        compute_res_type_id,
+                        underlying_op,
+                        compute_lhs_type_id,
+                        rhs_type_id,
+                        lhs,
+                        rhs,
+                    )
+                })?;
+
+                let val = self.make_cast(ctx.used(), compute_res_type_id, lhs_type_id, val)?;
+
+                val.map(|val| mk().assign_expr(write.clone(), val))
             }
         } else {
             // Regular assignment

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -454,7 +454,10 @@ impl<'c> Translation<'c> {
         let assign_stmt = if let Some(underlying_op) = op.underlying_assignment() {
             // Compound assignment
 
-            if is_volatile || is_unsigned_arith {
+            if is_volatile
+                || is_unsigned_arith
+                || underlying_op.is_pointer_arithmetic() && pointer_lhs.is_some()
+            {
                 // Some operations, including anything volatile, need to be desugared into a
                 // regular assignment with the underlying non-assignment operator.
                 // Cast the lhs to the compute lhs type, do the compute, and then
@@ -486,15 +489,6 @@ impl<'c> Translation<'c> {
                 } else {
                     val.map(|val| mk().assign_expr(write, val))
                 }
-            } else if underlying_op.is_pointer_arithmetic() && pointer_lhs.is_some() {
-                let ptr = self.convert_pointer_offset(
-                    write.clone(),
-                    rhs,
-                    pointer_lhs.unwrap().ctype,
-                    underlying_op == CBinOp::Subtract,
-                    false,
-                );
-                ptr.map(|ptr| mk().assign_expr(write, ptr))
             } else {
                 self.convert_assignment_operator_aux(
                     ctx,

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -451,74 +451,72 @@ impl<'c> Translation<'c> {
         } = lhs;
 
         // Assignment expression itself
-        use CBinOp::*;
-        let assign_stmt = if op == Assign && !is_volatile {
-            WithStmts::new_val(mk().assign_expr(write, rhs))
-        } else if op == Assign {
-            WithStmts::new_val(self.volatile_write(write, lhs_type_id, rhs)?).set_unsafe()
-        } else if is_volatile || is_unsigned_arith {
-            // Anything volatile needs to be desugared into explicit reads and writes.
-            // Cast the lhs to the compute lhs type, do the compute, and then
-            // cast the compute result to the final lhs type.
+        let assign_stmt = if let Some(underlying_op) = op.underlying_assignment() {
+            // Compound assignment
 
-            let op = op
-                .underlying_assignment()
-                .expect("Cannot convert non-assignment operator");
-
-            let lhs = self.make_cast(
-                ctx.used(),
-                lhs_type_id,
-                compute_lhs_type_id,
-                WithStmts::new_val(read.clone()),
-            )?;
-
-            let val = lhs.and_then_try(|lhs| {
-                self.convert_binary_operator(
-                    ctx,
-                    compute_res_type_id,
-                    op,
+            if is_volatile || is_unsigned_arith {
+                // Some operations, including anything volatile, need to be desugared into a
+                // regular assignment with the underlying non-assignment operator.
+                // Cast the lhs to the compute lhs type, do the compute, and then
+                // cast the compute result to the final lhs type.
+                let lhs = self.make_cast(
+                    ctx.used(),
+                    lhs_type_id,
                     compute_lhs_type_id,
-                    rhs_type_id,
-                    lhs,
-                    rhs,
-                )
-            })?;
+                    WithStmts::new_val(read.clone()),
+                )?;
 
-            let val = self.make_cast(ctx, compute_res_type_id, lhs_type_id, val)?;
+                let val = lhs.and_then_try(|lhs| {
+                    self.convert_binary_operator(
+                        ctx,
+                        compute_res_type_id,
+                        underlying_op,
+                        compute_lhs_type_id,
+                        rhs_type_id,
+                        lhs,
+                        rhs,
+                    )
+                })?;
+
+                let val = self.make_cast(ctx, compute_res_type_id, lhs_type_id, val)?;
+
+                if is_volatile {
+                    val.try_map(|val| self.volatile_write(write, lhs_type_id, val))?
+                        .set_unsafe()
+                } else {
+                    val.map(|val| mk().assign_expr(write, val))
+                }
+            } else if underlying_op.is_pointer_arithmetic() && pointer_lhs.is_some() {
+                let ptr = self.convert_pointer_offset(
+                    write.clone(),
+                    rhs,
+                    pointer_lhs.unwrap().ctype,
+                    underlying_op == CBinOp::Subtract,
+                    false,
+                );
+                ptr.map(|ptr| mk().assign_expr(write, ptr))
+            } else {
+                self.convert_assignment_operator_aux(
+                    ctx,
+                    BinOp::from(op),
+                    underlying_op,
+                    read.clone(),
+                    write,
+                    rhs,
+                    lhs_type_id,
+                    compute_lhs_type_id,
+                    compute_res_type_id,
+                    rhs_type_id,
+                )?
+            }
+        } else {
+            // Regular assignment
 
             if is_volatile {
-                val.try_map(|val| self.volatile_write(write, lhs_type_id, val))?
-                    .set_unsafe()
+                WithStmts::new_val(self.volatile_write(write, lhs_type_id, rhs)?).set_unsafe()
             } else {
-                val.map(|val| mk().assign_expr(write, val))
+                WithStmts::new_val(mk().assign_expr(write, rhs))
             }
-        } else if matches!(op, AssignAdd | AssignSubtract) && pointer_lhs.is_some() {
-            let ptr = self.convert_pointer_offset(
-                write.clone(),
-                rhs,
-                pointer_lhs.unwrap().ctype,
-                op == AssignSubtract,
-                false,
-            );
-            ptr.map(|ptr| mk().assign_expr(write, ptr))
-        } else {
-            let bin_op = op
-                .underlying_assignment()
-                .expect("Cannot convert non-assignment operator");
-            let bin_op_kind = BinOp::from(op);
-
-            self.convert_assignment_operator_aux(
-                ctx,
-                bin_op_kind,
-                bin_op,
-                read.clone(),
-                write,
-                rhs,
-                lhs_type_id,
-                compute_lhs_type_id,
-                compute_res_type_id,
-                rhs_type_id,
-            )?
         };
 
         let assign_result = if ctx.is_used() {

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -471,7 +471,7 @@ impl<'c> Translation<'c> {
                 let lhs = self.make_cast(
                     ctx.used(),
                     lhs_type_id,
-                    compute_res_type_id,
+                    compute_lhs_type_id,
                     WithStmts::new_val(read.clone()),
                 )?;
 


### PR DESCRIPTION
There's a lot of redundant common code here, and the code structure became a bit messy over time too. This cleans things up and makes it clearer what's going on wrt compound assignment desugaring.