### PR TITLE
test: snapshot atomic function pointer translation

### DIFF
--- a/c2rust-transpile/tests/snapshots.rs
+++ b/c2rust-transpile/tests/snapshots.rs
@@ -298,6 +298,11 @@ fn test_atomics() {
 }
 
 #[test]
+fn test_atomic_function_pointers() {
+    transpile("atomic_function_pointers.c").run();
+}
+
+#[test]
 fn test_auto_type() {
     transpile("auto_type.c").run();
 }

--- a/c2rust-transpile/tests/snapshots/atomic_function_pointers.c
+++ b/c2rust-transpile/tests/snapshots/atomic_function_pointers.c
@@ -1,0 +1,44 @@
+typedef int (*callback)(int);
+
+void atomic_function_pointers(callback desired) {
+    callback ptr = 0;
+    callback expected = 0;
+    callback result;
+
+    __atomic_store_n(&ptr, desired, __ATOMIC_RELEASE);
+    result = __atomic_load_n(&ptr, __ATOMIC_ACQUIRE);
+    result = __atomic_exchange_n(&ptr, (callback)0, __ATOMIC_ACQ_REL);
+    __atomic_compare_exchange_n(&ptr, &expected, desired, 0,
+                                __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+
+    __atomic_store(&ptr, &desired, __ATOMIC_RELEASE);
+    __atomic_load(&ptr, &result, __ATOMIC_ACQUIRE);
+    __atomic_exchange(&ptr, &desired, &result, __ATOMIC_ACQ_REL);
+    __atomic_compare_exchange(&ptr, &expected, &desired, 0,
+                              __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+void c11_atomic_function_pointers(callback desired) {
+    _Atomic(callback) ptr = (callback)0;
+    callback expected = 0;
+    callback result;
+
+    __c11_atomic_init(&ptr, (callback)0);
+    __c11_atomic_store(&ptr, desired, __ATOMIC_RELEASE);
+    result = __c11_atomic_load(&ptr, __ATOMIC_ACQUIRE);
+    result = __c11_atomic_exchange(&ptr, (callback)0, __ATOMIC_ACQ_REL);
+    __c11_atomic_compare_exchange_strong(&ptr, &expected, desired,
+                                        __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    __c11_atomic_compare_exchange_weak(&ptr, &expected, (callback)0,
+                                      __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+void sync_function_pointers(callback desired) {
+    callback ptr = 0;
+    callback result;
+
+    result = __sync_lock_test_and_set(&ptr, desired);
+    result = __sync_val_compare_and_swap(&ptr, desired, (callback)0);
+    __sync_bool_compare_and_swap(&ptr, (callback)0, desired);
+    __sync_lock_release(&ptr);
+}

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomic_function_pointers.c.2021.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomic_function_pointers.c.2021.clang15.snap
@@ -1,0 +1,118 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/atomic_function_pointers.2021.clang15.rs
+---
+#![allow(
+    clippy::missing_safety_doc,
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unused_assignments,
+    unused_mut
+)]
+#![feature(core_intrinsics, raw_ref_op)]
+pub type callback = Option<unsafe extern "C" fn(::core::ffi::c_int) -> ::core::ffi::c_int>;
+#[no_mangle]
+pub unsafe extern "C" fn atomic_function_pointers(mut desired: callback) {
+    let mut ptr: callback = None;
+    let mut expected: callback = None;
+    let mut result: callback = None;
+    ::core::intrinsics::atomic_store_release(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    );
+    result = ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_load_acquire(
+        &raw mut ptr as *mut *mut (),
+    ));
+    result = ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_xchg_acqrel(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(None),
+    ));
+    let c2rust_result = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut expected),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    );
+    *&raw mut expected = ::core::mem::transmute::<*mut (), callback>(c2rust_result.0);
+    c2rust_result.1;
+    ::core::intrinsics::atomic_store_release(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut desired),
+    );
+    *&raw mut result = ::core::mem::transmute::<*mut (), callback>(
+        ::core::intrinsics::atomic_load_acquire(&raw mut ptr as *mut *mut ()),
+    );
+    *&raw mut result =
+        ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_xchg_acqrel(
+            &raw mut ptr as *mut *mut (),
+            ::core::mem::transmute::<callback, *mut ()>(*&raw mut desired),
+        ));
+    let c2rust_result_0 = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut expected),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut desired),
+    );
+    *&raw mut expected = ::core::mem::transmute::<*mut (), callback>(c2rust_result_0.0);
+    c2rust_result_0.1;
+}
+#[no_mangle]
+pub unsafe extern "C" fn c11_atomic_function_pointers(mut desired: callback) {
+    let mut ptr: callback = None;
+    let mut expected: callback = None;
+    let mut result: callback = None;
+    *&raw mut ptr = None;
+    ::core::intrinsics::atomic_store_release(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    );
+    result = ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_load_acquire(
+        &raw mut ptr as *mut *mut (),
+    ));
+    result = ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_xchg_acqrel(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(None),
+    ));
+    let c2rust_result = ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut expected),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    );
+    *&raw mut expected = ::core::mem::transmute::<*mut (), callback>(c2rust_result.0);
+    c2rust_result.1;
+    let c2rust_result_0 = ::core::intrinsics::atomic_cxchgweak_seqcst_seqcst(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut expected),
+        ::core::mem::transmute::<callback, *mut ()>(None),
+    );
+    *&raw mut expected = ::core::mem::transmute::<*mut (), callback>(c2rust_result_0.0);
+    c2rust_result_0.1;
+}
+#[no_mangle]
+pub unsafe extern "C" fn sync_function_pointers(mut desired: callback) {
+    let mut ptr: callback = None;
+    let mut result: callback = None;
+    result = ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_xchg_acquire(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    ));
+    result = ::core::mem::transmute::<*mut (), callback>(
+        ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
+            &raw mut ptr as *mut *mut (),
+            ::core::mem::transmute::<callback, *mut ()>(desired),
+            ::core::mem::transmute::<callback, *mut ()>(None),
+        )
+        .0,
+    );
+    ::core::intrinsics::atomic_cxchg_seqcst_seqcst(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(None),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    )
+    .1;
+    ::core::intrinsics::atomic_store_release(&raw mut ptr as *mut *mut (), ::core::ptr::null_mut());
+}
+pub const __ATOMIC_ACQUIRE: ::core::ffi::c_int = 2 as ::core::ffi::c_int;
+pub const __ATOMIC_RELEASE: ::core::ffi::c_int = 3 as ::core::ffi::c_int;
+pub const __ATOMIC_ACQ_REL: ::core::ffi::c_int = 4 as ::core::ffi::c_int;
+pub const __ATOMIC_SEQ_CST: ::core::ffi::c_int = 5 as ::core::ffi::c_int;

