### PR TITLE
transpile: Remove `ternary_needs_parens`

### DIFF
--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -147,7 +147,6 @@ pub struct ExprContext {
     /// address in function pointer literals.
     needs_address: bool,
 
-    ternary_needs_parens: bool,
     expanding_macro: Option<CDeclId>,
 }
 
@@ -884,7 +883,6 @@ pub fn translate(
         decay_ref: DecayRef::Default,
         is_bitfield_write: false,
         needs_address: false,
-        ternary_needs_parens: false,
         expanding_macro: None,
     };
 
@@ -3576,15 +3574,7 @@ impl<'c> Translation<'c> {
                     let then = lhs.to_block();
                     let else_ = rhs.to_expr();
 
-                    Ok(cond.map(|c| {
-                        let ifte_expr = mk().ifte_expr(c, then, Some(else_));
-
-                        if ctx.ternary_needs_parens {
-                            mk().paren_expr(ifte_expr)
-                        } else {
-                            ifte_expr
-                        }
-                    }))
+                    Ok(cond.map(|c| mk().ifte_expr(c, then, Some(else_))))
                 }
             }
 

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -16,12 +16,6 @@ impl<'c> Translation<'c> {
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let expr_type_id = expected_type_id.unwrap_or(result_type_id);
 
-        // If we're not making an assignment, a binop will require parens
-        // applied to ternary conditionals
-        if !op.is_assignment() {
-            ctx.ternary_needs_parens = true;
-        }
-
         let lhs_loc = &self.ast_context.index_unwrap_parens(lhs).loc;
         let rhs_loc = &self.ast_context.index_unwrap_parens(rhs).loc;
         use CBinOp::*;


### PR DESCRIPTION
This seems to be leftover cruft from before c2rust used `syn` to generate its output. `syn` handles this automatically, so it's not necessary anymore.