### PR TITLE
ci: refresh APT indexes before cached Ubuntu provisioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,8 @@ jobs:
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@v1.6.3
         with:
-          # Bypass empty caches saved after failed package downloads.
+          # One-time cache key change to bypass empty caches saved by failed installs.
+          # This versions the cache, not the action; later runs reuse the new cache.
           version: 2
           packages: |
             clang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,18 @@ jobs:
           export RUSTDOCFLAGS="-D warnings"
           cargo fmt --check
 
+      # The cache action skips refreshing APT indexes on GitHub runners.
+      # Refresh before it resolves package versions to avoid stale download URLs.
+      - name: Update APT package indexes
+        if: runner.os == 'Linux'
+        run: sudo apt-get update
+
       - name: Install packages (Ubuntu)
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
         with:
+          # Bypass empty caches saved after failed package downloads.
+          version: 2
           packages: |
             clang
             clang-tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,6 @@ jobs:
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@v1.6.3
         with:
-          # One-time cache key change to bypass empty caches saved by failed installs.
-          # This versions the cache, not the action; later runs reuse the new cache.
-          version: 2
           packages: |
             clang
             clang-tools


### PR DESCRIPTION
Ubuntu 22.04 / Clang 15 jobs fail across unrelated PRs because stale APT indexes reference a `libncurses5-dev` download that returns 404. The package cache action reports success and saves an empty cache; the build then fails because `libclangBasic.a` is missing. This also affects [master](https://github.com/immunant/c2rust/actions/runs/33923341672).

Keep package caching and:
- Run `sudo apt-get update` before the action resolves package versions.
- Pin the action to `v1.6.3` instead of deprecated `latest`. Both currently resolve to the same revision.
