### PR TITLE
transpile: Conservatively disallow mutable lvalues inside macros

### DIFF
--- a/c2rust-transpile/src/translator/literals.rs
+++ b/c2rust-transpile/src/translator/literals.rs
@@ -197,9 +197,13 @@ impl<'c> Translation<'c> {
         val: CExprId,
         override_ty: Option<CQualTypeId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
+        if !qty.qualifiers.is_const && ctx.expanding_macro.is_some() {
+            return Err("mutable lvalues are not supported inside macros".into());
+        }
+
         // C compound literals are lvalues, but equivalent Rust expressions generally are not.
         // So if an address is needed, store it in an intermediate variable first.
-        if !ctx.needs_address || ctx.expanding_macro.is_some() {
+        if !ctx.needs_address {
             return self.convert_expr(ctx, val, override_ty);
         }
 

--- a/c2rust-transpile/src/translator/mod.rs
+++ b/c2rust-transpile/src/translator/mod.rs
@@ -3544,8 +3544,8 @@ impl<'c> Translation<'c> {
                 matches!(expr_kind, CExprKind::ExplicitCast(..)),
             ),
 
-            Unary(result_type_id, op, arg, _lrvalue) => {
-                self.convert_unary_operator(ctx, override_ty, result_type_id, op, arg)
+            Unary(result_type_id, op, arg, lrvalue) => {
+                self.convert_unary_operator(ctx, override_ty, result_type_id, op, arg, lrvalue)
             }
 
             Conditional(ty, cond, lhs, rhs) => {
@@ -3637,8 +3637,8 @@ impl<'c> Translation<'c> {
                 )
                 .map_err(|e| e.add_loc(self.ast_context.display_loc(src_loc))),
 
-            ArraySubscript(_, lhs, rhs, lrvalue) => self
-                .convert_array_subscript(ctx, override_ty, lhs, rhs, lrvalue, true)
+            ArraySubscript(result_type_id, lhs, rhs, lrvalue) => self
+                .convert_array_subscript(ctx, override_ty, result_type_id, lhs, rhs, lrvalue, true)
                 .map_err(|e| e.add_loc(self.ast_context.display_loc(src_loc))),
 
             Call(call_expr_ty, func, ref args) => {
@@ -3759,6 +3759,8 @@ impl<'c> Translation<'c> {
             .get_decl(&decl_id)
             .ok_or_else(|| format_err!("Missing declref {:?}", decl_id))?
             .kind;
+
+        #[allow(unreachable_code)] // TODO temporary (see below).
         if ctx.expanding_macro.is_some() {
             // TODO Determining which declarations have been declared within the scope of the const macro expr
             // vs. which are out-of-scope of the const macro is non-trivial,
@@ -3768,7 +3770,10 @@ impl<'c> Translation<'c> {
                 "Cannot yet refer to declarations in a const expr",
             ));
 
-            #[allow(unreachable_code)] // TODO temporary (see above).
+            if matches!(lrvalue, LRValue::LValue) && !result_type_id.qualifiers.is_const {
+                return Err("mutable lvalues are not supported inside macros".into());
+            }
+
             if let CDeclKind::Variable {
                 has_static_duration: true,
                 ..

--- a/c2rust-transpile/src/translator/operators.rs
+++ b/c2rust-transpile/src/translator/operators.rs
@@ -570,6 +570,7 @@ impl<'c> Translation<'c> {
         result_type_id: CQualTypeId,
         op: CUnOp,
         arg: CExprId,
+        lrvalue: LRValue,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
         let expr_type_id = expected_type_id.unwrap_or(result_type_id);
         let mut unary = match op {
@@ -582,7 +583,7 @@ impl<'c> Translation<'c> {
                 self.convert_indecrement_operator(ctx, expected_type_id, result_type_id, op, arg)
             }
 
-            CUnOp::Deref => self.convert_deref(ctx, expr_type_id, arg),
+            CUnOp::Deref => self.convert_deref(ctx, expr_type_id, arg, lrvalue),
             CUnOp::Plus => self.convert_expr(ctx.used(), arg, expected_type_id), // promotion is explicit in the clang AST
 
             CUnOp::Negate => self.convert_negate_operator(ctx, expr_type_id, arg),

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -30,10 +30,11 @@ impl<'c> Translation<'c> {
                 return self.convert_expr(ctx, *target, None)
             }
             // Array subscript functions as a deref too.
-            &CExprKind::ArraySubscript(_, lhs, rhs, _) => {
+            &CExprKind::ArraySubscript(result_type_id, lhs, rhs, _) => {
                 return self.convert_array_subscript(
                     ctx.used().needs_address(),
                     Some(cqual_type),
+                    result_type_id,
                     lhs,
                     rhs,
                     LRValue::RValue, // if we bypass the deref, we stay an RValue
@@ -194,7 +195,15 @@ impl<'c> Translation<'c> {
         ctx: ExprContext,
         cqual_type: CQualTypeId,
         arg: CExprId,
+        lrvalue: LRValue,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
+        if matches!(lrvalue, LRValue::LValue)
+            && !cqual_type.qualifiers.is_const
+            && ctx.expanding_macro.is_some()
+        {
+            return Err("mutable lvalues are not supported inside macros".into());
+        }
+
         let arg_expr_kind = &self.ast_context.index_unwrap_parens(arg).kind;
 
         if let &CExprKind::Unary(_, CUnOp::AddressOf, arg, _) = arg_expr_kind {
@@ -219,11 +228,19 @@ impl<'c> Translation<'c> {
         &self,
         ctx: ExprContext,
         expected_type_id: Option<CQualTypeId>,
+        result_type_id: CQualTypeId,
         lhs: CExprId,
         rhs: CExprId,
         lrvalue: LRValue,
         deref: bool,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
+        if matches!(lrvalue, LRValue::LValue)
+            && !result_type_id.qualifiers.is_const
+            && ctx.expanding_macro.is_some()
+        {
+            return Err("mutable lvalues are not supported inside macros".into());
+        }
+
         let (pointer_id, offset_id) = if self.ast_context.expr_is_indexable(lhs) {
             (lhs, rhs)
         } else {

--- a/c2rust-transpile/src/translator/pointers.rs
+++ b/c2rust-transpile/src/translator/pointers.rs
@@ -139,14 +139,14 @@ impl<'c> Translation<'c> {
         // Values that translate into const temporaries can't be raw-borrowed in Rust.
         // They must be regular-borrowed first, which will extend the lifetime to static.
         else if arg_is_macro || matches!(arg_expr_kind, Some(CExprKind::Literal(..))) {
+            if !pointee_cty.qualifiers.is_const {
+                return Err("taking mutable address of string literal or macro".into());
+            }
+
             let arg_cty_kind = &self.ast_context.resolve_type(arg_cty.ctype).kind;
 
             if is_array_decay {
-                let method = match mutbl {
-                    Mutability::Mutable => "as_mut_ptr",
-                    Mutability::Immutable => "as_ptr",
-                };
-                val = val.map(|val| mk().method_call_expr(val, method, vec![]));
+                val = val.map(|val| mk().method_call_expr(val, "as_ptr", vec![]));
 
                 // If the target pointee type is different from the source element type,
                 // then we need to cast the ptr type as well.
@@ -156,7 +156,7 @@ impl<'c> Translation<'c> {
                     needs_cast = true;
                 }
             } else {
-                val = val.map(|val| mk().set_mutbl(mutbl).borrow_expr(val));
+                val = val.map(|val| mk().borrow_expr(val));
 
                 // Add an intermediate reference-to-pointer cast if the context needs
                 // reference-to-pointer decay, or if another cast follows.

--- a/c2rust-transpile/src/translator/structs_unions.rs
+++ b/c2rust-transpile/src/translator/structs_unions.rs
@@ -1053,6 +1053,13 @@ impl<'a> Translation<'a> {
         lrvalue: LRValue,
         override_ty: Option<CQualTypeId>,
     ) -> TranslationResult<WithStmts<Box<Expr>>> {
+        if matches!(lrvalue, LRValue::LValue)
+            && !qual_ty.qualifiers.is_const
+            && ctx.expanding_macro.is_some()
+        {
+            return Err("mutable lvalues are not supported inside macros".into());
+        }
+
         if ctx.is_unused() {
             return self.convert_expr(ctx, expr, None);
         }

--- a/c2rust-transpile/tests/snapshots/macros.c
+++ b/c2rust-transpile/tests/snapshots/macros.c
@@ -52,131 +52,6 @@ struct S {
         mixed;                                                                 \
     })
 
-void local_muts() {
-    int literal_int = LITERAL_INT;
-    bool literal_bool = LITERAL_BOOL;
-    float literal_float = LITERAL_FLOAT;
-    char literal_char = LITERAL_CHAR;
-    const char *literal_str_ptr = LITERAL_STR;
-    char literal_str[] = LITERAL_STR;
-    int literal_array[] = LITERAL_ARRAY;
-    struct S literal_struct = LITERAL_STRUCT;
-    struct S literal_struct_mut = LITERAL_STRUCT_MUT;
-
-    int nested_int = NESTED_INT;
-    bool nested_bool = NESTED_BOOL;
-    float nested_float = NESTED_FLOAT;
-    char nested_char = NESTED_CHAR;
-    const char *nested_str_ptr = NESTED_STR;
-    char nested_str[] = NESTED_STR;
-    int nested_array[] = NESTED_ARRAY;
-    struct S nested_struct = NESTED_STRUCT;
-
-    int negative_int = NEGATIVE_INT;
-    int int_arithmetic = INT_ARITHMETIC;
-    float mixed_arithmetic = MIXED_ARITHMETIC;
-    int parens = PARENS;
-    const char *ptr_arithmetic = PTR_ARITHMETIC;
-    unsigned long long widening_cast = WIDENING_CAST;
-    char narrowing_cast = NARROWING_CAST;
-    double conversion_cast = CONVERSION_CAST;
-    char indexing = INDEXING;
-    const char *str_concatenation_ptr = STR_CONCATENATION;
-    char str_concatenation[] = STR_CONCATENATION;
-    int builtin = BUILTIN;
-    const char *ref_indexing = REF_MACRO;
-    const struct S *ref_struct = REF_LITERAL;
-    struct S *ref_struct_mut = REF_LITERAL_MUT;
-    int ternary = TERNARY;
-    int member = MEMBER;
-    int member_mut = MEMBER_MUT;
-    float stmt_expr = STMT_EXPR;
-}
-
-void local_consts() {
-    const int literal_int = LITERAL_INT;
-    const bool literal_bool = LITERAL_BOOL;
-    const float literal_float = LITERAL_FLOAT;
-    const char literal_char = LITERAL_CHAR;
-    const char *const literal_str_ptr = LITERAL_STR;
-    const char literal_str[] = LITERAL_STR;
-    const int literal_array[] = LITERAL_ARRAY;
-    const struct S literal_struct = LITERAL_STRUCT;
-    const struct S literal_struct_mut = LITERAL_STRUCT_MUT;
-
-    const int nested_int = NESTED_INT;
-    const bool nested_bool = NESTED_BOOL;
-    const float nested_float = NESTED_FLOAT;
-    const char nested_char = NESTED_CHAR;
-    const char *const nested_str_ptr = NESTED_STR;
-    const char nested_str[] = NESTED_STR;
-    const int nested_array[] = NESTED_ARRAY;
-    const struct S nested_struct = NESTED_STRUCT;
-
-    const int negative_int = NEGATIVE_INT;
-    const int int_arithmetic = INT_ARITHMETIC;
-    const float mixed_arithmetic = MIXED_ARITHMETIC;
-    const int parens = PARENS;
-    const char *const ptr_arithmetic = PTR_ARITHMETIC;
-    const unsigned long long widening_cast = WIDENING_CAST;
-    const char narrowing_cast = NARROWING_CAST;
-    const double conversion_cast = CONVERSION_CAST;
-    const char indexing = INDEXING;
-    const char *const str_concatenation_ptr = STR_CONCATENATION;
-    const char str_concatenation[] = STR_CONCATENATION;
-    const int builtin = BUILTIN;
-    const char *const ref_indexing = REF_MACRO;
-    const struct S *const ref_struct = REF_LITERAL;
-    struct S *const ref_struct_mut = REF_LITERAL_MUT;
-    const int ternary = TERNARY;
-    const int member = MEMBER;
-    const int member_mut = MEMBER_MUT;
-    const float stmt_expr = STMT_EXPR;
-}
-
-// TODO These are declared in the global scope and thus clash,
-// which is an error for statics.
-#if 0
-void local_static_consts() {
-    static const int literal_int = LITERAL_INT;
-    static const bool literal_bool = LITERAL_BOOL;
-    static const float literal_float = LITERAL_FLOAT;
-    static const char literal_char = LITERAL_CHAR;
-    static const char *const literal_str_ptr = LITERAL_STR;
-    static const char literal_str[] = LITERAL_STR;
-    static const int literal_array[] = LITERAL_ARRAY;
-    static const struct S literal_struct = LITERAL_STRUCT;
-    static const struct S literal_struct_mut = LITERAL_STRUCT_MUT;
-
-    static const int nested_int = NESTED_INT;
-    static const bool nested_bool = NESTED_BOOL;
-    static const float nested_float = NESTED_FLOAT;
-    static const char nested_char = NESTED_CHAR;
-    static const char *const nested_str_ptr = NESTED_STR;
-    static const char nested_str[] = NESTED_STR;
-    static const int nested_array[] = NESTED_ARRAY;
-    static const struct S nested_struct = NESTED_STRUCT;
-
-    static const int int_arithmetic = INT_ARITHMETIC;
-    static const float mixed_arithmetic = MIXED_ARITHMETIC;
-    static const int parens = PARENS;
-    static const char *const ptr_arithmetic = PTR_ARITHMETIC;
-    static const unsigned long long widening_cast = WIDENING_CAST;
-    static const char narrowing_cast = NARROWING_CAST;
-    static const double conversion_cast = CONVERSION_CAST;
-    static const char indexing = INDEXING;
-    static const char *const str_concatenation_ptr = STR_CONCATENATION;
-    static const char str_concatenation[] = STR_CONCATENATION;
-    static const int builtin = BUILTIN;
-    static const char *const ref_indexing = REF_MACRO;
-    static const struct S *const ref_struct = REF_LITERAL;
-    static struct S *const ref_struct_mut = REF_LITERAL_MUT;
-    static const int ternary = TERNARY;
-    static const int member = MEMBER;
-    static const float stmt_expr = STMT_EXPR;
-}
-#endif
-
 // global static consts
 
 static const int global_static_const_literal_int = LITERAL_INT;
@@ -302,6 +177,131 @@ const int global_const_ternary = TERNARY;
 const int global_const_member = MEMBER;
 const int global_const_member_mut = MEMBER_MUT;
 // const float global_const_stmt_expr = STMT_EXPR; // Statement expression not allowed at file scope.
+
+void local_muts() {
+    int literal_int = LITERAL_INT;
+    bool literal_bool = LITERAL_BOOL;
+    float literal_float = LITERAL_FLOAT;
+    char literal_char = LITERAL_CHAR;
+    const char *literal_str_ptr = LITERAL_STR;
+    char literal_str[] = LITERAL_STR;
+    int literal_array[] = LITERAL_ARRAY;
+    struct S literal_struct = LITERAL_STRUCT;
+    struct S literal_struct_mut = LITERAL_STRUCT_MUT;
+
+    int nested_int = NESTED_INT;
+    bool nested_bool = NESTED_BOOL;
+    float nested_float = NESTED_FLOAT;
+    char nested_char = NESTED_CHAR;
+    const char *nested_str_ptr = NESTED_STR;
+    char nested_str[] = NESTED_STR;
+    int nested_array[] = NESTED_ARRAY;
+    struct S nested_struct = NESTED_STRUCT;
+
+    int negative_int = NEGATIVE_INT;
+    int int_arithmetic = INT_ARITHMETIC;
+    float mixed_arithmetic = MIXED_ARITHMETIC;
+    int parens = PARENS;
+    const char *ptr_arithmetic = PTR_ARITHMETIC;
+    unsigned long long widening_cast = WIDENING_CAST;
+    char narrowing_cast = NARROWING_CAST;
+    double conversion_cast = CONVERSION_CAST;
+    char indexing = INDEXING;
+    const char *str_concatenation_ptr = STR_CONCATENATION;
+    char str_concatenation[] = STR_CONCATENATION;
+    int builtin = BUILTIN;
+    const char *ref_indexing = REF_MACRO;
+    const struct S *ref_struct = REF_LITERAL;
+    struct S *ref_struct_mut = REF_LITERAL_MUT;
+    int ternary = TERNARY;
+    int member = MEMBER;
+    int member_mut = MEMBER_MUT;
+    float stmt_expr = STMT_EXPR;
+}
+
+void local_consts() {
+    const int literal_int = LITERAL_INT;
+    const bool literal_bool = LITERAL_BOOL;
+    const float literal_float = LITERAL_FLOAT;
+    const char literal_char = LITERAL_CHAR;
+    const char *const literal_str_ptr = LITERAL_STR;
+    const char literal_str[] = LITERAL_STR;
+    const int literal_array[] = LITERAL_ARRAY;
+    const struct S literal_struct = LITERAL_STRUCT;
+    const struct S literal_struct_mut = LITERAL_STRUCT_MUT;
+
+    const int nested_int = NESTED_INT;
+    const bool nested_bool = NESTED_BOOL;
+    const float nested_float = NESTED_FLOAT;
+    const char nested_char = NESTED_CHAR;
+    const char *const nested_str_ptr = NESTED_STR;
+    const char nested_str[] = NESTED_STR;
+    const int nested_array[] = NESTED_ARRAY;
+    const struct S nested_struct = NESTED_STRUCT;
+
+    const int negative_int = NEGATIVE_INT;
+    const int int_arithmetic = INT_ARITHMETIC;
+    const float mixed_arithmetic = MIXED_ARITHMETIC;
+    const int parens = PARENS;
+    const char *const ptr_arithmetic = PTR_ARITHMETIC;
+    const unsigned long long widening_cast = WIDENING_CAST;
+    const char narrowing_cast = NARROWING_CAST;
+    const double conversion_cast = CONVERSION_CAST;
+    const char indexing = INDEXING;
+    const char *const str_concatenation_ptr = STR_CONCATENATION;
+    const char str_concatenation[] = STR_CONCATENATION;
+    const int builtin = BUILTIN;
+    const char *const ref_indexing = REF_MACRO;
+    const struct S *const ref_struct = REF_LITERAL;
+    struct S *const ref_struct_mut = REF_LITERAL_MUT;
+    const int ternary = TERNARY;
+    const int member = MEMBER;
+    const int member_mut = MEMBER_MUT;
+    const float stmt_expr = STMT_EXPR;
+}
+
+// TODO These are declared in the global scope and thus clash,
+// which is an error for statics.
+#if 0
+void local_static_consts() {
+    static const int literal_int = LITERAL_INT;
+    static const bool literal_bool = LITERAL_BOOL;
+    static const float literal_float = LITERAL_FLOAT;
+    static const char literal_char = LITERAL_CHAR;
+    static const char *const literal_str_ptr = LITERAL_STR;
+    static const char literal_str[] = LITERAL_STR;
+    static const int literal_array[] = LITERAL_ARRAY;
+    static const struct S literal_struct = LITERAL_STRUCT;
+    static const struct S literal_struct_mut = LITERAL_STRUCT_MUT;
+
+    static const int nested_int = NESTED_INT;
+    static const bool nested_bool = NESTED_BOOL;
+    static const float nested_float = NESTED_FLOAT;
+    static const char nested_char = NESTED_CHAR;
+    static const char *const nested_str_ptr = NESTED_STR;
+    static const char nested_str[] = NESTED_STR;
+    static const int nested_array[] = NESTED_ARRAY;
+    static const struct S nested_struct = NESTED_STRUCT;
+
+    static const int int_arithmetic = INT_ARITHMETIC;
+    static const float mixed_arithmetic = MIXED_ARITHMETIC;
+    static const int parens = PARENS;
+    static const char *const ptr_arithmetic = PTR_ARITHMETIC;
+    static const unsigned long long widening_cast = WIDENING_CAST;
+    static const char narrowing_cast = NARROWING_CAST;
+    static const double conversion_cast = CONVERSION_CAST;
+    static const char indexing = INDEXING;
+    static const char *const str_concatenation_ptr = STR_CONCATENATION;
+    static const char str_concatenation[] = STR_CONCATENATION;
+    static const int builtin = BUILTIN;
+    static const char *const ref_indexing = REF_MACRO;
+    static const struct S *const ref_struct = REF_LITERAL;
+    static struct S *const ref_struct_mut = REF_LITERAL_MUT;
+    static const int ternary = TERNARY;
+    static const int member = MEMBER;
+    static const float stmt_expr = STMT_EXPR;
+}
+#endif
 
 typedef unsigned long long U64;
 

--- a/c2rust-transpile/tests/snapshots/macros.c
+++ b/c2rust-transpile/tests/snapshots/macros.c
@@ -12,7 +12,8 @@ struct S {
 #define LITERAL_CHAR 'x'
 #define LITERAL_STR "hello"
 #define LITERAL_ARRAY {1, 2, 3}
-#define LITERAL_STRUCT ((struct S){.i = 5})
+#define LITERAL_STRUCT ((const struct S){.i = 5})
+#define LITERAL_STRUCT_MUT ((struct S){.i = 5})
 
 #define NESTED_INT LITERAL_INT
 #define NESTED_BOOL LITERAL_BOOL
@@ -35,8 +36,10 @@ struct S {
 #define BUILTIN __builtin_clz(LITERAL_INT)
 #define REF_MACRO &INDEXING
 #define REF_LITERAL &LITERAL_STRUCT
+#define REF_LITERAL_MUT &LITERAL_STRUCT_MUT
 #define TERNARY LITERAL_BOOL ? 1 : 2
 #define MEMBER LITERAL_STRUCT.i
+#define MEMBER_MUT LITERAL_STRUCT_MUT.i
 
 #define STMT_EXPR                                                              \
     ({                                                                         \
@@ -58,6 +61,7 @@ void local_muts() {
     char literal_str[] = LITERAL_STR;
     int literal_array[] = LITERAL_ARRAY;
     struct S literal_struct = LITERAL_STRUCT;
+    struct S literal_struct_mut = LITERAL_STRUCT_MUT;
 
     int nested_int = NESTED_INT;
     bool nested_bool = NESTED_BOOL;
@@ -82,8 +86,10 @@ void local_muts() {
     int builtin = BUILTIN;
     const char *ref_indexing = REF_MACRO;
     const struct S *ref_struct = REF_LITERAL;
+    struct S *ref_struct_mut = REF_LITERAL_MUT;
     int ternary = TERNARY;
     int member = MEMBER;
+    int member_mut = MEMBER_MUT;
     float stmt_expr = STMT_EXPR;
 }
 
@@ -96,6 +102,7 @@ void local_consts() {
     const char literal_str[] = LITERAL_STR;
     const int literal_array[] = LITERAL_ARRAY;
     const struct S literal_struct = LITERAL_STRUCT;
+    const struct S literal_struct_mut = LITERAL_STRUCT_MUT;
 
     const int nested_int = NESTED_INT;
     const bool nested_bool = NESTED_BOOL;
@@ -120,8 +127,10 @@ void local_consts() {
     const int builtin = BUILTIN;
     const char *const ref_indexing = REF_MACRO;
     const struct S *const ref_struct = REF_LITERAL;
+    struct S *const ref_struct_mut = REF_LITERAL_MUT;
     const int ternary = TERNARY;
     const int member = MEMBER;
+    const int member_mut = MEMBER_MUT;
     const float stmt_expr = STMT_EXPR;
 }
 
@@ -137,6 +146,7 @@ void local_static_consts() {
     static const char literal_str[] = LITERAL_STR;
     static const int literal_array[] = LITERAL_ARRAY;
     static const struct S literal_struct = LITERAL_STRUCT;
+    static const struct S literal_struct_mut = LITERAL_STRUCT_MUT;
 
     static const int nested_int = NESTED_INT;
     static const bool nested_bool = NESTED_BOOL;
@@ -160,6 +170,7 @@ void local_static_consts() {
     static const int builtin = BUILTIN;
     static const char *const ref_indexing = REF_MACRO;
     static const struct S *const ref_struct = REF_LITERAL;
+    static struct S *const ref_struct_mut = REF_LITERAL_MUT;
     static const int ternary = TERNARY;
     static const int member = MEMBER;
     static const float stmt_expr = STMT_EXPR;
@@ -176,6 +187,7 @@ static const char *const global_static_const_literal_str_ptr = LITERAL_STR;
 static const char global_static_const_literal_str[] = LITERAL_STR;
 static const int global_static_const_literal_array[] = LITERAL_ARRAY;
 static const struct S global_static_const_literal_struct = LITERAL_STRUCT;
+static const struct S global_static_const_literal_struct_mut = LITERAL_STRUCT_MUT;
 
 static const int global_static_const_nested_int = NESTED_INT;
 static const bool global_static_const_nested_bool = NESTED_BOOL;
@@ -202,8 +214,10 @@ static const char global_static_const_str_concatenation[] = STR_CONCATENATION;
 static const int global_static_const_builtin = BUILTIN;
 static const char *const global_static_const_ref_indexing = REF_MACRO;
 static const struct S *const global_static_const_ref_struct = REF_LITERAL;
+static struct S *const global_static_const_ref_struct_mut = REF_LITERAL_MUT;
 static const int global_static_const_ternary = TERNARY;
 static const int global_static_const_member = MEMBER;
+static const int global_static_const_member_mut = MEMBER_MUT;
 // static const float global_static_const_stmt_expr = STMT_EXPR; // Statement expression not allowed at file scope.
 
 void global_static_consts() {
@@ -216,6 +230,7 @@ void global_static_consts() {
     (void)global_static_const_literal_str;
     (void)global_static_const_literal_array;
     (void)global_static_const_literal_struct;
+    (void)global_static_const_literal_struct_mut;
 
     (void)global_static_const_nested_int;
     (void)global_static_const_nested_bool;
@@ -240,8 +255,10 @@ void global_static_consts() {
     (void)global_static_const_builtin;
     (void)global_static_const_ref_indexing;
     (void)global_static_const_ref_struct;
+    (void)global_static_const_ref_struct_mut;
     (void)global_static_const_ternary;
     (void)global_static_const_member;
+    (void)global_static_const_member_mut;
     // (void)global_static_const_stmt_expr;
 }
 
@@ -255,6 +272,7 @@ const char *const global_const_literal_str_ptr = LITERAL_STR;
 const char global_const_literal_str[] = LITERAL_STR;
 const int global_const_literal_array[] = LITERAL_ARRAY;
 const struct S global_const_literal_struct = LITERAL_STRUCT;
+const struct S global_const_literal_struct_mut = LITERAL_STRUCT_MUT;
 
 const int global_const_nested_int = NESTED_INT;
 const bool global_const_nested_bool = NESTED_BOOL;
@@ -279,8 +297,10 @@ const char global_const_str_concatenation[] = STR_CONCATENATION;
 const int global_const_builtin = BUILTIN;
 const char *const global_const_ref_indexing = REF_MACRO;
 const struct S *const global_const_ref_struct = REF_LITERAL;
+struct S *const global_const_ref_struct_mut = REF_LITERAL_MUT;
 const int global_const_ternary = TERNARY;
 const int global_const_member = MEMBER;
+const int global_const_member_mut = MEMBER_MUT;
 // const float global_const_stmt_expr = STMT_EXPR; // Statement expression not allowed at file scope.
 
 typedef unsigned long long U64;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2021.clang15.snap
@@ -40,11 +40,6 @@ static mut c2rust_lvalue_4: [::core::ffi::c_char; 6] =
 #[no_mangle]
 pub static mut static_char_array_ptr: *mut [::core::ffi::c_char; 6] =
     unsafe { &raw const c2rust_lvalue_4 as *mut [::core::ffi::c_char; 6] };
-pub const SINGLE_INT: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
-pub const INT_ARRAY: [::core::ffi::c_int; 2] =
-    [42 as ::core::ffi::c_int, 9001 as ::core::ffi::c_int];
-pub const CHAR_ARRAY: [::core::ffi::c_char; 6] =
-    unsafe { ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0") };
 #[no_mangle]
 pub unsafe extern "C" fn local_compound_literals() {
     let mut single_int: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
@@ -64,15 +59,23 @@ pub unsafe extern "C" fn local_compound_literals() {
     let mut c2rust_lvalue_9: [::core::ffi::c_char; 6] =
         ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0");
     let mut char_array_ptr: *mut [::core::ffi::c_char; 6] = &raw mut c2rust_lvalue_9;
-    let mut macro_single_int: ::core::ffi::c_int = SINGLE_INT;
-    let mut macro_single_int_ptr: *mut ::core::ffi::c_int =
-        &mut SINGLE_INT as *mut ::core::ffi::c_int;
-    let mut macro_int_ptr_to_array: *mut ::core::ffi::c_int = INT_ARRAY.as_mut_ptr();
-    let mut macro_char_ptr_to_array: *mut ::core::ffi::c_char = CHAR_ARRAY.as_mut_ptr();
-    let mut macro_int_array_ptr: *mut [::core::ffi::c_int; 2] =
-        &mut INT_ARRAY as *mut [::core::ffi::c_int; 2];
-    let mut macro_char_array_ptr: *mut [::core::ffi::c_char; 6] =
-        &mut CHAR_ARRAY as *mut [::core::ffi::c_char; 6];
+    let mut macro_single_int: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut c2rust_lvalue_10: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut macro_single_int_ptr: *mut ::core::ffi::c_int = &raw mut c2rust_lvalue_10;
+    let mut c2rust_lvalue_11: [::core::ffi::c_int; 2] =
+        [42 as ::core::ffi::c_int, 9001 as ::core::ffi::c_int];
+    let mut macro_int_ptr_to_array: *mut ::core::ffi::c_int =
+        &raw mut c2rust_lvalue_11 as *mut ::core::ffi::c_int;
+    let mut c2rust_lvalue_12: [::core::ffi::c_char; 6] =
+        ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0");
+    let mut macro_char_ptr_to_array: *mut ::core::ffi::c_char =
+        &raw mut c2rust_lvalue_12 as *mut ::core::ffi::c_char;
+    let mut c2rust_lvalue_13: [::core::ffi::c_int; 2] =
+        [42 as ::core::ffi::c_int, 9001 as ::core::ffi::c_int];
+    let mut macro_int_array_ptr: *mut [::core::ffi::c_int; 2] = &raw mut c2rust_lvalue_13;
+    let mut c2rust_lvalue_14: [::core::ffi::c_char; 6] =
+        ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0");
+    let mut macro_char_array_ptr: *mut [::core::ffi::c_char; 6] = &raw mut c2rust_lvalue_14;
 }
 #[no_mangle]
 pub unsafe extern "C" fn deref_addrof() {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@compound_literals.c.2024.clang15.snap
@@ -40,11 +40,6 @@ static mut c2rust_lvalue_4: [::core::ffi::c_char; 6] =
 #[unsafe(no_mangle)]
 pub static mut static_char_array_ptr: *mut [::core::ffi::c_char; 6] =
     &raw const c2rust_lvalue_4 as *mut [::core::ffi::c_char; 6];
-pub const SINGLE_INT: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
-pub const INT_ARRAY: [::core::ffi::c_int; 2] =
-    [42 as ::core::ffi::c_int, 9001 as ::core::ffi::c_int];
-pub const CHAR_ARRAY: [::core::ffi::c_char; 6] =
-    unsafe { ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0") };
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn local_compound_literals() {
     let mut single_int: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
@@ -64,15 +59,23 @@ pub unsafe extern "C" fn local_compound_literals() {
     let mut c2rust_lvalue_9: [::core::ffi::c_char; 6] =
         ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0");
     let mut char_array_ptr: *mut [::core::ffi::c_char; 6] = &raw mut c2rust_lvalue_9;
-    let mut macro_single_int: ::core::ffi::c_int = SINGLE_INT;
-    let mut macro_single_int_ptr: *mut ::core::ffi::c_int =
-        &mut SINGLE_INT as *mut ::core::ffi::c_int;
-    let mut macro_int_ptr_to_array: *mut ::core::ffi::c_int = INT_ARRAY.as_mut_ptr();
-    let mut macro_char_ptr_to_array: *mut ::core::ffi::c_char = CHAR_ARRAY.as_mut_ptr();
-    let mut macro_int_array_ptr: *mut [::core::ffi::c_int; 2] =
-        &mut INT_ARRAY as *mut [::core::ffi::c_int; 2];
-    let mut macro_char_array_ptr: *mut [::core::ffi::c_char; 6] =
-        &mut CHAR_ARRAY as *mut [::core::ffi::c_char; 6];
+    let mut macro_single_int: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut c2rust_lvalue_10: ::core::ffi::c_int = 42 as ::core::ffi::c_int;
+    let mut macro_single_int_ptr: *mut ::core::ffi::c_int = &raw mut c2rust_lvalue_10;
+    let mut c2rust_lvalue_11: [::core::ffi::c_int; 2] =
+        [42 as ::core::ffi::c_int, 9001 as ::core::ffi::c_int];
+    let mut macro_int_ptr_to_array: *mut ::core::ffi::c_int =
+        &raw mut c2rust_lvalue_11 as *mut ::core::ffi::c_int;
+    let mut c2rust_lvalue_12: [::core::ffi::c_char; 6] =
+        ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0");
+    let mut macro_char_ptr_to_array: *mut ::core::ffi::c_char =
+        &raw mut c2rust_lvalue_12 as *mut ::core::ffi::c_char;
+    let mut c2rust_lvalue_13: [::core::ffi::c_int; 2] =
+        [42 as ::core::ffi::c_int, 9001 as ::core::ffi::c_int];
+    let mut macro_int_array_ptr: *mut [::core::ffi::c_int; 2] = &raw mut c2rust_lvalue_13;
+    let mut c2rust_lvalue_14: [::core::ffi::c_char; 6] =
+        ::core::mem::transmute::<[u8; 6], [::core::ffi::c_char; 6]>(*b"hello\0");
+    let mut macro_char_array_ptr: *mut [::core::ffi::c_char; 6] = &raw mut c2rust_lvalue_14;
 }
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn deref_addrof() {

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.clang15.snap
@@ -48,12 +48,8 @@ pub const LITERAL_ARRAY: [::core::ffi::c_int; 3] = [
     2 as ::core::ffi::c_int,
     3 as ::core::ffi::c_int,
 ];
-pub const LITERAL_STRUCT: S = S {
-    i: 5 as ::core::ffi::c_int,
-};
-pub const LITERAL_STRUCT_MUT: S = S {
-    i: 5 as ::core::ffi::c_int,
-};
+pub const LITERAL_STRUCT: S = S { i: 5 };
+pub const LITERAL_STRUCT_MUT: S = S { i: 5 };
 pub const NESTED_INT: ::core::ffi::c_int = LITERAL_INT;
 pub const NESTED_BOOL: ::core::ffi::c_int = LITERAL_BOOL;
 pub const NESTED_FLOAT: ::core::ffi::c_double = LITERAL_FLOAT;
@@ -94,107 +90,6 @@ pub const TERNARY: ::core::ffi::c_int = if LITERAL_BOOL != 0 {
 };
 pub const MEMBER: ::core::ffi::c_int = LITERAL_STRUCT.i;
 pub const MEMBER_MUT: ::core::ffi::c_int = LITERAL_STRUCT_MUT.i;
-#[no_mangle]
-pub unsafe extern "C" fn local_muts() {
-    let mut literal_int: ::core::ffi::c_int = LITERAL_INT;
-    let mut literal_bool: bool = LITERAL_BOOL != 0;
-    let mut literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
-    let mut literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
-    let mut literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
-    let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
-    let mut literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
-    let mut literal_struct: S = LITERAL_STRUCT;
-    let mut literal_struct_mut: S = LITERAL_STRUCT_MUT;
-    let mut nested_int: ::core::ffi::c_int = NESTED_INT;
-    let mut nested_bool: bool = NESTED_BOOL != 0;
-    let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
-    let mut nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
-    let mut nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
-    let mut nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
-    let mut nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
-    let mut nested_struct: S = NESTED_STRUCT;
-    let mut negative_int: ::core::ffi::c_int = NEGATIVE_INT;
-    let mut int_arithmetic: ::core::ffi::c_int = INT_ARITHMETIC;
-    let mut mixed_arithmetic: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
-    let mut parens: ::core::ffi::c_int = PARENS;
-    let mut ptr_arithmetic: *const ::core::ffi::c_char = PTR_ARITHMETIC;
-    let mut widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
-    let mut narrowing_cast: ::core::ffi::c_char = NARROWING_CAST;
-    let mut conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
-    let mut indexing: ::core::ffi::c_char = INDEXING;
-    let mut str_concatenation_ptr: *const ::core::ffi::c_char = STR_CONCATENATION.as_ptr();
-    let mut str_concatenation: [::core::ffi::c_char; 18] = STR_CONCATENATION;
-    let mut builtin: ::core::ffi::c_int =
-        (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
-    let mut ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
-    let mut ref_struct: *const S = REF_LITERAL;
-    let mut ref_struct_mut: *mut S = REF_LITERAL_MUT;
-    let mut ternary: ::core::ffi::c_int = TERNARY;
-    let mut member: ::core::ffi::c_int = MEMBER;
-    let mut member_mut: ::core::ffi::c_int = MEMBER_MUT;
-    let mut stmt_expr: ::core::ffi::c_float = ({
-        let mut builtin_0: ::core::ffi::c_int =
-            (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
-        let mut indexing_0: ::core::ffi::c_char = INDEXING;
-        let mut mixed: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
-        let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-        while i < builtin_0 {
-            mixed += indexing_0 as ::core::ffi::c_float;
-            i += 1;
-        }
-        mixed
-    });
-}
-#[no_mangle]
-pub unsafe extern "C" fn local_consts() {
-    let literal_int: ::core::ffi::c_int = LITERAL_INT;
-    let literal_bool: bool = LITERAL_BOOL != 0;
-    let literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
-    let literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
-    let literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
-    let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
-    let literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
-    let literal_struct: S = LITERAL_STRUCT;
-    let literal_struct_mut: S = LITERAL_STRUCT_MUT;
-    let nested_int: ::core::ffi::c_int = NESTED_INT;
-    let nested_bool: bool = NESTED_BOOL != 0;
-    let nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
-    let nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
-    let nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
-    let nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
-    let nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
-    let nested_struct: S = NESTED_STRUCT;
-    let negative_int: ::core::ffi::c_int = NEGATIVE_INT;
-    let int_arithmetic: ::core::ffi::c_int = INT_ARITHMETIC;
-    let mixed_arithmetic: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
-    let parens: ::core::ffi::c_int = PARENS;
-    let ptr_arithmetic: *const ::core::ffi::c_char = PTR_ARITHMETIC;
-    let widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
-    let narrowing_cast: ::core::ffi::c_char = NARROWING_CAST;
-    let conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
-    let indexing: ::core::ffi::c_char = INDEXING;
-    let str_concatenation_ptr: *const ::core::ffi::c_char = STR_CONCATENATION.as_ptr();
-    let str_concatenation: [::core::ffi::c_char; 18] = STR_CONCATENATION;
-    let builtin: ::core::ffi::c_int = (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
-    let ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
-    let ref_struct: *const S = REF_LITERAL;
-    let ref_struct_mut: *mut S = REF_LITERAL_MUT;
-    let ternary: ::core::ffi::c_int = TERNARY;
-    let member: ::core::ffi::c_int = MEMBER;
-    let member_mut: ::core::ffi::c_int = MEMBER_MUT;
-    let stmt_expr: ::core::ffi::c_float = ({
-        let mut builtin_0: ::core::ffi::c_int =
-            (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
-        let mut indexing_0: ::core::ffi::c_char = INDEXING;
-        let mut mixed: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
-        let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-        while i < builtin_0 {
-            mixed += indexing_0 as ::core::ffi::c_float;
-            i += 1;
-        }
-        mixed
-    });
-}
 static mut global_static_const_literal_int: ::core::ffi::c_int = LITERAL_INT;
 static mut global_static_const_literal_bool: bool = LITERAL_BOOL != 0;
 static mut global_static_const_literal_float: ::core::ffi::c_float =
@@ -318,6 +213,107 @@ pub static mut global_const_ternary: ::core::ffi::c_int = 0;
 pub static mut global_const_member: ::core::ffi::c_int = 0;
 #[no_mangle]
 pub static mut global_const_member_mut: ::core::ffi::c_int = 0;
+#[no_mangle]
+pub unsafe extern "C" fn local_muts() {
+    let mut literal_int: ::core::ffi::c_int = LITERAL_INT;
+    let mut literal_bool: bool = LITERAL_BOOL != 0;
+    let mut literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
+    let mut literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
+    let mut literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
+    let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
+    let mut literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
+    let mut literal_struct: S = LITERAL_STRUCT;
+    let mut literal_struct_mut: S = LITERAL_STRUCT_MUT;
+    let mut nested_int: ::core::ffi::c_int = NESTED_INT;
+    let mut nested_bool: bool = NESTED_BOOL != 0;
+    let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
+    let mut nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
+    let mut nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
+    let mut nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
+    let mut nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
+    let mut nested_struct: S = NESTED_STRUCT;
+    let mut negative_int: ::core::ffi::c_int = NEGATIVE_INT;
+    let mut int_arithmetic: ::core::ffi::c_int = INT_ARITHMETIC;
+    let mut mixed_arithmetic: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
+    let mut parens: ::core::ffi::c_int = PARENS;
+    let mut ptr_arithmetic: *const ::core::ffi::c_char = PTR_ARITHMETIC;
+    let mut widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
+    let mut narrowing_cast: ::core::ffi::c_char = NARROWING_CAST;
+    let mut conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
+    let mut indexing: ::core::ffi::c_char = INDEXING;
+    let mut str_concatenation_ptr: *const ::core::ffi::c_char = STR_CONCATENATION.as_ptr();
+    let mut str_concatenation: [::core::ffi::c_char; 18] = STR_CONCATENATION;
+    let mut builtin: ::core::ffi::c_int =
+        (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
+    let mut ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
+    let mut ref_struct: *const S = REF_LITERAL;
+    let mut ref_struct_mut: *mut S = REF_LITERAL_MUT;
+    let mut ternary: ::core::ffi::c_int = TERNARY;
+    let mut member: ::core::ffi::c_int = MEMBER;
+    let mut member_mut: ::core::ffi::c_int = MEMBER_MUT;
+    let mut stmt_expr: ::core::ffi::c_float = ({
+        let mut builtin_0: ::core::ffi::c_int =
+            (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
+        let mut indexing_0: ::core::ffi::c_char = INDEXING;
+        let mut mixed: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
+        let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+        while i < builtin_0 {
+            mixed += indexing_0 as ::core::ffi::c_float;
+            i += 1;
+        }
+        mixed
+    });
+}
+#[no_mangle]
+pub unsafe extern "C" fn local_consts() {
+    let literal_int: ::core::ffi::c_int = LITERAL_INT;
+    let literal_bool: bool = LITERAL_BOOL != 0;
+    let literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
+    let literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
+    let literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
+    let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
+    let literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
+    let literal_struct: S = LITERAL_STRUCT;
+    let literal_struct_mut: S = LITERAL_STRUCT_MUT;
+    let nested_int: ::core::ffi::c_int = NESTED_INT;
+    let nested_bool: bool = NESTED_BOOL != 0;
+    let nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
+    let nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
+    let nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
+    let nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
+    let nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
+    let nested_struct: S = NESTED_STRUCT;
+    let negative_int: ::core::ffi::c_int = NEGATIVE_INT;
+    let int_arithmetic: ::core::ffi::c_int = INT_ARITHMETIC;
+    let mixed_arithmetic: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
+    let parens: ::core::ffi::c_int = PARENS;
+    let ptr_arithmetic: *const ::core::ffi::c_char = PTR_ARITHMETIC;
+    let widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
+    let narrowing_cast: ::core::ffi::c_char = NARROWING_CAST;
+    let conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
+    let indexing: ::core::ffi::c_char = INDEXING;
+    let str_concatenation_ptr: *const ::core::ffi::c_char = STR_CONCATENATION.as_ptr();
+    let str_concatenation: [::core::ffi::c_char; 18] = STR_CONCATENATION;
+    let builtin: ::core::ffi::c_int = (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
+    let ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
+    let ref_struct: *const S = REF_LITERAL;
+    let ref_struct_mut: *mut S = REF_LITERAL_MUT;
+    let ternary: ::core::ffi::c_int = TERNARY;
+    let member: ::core::ffi::c_int = MEMBER;
+    let member_mut: ::core::ffi::c_int = MEMBER_MUT;
+    let stmt_expr: ::core::ffi::c_float = ({
+        let mut builtin_0: ::core::ffi::c_int =
+            (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
+        let mut indexing_0: ::core::ffi::c_char = INDEXING;
+        let mut mixed: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
+        let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+        while i < builtin_0 {
+            mixed += indexing_0 as ::core::ffi::c_float;
+            i += 1;
+        }
+        mixed
+    });
+}
 #[no_mangle]
 pub unsafe extern "C" fn test_fn_macro(mut x: ::core::ffi::c_int) -> ::core::ffi::c_int {
     return x * x;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.clang15.snap
@@ -51,6 +51,9 @@ pub const LITERAL_ARRAY: [::core::ffi::c_int; 3] = [
 pub const LITERAL_STRUCT: S = S {
     i: 5 as ::core::ffi::c_int,
 };
+pub const LITERAL_STRUCT_MUT: S = S {
+    i: 5 as ::core::ffi::c_int,
+};
 pub const NESTED_INT: ::core::ffi::c_int = LITERAL_INT;
 pub const NESTED_BOOL: ::core::ffi::c_int = LITERAL_BOOL;
 pub const NESTED_FLOAT: ::core::ffi::c_double = LITERAL_FLOAT;
@@ -82,13 +85,15 @@ pub const REF_MACRO: *const ::core::ffi::c_char = unsafe {
         .as_ptr()
         .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
 };
-pub const REF_LITERAL: *mut S = &LITERAL_STRUCT as *const S as *mut S;
+pub const REF_LITERAL: *const S = &LITERAL_STRUCT as *const S;
+pub const REF_LITERAL_MUT: *mut S = &LITERAL_STRUCT_MUT as *const S as *mut S;
 pub const TERNARY: ::core::ffi::c_int = if LITERAL_BOOL != 0 {
     1 as ::core::ffi::c_int
 } else {
     2 as ::core::ffi::c_int
 };
 pub const MEMBER: ::core::ffi::c_int = LITERAL_STRUCT.i;
+pub const MEMBER_MUT: ::core::ffi::c_int = LITERAL_STRUCT_MUT.i;
 #[no_mangle]
 pub unsafe extern "C" fn local_muts() {
     let mut literal_int: ::core::ffi::c_int = LITERAL_INT;
@@ -99,6 +104,7 @@ pub unsafe extern "C" fn local_muts() {
     let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let mut literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let mut literal_struct: S = LITERAL_STRUCT;
+    let mut literal_struct_mut: S = LITERAL_STRUCT_MUT;
     let mut nested_int: ::core::ffi::c_int = NESTED_INT;
     let mut nested_bool: bool = NESTED_BOOL != 0;
     let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
@@ -122,8 +128,10 @@ pub unsafe extern "C" fn local_muts() {
         (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let mut ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
     let mut ref_struct: *const S = REF_LITERAL;
+    let mut ref_struct_mut: *mut S = REF_LITERAL_MUT;
     let mut ternary: ::core::ffi::c_int = TERNARY;
     let mut member: ::core::ffi::c_int = MEMBER;
+    let mut member_mut: ::core::ffi::c_int = MEMBER_MUT;
     let mut stmt_expr: ::core::ffi::c_float = ({
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
@@ -147,6 +155,7 @@ pub unsafe extern "C" fn local_consts() {
     let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let literal_struct: S = LITERAL_STRUCT;
+    let literal_struct_mut: S = LITERAL_STRUCT_MUT;
     let nested_int: ::core::ffi::c_int = NESTED_INT;
     let nested_bool: bool = NESTED_BOOL != 0;
     let nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
@@ -169,8 +178,10 @@ pub unsafe extern "C" fn local_consts() {
     let builtin: ::core::ffi::c_int = (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
     let ref_struct: *const S = REF_LITERAL;
+    let ref_struct_mut: *mut S = REF_LITERAL_MUT;
     let ternary: ::core::ffi::c_int = TERNARY;
     let member: ::core::ffi::c_int = MEMBER;
+    let member_mut: ::core::ffi::c_int = MEMBER_MUT;
     let stmt_expr: ::core::ffi::c_float = ({
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
@@ -194,6 +205,7 @@ static mut global_static_const_literal_str_ptr: *const ::core::ffi::c_char = LIT
 static mut global_static_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
 static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 static mut global_static_const_literal_struct: S = LITERAL_STRUCT;
+static mut global_static_const_literal_struct_mut: S = LITERAL_STRUCT_MUT;
 static mut global_static_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 static mut global_static_const_nested_bool: bool = NESTED_BOOL != 0;
 static mut global_static_const_nested_float: ::core::ffi::c_float =
@@ -223,8 +235,10 @@ static mut global_static_const_builtin: ::core::ffi::c_int =
 static mut global_static_const_ref_indexing: *const ::core::ffi::c_char =
     ::core::ptr::null::<::core::ffi::c_char>();
 static mut global_static_const_ref_struct: *const S = REF_LITERAL;
+static mut global_static_const_ref_struct_mut: *mut S = REF_LITERAL_MUT;
 static mut global_static_const_ternary: ::core::ffi::c_int = 0;
 static mut global_static_const_member: ::core::ffi::c_int = 0;
+static mut global_static_const_member_mut: ::core::ffi::c_int = 0;
 #[no_mangle]
 pub unsafe extern "C" fn global_static_consts() {}
 #[no_mangle]
@@ -244,6 +258,8 @@ pub static mut global_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
 pub static mut global_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 #[no_mangle]
 pub static mut global_const_literal_struct: S = LITERAL_STRUCT;
+#[no_mangle]
+pub static mut global_const_literal_struct_mut: S = LITERAL_STRUCT_MUT;
 #[no_mangle]
 pub static mut global_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 #[no_mangle]
@@ -295,9 +311,13 @@ pub static mut global_const_ref_indexing: *const ::core::ffi::c_char =
 #[no_mangle]
 pub static mut global_const_ref_struct: *const S = REF_LITERAL;
 #[no_mangle]
+pub static mut global_const_ref_struct_mut: *mut S = REF_LITERAL_MUT;
+#[no_mangle]
 pub static mut global_const_ternary: ::core::ffi::c_int = 0;
 #[no_mangle]
 pub static mut global_const_member: ::core::ffi::c_int = 0;
+#[no_mangle]
+pub static mut global_const_member_mut: ::core::ffi::c_int = 0;
 #[no_mangle]
 pub unsafe extern "C" fn test_fn_macro(mut x: ::core::ffi::c_int) -> ::core::ffi::c_int {
     return x * x;
@@ -403,11 +423,13 @@ unsafe extern "C" fn c2rust_run_static_initializers() {
     global_static_const_ref_indexing = REF_MACRO;
     global_static_const_ternary = TERNARY;
     global_static_const_member = MEMBER;
+    global_static_const_member_mut = MEMBER_MUT;
     global_const_ptr_arithmetic = PTR_ARITHMETIC;
     global_const_indexing = INDEXING;
     global_const_ref_indexing = REF_MACRO;
     global_const_ternary = TERNARY;
     global_const_member = MEMBER;
+    global_const_member_mut = MEMBER_MUT;
 }
 #[used]
 #[cfg_attr(target_os = "linux", link_section = ".init_array")]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2021.clang15.snap
@@ -49,7 +49,6 @@ pub const LITERAL_ARRAY: [::core::ffi::c_int; 3] = [
     3 as ::core::ffi::c_int,
 ];
 pub const LITERAL_STRUCT: S = S { i: 5 };
-pub const LITERAL_STRUCT_MUT: S = S { i: 5 };
 pub const NESTED_INT: ::core::ffi::c_int = LITERAL_INT;
 pub const NESTED_BOOL: ::core::ffi::c_int = LITERAL_BOOL;
 pub const NESTED_FLOAT: ::core::ffi::c_double = LITERAL_FLOAT;
@@ -82,14 +81,12 @@ pub const REF_MACRO: *const ::core::ffi::c_char = unsafe {
         .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
 };
 pub const REF_LITERAL: *const S = &LITERAL_STRUCT as *const S;
-pub const REF_LITERAL_MUT: *mut S = &LITERAL_STRUCT_MUT as *const S as *mut S;
 pub const TERNARY: ::core::ffi::c_int = if LITERAL_BOOL != 0 {
     1 as ::core::ffi::c_int
 } else {
     2 as ::core::ffi::c_int
 };
 pub const MEMBER: ::core::ffi::c_int = LITERAL_STRUCT.i;
-pub const MEMBER_MUT: ::core::ffi::c_int = LITERAL_STRUCT_MUT.i;
 static mut global_static_const_literal_int: ::core::ffi::c_int = LITERAL_INT;
 static mut global_static_const_literal_bool: bool = LITERAL_BOOL != 0;
 static mut global_static_const_literal_float: ::core::ffi::c_float =
@@ -100,7 +97,7 @@ static mut global_static_const_literal_str_ptr: *const ::core::ffi::c_char = LIT
 static mut global_static_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
 static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 static mut global_static_const_literal_struct: S = LITERAL_STRUCT;
-static mut global_static_const_literal_struct_mut: S = LITERAL_STRUCT_MUT;
+static mut global_static_const_literal_struct_mut: S = S { i: 5 };
 static mut global_static_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 static mut global_static_const_nested_bool: bool = NESTED_BOOL != 0;
 static mut global_static_const_nested_float: ::core::ffi::c_float =
@@ -130,7 +127,9 @@ static mut global_static_const_builtin: ::core::ffi::c_int =
 static mut global_static_const_ref_indexing: *const ::core::ffi::c_char =
     ::core::ptr::null::<::core::ffi::c_char>();
 static mut global_static_const_ref_struct: *const S = REF_LITERAL;
-static mut global_static_const_ref_struct_mut: *mut S = REF_LITERAL_MUT;
+static mut c2rust_lvalue: S = S { i: 5 };
+static mut global_static_const_ref_struct_mut: *mut S =
+    unsafe { &raw const c2rust_lvalue as *mut S };
 static mut global_static_const_ternary: ::core::ffi::c_int = 0;
 static mut global_static_const_member: ::core::ffi::c_int = 0;
 static mut global_static_const_member_mut: ::core::ffi::c_int = 0;
@@ -154,7 +153,7 @@ pub static mut global_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARR
 #[no_mangle]
 pub static mut global_const_literal_struct: S = LITERAL_STRUCT;
 #[no_mangle]
-pub static mut global_const_literal_struct_mut: S = LITERAL_STRUCT_MUT;
+pub static mut global_const_literal_struct_mut: S = S { i: 5 };
 #[no_mangle]
 pub static mut global_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 #[no_mangle]
@@ -205,8 +204,10 @@ pub static mut global_const_ref_indexing: *const ::core::ffi::c_char =
     ::core::ptr::null::<::core::ffi::c_char>();
 #[no_mangle]
 pub static mut global_const_ref_struct: *const S = REF_LITERAL;
+static mut c2rust_lvalue_0: S = S { i: 5 };
 #[no_mangle]
-pub static mut global_const_ref_struct_mut: *mut S = REF_LITERAL_MUT;
+pub static mut global_const_ref_struct_mut: *mut S =
+    unsafe { &raw const c2rust_lvalue_0 as *mut S };
 #[no_mangle]
 pub static mut global_const_ternary: ::core::ffi::c_int = 0;
 #[no_mangle]
@@ -223,7 +224,9 @@ pub unsafe extern "C" fn local_muts() {
     let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let mut literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let mut literal_struct: S = LITERAL_STRUCT;
-    let mut literal_struct_mut: S = LITERAL_STRUCT_MUT;
+    let mut literal_struct_mut: S = S {
+        i: 5 as ::core::ffi::c_int,
+    };
     let mut nested_int: ::core::ffi::c_int = NESTED_INT;
     let mut nested_bool: bool = NESTED_BOOL != 0;
     let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
@@ -247,10 +250,16 @@ pub unsafe extern "C" fn local_muts() {
         (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let mut ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
     let mut ref_struct: *const S = REF_LITERAL;
-    let mut ref_struct_mut: *mut S = REF_LITERAL_MUT;
+    let mut c2rust_lvalue_1: S = S {
+        i: 5 as ::core::ffi::c_int,
+    };
+    let mut ref_struct_mut: *mut S = &raw mut c2rust_lvalue_1;
     let mut ternary: ::core::ffi::c_int = TERNARY;
     let mut member: ::core::ffi::c_int = MEMBER;
-    let mut member_mut: ::core::ffi::c_int = MEMBER_MUT;
+    let mut member_mut: ::core::ffi::c_int = S {
+        i: 5 as ::core::ffi::c_int,
+    }
+    .i;
     let mut stmt_expr: ::core::ffi::c_float = ({
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
@@ -274,7 +283,9 @@ pub unsafe extern "C" fn local_consts() {
     let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let literal_struct: S = LITERAL_STRUCT;
-    let literal_struct_mut: S = LITERAL_STRUCT_MUT;
+    let literal_struct_mut: S = S {
+        i: 5 as ::core::ffi::c_int,
+    };
     let nested_int: ::core::ffi::c_int = NESTED_INT;
     let nested_bool: bool = NESTED_BOOL != 0;
     let nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
@@ -297,10 +308,16 @@ pub unsafe extern "C" fn local_consts() {
     let builtin: ::core::ffi::c_int = (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
     let ref_struct: *const S = REF_LITERAL;
-    let ref_struct_mut: *mut S = REF_LITERAL_MUT;
+    let mut c2rust_lvalue_1: S = S {
+        i: 5 as ::core::ffi::c_int,
+    };
+    let ref_struct_mut: *mut S = &raw mut c2rust_lvalue_1;
     let ternary: ::core::ffi::c_int = TERNARY;
     let member: ::core::ffi::c_int = MEMBER;
-    let member_mut: ::core::ffi::c_int = MEMBER_MUT;
+    let member_mut: ::core::ffi::c_int = S {
+        i: 5 as ::core::ffi::c_int,
+    }
+    .i;
     let stmt_expr: ::core::ffi::c_float = ({
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
@@ -419,13 +436,13 @@ unsafe extern "C" fn c2rust_run_static_initializers() {
     global_static_const_ref_indexing = REF_MACRO;
     global_static_const_ternary = TERNARY;
     global_static_const_member = MEMBER;
-    global_static_const_member_mut = MEMBER_MUT;
+    global_static_const_member_mut = S { i: 5 }.i;
     global_const_ptr_arithmetic = PTR_ARITHMETIC;
     global_const_indexing = INDEXING;
     global_const_ref_indexing = REF_MACRO;
     global_const_ternary = TERNARY;
     global_const_member = MEMBER;
-    global_const_member_mut = MEMBER_MUT;
+    global_const_member_mut = S { i: 5 }.i;
 }
 #[used]
 #[cfg_attr(target_os = "linux", link_section = ".init_array")]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.clang15.snap
@@ -48,12 +48,8 @@ pub const LITERAL_ARRAY: [::core::ffi::c_int; 3] = [
     2 as ::core::ffi::c_int,
     3 as ::core::ffi::c_int,
 ];
-pub const LITERAL_STRUCT: S = S {
-    i: 5 as ::core::ffi::c_int,
-};
-pub const LITERAL_STRUCT_MUT: S = S {
-    i: 5 as ::core::ffi::c_int,
-};
+pub const LITERAL_STRUCT: S = S { i: 5 };
+pub const LITERAL_STRUCT_MUT: S = S { i: 5 };
 pub const NESTED_INT: ::core::ffi::c_int = LITERAL_INT;
 pub const NESTED_BOOL: ::core::ffi::c_int = LITERAL_BOOL;
 pub const NESTED_FLOAT: ::core::ffi::c_double = LITERAL_FLOAT;
@@ -94,107 +90,6 @@ pub const TERNARY: ::core::ffi::c_int = if LITERAL_BOOL != 0 {
 };
 pub const MEMBER: ::core::ffi::c_int = LITERAL_STRUCT.i;
 pub const MEMBER_MUT: ::core::ffi::c_int = LITERAL_STRUCT_MUT.i;
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn local_muts() {
-    let mut literal_int: ::core::ffi::c_int = LITERAL_INT;
-    let mut literal_bool: bool = LITERAL_BOOL != 0;
-    let mut literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
-    let mut literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
-    let mut literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
-    let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
-    let mut literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
-    let mut literal_struct: S = LITERAL_STRUCT;
-    let mut literal_struct_mut: S = LITERAL_STRUCT_MUT;
-    let mut nested_int: ::core::ffi::c_int = NESTED_INT;
-    let mut nested_bool: bool = NESTED_BOOL != 0;
-    let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
-    let mut nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
-    let mut nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
-    let mut nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
-    let mut nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
-    let mut nested_struct: S = NESTED_STRUCT;
-    let mut negative_int: ::core::ffi::c_int = NEGATIVE_INT;
-    let mut int_arithmetic: ::core::ffi::c_int = INT_ARITHMETIC;
-    let mut mixed_arithmetic: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
-    let mut parens: ::core::ffi::c_int = PARENS;
-    let mut ptr_arithmetic: *const ::core::ffi::c_char = PTR_ARITHMETIC;
-    let mut widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
-    let mut narrowing_cast: ::core::ffi::c_char = NARROWING_CAST;
-    let mut conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
-    let mut indexing: ::core::ffi::c_char = INDEXING;
-    let mut str_concatenation_ptr: *const ::core::ffi::c_char = STR_CONCATENATION.as_ptr();
-    let mut str_concatenation: [::core::ffi::c_char; 18] = STR_CONCATENATION;
-    let mut builtin: ::core::ffi::c_int =
-        (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
-    let mut ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
-    let mut ref_struct: *const S = REF_LITERAL;
-    let mut ref_struct_mut: *mut S = REF_LITERAL_MUT;
-    let mut ternary: ::core::ffi::c_int = TERNARY;
-    let mut member: ::core::ffi::c_int = MEMBER;
-    let mut member_mut: ::core::ffi::c_int = MEMBER_MUT;
-    let mut stmt_expr: ::core::ffi::c_float = ({
-        let mut builtin_0: ::core::ffi::c_int =
-            (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
-        let mut indexing_0: ::core::ffi::c_char = INDEXING;
-        let mut mixed: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
-        let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-        while i < builtin_0 {
-            mixed += indexing_0 as ::core::ffi::c_float;
-            i += 1;
-        }
-        mixed
-    });
-}
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn local_consts() {
-    let literal_int: ::core::ffi::c_int = LITERAL_INT;
-    let literal_bool: bool = LITERAL_BOOL != 0;
-    let literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
-    let literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
-    let literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
-    let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
-    let literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
-    let literal_struct: S = LITERAL_STRUCT;
-    let literal_struct_mut: S = LITERAL_STRUCT_MUT;
-    let nested_int: ::core::ffi::c_int = NESTED_INT;
-    let nested_bool: bool = NESTED_BOOL != 0;
-    let nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
-    let nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
-    let nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
-    let nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
-    let nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
-    let nested_struct: S = NESTED_STRUCT;
-    let negative_int: ::core::ffi::c_int = NEGATIVE_INT;
-    let int_arithmetic: ::core::ffi::c_int = INT_ARITHMETIC;
-    let mixed_arithmetic: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
-    let parens: ::core::ffi::c_int = PARENS;
-    let ptr_arithmetic: *const ::core::ffi::c_char = PTR_ARITHMETIC;
-    let widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
-    let narrowing_cast: ::core::ffi::c_char = NARROWING_CAST;
-    let conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
-    let indexing: ::core::ffi::c_char = INDEXING;
-    let str_concatenation_ptr: *const ::core::ffi::c_char = STR_CONCATENATION.as_ptr();
-    let str_concatenation: [::core::ffi::c_char; 18] = STR_CONCATENATION;
-    let builtin: ::core::ffi::c_int = (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
-    let ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
-    let ref_struct: *const S = REF_LITERAL;
-    let ref_struct_mut: *mut S = REF_LITERAL_MUT;
-    let ternary: ::core::ffi::c_int = TERNARY;
-    let member: ::core::ffi::c_int = MEMBER;
-    let member_mut: ::core::ffi::c_int = MEMBER_MUT;
-    let stmt_expr: ::core::ffi::c_float = ({
-        let mut builtin_0: ::core::ffi::c_int =
-            (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
-        let mut indexing_0: ::core::ffi::c_char = INDEXING;
-        let mut mixed: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
-        let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-        while i < builtin_0 {
-            mixed += indexing_0 as ::core::ffi::c_float;
-            i += 1;
-        }
-        mixed
-    });
-}
 static mut global_static_const_literal_int: ::core::ffi::c_int = LITERAL_INT;
 static mut global_static_const_literal_bool: bool = LITERAL_BOOL != 0;
 static mut global_static_const_literal_float: ::core::ffi::c_float =
@@ -318,6 +213,107 @@ pub static mut global_const_ternary: ::core::ffi::c_int = 0;
 pub static mut global_const_member: ::core::ffi::c_int = 0;
 #[unsafe(no_mangle)]
 pub static mut global_const_member_mut: ::core::ffi::c_int = 0;
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn local_muts() {
+    let mut literal_int: ::core::ffi::c_int = LITERAL_INT;
+    let mut literal_bool: bool = LITERAL_BOOL != 0;
+    let mut literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
+    let mut literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
+    let mut literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
+    let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
+    let mut literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
+    let mut literal_struct: S = LITERAL_STRUCT;
+    let mut literal_struct_mut: S = LITERAL_STRUCT_MUT;
+    let mut nested_int: ::core::ffi::c_int = NESTED_INT;
+    let mut nested_bool: bool = NESTED_BOOL != 0;
+    let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
+    let mut nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
+    let mut nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
+    let mut nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
+    let mut nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
+    let mut nested_struct: S = NESTED_STRUCT;
+    let mut negative_int: ::core::ffi::c_int = NEGATIVE_INT;
+    let mut int_arithmetic: ::core::ffi::c_int = INT_ARITHMETIC;
+    let mut mixed_arithmetic: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
+    let mut parens: ::core::ffi::c_int = PARENS;
+    let mut ptr_arithmetic: *const ::core::ffi::c_char = PTR_ARITHMETIC;
+    let mut widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
+    let mut narrowing_cast: ::core::ffi::c_char = NARROWING_CAST;
+    let mut conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
+    let mut indexing: ::core::ffi::c_char = INDEXING;
+    let mut str_concatenation_ptr: *const ::core::ffi::c_char = STR_CONCATENATION.as_ptr();
+    let mut str_concatenation: [::core::ffi::c_char; 18] = STR_CONCATENATION;
+    let mut builtin: ::core::ffi::c_int =
+        (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
+    let mut ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
+    let mut ref_struct: *const S = REF_LITERAL;
+    let mut ref_struct_mut: *mut S = REF_LITERAL_MUT;
+    let mut ternary: ::core::ffi::c_int = TERNARY;
+    let mut member: ::core::ffi::c_int = MEMBER;
+    let mut member_mut: ::core::ffi::c_int = MEMBER_MUT;
+    let mut stmt_expr: ::core::ffi::c_float = ({
+        let mut builtin_0: ::core::ffi::c_int =
+            (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
+        let mut indexing_0: ::core::ffi::c_char = INDEXING;
+        let mut mixed: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
+        let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+        while i < builtin_0 {
+            mixed += indexing_0 as ::core::ffi::c_float;
+            i += 1;
+        }
+        mixed
+    });
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn local_consts() {
+    let literal_int: ::core::ffi::c_int = LITERAL_INT;
+    let literal_bool: bool = LITERAL_BOOL != 0;
+    let literal_float: ::core::ffi::c_float = LITERAL_FLOAT as ::core::ffi::c_float;
+    let literal_char: ::core::ffi::c_char = LITERAL_CHAR as ::core::ffi::c_char;
+    let literal_str_ptr: *const ::core::ffi::c_char = LITERAL_STR.as_ptr();
+    let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
+    let literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
+    let literal_struct: S = LITERAL_STRUCT;
+    let literal_struct_mut: S = LITERAL_STRUCT_MUT;
+    let nested_int: ::core::ffi::c_int = NESTED_INT;
+    let nested_bool: bool = NESTED_BOOL != 0;
+    let nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
+    let nested_char: ::core::ffi::c_char = NESTED_CHAR as ::core::ffi::c_char;
+    let nested_str_ptr: *const ::core::ffi::c_char = NESTED_STR.as_ptr();
+    let nested_str: [::core::ffi::c_char; 6] = NESTED_STR;
+    let nested_array: [::core::ffi::c_int; 3] = NESTED_ARRAY;
+    let nested_struct: S = NESTED_STRUCT;
+    let negative_int: ::core::ffi::c_int = NEGATIVE_INT;
+    let int_arithmetic: ::core::ffi::c_int = INT_ARITHMETIC;
+    let mixed_arithmetic: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
+    let parens: ::core::ffi::c_int = PARENS;
+    let ptr_arithmetic: *const ::core::ffi::c_char = PTR_ARITHMETIC;
+    let widening_cast: ::core::ffi::c_ulonglong = WIDENING_CAST;
+    let narrowing_cast: ::core::ffi::c_char = NARROWING_CAST;
+    let conversion_cast: ::core::ffi::c_double = CONVERSION_CAST;
+    let indexing: ::core::ffi::c_char = INDEXING;
+    let str_concatenation_ptr: *const ::core::ffi::c_char = STR_CONCATENATION.as_ptr();
+    let str_concatenation: [::core::ffi::c_char; 18] = STR_CONCATENATION;
+    let builtin: ::core::ffi::c_int = (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
+    let ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
+    let ref_struct: *const S = REF_LITERAL;
+    let ref_struct_mut: *mut S = REF_LITERAL_MUT;
+    let ternary: ::core::ffi::c_int = TERNARY;
+    let member: ::core::ffi::c_int = MEMBER;
+    let member_mut: ::core::ffi::c_int = MEMBER_MUT;
+    let stmt_expr: ::core::ffi::c_float = ({
+        let mut builtin_0: ::core::ffi::c_int =
+            (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
+        let mut indexing_0: ::core::ffi::c_char = INDEXING;
+        let mut mixed: ::core::ffi::c_float = MIXED_ARITHMETIC as ::core::ffi::c_float;
+        let mut i: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+        while i < builtin_0 {
+            mixed += indexing_0 as ::core::ffi::c_float;
+            i += 1;
+        }
+        mixed
+    });
+}
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn test_fn_macro(mut x: ::core::ffi::c_int) -> ::core::ffi::c_int {
     return x * x;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.clang15.snap
@@ -51,6 +51,9 @@ pub const LITERAL_ARRAY: [::core::ffi::c_int; 3] = [
 pub const LITERAL_STRUCT: S = S {
     i: 5 as ::core::ffi::c_int,
 };
+pub const LITERAL_STRUCT_MUT: S = S {
+    i: 5 as ::core::ffi::c_int,
+};
 pub const NESTED_INT: ::core::ffi::c_int = LITERAL_INT;
 pub const NESTED_BOOL: ::core::ffi::c_int = LITERAL_BOOL;
 pub const NESTED_FLOAT: ::core::ffi::c_double = LITERAL_FLOAT;
@@ -82,13 +85,15 @@ pub const REF_MACRO: *const ::core::ffi::c_char = unsafe {
         .as_ptr()
         .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
 };
-pub const REF_LITERAL: *mut S = &LITERAL_STRUCT as *const S as *mut S;
+pub const REF_LITERAL: *const S = &LITERAL_STRUCT as *const S;
+pub const REF_LITERAL_MUT: *mut S = &LITERAL_STRUCT_MUT as *const S as *mut S;
 pub const TERNARY: ::core::ffi::c_int = if LITERAL_BOOL != 0 {
     1 as ::core::ffi::c_int
 } else {
     2 as ::core::ffi::c_int
 };
 pub const MEMBER: ::core::ffi::c_int = LITERAL_STRUCT.i;
+pub const MEMBER_MUT: ::core::ffi::c_int = LITERAL_STRUCT_MUT.i;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn local_muts() {
     let mut literal_int: ::core::ffi::c_int = LITERAL_INT;
@@ -99,6 +104,7 @@ pub unsafe extern "C" fn local_muts() {
     let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let mut literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let mut literal_struct: S = LITERAL_STRUCT;
+    let mut literal_struct_mut: S = LITERAL_STRUCT_MUT;
     let mut nested_int: ::core::ffi::c_int = NESTED_INT;
     let mut nested_bool: bool = NESTED_BOOL != 0;
     let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
@@ -122,8 +128,10 @@ pub unsafe extern "C" fn local_muts() {
         (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let mut ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
     let mut ref_struct: *const S = REF_LITERAL;
+    let mut ref_struct_mut: *mut S = REF_LITERAL_MUT;
     let mut ternary: ::core::ffi::c_int = TERNARY;
     let mut member: ::core::ffi::c_int = MEMBER;
+    let mut member_mut: ::core::ffi::c_int = MEMBER_MUT;
     let mut stmt_expr: ::core::ffi::c_float = ({
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
@@ -147,6 +155,7 @@ pub unsafe extern "C" fn local_consts() {
     let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let literal_struct: S = LITERAL_STRUCT;
+    let literal_struct_mut: S = LITERAL_STRUCT_MUT;
     let nested_int: ::core::ffi::c_int = NESTED_INT;
     let nested_bool: bool = NESTED_BOOL != 0;
     let nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
@@ -169,8 +178,10 @@ pub unsafe extern "C" fn local_consts() {
     let builtin: ::core::ffi::c_int = (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
     let ref_struct: *const S = REF_LITERAL;
+    let ref_struct_mut: *mut S = REF_LITERAL_MUT;
     let ternary: ::core::ffi::c_int = TERNARY;
     let member: ::core::ffi::c_int = MEMBER;
+    let member_mut: ::core::ffi::c_int = MEMBER_MUT;
     let stmt_expr: ::core::ffi::c_float = ({
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
@@ -194,6 +205,7 @@ static mut global_static_const_literal_str_ptr: *const ::core::ffi::c_char = LIT
 static mut global_static_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
 static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 static mut global_static_const_literal_struct: S = LITERAL_STRUCT;
+static mut global_static_const_literal_struct_mut: S = LITERAL_STRUCT_MUT;
 static mut global_static_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 static mut global_static_const_nested_bool: bool = NESTED_BOOL != 0;
 static mut global_static_const_nested_float: ::core::ffi::c_float =
@@ -223,8 +235,10 @@ static mut global_static_const_builtin: ::core::ffi::c_int =
 static mut global_static_const_ref_indexing: *const ::core::ffi::c_char =
     ::core::ptr::null::<::core::ffi::c_char>();
 static mut global_static_const_ref_struct: *const S = REF_LITERAL;
+static mut global_static_const_ref_struct_mut: *mut S = REF_LITERAL_MUT;
 static mut global_static_const_ternary: ::core::ffi::c_int = 0;
 static mut global_static_const_member: ::core::ffi::c_int = 0;
+static mut global_static_const_member_mut: ::core::ffi::c_int = 0;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn global_static_consts() {}
 #[unsafe(no_mangle)]
@@ -244,6 +258,8 @@ pub static mut global_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
 pub static mut global_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 #[unsafe(no_mangle)]
 pub static mut global_const_literal_struct: S = LITERAL_STRUCT;
+#[unsafe(no_mangle)]
+pub static mut global_const_literal_struct_mut: S = LITERAL_STRUCT_MUT;
 #[unsafe(no_mangle)]
 pub static mut global_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 #[unsafe(no_mangle)]
@@ -295,9 +311,13 @@ pub static mut global_const_ref_indexing: *const ::core::ffi::c_char =
 #[unsafe(no_mangle)]
 pub static mut global_const_ref_struct: *const S = REF_LITERAL;
 #[unsafe(no_mangle)]
+pub static mut global_const_ref_struct_mut: *mut S = REF_LITERAL_MUT;
+#[unsafe(no_mangle)]
 pub static mut global_const_ternary: ::core::ffi::c_int = 0;
 #[unsafe(no_mangle)]
 pub static mut global_const_member: ::core::ffi::c_int = 0;
+#[unsafe(no_mangle)]
+pub static mut global_const_member_mut: ::core::ffi::c_int = 0;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn test_fn_macro(mut x: ::core::ffi::c_int) -> ::core::ffi::c_int {
     return x * x;
@@ -403,11 +423,13 @@ unsafe extern "C" fn c2rust_run_static_initializers() {
     global_static_const_ref_indexing = REF_MACRO;
     global_static_const_ternary = TERNARY;
     global_static_const_member = MEMBER;
+    global_static_const_member_mut = MEMBER_MUT;
     global_const_ptr_arithmetic = PTR_ARITHMETIC;
     global_const_indexing = INDEXING;
     global_const_ref_indexing = REF_MACRO;
     global_const_ternary = TERNARY;
     global_const_member = MEMBER;
+    global_const_member_mut = MEMBER_MUT;
 }
 #[used]
 #[cfg_attr(target_os = "linux", unsafe(link_section = ".init_array"))]

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@macros.c.2024.clang15.snap
@@ -49,7 +49,6 @@ pub const LITERAL_ARRAY: [::core::ffi::c_int; 3] = [
     3 as ::core::ffi::c_int,
 ];
 pub const LITERAL_STRUCT: S = S { i: 5 };
-pub const LITERAL_STRUCT_MUT: S = S { i: 5 };
 pub const NESTED_INT: ::core::ffi::c_int = LITERAL_INT;
 pub const NESTED_BOOL: ::core::ffi::c_int = LITERAL_BOOL;
 pub const NESTED_FLOAT: ::core::ffi::c_double = LITERAL_FLOAT;
@@ -82,14 +81,12 @@ pub const REF_MACRO: *const ::core::ffi::c_char = unsafe {
         .offset(LITERAL_FLOAT as ::core::ffi::c_int as isize)
 };
 pub const REF_LITERAL: *const S = &LITERAL_STRUCT as *const S;
-pub const REF_LITERAL_MUT: *mut S = &LITERAL_STRUCT_MUT as *const S as *mut S;
 pub const TERNARY: ::core::ffi::c_int = if LITERAL_BOOL != 0 {
     1 as ::core::ffi::c_int
 } else {
     2 as ::core::ffi::c_int
 };
 pub const MEMBER: ::core::ffi::c_int = LITERAL_STRUCT.i;
-pub const MEMBER_MUT: ::core::ffi::c_int = LITERAL_STRUCT_MUT.i;
 static mut global_static_const_literal_int: ::core::ffi::c_int = LITERAL_INT;
 static mut global_static_const_literal_bool: bool = LITERAL_BOOL != 0;
 static mut global_static_const_literal_float: ::core::ffi::c_float =
@@ -100,7 +97,7 @@ static mut global_static_const_literal_str_ptr: *const ::core::ffi::c_char = LIT
 static mut global_static_const_literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
 static mut global_static_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
 static mut global_static_const_literal_struct: S = LITERAL_STRUCT;
-static mut global_static_const_literal_struct_mut: S = LITERAL_STRUCT_MUT;
+static mut global_static_const_literal_struct_mut: S = S { i: 5 };
 static mut global_static_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 static mut global_static_const_nested_bool: bool = NESTED_BOOL != 0;
 static mut global_static_const_nested_float: ::core::ffi::c_float =
@@ -130,7 +127,8 @@ static mut global_static_const_builtin: ::core::ffi::c_int =
 static mut global_static_const_ref_indexing: *const ::core::ffi::c_char =
     ::core::ptr::null::<::core::ffi::c_char>();
 static mut global_static_const_ref_struct: *const S = REF_LITERAL;
-static mut global_static_const_ref_struct_mut: *mut S = REF_LITERAL_MUT;
+static mut c2rust_lvalue: S = S { i: 5 };
+static mut global_static_const_ref_struct_mut: *mut S = &raw const c2rust_lvalue as *mut S;
 static mut global_static_const_ternary: ::core::ffi::c_int = 0;
 static mut global_static_const_member: ::core::ffi::c_int = 0;
 static mut global_static_const_member_mut: ::core::ffi::c_int = 0;
@@ -154,7 +152,7 @@ pub static mut global_const_literal_array: [::core::ffi::c_int; 3] = LITERAL_ARR
 #[unsafe(no_mangle)]
 pub static mut global_const_literal_struct: S = LITERAL_STRUCT;
 #[unsafe(no_mangle)]
-pub static mut global_const_literal_struct_mut: S = LITERAL_STRUCT_MUT;
+pub static mut global_const_literal_struct_mut: S = S { i: 5 };
 #[unsafe(no_mangle)]
 pub static mut global_const_nested_int: ::core::ffi::c_int = NESTED_INT;
 #[unsafe(no_mangle)]
@@ -205,8 +203,9 @@ pub static mut global_const_ref_indexing: *const ::core::ffi::c_char =
     ::core::ptr::null::<::core::ffi::c_char>();
 #[unsafe(no_mangle)]
 pub static mut global_const_ref_struct: *const S = REF_LITERAL;
+static mut c2rust_lvalue_0: S = S { i: 5 };
 #[unsafe(no_mangle)]
-pub static mut global_const_ref_struct_mut: *mut S = REF_LITERAL_MUT;
+pub static mut global_const_ref_struct_mut: *mut S = &raw const c2rust_lvalue_0 as *mut S;
 #[unsafe(no_mangle)]
 pub static mut global_const_ternary: ::core::ffi::c_int = 0;
 #[unsafe(no_mangle)]
@@ -223,7 +222,9 @@ pub unsafe extern "C" fn local_muts() {
     let mut literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let mut literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let mut literal_struct: S = LITERAL_STRUCT;
-    let mut literal_struct_mut: S = LITERAL_STRUCT_MUT;
+    let mut literal_struct_mut: S = S {
+        i: 5 as ::core::ffi::c_int,
+    };
     let mut nested_int: ::core::ffi::c_int = NESTED_INT;
     let mut nested_bool: bool = NESTED_BOOL != 0;
     let mut nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
@@ -247,10 +248,16 @@ pub unsafe extern "C" fn local_muts() {
         (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let mut ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
     let mut ref_struct: *const S = REF_LITERAL;
-    let mut ref_struct_mut: *mut S = REF_LITERAL_MUT;
+    let mut c2rust_lvalue_1: S = S {
+        i: 5 as ::core::ffi::c_int,
+    };
+    let mut ref_struct_mut: *mut S = &raw mut c2rust_lvalue_1;
     let mut ternary: ::core::ffi::c_int = TERNARY;
     let mut member: ::core::ffi::c_int = MEMBER;
-    let mut member_mut: ::core::ffi::c_int = MEMBER_MUT;
+    let mut member_mut: ::core::ffi::c_int = S {
+        i: 5 as ::core::ffi::c_int,
+    }
+    .i;
     let mut stmt_expr: ::core::ffi::c_float = ({
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
@@ -274,7 +281,9 @@ pub unsafe extern "C" fn local_consts() {
     let literal_str: [::core::ffi::c_char; 6] = LITERAL_STR;
     let literal_array: [::core::ffi::c_int; 3] = LITERAL_ARRAY;
     let literal_struct: S = LITERAL_STRUCT;
-    let literal_struct_mut: S = LITERAL_STRUCT_MUT;
+    let literal_struct_mut: S = S {
+        i: 5 as ::core::ffi::c_int,
+    };
     let nested_int: ::core::ffi::c_int = NESTED_INT;
     let nested_bool: bool = NESTED_BOOL != 0;
     let nested_float: ::core::ffi::c_float = NESTED_FLOAT as ::core::ffi::c_float;
@@ -297,10 +306,16 @@ pub unsafe extern "C" fn local_consts() {
     let builtin: ::core::ffi::c_int = (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
     let ref_indexing: *const ::core::ffi::c_char = REF_MACRO;
     let ref_struct: *const S = REF_LITERAL;
-    let ref_struct_mut: *mut S = REF_LITERAL_MUT;
+    let mut c2rust_lvalue_1: S = S {
+        i: 5 as ::core::ffi::c_int,
+    };
+    let ref_struct_mut: *mut S = &raw mut c2rust_lvalue_1;
     let ternary: ::core::ffi::c_int = TERNARY;
     let member: ::core::ffi::c_int = MEMBER;
-    let member_mut: ::core::ffi::c_int = MEMBER_MUT;
+    let member_mut: ::core::ffi::c_int = S {
+        i: 5 as ::core::ffi::c_int,
+    }
+    .i;
     let stmt_expr: ::core::ffi::c_float = ({
         let mut builtin_0: ::core::ffi::c_int =
             (LITERAL_INT as ::core::ffi::c_uint).leading_zeros() as i32;
@@ -419,13 +434,13 @@ unsafe extern "C" fn c2rust_run_static_initializers() {
     global_static_const_ref_indexing = REF_MACRO;
     global_static_const_ternary = TERNARY;
     global_static_const_member = MEMBER;
-    global_static_const_member_mut = MEMBER_MUT;
+    global_static_const_member_mut = S { i: 5 }.i;
     global_const_ptr_arithmetic = PTR_ARITHMETIC;
     global_const_indexing = INDEXING;
     global_const_ref_indexing = REF_MACRO;
     global_const_ternary = TERNARY;
     global_const_member = MEMBER;
-    global_const_member_mut = MEMBER_MUT;
+    global_const_member_mut = S { i: 5 }.i;
 }
 #[used]
 #[cfg_attr(target_os = "linux", unsafe(link_section = ".init_array"))]


### PR DESCRIPTION
- Depends on #1993 

Mutable lvalues are values that can either be assigned to, or have a mutable pointer created to them. If they are in a macro, that could pose problems. DeclRefs (including those to mutable variables) are already disallowed in macros, but another "out of nothing" source of mutable lvalues is compound literals. Currently, a macro containing a mutable compound literal is translated as-is, including something like this:

```c
#define MUTATE_ME (&(int){ 42 })

int *p1 = MUTATE_ME;
int *p2 = MUTATE_ME;
```

Each mutable compound literal expression is supposed to create its own distinct memory location (immutable ones are allowed to be coalesced). So these pointers *must* be different, and their pointees must be able to be modified independently.

I've been very conservative here and disallowed all mutable lvalues in macros. There are certainly instances that could be re-allowed on a case-by-case basis. Certain instances of lvalues that undergo an `LValueToRValue` cast for example.