### PR TITLE
transpile: Refactor code related to `MacroExpansion`

### DIFF
--- a/c2rust-transpile/src/translator/macros.rs
+++ b/c2rust-transpile/src/translator/macros.rs
@@ -30,14 +30,13 @@ impl<'c> Translation<'c> {
         );
 
         match maybe_replacement {
-            Ok((replacement, ty)) => {
+            Ok((replacement, converted)) => {
                 trace!("  to {:?}", replacement);
 
-                let converted = ConvertedMacro { ty };
+                let ty = self.convert_type(converted.ty)?;
                 self.converted_macros
                     .borrow_mut()
                     .insert(decl_id, Some(converted));
-                let ty = self.convert_type(ty)?;
 
                 Ok(ConvertedDecl::Item(mk().span(span).pub_().const_item(
                     name,
@@ -68,7 +67,7 @@ impl<'c> Translation<'c> {
         &self,
         ctx: ExprContext,
         expansions: &[CExprId],
-    ) -> TranslationResult<(Box<Expr>, CTypeId)> {
+    ) -> TranslationResult<(Box<Expr>, ConvertedMacro)> {
         struct ConvertedMacroExpr {
             val: WithStmts<Box<Expr>>,
             ty: CTypeId,
@@ -111,9 +110,10 @@ impl<'c> Translation<'c> {
             .ok_or_else(|| format_err!("Could not find a valid type for macro"))?;
 
         let ConvertedMacroExpr { val, ty } = canonical;
+        let converted = ConvertedMacro { ty };
         val.wrap_unsafe()
             .to_pure_expr()
-            .map(|val| (val, ty))
+            .map(|val| (val, converted))
             .ok_or_else(|| TranslationError::generic("Macro expansion is not a pure expression"))
 
         // TODO: Validate that all replacements are equivalent and pick the most

--- a/c2rust-transpile/src/translator/macros.rs
+++ b/c2rust-transpile/src/translator/macros.rs
@@ -69,9 +69,14 @@ impl<'c> Translation<'c> {
         ctx: ExprContext,
         expansions: &[CExprId],
     ) -> TranslationResult<(Box<Expr>, CTypeId)> {
-        let (val, ty) = expansions
+        struct ConvertedMacroExpr {
+            val: WithStmts<Box<Expr>>,
+            ty: CTypeId,
+        }
+
+        let canonical = expansions
             .iter()
-            .try_fold::<Option<(WithStmts<Box<Expr>>, CTypeId)>, _, _>(None, |canonical, &id| {
+            .try_fold::<Option<ConvertedMacroExpr>, _, _>(None, |canonical, &id| {
                 self.can_convert_const_macro_expansion(id)?;
 
                 let ty = self
@@ -80,30 +85,32 @@ impl<'c> Translation<'c> {
                     .kind
                     .get_type()
                     .ok_or_else(|| format_err!("Invalid expression type"))?;
-                let expr = self.convert_expr(ctx, id, None)?;
+                let val = self.convert_expr(ctx, id, None)?;
+                let new = ConvertedMacroExpr { val, ty };
 
                 // Join ty and cur_ty to the smaller of the two types. If the
                 // types are not cast-compatible, abort the fold.
-                let ty_kind = self.ast_context.resolve_type(ty).kind.clone();
-                if let Some((canon_val, canon_ty)) = canonical {
-                    let canon_ty_kind = self.ast_context.resolve_type(canon_ty).kind.clone();
+                let ty_kind = self.ast_context.resolve_type(new.ty).kind.clone();
+                if let Some(canonical) = canonical {
+                    let canon_ty_kind = self.ast_context.resolve_type(canonical.ty).kind.clone();
                     if let Some(smaller_ty) =
                         CTypeKind::smaller_compatible_type(canon_ty_kind.clone(), ty_kind)
                     {
                         if smaller_ty == canon_ty_kind {
-                            Ok(Some((canon_val, canon_ty)))
+                            Ok(Some(canonical))
                         } else {
-                            Ok(Some((expr, ty)))
+                            Ok(Some(new))
                         }
                     } else {
                         Err(format_err!("Not all macro expansions are compatible types"))
                     }
                 } else {
-                    Ok(Some((expr, ty)))
+                    Ok(Some(new))
                 }
             })?
             .ok_or_else(|| format_err!("Could not find a valid type for macro"))?;
 
+        let ConvertedMacroExpr { val, ty } = canonical;
         val.wrap_unsafe()
             .to_pure_expr()
             .map(|val| (val, ty))

--- a/c2rust-transpile/src/translator/macros.rs
+++ b/c2rust-transpile/src/translator/macros.rs
@@ -2,6 +2,7 @@ use c2rust_ast_builder::mk;
 use failure::format_err;
 use log::{info, trace};
 use proc_macro2::{Span, TokenStream};
+use std::rc::Rc;
 use syn::{Expr, MacroDelimiter};
 
 use crate::c_ast::{CDeclId, CExprId, CQualTypeId, CTypeId, CTypeKind};
@@ -36,7 +37,7 @@ impl<'c> Translation<'c> {
                 let ty = self.convert_type(converted.ty)?;
                 self.converted_macros
                     .borrow_mut()
-                    .insert(decl_id, Some(converted));
+                    .insert(decl_id, Some(Rc::new(converted)));
 
                 Ok(ConvertedDecl::Item(mk().span(span).pub_().const_item(
                     name,

--- a/c2rust-transpile/src/translator/macros.rs
+++ b/c2rust-transpile/src/translator/macros.rs
@@ -186,10 +186,10 @@ impl<'c> Translation<'c> {
 
         trace!("  found macro expansion: {macro_id:?}");
         // Ensure that we've converted this macro and that it has a valid definition.
-        let converted = self.converted_macros.borrow().get(macro_id).cloned();
-        let macro_ty = match converted {
+        let maybe_converted = self.converted_macros.borrow().get(macro_id).cloned();
+        let converted = match maybe_converted {
             // Macro was converted previously.
-            Some(Some(converted)) => converted.ty,
+            Some(Some(converted)) => converted,
 
             // Macro failed to convert previously.
             Some(None) => return Ok(None),
@@ -197,8 +197,9 @@ impl<'c> Translation<'c> {
             // We haven't tried to convert it yet.
             None => {
                 self.convert_decl(ctx.not_pattern(), *macro_id)?;
-                if let Some(Some(converted)) = self.converted_macros.borrow().get(macro_id) {
-                    converted.ty
+                let maybe_converted = self.converted_macros.borrow().get(macro_id).cloned();
+                if let Some(Some(converted)) = maybe_converted {
+                    converted
                 } else {
                     return Ok(None);
                 }
@@ -222,7 +223,7 @@ impl<'c> Translation<'c> {
         // so we need to cast it to the `override_ty` here.
         let expr_ty = override_ty.or_else(|| expr_kind.get_qual_type());
         if let Some(expr_ty) = expr_ty {
-            match self.make_cast(ctx, CQualTypeId::new(macro_ty), expr_ty, val) {
+            match self.make_cast(ctx, CQualTypeId::new(converted.ty), expr_ty, val) {
                 Ok(new_val) => val = new_val,
                 Err(err) => {
                     info!(

--- a/c2rust-transpile/src/translator/macros.rs
+++ b/c2rust-transpile/src/translator/macros.rs
@@ -6,7 +6,7 @@ use syn::{Expr, MacroDelimiter};
 
 use crate::c_ast::{CDeclId, CExprId, CQualTypeId, CTypeId, CTypeKind};
 use crate::diagnostics::{TranslationError, TranslationResult};
-use crate::translator::{ConvertedDecl, ExprContext, MacroExpansion, Translation};
+use crate::translator::{ConvertedDecl, ConvertedMacro, ExprContext, Translation};
 use crate::with_stmts::WithStmts;
 use crate::TranslateMacros;
 
@@ -33,10 +33,10 @@ impl<'c> Translation<'c> {
             Ok((replacement, ty)) => {
                 trace!("  to {:?}", replacement);
 
-                let expansion = MacroExpansion { ty };
-                self.macro_expansions
+                let converted = ConvertedMacro { ty };
+                self.converted_macros
                     .borrow_mut()
-                    .insert(decl_id, Some(expansion));
+                    .insert(decl_id, Some(converted));
                 let ty = self.convert_type(ty)?;
 
                 Ok(ConvertedDecl::Item(mk().span(span).pub_().const_item(
@@ -46,7 +46,7 @@ impl<'c> Translation<'c> {
                 )))
             }
             Err(e) => {
-                self.macro_expansions.borrow_mut().insert(decl_id, None);
+                self.converted_macros.borrow_mut().insert(decl_id, None);
                 info!("Could not expand macro {}: {}", name, e);
                 Ok(ConvertedDecl::NoItem)
             }
@@ -185,19 +185,19 @@ impl<'c> Translation<'c> {
 
         trace!("  found macro expansion: {macro_id:?}");
         // Ensure that we've converted this macro and that it has a valid definition.
-        let expansion = self.macro_expansions.borrow().get(macro_id).cloned();
-        let macro_ty = match expansion {
-            // Expansion exists.
-            Some(Some(expansion)) => expansion.ty,
+        let converted = self.converted_macros.borrow().get(macro_id).cloned();
+        let macro_ty = match converted {
+            // Macro was converted previously.
+            Some(Some(converted)) => converted.ty,
 
-            // Expansion wasn't possible.
+            // Macro failed to convert previously.
             Some(None) => return Ok(None),
 
-            // We haven't tried to expand it yet.
+            // We haven't tried to convert it yet.
             None => {
                 self.convert_decl(ctx.not_pattern(), *macro_id)?;
-                if let Some(Some(expansion)) = self.macro_expansions.borrow().get(macro_id) {
-                    expansion.ty
+                if let Some(Some(converted)) = self.converted_macros.borrow().get(macro_id) {
+                    converted.ty
                 } else {
                     return Ok(None);
                 }

--- a/c2rust-transpile/src/translator/macros.rs
+++ b/c2rust-transpile/src/translator/macros.rs
@@ -18,39 +18,36 @@ impl<'c> Translation<'c> {
         decl_id: CDeclId,
         span: Span,
         name: &str,
-    ) -> TranslationResult<ConvertedDecl> {
+    ) -> ConvertedDecl {
         trace!(
             "Expanding macro {:?}: {:?}",
             decl_id,
             self.ast_context[decl_id]
         );
 
-        let maybe_replacement = self.recreate_const_macro_from_expansions(
+        self.recreate_const_macro_from_expansions(
             ctx.const_().set_expanding_macro(decl_id),
             &self.ast_context.macro_expansions[&decl_id],
-        );
+        )
+        .and_then(|(replacement, converted)| {
+            trace!("  to {:?}", replacement);
 
-        match maybe_replacement {
-            Ok((replacement, converted)) => {
-                trace!("  to {:?}", replacement);
+            let ty = self.convert_type(converted.ty)?;
+            self.converted_macros
+                .borrow_mut()
+                .insert(decl_id, Some(Rc::new(converted)));
 
-                let ty = self.convert_type(converted.ty)?;
-                self.converted_macros
-                    .borrow_mut()
-                    .insert(decl_id, Some(Rc::new(converted)));
-
-                Ok(ConvertedDecl::Item(mk().span(span).pub_().const_item(
-                    name,
-                    ty,
-                    replacement,
-                )))
-            }
-            Err(e) => {
-                self.converted_macros.borrow_mut().insert(decl_id, None);
-                info!("Could not expand macro {}: {}", name, e);
-                Ok(ConvertedDecl::NoItem)
-            }
-        }
+            Ok(ConvertedDecl::Item(mk().span(span).pub_().const_item(
+                name,
+                ty,
+                replacement,
+            )))
+        })
+        .unwrap_or_else(|e| {
+            self.converted_macros.borrow_mut().insert(decl_id, None);
+            info!("Could not expand macro {}: {}", name, e);
+            ConvertedDecl::NoItem
+        })
     }
 
     /// Given all of the expansions of a const macro,

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -2326,7 +2326,7 @@ impl<'c> Translation<'c> {
                     .get(&decl_id)
                     .expect("Macro object not named");
 
-                self.convert_macro(ctx, decl_id, span, &name)
+                Ok(self.convert_macro(ctx, decl_id, span, &name))
             }
 
             // We aren't doing anything with the definitions of function-like

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -279,7 +279,6 @@ impl FuncContext {
     }
 }
 
-#[derive(Clone)]
 struct ConvertedMacro {
     ty: CTypeId,
 }
@@ -305,7 +304,7 @@ pub struct Translation<'c> {
     zero_inits: RefCell<ZeroInits>,
     function_context: RefCell<FuncContext>,
     potential_flexible_array_members: RefCell<IndexSet<CDeclId>>,
-    converted_macros: RefCell<IndexMap<CDeclId, Option<ConvertedMacro>>>,
+    converted_macros: RefCell<IndexMap<CDeclId, Option<Rc<ConvertedMacro>>>>,
     /// Sets of imports deferred while translating nested expressions for caching. Imports are
     /// deferred when caching translations to make them pure and thus cache the translation
     /// alongside its required imports. Each additional nested level of caching translation

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -280,7 +280,7 @@ impl FuncContext {
 }
 
 #[derive(Clone)]
-struct MacroExpansion {
+struct ConvertedMacro {
     ty: CTypeId,
 }
 
@@ -305,7 +305,7 @@ pub struct Translation<'c> {
     zero_inits: RefCell<ZeroInits>,
     function_context: RefCell<FuncContext>,
     potential_flexible_array_members: RefCell<IndexSet<CDeclId>>,
-    macro_expansions: RefCell<IndexMap<CDeclId, Option<MacroExpansion>>>,
+    converted_macros: RefCell<IndexMap<CDeclId, Option<ConvertedMacro>>>,
     /// Sets of imports deferred while translating nested expressions for caching. Imports are
     /// deferred when caching translations to make them pure and thus cache the translation
     /// alongside its required imports. Each additional nested level of caching translation
@@ -1676,7 +1676,7 @@ impl<'c> Translation<'c> {
             zero_inits: RefCell::new(IndexMap::new()),
             function_context: RefCell::new(FuncContext::new()),
             potential_flexible_array_members: RefCell::new(IndexSet::new()),
-            macro_expansions: RefCell::new(IndexMap::new()),
+            converted_macros: RefCell::new(IndexMap::new()),
             deferred_imports: RefCell::new(Vec::new()),
             cleanup_guard_emitted: Cell::new(false),
             comment_context,
@@ -4979,8 +4979,8 @@ impl<'c> Translation<'c> {
             } => add_use_items_for_type(typ),
 
             CDeclKind::MacroObject { .. } => {
-                if let Some(Some(expansion)) = self.macro_expansions.borrow().get(&decl_id) {
-                    add_use_items_for_type(expansion.ty)
+                if let Some(Some(converted)) = self.converted_macros.borrow().get(&decl_id) {
+                    add_use_items_for_type(converted.ty)
                 }
             }
 


### PR DESCRIPTION
This prepares the code for adding a hashmap with macro arguments to both `ConvertedMacro` and `ConvertedMacroExpr`, and also generally looks a little cleaner?