--- a/c2rust-transpile/tests/snapshots/snapshots__transpile@atomic_function_pointers.c.2024.clang15.snap
+++ b/c2rust-transpile/tests/snapshots/snapshots__transpile@atomic_function_pointers.c.2024.clang15.snap
@@ -1,0 +1,162 @@
+---
+source: c2rust-transpile/tests/snapshots.rs
+expression: cat tests/snapshots/atomic_function_pointers.2024.clang15.rs
+---
+#![allow(
+    clippy::missing_safety_doc,
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    unsafe_op_in_unsafe_fn,
+    unused_assignments,
+    unused_mut
+)]
+#![feature(core_intrinsics)]
+pub type callback = Option<unsafe extern "C" fn(::core::ffi::c_int) -> ::core::ffi::c_int>;
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn atomic_function_pointers(mut desired: callback) {
+    let mut ptr: callback = None;
+    let mut expected: callback = None;
+    let mut result: callback = None;
+    ::core::intrinsics::atomic_store::<_, { ::core::intrinsics::AtomicOrdering::Release }>(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    );
+    result = ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_load::<
+        _,
+        { ::core::intrinsics::AtomicOrdering::Acquire },
+    >(&raw mut ptr as *mut *mut ()));
+    result = ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_xchg::<
+        _,
+        { ::core::intrinsics::AtomicOrdering::AcqRel },
+    >(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(None),
+    ));
+    let c2rust_result = ::core::intrinsics::atomic_cxchg::<
+        _,
+        { ::core::intrinsics::AtomicOrdering::SeqCst },
+        { ::core::intrinsics::AtomicOrdering::SeqCst },
+    >(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut expected),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    );
+    *&raw mut expected = ::core::mem::transmute::<*mut (), callback>(c2rust_result.0);
+    c2rust_result.1;
+    ::core::intrinsics::atomic_store::<_, { ::core::intrinsics::AtomicOrdering::Release }>(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut desired),
+    );
+    *&raw mut result =
+        ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_load::<
+            _,
+            { ::core::intrinsics::AtomicOrdering::Acquire },
+        >(&raw mut ptr as *mut *mut ()));
+    *&raw mut result =
+        ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_xchg::<
+            _,
+            { ::core::intrinsics::AtomicOrdering::AcqRel },
+        >(
+            &raw mut ptr as *mut *mut (),
+            ::core::mem::transmute::<callback, *mut ()>(*&raw mut desired),
+        ));
+    let c2rust_result_0 = ::core::intrinsics::atomic_cxchg::<
+        _,
+        { ::core::intrinsics::AtomicOrdering::SeqCst },
+        { ::core::intrinsics::AtomicOrdering::SeqCst },
+    >(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut expected),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut desired),
+    );
+    *&raw mut expected = ::core::mem::transmute::<*mut (), callback>(c2rust_result_0.0);
+    c2rust_result_0.1;
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn c11_atomic_function_pointers(mut desired: callback) {
+    let mut ptr: callback = None;
+    let mut expected: callback = None;
+    let mut result: callback = None;
+    *&raw mut ptr = None;
+    ::core::intrinsics::atomic_store::<_, { ::core::intrinsics::AtomicOrdering::Release }>(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    );
+    result = ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_load::<
+        _,
+        { ::core::intrinsics::AtomicOrdering::Acquire },
+    >(&raw mut ptr as *mut *mut ()));
+    result = ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_xchg::<
+        _,
+        { ::core::intrinsics::AtomicOrdering::AcqRel },
+    >(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(None),
+    ));
+    let c2rust_result = ::core::intrinsics::atomic_cxchg::<
+        _,
+        { ::core::intrinsics::AtomicOrdering::SeqCst },
+        { ::core::intrinsics::AtomicOrdering::SeqCst },
+    >(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut expected),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    );
+    *&raw mut expected = ::core::mem::transmute::<*mut (), callback>(c2rust_result.0);
+    c2rust_result.1;
+    let c2rust_result_0 = ::core::intrinsics::atomic_cxchgweak::<
+        _,
+        { ::core::intrinsics::AtomicOrdering::SeqCst },
+        { ::core::intrinsics::AtomicOrdering::SeqCst },
+    >(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(*&raw mut expected),
+        ::core::mem::transmute::<callback, *mut ()>(None),
+    );
+    *&raw mut expected = ::core::mem::transmute::<*mut (), callback>(c2rust_result_0.0);
+    c2rust_result_0.1;
+}
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sync_function_pointers(mut desired: callback) {
+    let mut ptr: callback = None;
+    let mut result: callback = None;
+    result = ::core::mem::transmute::<*mut (), callback>(::core::intrinsics::atomic_xchg::<
+        _,
+        { ::core::intrinsics::AtomicOrdering::Acquire },
+    >(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    ));
+    result = ::core::mem::transmute::<*mut (), callback>(
+        ::core::intrinsics::atomic_cxchg::<
+            _,
+            { ::core::intrinsics::AtomicOrdering::SeqCst },
+            { ::core::intrinsics::AtomicOrdering::SeqCst },
+        >(
+            &raw mut ptr as *mut *mut (),
+            ::core::mem::transmute::<callback, *mut ()>(desired),
+            ::core::mem::transmute::<callback, *mut ()>(None),
+        )
+        .0,
+    );
+    ::core::intrinsics::atomic_cxchg::<
+        _,
+        { ::core::intrinsics::AtomicOrdering::SeqCst },
+        { ::core::intrinsics::AtomicOrdering::SeqCst },
+    >(
+        &raw mut ptr as *mut *mut (),
+        ::core::mem::transmute::<callback, *mut ()>(None),
+        ::core::mem::transmute::<callback, *mut ()>(desired),
+    )
+    .1;
+    ::core::intrinsics::atomic_store::<_, { ::core::intrinsics::AtomicOrdering::Release }>(
+        &raw mut ptr as *mut *mut (),
+        ::core::ptr::null_mut(),
+    );
+}
+pub const __ATOMIC_ACQUIRE: ::core::ffi::c_int = 2 as ::core::ffi::c_int;
+pub const __ATOMIC_RELEASE: ::core::ffi::c_int = 3 as ::core::ffi::c_int;
+pub const __ATOMIC_ACQ_REL: ::core::ffi::c_int = 4 as ::core::ffi::c_int;
+pub const __ATOMIC_SEQ_CST: ::core::ffi::c_int = 5 as ::core::ffi::c_int;


### PR DESCRIPTION
Add Rust 2021 and 2024 snapshots for GNU, C11, and legacy `__sync` function-pointer atomics using the existing test harness.