### PR TITLE
postprocess: default to `gpt-5.6-luna`

### DIFF
--- a/.github/workflows/ci-c2rust-postprocess.yml
+++ b/.github/workflows/ci-c2rust-postprocess.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Run c2rust testsuite
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # TODO: Remove the ident filter when we know the cronjob works.
           # The value is expanded unquoted by postprocess.gen.sh, so no shell
           # quoting: args must not contain whitespace.

--- a/c2rust-postprocess/postprocess/__init__.py
+++ b/c2rust-postprocess/postprocess/__init__.py
@@ -20,7 +20,7 @@ from postprocess.transforms.comments import AbstractGenerativeModel
 from postprocess.utils import existing_file
 from postprocess.validate import BaselineError, make_validator
 
-DEFAULT_LLM_MODEL = "gemini-3.5-flash"
+DEFAULT_LLM_MODEL = "gpt-5.6-luna"
 
 
 def build_arg_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
- add OpenAI key to the postprocess CI workflow
- Switch default model to `gpt-5.6-luna`