### PR TITLE
transpile: Bring `needs_address` and `is_bitfield_write` in line with other contexts

### DIFF
--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -211,7 +211,7 @@ impl<'c> Translation<'c> {
 
         // Translate the expression to be assigned to the fresh variable.
         // It will be assigned by value, so we don't need its address anymore.
-        let val = self.convert_expr(ctx.set_needs_address(false), val, override_ty)?;
+        let val = self.convert_expr(ctx.not_needs_address(), val, override_ty)?;
 
         // If we are translating a static variable,
         // then the fresh variable should also be static.

--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -199,7 +199,7 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         // C compound literals are lvalues, but equivalent Rust expressions generally are not.
         // So if an address is needed, store it in an intermediate variable first.
-        if !ctx.needs_address() || ctx.expanding_macro.is_some() {
+        if !ctx.needs_address || ctx.expanding_macro.is_some() {
             return self.convert_expr(ctx, val, override_ty);
         }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -209,18 +209,14 @@ impl ExprContext {
             ..self
         }
     }
-    pub fn is_bitfield_write(&self) -> bool {
-        self.is_bitfield_write
-    }
+
     pub fn set_bitfield_write(self, is_bitfield_write: bool) -> Self {
         ExprContext {
             is_bitfield_write,
             ..self
         }
     }
-    pub fn needs_address(&self) -> bool {
-        self.needs_address
-    }
+
     pub fn set_needs_address(self, needs_address: bool) -> Self {
         ExprContext {
             needs_address,
@@ -3824,7 +3820,7 @@ impl<'c> Translation<'c> {
             CDeclKind::Function { parameters, .. } => {
                 // If we are referring to a function and need its address, we
                 // need to cast it to fn() to ensure that it has a real address.
-                if ctx.needs_address() {
+                if ctx.needs_address {
                     let ty = self.convert_type(result_type_id.ctype)?;
                     let actual_ty = self
                         .type_converter
@@ -3872,7 +3868,7 @@ impl<'c> Translation<'c> {
                 // but this requirement was removed in later versions of the
                 // `raw_ref_op` feature.
                 if (*has_static_duration || *has_thread_duration)
-                    && (self.tcfg.edition < Edition2024 || !ctx.needs_address())
+                    && (self.tcfg.edition < Edition2024 || !ctx.needs_address)
                 {
                     set_unsafe = true;
                 }

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -210,16 +210,23 @@ impl ExprContext {
         }
     }
 
-    pub fn set_bitfield_write(self, is_bitfield_write: bool) -> Self {
+    pub fn bitfield_write(self) -> Self {
         ExprContext {
-            is_bitfield_write,
+            is_bitfield_write: true,
             ..self
         }
     }
 
-    pub fn set_needs_address(self, needs_address: bool) -> Self {
+    pub fn needs_address(self) -> Self {
         ExprContext {
-            needs_address,
+            needs_address: true,
+            ..self
+        }
+    }
+
+    pub fn not_needs_address(self) -> Self {
+        ExprContext {
+            needs_address: false,
             ..self
         }
     }

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -243,7 +243,7 @@ impl<'c> Translation<'c> {
             ));
         }
 
-        let simple_index_array = if ctx.needs_address() {
+        let simple_index_array = if ctx.needs_address {
             // We can't necessarily index into an array if we're using
             // that element to compute an address.
             None

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -32,7 +32,7 @@ impl<'c> Translation<'c> {
             // Array subscript functions as a deref too.
             &CExprKind::ArraySubscript(_, lhs, rhs, _) => {
                 return self.convert_array_subscript(
-                    ctx.used().set_needs_address(true),
+                    ctx.used().needs_address(),
                     Some(cqual_type),
                     lhs,
                     rhs,
@@ -47,7 +47,7 @@ impl<'c> Translation<'c> {
             _ => (),
         }
 
-        let val = self.convert_expr(ctx.used().set_needs_address(true), arg, None)?;
+        let val = self.convert_expr(ctx.used().needs_address(), arg, None)?;
 
         // & becomes a no-op when applied to a function.
         if self.ast_context.is_function_pointer(cqual_type.ctype) {
@@ -201,7 +201,7 @@ impl<'c> Translation<'c> {
             return self.convert_expr(ctx.used(), arg, None);
         }
 
-        self.convert_expr(ctx.used().set_needs_address(false), arg, None)?
+        self.convert_expr(ctx.used().not_needs_address(), arg, None)?
             .try_map(|val: Box<Expr>| {
                 if let CTypeKind::Function(..) =
                     self.ast_context.resolve_type(cqual_type.ctype).kind
@@ -291,14 +291,13 @@ impl<'c> Translation<'c> {
                 ref other => panic!("Unexpected array type {:?}", other),
             };
 
-            let array_rs =
-                self.convert_expr(ctx.used().set_needs_address(false), array_id, None)?;
+            let array_rs = self.convert_expr(ctx.used().not_needs_address(), array_id, None)?;
 
             // Don't dereference the offset if we're still within the variable portion
             let val = if let Some(elt_type_id) = var_elt_type_id {
                 let target_type_id = self.ast_context.type_for_kind(&CTypeKind::SSize);
                 let offset_rs = self.convert_expr_with_cast(
-                    ctx.used().set_needs_address(false),
+                    ctx.used().not_needs_address(),
                     CQualTypeId::new(target_type_id),
                     offset_id,
                 )?;
@@ -308,7 +307,7 @@ impl<'c> Translation<'c> {
             } else {
                 let target_type_id = self.ast_context.type_for_kind(&CTypeKind::Size);
                 let offset_rs = self.convert_expr_with_cast(
-                    ctx.used().set_needs_address(false),
+                    ctx.used().not_needs_address(),
                     CQualTypeId::new(target_type_id),
                     offset_id,
                 )?;
@@ -332,14 +331,11 @@ impl<'c> Translation<'c> {
             };
 
             // LHS must be ref decayed for the offset method call's self param
-            let pointer_rs = self.convert_expr(
-                ctx.used().set_needs_address(false).decay_ref(),
-                pointer_id,
-                None,
-            )?;
+            let pointer_rs =
+                self.convert_expr(ctx.used().not_needs_address().decay_ref(), pointer_id, None)?;
             let target_type_id = self.ast_context.type_for_kind(&CTypeKind::SSize);
             let offset_rs = self.convert_expr_with_cast(
-                ctx.used().set_needs_address(false),
+                ctx.used().not_needs_address(),
                 CQualTypeId::new(target_type_id),
                 offset_id,
             )?;

--- a/c2rust-transpile/src/translator/structs_unions.rs
+++ b/c2rust-transpile/src/translator/structs_unions.rs
@@ -743,8 +743,7 @@ impl<'a> Translation<'a> {
         rhs_expr: Box<Expr>,
         field_id: CDeclId,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
-        let ctx = ctx.set_bitfield_write(true);
-        let named_reference = self.name_reference_write_read(ctx, lhs)?;
+        let named_reference = self.name_reference_write_read(ctx.bitfield_write(), lhs)?;
         named_reference.and_then_try(
             |NamedReference {
                  lvalue: lhs_expr, ..


### PR DESCRIPTION
A small refactor to make things more consistent.