### PR TITLE
transpile: Do not try to eliminate casts from integer literal to enum 

### DIFF
--- a/c2rust-transpile/src/translator/enums.rs
+++ b/c2rust-transpile/src/translator/enums.rs
@@ -2,13 +2,11 @@ use c2rust_ast_builder::mk;
 use proc_macro2::Span;
 use syn::Expr;
 
-use crate::c_ast::CUnOp;
 use crate::{
     diagnostics::TranslationResult,
     translator::{signed_int_expr, ConvertedDecl, ExprContext, Translation},
     with_stmts::WithStmts,
-    CDeclKind, CEnumConstantId, CEnumId, CExprId, CExprKind, CLiteral, CQualTypeId, CTypeKind,
-    ConstIntExpr,
+    CDeclKind, CEnumConstantId, CEnumId, CExprId, CExprKind, CQualTypeId, CTypeKind, ConstIntExpr,
 };
 
 impl<'c> Translation<'c> {
@@ -128,20 +126,6 @@ impl<'c> Translation<'c> {
                     // because the translation of a const macro skips implicit casts in its context.
                     if !expr_is_macro {
                         val = self.enum_constant_expr(enum_constant_id);
-                        return Ok(WithStmts::new_val(val));
-                    }
-                }
-
-                CExprKind::Literal(_, CLiteral::Integer(i, _)) => {
-                    val = self.enum_for_i64(enum_id, i as i64);
-                    return Ok(WithStmts::new_val(val));
-                }
-
-                CExprKind::Unary(_, CUnOp::Negate, subexpr_id, _) => {
-                    if let &CExprKind::Literal(_, CLiteral::Integer(i, _)) =
-                        &self.ast_context.index_unwrap_parens(subexpr_id).kind
-                    {
-                        val = self.enum_for_i64(enum_id, -(i as i64));
                         return Ok(WithStmts::new_val(val));
                     }
                 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2021.clang15.snap
@@ -36,10 +36,10 @@ pub unsafe extern "C" fn test_enums() {
     bar = BarN1;
     foo = Foo(Bar0.0 as ::core::ffi::c_uint);
     bar = Bar(Foo0.0 as ::core::ffi::c_int);
-    foo = Foo1;
-    bar = Bar1;
-    foo = Foo3;
-    bar = Bar3;
+    foo = Foo(1 as ::core::ffi::c_int as ::core::ffi::c_uint);
+    bar = Bar(1 as ::core::ffi::c_int);
+    foo = Foo(3 as ::core::ffi::c_int as ::core::ffi::c_uint);
+    bar = Bar(3 as ::core::ffi::c_int);
     foo = Foo(foo.0.wrapping_sub(2 as ::core::ffi::c_uint));
     bar = Bar(bar.0 - 2 as ::core::ffi::c_int);
     foo = Foo(foo.0.wrapping_add(1));

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@enums.c.2024.clang15.snap
@@ -37,10 +37,10 @@ pub unsafe extern "C" fn test_enums() {
     bar = BarN1;
     foo = Foo(Bar0.0 as ::core::ffi::c_uint);
     bar = Bar(Foo0.0 as ::core::ffi::c_int);
-    foo = Foo1;
-    bar = Bar1;
-    foo = Foo3;
-    bar = Bar3;
+    foo = Foo(1 as ::core::ffi::c_int as ::core::ffi::c_uint);
+    bar = Bar(1 as ::core::ffi::c_int);
+    foo = Foo(3 as ::core::ffi::c_int as ::core::ffi::c_uint);
+    bar = Bar(3 as ::core::ffi::c_int);
     foo = Foo(foo.0.wrapping_sub(2 as ::core::ffi::c_uint));
     bar = Bar(bar.0 - 2 as ::core::ffi::c_int);
     foo = Foo(foo.0.wrapping_add(1));

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2021.clang15.snap
@@ -120,7 +120,8 @@ pub unsafe extern "C" fn cast_literals() {
 }
 #[no_mangle]
 pub unsafe extern "C" fn compound_literal() {
-    let mut i: ::core::ffi::c_int = B.0 as ::core::ffi::c_int;
+    let mut i: ::core::ffi::c_int =
+        C2Rust_Unnamed(1 as ::core::ffi::c_int as ::core::ffi::c_uint).0 as ::core::ffi::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn statement_expr() {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@exprs.c.2024.clang15.snap
@@ -120,7 +120,8 @@ pub unsafe extern "C" fn cast_literals() {
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn compound_literal() {
-    let mut i: ::core::ffi::c_int = B.0 as ::core::ffi::c_int;
+    let mut i: ::core::ffi::c_int =
+        C2Rust_Unnamed(1 as ::core::ffi::c_int as ::core::ffi::c_uint).0 as ::core::ffi::c_int;
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn statement_expr() {


### PR DESCRIPTION
 - Depends on #1620 

c2rust has for a long time created a "shortcut" if an integer literal is cast to an enum type, first added in https://github.com/immunant/c2rust/commit/e9e7e4609bc9d6eb4e8334a76ead93324b35d850. Instead of translating each of them as-is, it would attempt to emit an enum constant and fall back to an integer literal otherwise. But I think that's bad:
- If the original source code contained an integer literal rather than an enum constant, it may be more faithful to preserve that.
- As noted in https://github.com/immunant/c2rust/pull/1620#discussion_r3693984717, that shortcut causes problems if the literal doesn't fit into the integral type of the enum.

So I think it's best to just remove it and emit the literal and cast as they are.