### PR TITLE
ast-exporter: pass compilation database directory to Clang

### DIFF
--- a/c2rust-ast-exporter/src/lib.rs
+++ b/c2rust-ast-exporter/src/lib.rs
@@ -58,6 +58,13 @@ pub fn get_untyped_ast(
 /// libClangTooling is not thread-safe, so we must not allow concurrent calls to `ast_exporter`.
 static CLANG_MUTEX: Mutex<()> = Mutex::new(());
 
+fn clang_build_path(cc_db: &Path) -> &Path {
+    cc_db
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
 fn get_ast_cbors(
     file_path: &Path,
     cc_db: &Path,
@@ -68,7 +75,7 @@ fn get_ast_cbors(
     let mut args_owned = vec![CString::new("ast_exporter").unwrap()];
     args_owned.push(CString::new(file_path.to_str().unwrap()).unwrap());
     args_owned.push(CString::new("-p").unwrap());
-    args_owned.push(CString::new(cc_db.to_str().unwrap()).unwrap());
+    args_owned.push(CString::new(clang_build_path(cc_db).to_str().unwrap()).unwrap());
 
     for &arg in extra_args {
         args_owned.push(CString::new(["-extra-arg=", arg].join("")).unwrap())
@@ -150,4 +157,25 @@ unsafe fn marshal_result(
         output.insert(name, (v, preprocessed));
     }
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clang_build_path_uses_compilation_database_parent() {
+        assert_eq!(
+            clang_build_path(Path::new("/project/build/compile_commands.json")),
+            Path::new("/project/build")
+        );
+    }
+
+    #[test]
+    fn clang_build_path_defaults_to_current_directory() {
+        assert_eq!(
+            clang_build_path(Path::new("compile_commands.json")),
+            Path::new(".")
+        );
+    }
 }

--- a/c2rust-ast-exporter/src/lib.rs
+++ b/c2rust-ast-exporter/src/lib.rs
@@ -158,24 +158,3 @@ unsafe fn marshal_result(
     }
     output
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn clang_build_path_uses_compilation_database_parent() {
-        assert_eq!(
-            clang_build_path(Path::new("/project/build/compile_commands.json")),
-            Path::new("/project/build")
-        );
-    }
-
-    #[test]
-    fn clang_build_path_defaults_to_current_directory() {
-        assert_eq!(
-            clang_build_path(Path::new("compile_commands.json")),
-            Path::new(".")
-        );
-    }
-}


### PR DESCRIPTION
Fixes #1809.

`CommonOptionsParser` expects `-p` to name the build directory, but the AST exporter passed `compile_commands.json` itself. Pass its parent directory instead, using `.` for a bare relative path, and cover both forms.

This is a general correctness fix; #1809 exposed the existing mismatch on Clang 22.
