### PR TITLE
Recognize `__c11_atomic_signal_fence`

### DIFF
--- a/c2rust-transpile/src/translator/builtins.rs
+++ b/c2rust-transpile/src/translator/builtins.rs
@@ -532,7 +532,7 @@ impl<'c> Translation<'c> {
             // (`compiler_fence`). The order picks the intrinsic at
             // compile time, so we only support a constant one. A relaxed fence
             // is a no-op (and Rust has no relaxed fence intrinsic), so we drop it.
-            "__atomic_thread_fence" | "__atomic_signal_fence" => {
+            "__atomic_thread_fence" | "__atomic_signal_fence" | "__c11_atomic_signal_fence" => {
                 let order = self.convert_memordering(args[0]).ok_or_else(|| {
                     format_translation_err!(
                         self.ast_context.display_loc(src_loc),

--- a/c2rust-transpile/tests/snapshots/atomics.c
+++ b/c2rust-transpile/tests/snapshots/atomics.c
@@ -40,3 +40,8 @@ unsigned int fetch_after_atomics_unsigned(unsigned int x) {
 
     return x;
 }
+
+int initialized_atomic(void) {
+    atomic_int value = 5;
+    return atomic_load(&value);
+}

--- a/c2rust-transpile/tests/snapshots/fences.c
+++ b/c2rust-transpile/tests/snapshots/fences.c
@@ -10,4 +10,6 @@ void fences(void) {
     __atomic_signal_fence(__ATOMIC_RELEASE);
     __atomic_signal_fence(__ATOMIC_ACQ_REL);
     __atomic_signal_fence(__ATOMIC_SEQ_CST);
+
+    __c11_atomic_signal_fence(__ATOMIC_SEQ_CST);
 }

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2021.clang15.snap
@@ -12,6 +12,7 @@ expression: cat tests/snapshots/atomics.2021.clang15.rs
     unused_mut
 )]
 #![feature(core_intrinsics, raw_ref_op)]
+pub type atomic_int = ::core::ffi::c_int;
 #[no_mangle]
 pub unsafe extern "C" fn c11_atomics(mut x: ::core::ffi::c_int) -> ::core::ffi::c_int {
     *&raw mut x = 0 as ::core::ffi::c_int;
@@ -78,5 +79,10 @@ pub unsafe extern "C" fn fetch_after_atomics_unsigned(
     let c2rust_rhs_3 = 0xff as ::core::ffi::c_uint;
     !(::core::intrinsics::atomic_nand_seqcst(c2rust_lhs_3, c2rust_rhs_3) & c2rust_rhs_3);
     return x;
+}
+#[no_mangle]
+pub unsafe extern "C" fn initialized_atomic() -> ::core::ffi::c_int {
+    let mut value: atomic_int = 5 as ::core::ffi::c_int;
+    return ::core::intrinsics::atomic_load_seqcst(&raw mut value);
 }
 pub const __ATOMIC_SEQ_CST: ::core::ffi::c_int = 5 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomics.c.2024.clang15.snap
@@ -13,6 +13,7 @@ expression: cat tests/snapshots/atomics.2024.clang15.rs
     unused_mut
 )]
 #![feature(core_intrinsics)]
+pub type atomic_int = ::core::ffi::c_int;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn c11_atomics(mut x: ::core::ffi::c_int) -> ::core::ffi::c_int {
     *&raw mut x = 0 as ::core::ffi::c_int;
@@ -138,5 +139,12 @@ pub unsafe extern "C" fn fetch_after_atomics_unsigned(
         c2rust_rhs_3,
     ) & c2rust_rhs_3);
     return x;
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn initialized_atomic() -> ::core::ffi::c_int {
+    let mut value: atomic_int = 5 as ::core::ffi::c_int;
+    return ::core::intrinsics::atomic_load::<_, { ::core::intrinsics::AtomicOrdering::SeqCst }>(
+        &raw mut value,
+    );
 }
 pub const __ATOMIC_SEQ_CST: ::core::ffi::c_int = 5 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@fences.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@fences.c.2021.clang15.snap
@@ -24,6 +24,7 @@ pub unsafe extern "C" fn fences() {
     ::core::sync::atomic::compiler_fence(::core::sync::atomic::Ordering::Release);
     ::core::sync::atomic::compiler_fence(::core::sync::atomic::Ordering::AcqRel);
     ::core::sync::atomic::compiler_fence(::core::sync::atomic::Ordering::SeqCst);
+    ::core::sync::atomic::compiler_fence(::core::sync::atomic::Ordering::SeqCst);
 }
 pub const __ATOMIC_RELAXED: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
 pub const __ATOMIC_ACQUIRE: ::core::ffi::c_int = 2 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@fences.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@fences.c.2024.clang15.snap
@@ -25,6 +25,7 @@ pub unsafe extern "C" fn fences() {
     ::core::sync::atomic::compiler_fence(::core::sync::atomic::Ordering::Release);
     ::core::sync::atomic::compiler_fence(::core::sync::atomic::Ordering::AcqRel);
     ::core::sync::atomic::compiler_fence(::core::sync::atomic::Ordering::SeqCst);
+    ::core::sync::atomic::compiler_fence(::core::sync::atomic::Ordering::SeqCst);
 }
 pub const __ATOMIC_RELAXED: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
 pub const __ATOMIC_ACQUIRE: ::core::ffi::c_int = 2 as ::core::ffi::c_int;


### PR DESCRIPTION
Fixes #1667.

AI disclosure: this code was written by Codex.