### PR TITLE
transpile: Unset `needs_address` in various places

### DIFF
--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -201,7 +201,7 @@ impl<'c> Translation<'c> {
             return self.convert_expr(ctx.used(), arg, None);
         }
 
-        self.convert_expr(ctx.used(), arg, None)?
+        self.convert_expr(ctx.used().set_needs_address(false), arg, None)?
             .try_map(|val: Box<Expr>| {
                 if let CTypeKind::Function(..) =
                     self.ast_context.resolve_type(cqual_type.ctype).kind
@@ -291,13 +291,14 @@ impl<'c> Translation<'c> {
                 ref other => panic!("Unexpected array type {:?}", other),
             };
 
-            let array_rs = self.convert_expr(ctx.used(), array_id, None)?;
+            let array_rs =
+                self.convert_expr(ctx.used().set_needs_address(false), array_id, None)?;
 
             // Don't dereference the offset if we're still within the variable portion
             let val = if let Some(elt_type_id) = var_elt_type_id {
                 let target_type_id = self.ast_context.type_for_kind(&CTypeKind::SSize);
                 let offset_rs = self.convert_expr_with_cast(
-                    ctx.used(),
+                    ctx.used().set_needs_address(false),
                     CQualTypeId::new(target_type_id),
                     offset_id,
                 )?;
@@ -307,7 +308,7 @@ impl<'c> Translation<'c> {
             } else {
                 let target_type_id = self.ast_context.type_for_kind(&CTypeKind::Size);
                 let offset_rs = self.convert_expr_with_cast(
-                    ctx.used(),
+                    ctx.used().set_needs_address(false),
                     CQualTypeId::new(target_type_id),
                     offset_id,
                 )?;
@@ -331,10 +332,14 @@ impl<'c> Translation<'c> {
             };
 
             // LHS must be ref decayed for the offset method call's self param
-            let pointer_rs = self.convert_expr(ctx.used().decay_ref(), pointer_id, None)?;
+            let pointer_rs = self.convert_expr(
+                ctx.used().set_needs_address(false).decay_ref(),
+                pointer_id,
+                None,
+            )?;
             let target_type_id = self.ast_context.type_for_kind(&CTypeKind::SSize);
             let offset_rs = self.convert_expr_with_cast(
-                ctx.used(),
+                ctx.used().set_needs_address(false),
                 CQualTypeId::new(target_type_id),
                 offset_id,
             )?;

--- a/c2rust-transpile/tests/snapshots/arrays.c
+++ b/c2rust-transpile/tests/snapshots/arrays.c
@@ -79,3 +79,18 @@ void variable_length(void) {
     int (*second)[length] = first + 1;
     ptrdiff_t diff = second - first;
 }
+
+extern int my_array[1];
+extern int my_indexes[1];
+unsigned long my_index(void);
+
+void addr_of_subscript(void) {
+    int *array = &my_array[my_indexes[0]];
+    int *call = &my_array[my_index()];
+}
+
+extern void (*funcs[1])(void);
+
+void func_ptr_array(void) {
+    (*funcs[0])();
+}

--- a/c2rust-transpile/tests/snapshots/compound_literals.c
+++ b/c2rust-transpile/tests/snapshots/compound_literals.c
@@ -25,3 +25,7 @@ void local_compound_literals() {
     int (*macro_int_array_ptr)[2] = &INT_ARRAY;
     char (*macro_char_array_ptr)[6] = &CHAR_ARRAY;
 }
+
+void deref_addrof(void) {
+    int *p = *&(int[]){1, 2, 3};
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.clang15.snap
@@ -12,6 +12,12 @@ expression: cat tests/snapshots/arrays.2021.clang15.rs
     unused_mut
 )]
 #![feature(raw_ref_op)]
+extern "C" {
+    static mut my_array: [::core::ffi::c_int; 1];
+    static mut my_indexes: [::core::ffi::c_int; 1];
+    fn my_index() -> ::core::ffi::c_ulong;
+    static mut funcs: [Option<unsafe extern "C" fn() -> ()>; 1];
+}
 pub type ptrdiff_t = isize;
 pub type size_t = usize;
 pub type int_t = ::core::ffi::c_int;
@@ -160,4 +166,19 @@ pub unsafe extern "C" fn variable_length() {
     let mut second: *mut ::core::ffi::c_int =
         first.offset(1 as ::core::ffi::c_int as isize * vla_2 as isize) as *mut ::core::ffi::c_int;
     let mut diff: ptrdiff_t = second.offset_from(first) / vla_2 as isize;
+}
+#[no_mangle]
+pub unsafe extern "C" fn addr_of_subscript() {
+    let mut array: *mut ::core::ffi::c_int = (&raw mut my_array as *mut ::core::ffi::c_int)
+        .offset(*(&raw mut my_indexes as *mut ::core::ffi::c_int).offset(0isize) as isize);
+    let mut call: *mut ::core::ffi::c_int = (&raw mut my_array as *mut ::core::ffi::c_int)
+        .offset((my_index as unsafe extern "C" fn() -> ::core::ffi::c_ulong)() as isize);
+}
+#[no_mangle]
+pub unsafe extern "C" fn func_ptr_array() {
+    Some(
+        (*(&raw mut funcs as *mut Option<unsafe extern "C" fn() -> ()>).offset(0isize))
+            .expect("non-null function pointer"),
+    )
+    .expect("non-null function pointer")();
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2021.clang15.snap
@@ -169,16 +169,12 @@ pub unsafe extern "C" fn variable_length() {
 }
 #[no_mangle]
 pub unsafe extern "C" fn addr_of_subscript() {
-    let mut array: *mut ::core::ffi::c_int = (&raw mut my_array as *mut ::core::ffi::c_int)
-        .offset(*(&raw mut my_indexes as *mut ::core::ffi::c_int).offset(0isize) as isize);
-    let mut call: *mut ::core::ffi::c_int = (&raw mut my_array as *mut ::core::ffi::c_int)
-        .offset((my_index as unsafe extern "C" fn() -> ::core::ffi::c_ulong)() as isize);
+    let mut array: *mut ::core::ffi::c_int =
+        (&raw mut my_array as *mut ::core::ffi::c_int).offset(my_indexes[0usize] as isize);
+    let mut call: *mut ::core::ffi::c_int =
+        (&raw mut my_array as *mut ::core::ffi::c_int).offset(my_index() as isize);
 }
 #[no_mangle]
 pub unsafe extern "C" fn func_ptr_array() {
-    Some(
-        (*(&raw mut funcs as *mut Option<unsafe extern "C" fn() -> ()>).offset(0isize))
-            .expect("non-null function pointer"),
-    )
-    .expect("non-null function pointer")();
+    Some(funcs[0usize].expect("non-null function pointer")).expect("non-null function pointer")();
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.clang15.snap
@@ -12,6 +12,12 @@ expression: cat tests/snapshots/arrays.2024.clang15.rs
     unused_assignments,
     unused_mut
 )]
+unsafe extern "C" {
+    static mut my_array: [::core::ffi::c_int; 1];
+    static mut my_indexes: [::core::ffi::c_int; 1];
+    unsafe fn my_index() -> ::core::ffi::c_ulong;
+    static mut funcs: [Option<unsafe extern "C" fn() -> ()>; 1];
+}
 pub type ptrdiff_t = isize;
 pub type size_t = usize;
 pub type int_t = ::core::ffi::c_int;
@@ -160,4 +166,19 @@ pub unsafe extern "C" fn variable_length() {
     let mut second: *mut ::core::ffi::c_int =
         first.offset(1 as ::core::ffi::c_int as isize * vla_2 as isize) as *mut ::core::ffi::c_int;
     let mut diff: ptrdiff_t = second.offset_from(first) / vla_2 as isize;
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn addr_of_subscript() {
+    let mut array: *mut ::core::ffi::c_int = (&raw mut my_array as *mut ::core::ffi::c_int)
+        .offset(*(&raw mut my_indexes as *mut ::core::ffi::c_int).offset(0isize) as isize);
+    let mut call: *mut ::core::ffi::c_int = (&raw mut my_array as *mut ::core::ffi::c_int)
+        .offset((my_index as unsafe extern "C" fn() -> ::core::ffi::c_ulong)() as isize);
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn func_ptr_array() {
+    Some(
+        (*(&raw mut funcs as *mut Option<unsafe extern "C" fn() -> ()>).offset(0isize))
+            .expect("non-null function pointer"),
+    )
+    .expect("non-null function pointer")();
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@arrays.c.2024.clang15.snap
@@ -169,16 +169,12 @@ pub unsafe extern "C" fn variable_length() {
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn addr_of_subscript() {
-    let mut array: *mut ::core::ffi::c_int = (&raw mut my_array as *mut ::core::ffi::c_int)
-        .offset(*(&raw mut my_indexes as *mut ::core::ffi::c_int).offset(0isize) as isize);
-    let mut call: *mut ::core::ffi::c_int = (&raw mut my_array as *mut ::core::ffi::c_int)
-        .offset((my_index as unsafe extern "C" fn() -> ::core::ffi::c_ulong)() as isize);
+    let mut array: *mut ::core::ffi::c_int =
+        (&raw mut my_array as *mut ::core::ffi::c_int).offset(my_indexes[0usize] as isize);
+    let mut call: *mut ::core::ffi::c_int =
+        (&raw mut my_array as *mut ::core::ffi::c_int).offset(my_index() as isize);
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn func_ptr_array() {
-    Some(
-        (*(&raw mut funcs as *mut Option<unsafe extern "C" fn() -> ()>).offset(0isize))
-            .expect("non-null function pointer"),
-    )
-    .expect("non-null function pointer")();
+    Some(funcs[0usize].expect("non-null function pointer")).expect("non-null function pointer")();
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2021.clang15.snap
@@ -74,3 +74,12 @@ pub unsafe extern "C" fn local_compound_literals() {
     let mut macro_char_array_ptr: *mut [::core::ffi::c_char; 6] =
         &mut CHAR_ARRAY as *mut [::core::ffi::c_char; 6];
 }
+#[no_mangle]
+pub unsafe extern "C" fn deref_addrof() {
+    let mut c2rust_lvalue_5: [::core::ffi::c_int; 3] = [
+        1 as ::core::ffi::c_int,
+        2 as ::core::ffi::c_int,
+        3 as ::core::ffi::c_int,
+    ];
+    let mut p: *mut ::core::ffi::c_int = &raw mut c2rust_lvalue_5 as *mut ::core::ffi::c_int;
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2024.clang15.snap
@@ -74,3 +74,12 @@ pub unsafe extern "C" fn local_compound_literals() {
     let mut macro_char_array_ptr: *mut [::core::ffi::c_char; 6] =
         &mut CHAR_ARRAY as *mut [::core::ffi::c_char; 6];
 }
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn deref_addrof() {
+    let mut c2rust_lvalue_5: [::core::ffi::c_int; 3] = [
+        1 as ::core::ffi::c_int,
+        2 as ::core::ffi::c_int,
+        3 as ::core::ffi::c_int,
+    ];
+    let mut p: *mut ::core::ffi::c_int = &raw mut c2rust_lvalue_5 as *mut ::core::ffi::c_int;
+}


### PR DESCRIPTION
`needs_address` is being set, but it is then passed down to all subexpressions, even those whose address is never actually taken.