### PR TITLE
Fix Serde Dependency Feature

### DIFF
--- a/c2rust-ast-exporter/Cargo.toml
+++ b/c2rust-ast-exporter/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 links = "clangAstExporter"
 
 [dependencies]
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_cbor = "0.11"
 


### PR DESCRIPTION
Currently, simply calling `cargo install --locked --git https://github.com/immunant/c2rust.git c2rust` fails with `use serde::Deserialize` not being a macro.

I didn't look into the CI and why its not catching it, but this fixes the issue locally. Arguably, this should be set anyway instead of relying on other dependencies in the dependency graph to enable that feature for this crate.