### PR TITLE
ast-exporter: Convert RISC-V vector tuple types

### DIFF
--- a/c2rust-ast-exporter/src/AstExporter.cpp
+++ b/c2rust-ast-exporter/src/AstExporter.cpp
@@ -407,6 +407,10 @@ private:
             /* RISC-V vector types */
             || kind >= BuiltinType::RvvInt8mf8 && kind <= BuiltinType::RvvBool64
 #endif // CLANG_VERSION_MAJOR >= 13
+#if CLANG_VERSION_MAJOR >= 17
+            /* RISC-V vector tuple types, e.g. __rvv_int8mf8x2_t .. __rvv_float64m4x2_t */
+            || kind >= BuiltinType::RvvInt8mf8x2 && kind <= BuiltinType::RvvFloat64m4x2
+#endif // CLANG_VERSION_MAJOR >= 17
             ) {
 // Declare ElemType and ElemCount as needed by various Clang versions
 #if CLANG_VERSION_MAJOR >= 11


### PR DESCRIPTION
### Description

Similarly to #692 and #693, LLVM 17 introduced new vector tuple types for RISC-V that cause build issues.

Context: in RIOT OS, we are currently updating our build container that now uses Ubuntu 26.04LTS, which ships with at least LLVM 17 and there we ran into this issue.

Unrelated note: there are some code paths for LLVM<15 versions, which are not supported anymore according to the README, I guess they could be deleted?

### Minimal Example

Note: I bumped the version to distinguish between the installations.

Behavior with `master`:
```
root@fabe22589399:/tmp/test# touch empty.h

root@fabe22589399:/tmp/test# cat compile_commands.json
[
        {
                "arguments": [
                        "any-cc",
                        "-target",
                        "riscv32",
                        "empty.h"
                ],
                "directory": "/tmp/test",
                "file": "empty.h"
        }
]

root@fabe22589399:/tmp/test# c2rust --version
C2Rust 0.22.1

root@fabe22589399:/tmp/test# c2rust transpile compile_commands.json
warning: c2rust: Encountered unsupported BuiltinType kind 168 for type __rvv_int8mf8x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 169 for type __rvv_int8mf8x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 170 for type __rvv_int8mf8x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 171 for type __rvv_int8mf8x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 172 for type __rvv_int8mf8x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 173 for type __rvv_int8mf8x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 174 for type __rvv_int8mf8x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 175 for type __rvv_int8mf4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 176 for type __rvv_int8mf4x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 177 for type __rvv_int8mf4x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 178 for type __rvv_int8mf4x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 179 for type __rvv_int8mf4x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 180 for type __rvv_int8mf4x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 181 for type __rvv_int8mf4x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 182 for type __rvv_int8mf2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 183 for type __rvv_int8mf2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 184 for type __rvv_int8mf2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 185 for type __rvv_int8mf2x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 186 for type __rvv_int8mf2x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 187 for type __rvv_int8mf2x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 188 for type __rvv_int8mf2x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 189 for type __rvv_int8m1x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 190 for type __rvv_int8m1x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 191 for type __rvv_int8m1x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 192 for type __rvv_int8m1x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 193 for type __rvv_int8m1x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 194 for type __rvv_int8m1x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 195 for type __rvv_int8m1x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 196 for type __rvv_int8m2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 197 for type __rvv_int8m2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 198 for type __rvv_int8m2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 199 for type __rvv_int8m4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 200 for type __rvv_uint8mf8x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 201 for type __rvv_uint8mf8x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 202 for type __rvv_uint8mf8x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 203 for type __rvv_uint8mf8x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 204 for type __rvv_uint8mf8x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 205 for type __rvv_uint8mf8x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 206 for type __rvv_uint8mf8x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 207 for type __rvv_uint8mf4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 208 for type __rvv_uint8mf4x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 209 for type __rvv_uint8mf4x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 210 for type __rvv_uint8mf4x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 211 for type __rvv_uint8mf4x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 212 for type __rvv_uint8mf4x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 213 for type __rvv_uint8mf4x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 214 for type __rvv_uint8mf2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 215 for type __rvv_uint8mf2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 216 for type __rvv_uint8mf2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 217 for type __rvv_uint8mf2x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 218 for type __rvv_uint8mf2x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 219 for type __rvv_uint8mf2x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 220 for type __rvv_uint8mf2x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 221 for type __rvv_uint8m1x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 222 for type __rvv_uint8m1x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 223 for type __rvv_uint8m1x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 224 for type __rvv_uint8m1x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 225 for type __rvv_uint8m1x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 226 for type __rvv_uint8m1x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 227 for type __rvv_uint8m1x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 228 for type __rvv_uint8m2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 229 for type __rvv_uint8m2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 230 for type __rvv_uint8m2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 231 for type __rvv_uint8m4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 232 for type __rvv_int16mf4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 233 for type __rvv_int16mf4x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 234 for type __rvv_int16mf4x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 235 for type __rvv_int16mf4x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 236 for type __rvv_int16mf4x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 237 for type __rvv_int16mf4x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 238 for type __rvv_int16mf4x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 239 for type __rvv_int16mf2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 240 for type __rvv_int16mf2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 241 for type __rvv_int16mf2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 242 for type __rvv_int16mf2x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 243 for type __rvv_int16mf2x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 244 for type __rvv_int16mf2x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 245 for type __rvv_int16mf2x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 246 for type __rvv_int16m1x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 247 for type __rvv_int16m1x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 248 for type __rvv_int16m1x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 249 for type __rvv_int16m1x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 250 for type __rvv_int16m1x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 251 for type __rvv_int16m1x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 252 for type __rvv_int16m1x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 253 for type __rvv_int16m2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 254 for type __rvv_int16m2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 255 for type __rvv_int16m2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 256 for type __rvv_int16m4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 257 for type __rvv_uint16mf4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 258 for type __rvv_uint16mf4x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 259 for type __rvv_uint16mf4x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 260 for type __rvv_uint16mf4x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 261 for type __rvv_uint16mf4x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 262 for type __rvv_uint16mf4x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 263 for type __rvv_uint16mf4x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 264 for type __rvv_uint16mf2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 265 for type __rvv_uint16mf2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 266 for type __rvv_uint16mf2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 267 for type __rvv_uint16mf2x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 268 for type __rvv_uint16mf2x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 269 for type __rvv_uint16mf2x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 270 for type __rvv_uint16mf2x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 271 for type __rvv_uint16m1x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 272 for type __rvv_uint16m1x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 273 for type __rvv_uint16m1x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 274 for type __rvv_uint16m1x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 275 for type __rvv_uint16m1x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 276 for type __rvv_uint16m1x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 277 for type __rvv_uint16m1x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 278 for type __rvv_uint16m2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 279 for type __rvv_uint16m2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 280 for type __rvv_uint16m2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 281 for type __rvv_uint16m4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 282 for type __rvv_int32mf2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 283 for type __rvv_int32mf2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 284 for type __rvv_int32mf2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 285 for type __rvv_int32mf2x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 286 for type __rvv_int32mf2x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 287 for type __rvv_int32mf2x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 288 for type __rvv_int32mf2x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 289 for type __rvv_int32m1x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 290 for type __rvv_int32m1x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 291 for type __rvv_int32m1x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 292 for type __rvv_int32m1x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 293 for type __rvv_int32m1x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 294 for type __rvv_int32m1x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 295 for type __rvv_int32m1x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 296 for type __rvv_int32m2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 297 for type __rvv_int32m2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 298 for type __rvv_int32m2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 299 for type __rvv_int32m4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 300 for type __rvv_uint32mf2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 301 for type __rvv_uint32mf2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 302 for type __rvv_uint32mf2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 303 for type __rvv_uint32mf2x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 304 for type __rvv_uint32mf2x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 305 for type __rvv_uint32mf2x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 306 for type __rvv_uint32mf2x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 307 for type __rvv_uint32m1x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 308 for type __rvv_uint32m1x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 309 for type __rvv_uint32m1x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 310 for type __rvv_uint32m1x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 311 for type __rvv_uint32m1x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 312 for type __rvv_uint32m1x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 313 for type __rvv_uint32m1x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 314 for type __rvv_uint32m2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 315 for type __rvv_uint32m2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 316 for type __rvv_uint32m2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 317 for type __rvv_uint32m4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 318 for type __rvv_int64m1x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 319 for type __rvv_int64m1x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 320 for type __rvv_int64m1x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 321 for type __rvv_int64m1x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 322 for type __rvv_int64m1x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 323 for type __rvv_int64m1x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 324 for type __rvv_int64m1x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 325 for type __rvv_int64m2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 326 for type __rvv_int64m2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 327 for type __rvv_int64m2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 328 for type __rvv_int64m4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 329 for type __rvv_uint64m1x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 330 for type __rvv_uint64m1x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 331 for type __rvv_uint64m1x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 332 for type __rvv_uint64m1x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 333 for type __rvv_uint64m1x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 334 for type __rvv_uint64m1x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 335 for type __rvv_uint64m1x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 336 for type __rvv_uint64m2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 337 for type __rvv_uint64m2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 338 for type __rvv_uint64m2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 339 for type __rvv_uint64m4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 340 for type __rvv_float16mf4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 341 for type __rvv_float16mf4x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 342 for type __rvv_float16mf4x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 343 for type __rvv_float16mf4x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 344 for type __rvv_float16mf4x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 345 for type __rvv_float16mf4x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 346 for type __rvv_float16mf4x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 347 for type __rvv_float16mf2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 348 for type __rvv_float16mf2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 349 for type __rvv_float16mf2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 350 for type __rvv_float16mf2x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 351 for type __rvv_float16mf2x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 352 for type __rvv_float16mf2x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 353 for type __rvv_float16mf2x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 354 for type __rvv_float16m1x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 355 for type __rvv_float16m1x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 356 for type __rvv_float16m1x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 357 for type __rvv_float16m1x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 358 for type __rvv_float16m1x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 359 for type __rvv_float16m1x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 360 for type __rvv_float16m1x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 361 for type __rvv_float16m2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 362 for type __rvv_float16m2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 363 for type __rvv_float16m2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 364 for type __rvv_float16m4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 365 for type __rvv_float32mf2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 366 for type __rvv_float32mf2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 367 for type __rvv_float32mf2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 368 for type __rvv_float32mf2x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 369 for type __rvv_float32mf2x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 370 for type __rvv_float32mf2x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 371 for type __rvv_float32mf2x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 372 for type __rvv_float32m1x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 373 for type __rvv_float32m1x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 374 for type __rvv_float32m1x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 375 for type __rvv_float32m1x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 376 for type __rvv_float32m1x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 377 for type __rvv_float32m1x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 378 for type __rvv_float32m1x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 379 for type __rvv_float32m2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 380 for type __rvv_float32m2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 381 for type __rvv_float32m2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 382 for type __rvv_float32m4x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 383 for type __rvv_float64m1x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 384 for type __rvv_float64m1x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 385 for type __rvv_float64m1x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 386 for type __rvv_float64m1x5_t
warning: c2rust: Encountered unsupported BuiltinType kind 387 for type __rvv_float64m1x6_t
warning: c2rust: Encountered unsupported BuiltinType kind 388 for type __rvv_float64m1x7_t
warning: c2rust: Encountered unsupported BuiltinType kind 389 for type __rvv_float64m1x8_t
warning: c2rust: Encountered unsupported BuiltinType kind 390 for type __rvv_float64m2x2_t
warning: c2rust: Encountered unsupported BuiltinType kind 391 for type __rvv_float64m2x3_t
warning: c2rust: Encountered unsupported BuiltinType kind 392 for type __rvv_float64m2x4_t
warning: c2rust: Encountered unsupported BuiltinType kind 393 for type __rvv_float64m4x2_t
226 warnings generated.
Transpiling empty.h

thread 'main' (154) panicked at c2rust-transpile/src/c_ast/conversion.rs:950:22:
Type conversion not implemented for TagTypeUnknown expecting 3
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Behavior with this PR:
```
root@fabe22589399:/tmp/test# touch empty.h

root@c2rustcontainer:/tmp/test# cat compile_commands.json
[
        {
                "arguments": [
                        "any-cc",
                        "-target",
                        "riscv32",
                        "empty.h"
                ],
                "directory": "/tmp/test",
                "file": "empty.h"
        }
]

root@c2rustcontainer:/tmp/test# c2rust --version
C2Rust 0.22.2

root@c2rustcontainer:/tmp/test# c2rust transpile compile_commands.json
Transpiling empty.h
```

### Less Minimal Example

To see whether or not the types are actually interpreted correctly, I created a less minimal example that defines four functions that use the tuple types.

The transpilation still fails because there is no support for the resulting vector types, but it shows that the vectors are interpreted correctly, there is just no further support for them.
This is beyond the scope of the PR though I guess.

From the error message together with the according type.
```
Vector(..., ctype: CTypeId(31) ..., 1)   // __rvv_int8mf8_t
Vector(..., ctype: CTypeId(31) ..., 2)   // __rvv_int8mf8x2_t
Vector(..., ctype: CTypeId(31) ..., 3)   // __rvv_int8mf8x3_t
Vector(..., ctype: CTypeId(31) ..., 4)   // __rvv_int8mf8x4_t
```

```
root@c2rustcontainer:/tmp/test# cat types.h
void func_a(__rvv_int8mf8_t a) {}
void func_b(__rvv_int8mf8x2_t b) {}
void func_c(__rvv_int8mf8x3_t c) {}
void func_d(__rvv_int8mf8x4_t d) {}

root@c2rustcontainer:/tmp/test# cat compile_commands2.json
[
        {
                "arguments": [
                        "any-cc",
                        "-target",
                        "riscv64",
                        "types.h"
                ],
                "directory": "/tmp/test",
                "file": "types.h"
        }
]

root@c2rustcontainer:/tmp/test# c2rust transpile compile_commands2.json -- -march=rv64gcv1p0
Transpiling types.h
error: Skipping declaration Some(Typedef { name: "__rvv_int8mf8_t", typ: CQualTypeId { qualifiers: Qualifiers { is_const: false, is_restrict: false, is_volatile: false }, ctype: CTypeId(34) }, is_implicit: true, target_dependent_macro: None }) due to error: Unsupported type Vector(CQualTypeId { qualifiers: Qualifiers { is_const: false, is_restrict: false, is_volatile: false }, ctype: CTypeId(35) }, 1)

error: Skipping declaration Some(Typedef { name: "__rvv_int8mf8x2_t", typ: CQualTypeId { qualifiers: Qualifiers { is_const: false, is_restrict: false, is_volatile: false }, ctype: CTypeId(176) }, is_implicit: true, target_dependent_macro: None }) due to error: Unsupported type Vector(CQualTypeId { qualifiers: Qualifiers { is_const: false, is_restrict: false, is_volatile: false }, ctype: CTypeId(35) }, 2)

error: Skipping declaration Some(Typedef { name: "__rvv_int8mf8x3_t", typ: CQualTypeId { qualifiers: Qualifiers { is_const: false, is_restrict: false, is_volatile: false }, ctype: CTypeId(178) }, is_implicit: true, target_dependent_macro: None }) due to error: Unsupported type Vector(CQualTypeId { qualifiers: Qualifiers { is_const: false, is_restrict: false, is_volatile: false }, ctype: CTypeId(35) }, 3)

error: Skipping declaration Some(Typedef { name: "__rvv_int8mf8x4_t", typ: CQualTypeId { qualifiers: Qualifiers { is_const: false, is_restrict: false, is_volatile: false }, ctype: CTypeId(180) }, is_implicit: true, target_dependent_macro: None }) due to error: Unsupported type Vector(CQualTypeId { qualifiers: Qualifiers { is_const: false, is_restrict: false, is_volatile: false }, ctype: CTypeId(35) }, 4)

root@c2rustcontainer:/tmp/test# cat types.rs
#![allow(
    dead_code,
    non_camel_case_types,
    non_snake_case,
    non_upper_case_globals,
    unused_assignments,
    unused_mut
)]
#[no_mangle]
pub unsafe extern "C" fn func_a(mut a: __rvv_int8mf8_t) {}
#[no_mangle]
pub unsafe extern "C" fn func_b(mut b: __rvv_int8mf8x2_t) {}
#[no_mangle]
pub unsafe extern "C" fn func_c(mut c: __rvv_int8mf8x3_t) {}
#[no_mangle]
pub unsafe extern "C" fn func_d(mut d: __rvv_int8mf8x4_t) {}
```